### PR TITLE
fix: exponential with on create

### DIFF
--- a/packages/graphql/tests/tck/tck-test-files/cypher-connect.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-connect.md
@@ -84,58 +84,62 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Product)
-SET this0.id = $this0_id
-SET this0.name = $this0_name
+CALL {
+  CREATE (this0:Product)
+  SET this0.id = $this0_id
+  SET this0.name = $this0_name
 
-WITH this0
-OPTIONAL MATCH (this0_colors_connect0:Color)
-WHERE this0_colors_connect0.name = $this0_colors_connect0_name
-FOREACH(_ IN CASE this0_colors_connect0 WHEN NULL THEN [] ELSE [1] END |
-    MERGE (this0)-[:HAS_COLOR]->(this0_colors_connect0)
-)
+  WITH this0
+  OPTIONAL MATCH (this0_colors_connect0:Color)
+  WHERE this0_colors_connect0.name = $this0_colors_connect0_name
+  FOREACH(_ IN CASE this0_colors_connect0 WHEN NULL THEN [] ELSE [1] END |
+      MERGE (this0)-[:HAS_COLOR]->(this0_colors_connect0)
+  )
 
-    WITH this0, this0_colors_connect0
-    OPTIONAL MATCH (this0_colors_connect0_photos0:Photo)
-    WHERE this0_colors_connect0_photos0.id = $this0_colors_connect0_photos0_id
-    FOREACH(_ IN CASE this0_colors_connect0_photos0 WHEN NULL THEN [] ELSE [1] END |
-        MERGE (this0_colors_connect0)<-[:OF_COLOR]-(this0_colors_connect0_photos0)
-    )
+      WITH this0, this0_colors_connect0
+      OPTIONAL MATCH (this0_colors_connect0_photos0:Photo)
+      WHERE this0_colors_connect0_photos0.id = $this0_colors_connect0_photos0_id
+      FOREACH(_ IN CASE this0_colors_connect0_photos0 WHEN NULL THEN [] ELSE [1] END |
+          MERGE (this0_colors_connect0)<-[:OF_COLOR]-(this0_colors_connect0_photos0)
+      )
 
-        WITH this0, this0_colors_connect0, this0_colors_connect0_photos0
-        OPTIONAL MATCH (this0_colors_connect0_photos0_color0:Color)
-        WHERE this0_colors_connect0_photos0_color0.id = $this0_colors_connect0_photos0_color0_id
-        FOREACH(_ IN CASE this0_colors_connect0_photos0_color0 WHEN NULL THEN [] ELSE [1] END |
-            MERGE (this0_colors_connect0_photos0)-[:OF_COLOR]->(this0_colors_connect0_photos0_color0)
-        )
+          WITH this0, this0_colors_connect0, this0_colors_connect0_photos0
+          OPTIONAL MATCH (this0_colors_connect0_photos0_color0:Color)
+          WHERE this0_colors_connect0_photos0_color0.id = $this0_colors_connect0_photos0_color0_id
+          FOREACH(_ IN CASE this0_colors_connect0_photos0_color0 WHEN NULL THEN [] ELSE [1] END |
+              MERGE (this0_colors_connect0_photos0)-[:OF_COLOR]->(this0_colors_connect0_photos0_color0)
+          )
 
-WITH this0
-OPTIONAL MATCH (this0_photos_connect0:Photo)
-WHERE this0_photos_connect0.id = $this0_photos_connect0_id
-FOREACH(_ IN CASE this0_photos_connect0 WHEN NULL THEN [] ELSE [1] END |
-    MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect0)
-)
+  WITH this0
+  OPTIONAL MATCH (this0_photos_connect0:Photo)
+  WHERE this0_photos_connect0.id = $this0_photos_connect0_id
+  FOREACH(_ IN CASE this0_photos_connect0 WHEN NULL THEN [] ELSE [1] END |
+      MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect0)
+  )
 
-    WITH this0, this0_photos_connect0
-    OPTIONAL MATCH (this0_photos_connect0_color0:Color)
-    WHERE this0_photos_connect0_color0.name = $this0_photos_connect0_color0_name
-    FOREACH(_ IN CASE this0_photos_connect0_color0 WHEN NULL THEN [] ELSE [1] END |
-        MERGE (this0_photos_connect0)-[:OF_COLOR]->(this0_photos_connect0_color0)
-    )
+      WITH this0, this0_photos_connect0
+      OPTIONAL MATCH (this0_photos_connect0_color0:Color)
+      WHERE this0_photos_connect0_color0.name = $this0_photos_connect0_color0_name
+      FOREACH(_ IN CASE this0_photos_connect0_color0 WHEN NULL THEN [] ELSE [1] END |
+          MERGE (this0_photos_connect0)-[:OF_COLOR]->(this0_photos_connect0_color0)
+      )
 
-WITH this0
-OPTIONAL MATCH (this0_photos_connect1:Photo)
-WHERE this0_photos_connect1.id = $this0_photos_connect1_id
-FOREACH(_ IN CASE this0_photos_connect1 WHEN NULL THEN [] ELSE [1] END |
-    MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect1)
-)
+  WITH this0
+  OPTIONAL MATCH (this0_photos_connect1:Photo)
+  WHERE this0_photos_connect1.id = $this0_photos_connect1_id
+  FOREACH(_ IN CASE this0_photos_connect1 WHEN NULL THEN [] ELSE [1] END |
+      MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect1)
+  )
 
-    WITH this0, this0_photos_connect1
-    OPTIONAL MATCH (this0_photos_connect1_color0:Color)
-    WHERE this0_photos_connect1_color0.name = $this0_photos_connect1_color0_name
-    FOREACH(_ IN CASE this0_photos_connect1_color0 WHEN NULL THEN [] ELSE [1] END |
-        MERGE (this0_photos_connect1)-[:OF_COLOR]->(this0_photos_connect1_color0)
-    )
+      WITH this0, this0_photos_connect1
+      OPTIONAL MATCH (this0_photos_connect1_color0:Color)
+      WHERE this0_photos_connect1_color0.name = $this0_photos_connect1_color0_name
+      FOREACH(_ IN CASE this0_photos_connect1_color0 WHEN NULL THEN [] ELSE [1] END |
+          MERGE (this0_photos_connect1)-[:OF_COLOR]->(this0_photos_connect1_color0)
+      )
+      
+  RETURN this0
+}
 
 RETURN
 this0 { .id } AS this0

--- a/packages/graphql/tests/tck/tck-test-files/cypher-create.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-create.md
@@ -33,8 +33,11 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie)
-SET this0.id = $this0_id
+CALL {
+  CREATE (this0:Movie)
+  SET this0.id = $this0_id
+  RETURN this0
+}
 
 RETURN this0 { .id } AS this0
 ```
@@ -64,12 +67,17 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie)
-SET this0.id = $this0_id
+CALL {
+  CREATE (this0:Movie)
+  SET this0.id = $this0_id
+  RETURN this0
+}
 
-WITH this0
-CREATE (this1:Movie)
-SET this1.id = $this1_id
+CALL {
+  CREATE (this1:Movie)
+  SET this1.id = $this1_id
+  RETURN this1  
+}
 
 RETURN this0 { .id } AS this0,
        this1 { .id } AS this1
@@ -106,23 +114,29 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie)
-SET this0.id = $this0_id
+CALL {
+  CREATE (this0:Movie)
+  SET this0.id = $this0_id
 
-  WITH this0
-  CREATE (this0_actors0:Actor)
-  SET this0_actors0.name = $this0_actors0_name
-  MERGE (this0)<-[:ACTED_IN]-(this0_actors0)
+    WITH this0
+    CREATE (this0_actors0:Actor)
+    SET this0_actors0.name = $this0_actors0_name
+    MERGE (this0)<-[:ACTED_IN]-(this0_actors0)
 
+  RETURN this0
+}
 
-WITH this0
-CREATE (this1:Movie)
-SET this1.id = $this1_id
+CALL {
+  CREATE (this1:Movie)
+  SET this1.id = $this1_id
 
-  WITH this0, this1
-  CREATE (this1_actors0:Actor)
-  SET this1_actors0.name = $this1_actors0_name
-  MERGE (this1)<-[:ACTED_IN]-(this1_actors0)
+    WITH this1
+    CREATE (this1_actors0:Actor)
+    SET this1_actors0.name = $this1_actors0_name
+    MERGE (this1)<-[:ACTED_IN]-(this1_actors0)
+  
+  RETURN this1
+}
 
 RETURN this0 { .id } AS this0, this1 { .id } AS this1
 ```
@@ -171,30 +185,37 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie)
-SET this0.id = $this0_id
+CALL {
+  CREATE (this0:Movie)
+  SET this0.id = $this0_id
 
-  WITH this0
-  CREATE (this0_actors0:Actor)
-  SET this0_actors0.name = $this0_actors0_name
-    WITH this0, this0_actors0
-    CREATE (this0_actors0_movies0:Movie)
-    SET this0_actors0_movies0.id = $this0_actors0_movies0_id
-    MERGE (this0_actors0)-[:ACTED_IN]->(this0_actors0_movies0)
-    MERGE (this0)<-[:ACTED_IN]-(this0_actors0)
+    WITH this0
+    CREATE (this0_actors0:Actor)
+    SET this0_actors0.name = $this0_actors0_name
+      WITH this0, this0_actors0
+      CREATE (this0_actors0_movies0:Movie)
+      SET this0_actors0_movies0.id = $this0_actors0_movies0_id
+      MERGE (this0_actors0)-[:ACTED_IN]->(this0_actors0_movies0)
+      MERGE (this0)<-[:ACTED_IN]-(this0_actors0)
 
-WITH this0
-CREATE (this1:Movie)
-SET this1.id = $this1_id
+  RETURN this0
+}
 
-  WITH this0, this1
-  CREATE (this1_actors0:Actor)
-  SET this1_actors0.name = $this1_actors0_name
-    WITH this0, this1, this1_actors0
-    CREATE (this1_actors0_movies0:Movie)
-    SET this1_actors0_movies0.id = $this1_actors0_movies0_id
-    MERGE (this1_actors0)-[:ACTED_IN]->(this1_actors0_movies0)
-    MERGE (this1)<-[:ACTED_IN]-(this1_actors0)
+CALL {
+  CREATE (this1:Movie)
+  SET this1.id = $this1_id
+
+    WITH this1
+    CREATE (this1_actors0:Actor)
+    SET this1_actors0.name = $this1_actors0_name
+      WITH this1, this1_actors0
+      CREATE (this1_actors0_movies0:Movie)
+      SET this1_actors0_movies0.id = $this1_actors0_movies0_id
+      MERGE (this1_actors0)-[:ACTED_IN]->(this1_actors0_movies0)
+      MERGE (this1)<-[:ACTED_IN]-(this1_actors0)
+
+  RETURN this1
+}
 
 RETURN this0 { .id } AS this0, this1 { .id } AS this1
 ```
@@ -231,15 +252,19 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie)
-SET this0.id = $this0_id
+CALL {
+  CREATE (this0:Movie)
+  SET this0.id = $this0_id
 
-  WITH this0
-  OPTIONAL MATCH (this0_actors_connect0:Actor)
-  WHERE this0_actors_connect0.name = $this0_actors_connect0_name
-  FOREACH(_ IN CASE this0_actors_connect0 WHEN NULL THEN [] ELSE [1] END | 
-    MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0)
-  )
+    WITH this0
+    OPTIONAL MATCH (this0_actors_connect0:Actor)
+    WHERE this0_actors_connect0.name = $this0_actors_connect0_name
+    FOREACH(_ IN CASE this0_actors_connect0 WHEN NULL THEN [] ELSE [1] END | 
+      MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0)
+    )
+
+  RETURN this0
+}
 
 RETURN this0 { .id } AS this0
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher-pringles.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-pringles.md
@@ -81,68 +81,72 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Product)
-SET this0.id = $this0_id
-SET this0.name = $this0_name
-  
-  WITH this0
-  CREATE (this0_sizes0:Size)
-  SET this0_sizes0.id = $this0_sizes0_id
-  SET this0_sizes0.name = $this0_sizes0_name
-  MERGE (this0)-[:HAS_SIZE]->(this0_sizes0)
-
-  WITH this0
-  CREATE (this0_sizes1:Size)
-  SET this0_sizes1.id = $this0_sizes1_id
-  SET this0_sizes1.name = $this0_sizes1_name
-  MERGE (this0)-[:HAS_SIZE]->(this0_sizes1)
-
-  WITH this0
-  CREATE (this0_colors0:Color)
-  SET this0_colors0.id = $this0_colors0_id
-  SET this0_colors0.name = $this0_colors0_name
-  MERGE (this0)-[:HAS_COLOR]->(this0_colors0)
-
-  WITH this0
-  CREATE (this0_colors1:Color)
-  SET this0_colors1.id = $this0_colors1_id
-  SET this0_colors1.name = $this0_colors1_name
-  MERGE (this0)-[:HAS_COLOR]->(this0_colors1)
-
-  WITH this0
-  CREATE (this0_photos0:Photo)
-  SET this0_photos0.id = $this0_photos0_id
-  SET this0_photos0.description = $this0_photos0_description
-  SET this0_photos0.url = $this0_photos0_url
-  MERGE (this0)-[:HAS_PHOTO]->(this0_photos0)
-
-  WITH this0
-  CREATE (this0_photos1:Photo)
-  SET this0_photos1.id = $this0_photos1_id
-  SET this0_photos1.description = $this0_photos1_description
-  SET this0_photos1.url = $this0_photos1_url
+CALL {
+  CREATE (this0:Product)
+  SET this0.id = $this0_id
+  SET this0.name = $this0_name
     
-    WITH this0, this0_photos1
-    OPTIONAL MATCH (this0_photos1_color_connect0:Color)
-    WHERE this0_photos1_color_connect0.id = $this0_photos1_color_connect0_id
-    FOREACH(_ IN CASE this0_photos1_color_connect0 WHEN NULL THEN [] ELSE [1] END |
-      MERGE (this0_photos1)-[:OF_COLOR]->(this0_photos1_color_connect0)
-    )
-  MERGE (this0)-[:HAS_PHOTO]->(this0_photos1)
+    WITH this0
+    CREATE (this0_sizes0:Size)
+    SET this0_sizes0.id = $this0_sizes0_id
+    SET this0_sizes0.name = $this0_sizes0_name
+    MERGE (this0)-[:HAS_SIZE]->(this0_sizes0)
 
-  WITH this0
-  CREATE (this0_photos2:Photo)
-  SET this0_photos2.id = $this0_photos2_id
-  SET this0_photos2.description = $this0_photos2_description
-  SET this0_photos2.url = $this0_photos2_url
+    WITH this0
+    CREATE (this0_sizes1:Size)
+    SET this0_sizes1.id = $this0_sizes1_id
+    SET this0_sizes1.name = $this0_sizes1_name
+    MERGE (this0)-[:HAS_SIZE]->(this0_sizes1)
 
-    WITH this0, this0_photos2
-    OPTIONAL MATCH (this0_photos2_color_connect0:Color)
-    WHERE this0_photos2_color_connect0.id = $this0_photos2_color_connect0_id
-    FOREACH(_ IN CASE this0_photos2_color_connect0 WHEN NULL THEN [] ELSE [1] END | 
-      MERGE (this0_photos2)-[:OF_COLOR]->(this0_photos2_color_connect0)  
-    )
-  MERGE (this0)-[:HAS_PHOTO]->(this0_photos2)
+    WITH this0
+    CREATE (this0_colors0:Color)
+    SET this0_colors0.id = $this0_colors0_id
+    SET this0_colors0.name = $this0_colors0_name
+    MERGE (this0)-[:HAS_COLOR]->(this0_colors0)
+
+    WITH this0
+    CREATE (this0_colors1:Color)
+    SET this0_colors1.id = $this0_colors1_id
+    SET this0_colors1.name = $this0_colors1_name
+    MERGE (this0)-[:HAS_COLOR]->(this0_colors1)
+
+    WITH this0
+    CREATE (this0_photos0:Photo)
+    SET this0_photos0.id = $this0_photos0_id
+    SET this0_photos0.description = $this0_photos0_description
+    SET this0_photos0.url = $this0_photos0_url
+    MERGE (this0)-[:HAS_PHOTO]->(this0_photos0)
+
+    WITH this0
+    CREATE (this0_photos1:Photo)
+    SET this0_photos1.id = $this0_photos1_id
+    SET this0_photos1.description = $this0_photos1_description
+    SET this0_photos1.url = $this0_photos1_url
+      
+      WITH this0, this0_photos1
+      OPTIONAL MATCH (this0_photos1_color_connect0:Color)
+      WHERE this0_photos1_color_connect0.id = $this0_photos1_color_connect0_id
+      FOREACH(_ IN CASE this0_photos1_color_connect0 WHEN NULL THEN [] ELSE [1] END |
+        MERGE (this0_photos1)-[:OF_COLOR]->(this0_photos1_color_connect0)
+      )
+    MERGE (this0)-[:HAS_PHOTO]->(this0_photos1)
+
+    WITH this0
+    CREATE (this0_photos2:Photo)
+    SET this0_photos2.id = $this0_photos2_id
+    SET this0_photos2.description = $this0_photos2_description
+    SET this0_photos2.url = $this0_photos2_url
+
+      WITH this0, this0_photos2
+      OPTIONAL MATCH (this0_photos2_color_connect0:Color)
+      WHERE this0_photos2_color_connect0.id = $this0_photos2_color_connect0_id
+      FOREACH(_ IN CASE this0_photos2_color_connect0 WHEN NULL THEN [] ELSE [1] END | 
+        MERGE (this0_photos2)-[:OF_COLOR]->(this0_photos2_color_connect0)  
+      )
+    MERGE (this0)-[:HAS_PHOTO]->(this0_photos2)
+
+  RETURN this0
+}
 
 RETURN this0 { .id } AS this0
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher-projection.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-projection.md
@@ -58,12 +58,19 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Product)
-SET this0.id = $this0_id
+CALL {
+  CREATE (this0:Product)
+  SET this0.id = $this0_id
 
-WITH this0
-CREATE (this1:Product)
-SET this1.id = $this1_id
+  RETURN this0
+}
+
+CALL {
+  CREATE (this1:Product)
+  SET this1.id = $this1_id
+
+  RETURN this1
+}
 
 RETURN 
 this0 { 

--- a/packages/graphql/tests/tck/tck-test-files/cypher-union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-union.md
@@ -118,13 +118,17 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie) 
-SET this0.title = $this0_title
+CALL {
+    CREATE (this0:Movie) 
+    SET this0.title = $this0_title
 
-WITH this0 
-CREATE (this0_search_Genre0:Genre) 
-SET this0_search_Genre0.name = $this0_search_Genre0_name 
-MERGE (this0)-[:SEARCH]->(this0_search_Genre0) 
+    WITH this0 
+    CREATE (this0_search_Genre0:Genre) 
+    SET this0_search_Genre0.name = $this0_search_Genre0_name 
+    MERGE (this0)-[:SEARCH]->(this0_search_Genre0) 
+
+    RETURN this0
+}
 
 RETURN this0 { 
     .title
@@ -164,15 +168,19 @@ mutation {
 **Expected Cypher output**
 
 ```cypher
-CREATE (this0:Movie) 
-SET this0.title = $this0_title 
+CALL {
+    CREATE (this0:Movie) 
+    SET this0.title = $this0_title 
 
-WITH this0 
-OPTIONAL MATCH (this0_search_Genre_connect0:Genre) 
-WHERE this0_search_Genre_connect0.name = $this0_search_Genre_connect0_name 
-FOREACH(_ IN CASE this0_search_Genre_connect0 WHEN NULL THEN [] ELSE [1] END | 
-    MERGE (this0)-[:SEARCH]->(this0_search_Genre_connect0) 
-) 
+    WITH this0 
+    OPTIONAL MATCH (this0_search_Genre_connect0:Genre) 
+    WHERE this0_search_Genre_connect0.name = $this0_search_Genre_connect0_name 
+    FOREACH(_ IN CASE this0_search_Genre_connect0 WHEN NULL THEN [] ELSE [1] END | 
+        MERGE (this0)-[:SEARCH]->(this0_search_Genre_connect0) 
+    ) 
+
+    RETURN this0
+}
 
 RETURN this0 { .title } AS this0
 ```


### PR DESCRIPTION
## Problem

On creating many nodes we were using `WITH` to 'carry' each created node to the bottom of the query;

```
CREATE (this0:Movie)
WITH this0
CREATE (this1:Movie)
WITH this0, this1
RETURN this0, this1
```

 This was causing exponential appearances of each node in the `WITH` clauses. I tried creating 1000 nodes and the query was +10000 lines long and crashed my whole PC. The problem is even more apparent when you are using nested mutations;

```
CREATE (this0:Movie)
WITH this0
    OPTIONAL MATCH (this0_actors_connect0:Actor)
    FOREACH(_ IN CASE this0_actors_connect0 WHEN NULL THEN [] ELSE [1] END | 
      MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0)
    )

WITH this0
CREATE (this1:Movie)
WITH this0, this1
    OPTIONAL MATCH (this1_actors_connect0:Actor)
    FOREACH(_ IN CASE this1_actors_connect0 WHEN NULL THEN [] ELSE [1] END | 
      MERGE (this1)<-[:ACTED_IN]-(this1_actors_connect0)
    )


RETURN this0, this1
```

The above example `this0` appears in 3 separate `WITH` statements. 

## Solution
Using subqueries to seperate each node creation.

```
CALL {
  CREATE (this0:Movie)
  WITH this0
      OPTIONAL MATCH (this0_actors_connect0:Actor)
      FOREACH(_ IN CASE this0_actors_connect0 WHEN NULL THEN [] ELSE [1] END | 
        MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0)
      )
  RETURN this0
}

CALL {
  CREATE (this1:Movie)
  WITH this1
      OPTIONAL MATCH (this1_actors_connect0:Actor)
      FOREACH(_ IN CASE this1_actors_connect0 WHEN NULL THEN [] ELSE [1] END | 
        MERGE (this1)<-[:ACTED_IN]-(this1_actors_connect0)
      )
  RETURN this1
}

RETURN this0, this1

```

As you can see using the subqueries the `WITH` is contained to each node.