### PR TITLE
fix: parse default values

### DIFF
--- a/packages/graphql/src/schema/cypher-resolver.ts
+++ b/packages/graphql/src/schema/cypher-resolver.ts
@@ -1,8 +1,11 @@
 import { isInt, Driver } from "neo4j-driver";
+import { ValueNode } from "graphql";
 import { execute } from "../utils";
 import { BaseField } from "../types";
 import getFieldTypeMeta from "./get-field-type-meta";
 import { NeoSchema, Context } from "../classes";
+import parseValueNode from "./parse-value-node";
+import graphqlArgsToCompose from "./graphql-arg-to-compose";
 
 /**
  * Called on custom (Queries & Mutations "TOP LEVEL") with a @cypher directive. Not to mistaken for @cypher type fields.
@@ -75,18 +78,7 @@ function cypherResolver({
     return {
         type: field.typeMeta.pretty,
         resolve,
-        args: field.arguments.reduce((args, arg) => {
-            const meta = getFieldTypeMeta(arg);
-
-            return {
-                ...args,
-                [arg.name.value]: {
-                    type: meta.pretty,
-                    description: arg.description,
-                    defaultValue: arg.defaultValue,
-                },
-            };
-        }, {}),
+        args: graphqlArgsToCompose(field.arguments),
     };
 }
 

--- a/packages/graphql/src/schema/graphql-arg-to-compose.ts
+++ b/packages/graphql/src/schema/graphql-arg-to-compose.ts
@@ -1,0 +1,20 @@
+import { InputValueDefinitionNode, ValueNode } from "graphql";
+import getFieldTypeMeta from "./get-field-type-meta";
+import parseValueNode from "./parse-value-node";
+
+function graphqlArgsToCompose(args: InputValueDefinitionNode[]) {
+    return args.reduce((res, arg) => {
+        const meta = getFieldTypeMeta(arg);
+
+        return {
+            ...res,
+            [arg.name.value]: {
+                type: meta.pretty,
+                description: arg.description,
+                ...(arg.defaultValue ? { defaultValue: parseValueNode(arg.defaultValue as ValueNode) } : {}),
+            },
+        };
+    }, {});
+}
+
+export default graphqlArgsToCompose;

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -7,7 +7,6 @@ import {
     InterfaceTypeDefinitionNode,
     NamedTypeNode,
     ObjectTypeDefinitionNode,
-    parse,
     print,
     ScalarTypeDefinitionNode,
     UnionTypeDefinitionNode,
@@ -50,6 +49,7 @@ import mergeTypeDefs from "./merge-typedefs";
 import checkNodeImplementsInterfaces from "./check-node-implements-interfaces";
 import { Float, Int } from "./scalars";
 import parseExcludeDirective from "./parse-exclude-directive";
+import graphqlArgsToCompose from "./graphql-arg-to-compose";
 
 export interface MakeAugmentedSchemaOptions {
     typeDefs: any;
@@ -232,18 +232,7 @@ function objectFieldsToComposeFields(
         }
 
         if (field.arguments) {
-            newField.args = field.arguments.reduce((args, arg) => {
-                const meta = getFieldTypeMeta(arg);
-
-                return {
-                    ...args,
-                    [arg.name.value]: {
-                        type: meta.pretty,
-                        description: arg.description,
-                        defaultValue: arg.defaultValue,
-                    },
-                };
-            }, {});
+            newField.args = graphqlArgsToCompose(field.arguments);
         }
 
         return { ...res, [field.fieldName]: newField };

--- a/packages/graphql/tests/integration/default-values.int.test.ts
+++ b/packages/graphql/tests/integration/default-values.int.test.ts
@@ -1,0 +1,118 @@
+/* eslint-disable no-useless-escape */
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { generate } from "randomstring";
+import { describe, beforeAll, afterAll, test, expect } from "@jest/globals";
+import makeAugmentedSchema from "../../src/schema/make-augmented-schema";
+import neo4j from "./neo4j";
+
+describe("Default values", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+        process.env.JWT_SECRET = "secret";
+    });
+
+    afterAll(async () => {
+        await driver.close();
+        delete process.env.JWT_SECRET;
+    });
+
+    test("should allow default value on custom @cypher node field", async () => {
+        const session = driver.session();
+
+        const typeDefs = `          
+            type Movie {
+              id: ID
+              field(skip: Int = 100): Int
+                @cypher(
+                    statement: """
+                    return $skip
+                    """
+                )
+            }
+        `;
+
+        const neoSchema = makeAugmentedSchema({
+            typeDefs,
+        });
+
+        const id = generate({
+            charset: "alphabetic",
+        });
+
+        const create = `
+            {
+                Movies(where: {id: "${id}"}){
+                    id
+                    field
+                }
+            }
+        `;
+
+        try {
+            await session.run(`
+                CREATE (:Movie {id: "${id}"})
+            `);
+
+            const gqlResult = await graphql({
+                schema: neoSchema.schema,
+                source: create,
+                contextValue: { driver },
+            });
+
+            expect(gqlResult.errors).toBeFalsy();
+
+            expect((gqlResult.data as any).Movies[0] as any).toEqual({
+                id,
+                field: 100,
+            });
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should allow default value on custom @cypher custom resolver field", async () => {
+        const session = driver.session();
+
+        const typeDefs = `          
+            type Movie {
+                id: ID
+            }
+
+            type Query {
+                field(skip: Int = 100): Int
+                @cypher(
+                    statement: """
+                    return $skip
+                    """
+                )
+            }
+        `;
+
+        const neoSchema = makeAugmentedSchema({
+            typeDefs,
+        });
+
+        const create = `
+            {
+                field
+            }
+        `;
+
+        try {
+            const gqlResult = await graphql({
+                schema: neoSchema.schema,
+                source: create,
+                contextValue: { driver },
+            });
+
+            expect(gqlResult.errors).toBeFalsy();
+
+            expect((gqlResult.data as any).field as any).toEqual(100);
+        } finally {
+            await session.close();
+        }
+    });
+});


### PR DESCRIPTION
We were not parsing the default values correctly. Beforehand you couldn't do; 

```graphql
type User {
  posts(skip: Int = 0, limit: Int = 10): [Post] @cypher(...)
}
```

Now you can! 