### PR TITLE
Rename queries from pascal case to camel case

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -130,7 +130,7 @@ mutation {
 
 ```graphql
 query {
-    Movies {
+    movies {
         title
         genres {
             name

--- a/packages/graphql/docs/asciidoc/reference.adoc
+++ b/packages/graphql/docs/asciidoc/reference.adoc
@@ -153,7 +153,7 @@ const typeDefs = `
 
 const resolvers = {
     Query: {
-        Users: (root, args, context, resolveInfo) => {
+        users: (root, args, context, resolveInfo) => {
             // pre
             const [cypher, params] = translate({
                 context,
@@ -584,7 +584,7 @@ You are highly encouraged to 'spin up' a playground and experiment will the full
 [source, graphql]
 ----
 query {
-    Users {
+    users {
         id
         name
     }
@@ -597,7 +597,7 @@ query {
 [source, graphql]
 ----
 query {
-    Users {
+    users {
         posts {
             content
         }
@@ -614,7 +614,7 @@ Use the `where` argument;
 [source, graphql]
 ----
 query {
-    Users(where: { id: "123" }) {
+    users(where: { id: "123" }) {
         id
         name
     }
@@ -628,7 +628,7 @@ Use the `where` argument, on the field;
 [source, graphql]
 ----
 query {
-    Users {
+    users {
         id
         name
         posts(where: { id: "123" }) {
@@ -646,7 +646,7 @@ Sort using the `options` argument;
 [source, graphql]
 ----
 query {
-    Users(options: { sort: createdAt_DESC }) {
+    users(options: { sort: createdAt_DESC }) {
         id
         name
         createdAt
@@ -662,7 +662,7 @@ Sort using the `options` argument, on the field;
 [source, graphql]
 ----
 query {
-    Users {
+    users {
         id
         name
         posts(options: { sort: createdAt_DESC }) {
@@ -679,7 +679,7 @@ Limit using the `options` argument;
 [source, graphql]
 ----
 query {
-    Users(options: { limit: 10 }) {
+    users(options: { limit: 10 }) {
         id
         name
         createdAt
@@ -694,7 +694,7 @@ Limit using the `options` argument, on the field;
 [source, graphql]
 ----
 query {
-    Users {
+    users {
         id
         name
         posts(options: { limit: 10 }) {
@@ -711,7 +711,7 @@ Limit using the `options` argument;
 [source, graphql]
 ----
 query {
-    Users(options: { skip: 10 }) {
+    users(options: { skip: 10 }) {
         id
         name
         createdAt
@@ -726,7 +726,7 @@ Limit using the `options` argument, on the field;
 [source, graphql]
 ----
 query {
-    Users {
+    users {
         id
         name
         posts(options: { skip: 10 }) {

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -787,7 +787,7 @@ function makeAugmentedSchema(options: MakeAugmentedSchemaOptions): NeoSchema {
 
         if (!node.exclude?.operations.includes("read")) {
             composer.Query.addFields({
-                [pluralize(node.name)]: findResolver({ node, getSchema: () => neoSchema }),
+                [pluralize(camelCase(node.name))]: findResolver({ node, getSchema: () => neoSchema }),
             });
         }
 

--- a/packages/graphql/src/translate/translate.ts
+++ b/packages/graphql/src/translate/translate.ts
@@ -420,7 +420,7 @@ function translate({
         ) as Node;
     } else {
         operation = "read";
-        node = context.neoSchema.nodes.find((x) => x.name === pluralize.singular(resolveTree.name)) as Node;
+        node = context.neoSchema.nodes.find((x) => camelCase(x.name) === pluralize.singular(resolveTree.name)) as Node;
     }
 
     if (node.auth) {

--- a/packages/graphql/tests/integration/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/advanced-filtering.int.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import camelCase from "camelcase";
 import { describe, expect, test, afterAll, beforeAll } from "@jest/globals";
 import { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
@@ -57,7 +58,7 @@ describe("Advanced Filtering", () => {
 
                         const query = `
                             { 
-                                Movies(where: { property_IN: ["${value}", "${randomValue1}", "${randomValue2}"] }) {
+                                movies(where: { property_IN: ["${value}", "${randomValue1}", "${randomValue2}"] }) {
                                     property
                                 }
                             }
@@ -75,9 +76,9 @@ describe("Advanced Filtering", () => {
 
                         expect(gqlResult.errors).toEqual(undefined);
 
-                        expect((gqlResult.data as any).Movies.length).toEqual(1);
+                        expect((gqlResult.data as any).movies.length).toEqual(1);
 
-                        expect((gqlResult.data as any).Movies[0].property).toEqual(value);
+                        expect((gqlResult.data as any).movies[0].property).toEqual(value);
                     } finally {
                         session.close();
                     }
@@ -94,7 +95,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -156,7 +157,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -224,7 +225,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -298,7 +299,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -364,7 +365,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -433,7 +434,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -501,7 +502,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -568,7 +569,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -637,7 +638,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -709,7 +710,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -782,7 +783,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -862,7 +863,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -944,7 +945,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -1011,7 +1012,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -1077,7 +1078,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -1144,7 +1145,7 @@ describe("Advanced Filtering", () => {
                         charset: "alphabetic",
                     })}Movie`;
 
-                    const pluralRandomType = pluralize(randomType);
+                    const pluralRandomType = pluralize(camelCase(randomType));
 
                     const typeDefs = `
                         type ${randomType} {
@@ -1210,7 +1211,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             })}Movie`;
 
-            const pluralRandomType = pluralize(randomType);
+            const pluralRandomType = pluralize(camelCase(randomType));
 
             const typeDefs = `
                         type ${randomType} {
@@ -1263,7 +1264,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             })}Movie`;
 
-            const pluralRandomType = pluralize(randomType);
+            const pluralRandomType = pluralize(camelCase(randomType));
 
             const typeDefs = `
                         type ${randomType} {
@@ -1322,8 +1323,8 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             })}Genre`;
 
-            const pluralRandomType1 = pluralize(randomType1);
-            const pluralRandomType2 = pluralize(randomType2);
+            const pluralRandomType1 = pluralize(camelCase(randomType1));
+            const pluralRandomType2 = pluralize(camelCase(randomType2));
 
             const typeDefs = `
                     type ${randomType1} {
@@ -1406,8 +1407,8 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             })}Genre`;
 
-            const pluralRandomType1 = pluralize(randomType1);
-            const pluralRandomType2 = pluralize(randomType2);
+            const pluralRandomType1 = pluralize(camelCase(randomType1));
+            const pluralRandomType2 = pluralize(camelCase(randomType2));
 
             const typeDefs = `
                     type ${randomType1} {
@@ -1493,8 +1494,8 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             })}Genre`;
 
-            const pluralRandomType1 = pluralize(randomType1);
-            const pluralRandomType2 = pluralize(randomType2);
+            const pluralRandomType1 = pluralize(camelCase(randomType1));
+            const pluralRandomType2 = pluralize(camelCase(randomType2));
 
             const typeDefs = `
                     type ${randomType1} {
@@ -1586,8 +1587,8 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             })}Genre`;
 
-            const pluralRandomType1 = pluralize(randomType1);
-            const pluralRandomType2 = pluralize(randomType2);
+            const pluralRandomType1 = pluralize(camelCase(randomType1));
+            const pluralRandomType2 = pluralize(camelCase(randomType2));
 
             const typeDefs = `
                     type ${randomType1} {

--- a/packages/graphql/tests/integration/auth.int.test.ts
+++ b/packages/graphql/tests/integration/auth.int.test.ts
@@ -38,7 +38,7 @@ describe("auth", () => {
 
         const query = `
             {
-                Products {
+                products {
                     id
                 }
             }
@@ -107,7 +107,7 @@ describe("auth", () => {
                 if (type === "read") {
                     query = `
                         {
-                            Products {
+                            products {
                                 id
                             }
                         }
@@ -196,7 +196,7 @@ describe("auth", () => {
                     if (type === "read") {
                         query = `
                             {
-                                Products(where: {id: "${id}"}) {
+                                products(where: {id: "${id}"}) {
                                     id
                                 }
                             }
@@ -279,7 +279,7 @@ describe("auth", () => {
                     if (type === "read") {
                         query = `
                                 {
-                                    Products(where: {id: "${id}"}) {
+                                    products(where: {id: "${id}"}) {
                                         id
                                     }
                                 }
@@ -311,7 +311,7 @@ describe("auth", () => {
                         }
 
                         if (type === "read") {
-                            expect((gqlResult.data as any).Products).toEqual([{ id }]);
+                            expect((gqlResult.data as any).products).toEqual([{ id }]);
                         }
                     } finally {
                         await session.close();
@@ -418,7 +418,7 @@ describe("auth", () => {
 
                         query = `
                             {
-                                Products(where: {id: "${id}"}) {
+                                products(where: {id: "${id}"}) {
                                     id
                                 }
                             }
@@ -997,7 +997,7 @@ describe("auth", () => {
 
             const query = `
                 {
-                    Users(where: {id: "${userId}"}) {
+                    users(where: {id: "${userId}"}) {
                         id
                         posts {
                             id
@@ -1070,7 +1070,7 @@ describe("auth", () => {
 
             const query = `
                 {
-                    Users(where: {id: "${userId}"}) {
+                    users(where: {id: "${userId}"}) {
                         id
                         posts {
                             id
@@ -1102,7 +1102,7 @@ describe("auth", () => {
                     contextValue: { driver, req },
                 });
 
-                expect((gqlResult.data as any).Users[0]).toMatchObject({ id: userId, posts: [{ id: postId }] });
+                expect((gqlResult.data as any).users[0]).toMatchObject({ id: userId, posts: [{ id: postId }] });
             } finally {
                 await session.close();
             }
@@ -1154,7 +1154,7 @@ describe("auth", () => {
 
                 const query = `
                     {
-                        Posts(where: {id: "${postId}"}) {
+                        posts(where: {id: "${postId}"}) {
                             id
                             title
                             creator {
@@ -1233,7 +1233,7 @@ describe("auth", () => {
 
                 const query = `
                     {
-                        Posts(where: {id: "${postId}"}) {
+                        posts(where: {id: "${postId}"}) {
                             id
                             title
                             creator {
@@ -1321,7 +1321,7 @@ describe("auth", () => {
 
                 const query = `
                     {
-                        Posts(where: {id: "${postId}"}) {
+                        posts(where: {id: "${postId}"}) {
                             id
                         }
                     }
@@ -1409,7 +1409,7 @@ describe("auth", () => {
 
                 const query = `
                 {
-                    Posts(where: {id: "${postId}"}) {
+                    posts(where: {id: "${postId}"}) {
                         id
                     }
                 }
@@ -1441,7 +1441,7 @@ describe("auth", () => {
                         contextValue: { driver, req },
                     });
 
-                    expect((gqlResult.data as any).Posts[0]).toMatchObject({ id: postId });
+                    expect((gqlResult.data as any).posts[0]).toMatchObject({ id: postId });
                 } finally {
                     await session.close();
                 }
@@ -1499,7 +1499,7 @@ describe("auth", () => {
 
                 const query = `
                     {
-                        Users(where: {id: "${userId}"}) {
+                        users(where: {id: "${userId}"}) {
                             name
                             posts {
                                 title
@@ -1588,7 +1588,7 @@ describe("auth", () => {
 
                 const query = `
                 {
-                    Users(where: {id: "${userId}"}) {
+                    users(where: {id: "${userId}"}) {
                         id
                         posts {
                             id
@@ -1626,7 +1626,7 @@ describe("auth", () => {
 
                     expect(gqlResult.errors as any[]).toEqual(undefined);
 
-                    expect((gqlResult.data as any).Users[0]).toMatchObject({ id: userId, posts: [{ id: postId }] });
+                    expect((gqlResult.data as any).users[0]).toMatchObject({ id: userId, posts: [{ id: postId }] });
                 } finally {
                     await session.close();
                 }

--- a/packages/graphql/tests/integration/custom-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/custom-resolvers-int.test.ts
@@ -537,7 +537,7 @@ describe("Custom Resolvers", () => {
 
                 const query = `
                 {
-                     Users(where: {id: "${userId}"}){
+                     users(where: {id: "${userId}"}){
                         userId
                     }
                 }
@@ -560,7 +560,7 @@ describe("Custom Resolvers", () => {
 
                     expect(gqlResult.errors).toEqual(undefined);
 
-                    expect((gqlResult.data as any).Users[0].userId).toEqual(userId);
+                    expect((gqlResult.data as any).users[0].userId).toEqual(userId);
                 } finally {
                     await session.close();
                 }

--- a/packages/graphql/tests/integration/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/datetime.int.test.ts
@@ -1,3 +1,4 @@
+import camelCase from "camelcase";
 import { Driver, DateTime } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
@@ -136,7 +137,7 @@ describe("DateTime", () => {
                 charset: "alphabetic",
             })}Movie`;
 
-            const pluralRandomType = pluralize(randomType);
+            const pluralRandomType = pluralize(camelCase(randomType));
 
             const typeDefs = `
                 type ${randomType} {

--- a/packages/graphql/tests/integration/default-values.int.test.ts
+++ b/packages/graphql/tests/integration/default-values.int.test.ts
@@ -44,7 +44,7 @@ describe("Default values", () => {
 
         const create = `
             {
-                Movies(where: {id: "${id}"}){
+                movies(where: {id: "${id}"}){
                     id
                     field
                 }
@@ -64,7 +64,7 @@ describe("Default values", () => {
 
             expect(gqlResult.errors).toBeFalsy();
 
-            expect((gqlResult.data as any).Movies[0] as any).toEqual({
+            expect((gqlResult.data as any).movies[0] as any).toEqual({
                 id,
                 field: 100,
             });

--- a/packages/graphql/tests/integration/find.int.test.ts
+++ b/packages/graphql/tests/integration/find.int.test.ts
@@ -39,7 +39,7 @@ describe("find", () => {
 
         const query = `
             query($id: ID){
-                Movies(where: {id: $id}){
+                movies(where: {id: $id}){
                     id
                 }
             }
@@ -62,7 +62,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            expect(result?.data?.Movies).toEqual([{ id }, { id }, { id }]);
+            expect(result?.data?.movies).toEqual([{ id }, { id }, { id }]);
         } finally {
             await session.close();
         }
@@ -92,7 +92,7 @@ describe("find", () => {
 
         const query = `
             query($id: ID){
-                Movies(where: {id: $id}, options: {limit: 2}){
+                movies(where: {id: $id}, options: {limit: 2}){
                     id
                 }
             }
@@ -115,7 +115,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            expect(result?.data?.Movies).toEqual([{ id }, { id }]);
+            expect(result?.data?.movies).toEqual([{ id }, { id }]);
         } finally {
             await session.close();
         }
@@ -151,7 +151,7 @@ describe("find", () => {
 
         const query = `
             query($ids: [ID]){
-                Movies(where: {id_IN: $ids}){
+                movies(where: {id_IN: $ids}){
                     id
                 }
             }
@@ -174,7 +174,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            result?.data?.Movies.forEach((e: { id: string }) => {
+            result?.data?.movies.forEach((e: { id: string }) => {
                 expect([id1, id2, id3].includes(e.id)).toBeTruthy();
             });
         } finally {
@@ -215,7 +215,7 @@ describe("find", () => {
 
         const query = `
             query($ids: [ID], $title: String){
-                Movies(where: {id_IN: $ids, title: $title}){
+                movies(where: {id_IN: $ids, title: $title}){
                     id
                     title
                 }
@@ -239,7 +239,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            result?.data?.Movies.forEach((e: { id: string; title: string }) => {
+            result?.data?.movies.forEach((e: { id: string; title: string }) => {
                 expect([id1, id2, id3].includes(e.id)).toBeTruthy();
                 expect(e.title).toEqual(title);
             });
@@ -287,7 +287,7 @@ describe("find", () => {
 
         const query = `
             query($movieIds: [ID], $actorIds: [ID]){
-                Movies(where: {id_IN: $movieIds}){
+                movies(where: {id_IN: $movieIds}){
                     id
                     actors(where: {id_IN: $actorIds}){
                         id
@@ -331,7 +331,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            result?.data?.Movies.forEach((movie: { id: string; title: string; actors: { id: string }[] }) => {
+            result?.data?.movies.forEach((movie: { id: string; title: string; actors: { id: string }[] }) => {
                 expect([movieId1, movieId2, movieId3].includes(movie.id)).toBeTruthy();
 
                 switch (movie.id) {
@@ -427,7 +427,7 @@ describe("find", () => {
 
         const query = `
             query($movieIds: [ID], $actorIds: [ID]){
-                Movies(where: {id_IN: $movieIds}){
+                movies(where: {id_IN: $movieIds}){
                     id
                     actors(actorIds: $actorIds) {
                         id
@@ -465,7 +465,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            result?.data?.Movies.forEach((movie: { id: string; actors: { id: string }[] }) => {
+            result?.data?.movies.forEach((movie: { id: string; actors: { id: string }[] }) => {
                 expect([movieId1, movieId2, movieId3].includes(movie.id)).toBeTruthy();
 
                 movie.actors.forEach((actor) => {
@@ -506,7 +506,7 @@ describe("find", () => {
 
         const query = `
             query($movieWhere: MovieWhere){
-                Movies(where: $movieWhere){
+                movies(where: $movieWhere){
                     id
                     title
                 }
@@ -530,7 +530,7 @@ describe("find", () => {
 
             expect(result.errors).toBeFalsy();
 
-            expect(result?.data?.Movies).toEqual([{ id, title }]);
+            expect(result?.data?.movies).toEqual([{ id, title }]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/translate.int.test.ts
+++ b/packages/graphql/tests/integration/translate.int.test.ts
@@ -12,7 +12,7 @@ describe("translate", () => {
             }
         `;
 
-        const neoSchema = makeAugmentedSchema({ typeDefs, resolvers: { Query: { Movies: MoviesResolver } } });
+        const neoSchema = makeAugmentedSchema({ typeDefs, resolvers: { Query: { movies: MoviesResolver } } });
 
         function MoviesResolver(_root, _args, context, resolveInfo) {
             context.neoSchema = neoSchema;
@@ -34,7 +34,7 @@ describe("translate", () => {
 
         const query = `
             query {
-                Movies {
+                movies {
                     id
                 }
             }

--- a/packages/graphql/tests/integration/unions.int.test.ts
+++ b/packages/graphql/tests/integration/unions.int.test.ts
@@ -47,7 +47,7 @@ describe("unions", () => {
 
         const query = `
             {
-                Movies (where: {title: "${movieTitle}"}) {
+                movies (where: {title: "${movieTitle}"}) {
                     search {
                         __typename
                         ... on Movie {
@@ -76,7 +76,7 @@ describe("unions", () => {
 
             expect(gqlResult.errors).toBeFalsy();
 
-            const movies = (gqlResult.data as any).Movies[0] as any;
+            const movies = (gqlResult.data as any).movies[0] as any;
 
             const movieSearch = movies.search.find((x) => x.__typename === "Movie");
             expect(movieSearch.title).toEqual(movieTitle);

--- a/packages/graphql/tests/tck/tck-test-files/cypher-advanced-filtering.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-advanced-filtering.md
@@ -27,7 +27,7 @@ type Genre {
 
 ```graphql
 {
-    Movies(where: { _id_IN: ["123"] }){
+    movies(where: { _id_IN: ["123"] }) {
         _id
     }
 }
@@ -57,7 +57,7 @@ RETURN this { ._id } as this
 
 ```graphql
 {
-    Movies(where: { id_REGEX: "(?i)123.*" }){
+    movies(where: { id_REGEX: "(?i)123.*" }) {
         id
     }
 }
@@ -87,7 +87,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_NOT: "123" }){
+    movies(where: { id_NOT: "123" }) {
         id
     }
 }
@@ -117,7 +117,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_NOT_IN: ["123"] }){
+    movies(where: { id_NOT_IN: ["123"] }) {
         id
     }
 }
@@ -147,7 +147,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_CONTAINS: "123" }){
+    movies(where: { id_CONTAINS: "123" }) {
         id
     }
 }
@@ -177,7 +177,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_NOT_CONTAINS: "123" }){
+    movies(where: { id_NOT_CONTAINS: "123" }) {
         id
     }
 }
@@ -207,7 +207,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_STARTS_WITH: "123" }){
+    movies(where: { id_STARTS_WITH: "123" }) {
         id
     }
 }
@@ -237,7 +237,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_NOT_STARTS_WITH: "123" }){
+    movies(where: { id_NOT_STARTS_WITH: "123" }) {
         id
     }
 }
@@ -267,7 +267,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_ENDS_WITH: "123" }){
+    movies(where: { id_ENDS_WITH: "123" }) {
         id
     }
 }
@@ -297,7 +297,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { id_NOT_ENDS_WITH: "123" }){
+    movies(where: { id_NOT_ENDS_WITH: "123" }) {
         id
     }
 }
@@ -327,7 +327,7 @@ RETURN this { .id } as this
 
 ```graphql
 {
-    Movies(where: { actorCount_LT: 123 }){
+    movies(where: { actorCount_LT: 123 }) {
         actorCount
     }
 }
@@ -360,7 +360,7 @@ RETURN this { .actorCount } as this
 
 ```graphql
 {
-    Movies(where: { actorCount_LTE: 123 }){
+    movies(where: { actorCount_LTE: 123 }) {
         actorCount
     }
 }
@@ -387,14 +387,13 @@ RETURN this { .actorCount } as this
 
 ---
 
-
 ### GT
 
 **GraphQL input**
 
 ```graphql
 {
-    Movies(where: { actorCount_GT: 123 }){
+    movies(where: { actorCount_GT: 123 }) {
         actorCount
     }
 }
@@ -427,7 +426,7 @@ RETURN this { .actorCount } as this
 
 ```graphql
 {
-    Movies(where: { actorCount_GTE: 123 }){
+    movies(where: { actorCount_GTE: 123 }) {
         actorCount
     }
 }
@@ -460,7 +459,7 @@ RETURN this { .actorCount } as this
 
 ```graphql
 {
-    Movies(where: { genres: { name: "some genre" } }){
+    movies(where: { genres: { name: "some genre" } }) {
         actorCount
     }
 }
@@ -469,8 +468,8 @@ RETURN this { .actorCount } as this
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
-WHERE EXISTS((this)-[:IN_GENRE]->(:Genre)) AND ALL(this_genres IN [(this)-[:IN_GENRE]->(this_genres:Genre) | this_genres] WHERE this_genres.name = $this_genres_name) 
+MATCH (this:Movie)
+WHERE EXISTS((this)-[:IN_GENRE]->(:Genre)) AND ALL(this_genres IN [(this)-[:IN_GENRE]->(this_genres:Genre) | this_genres] WHERE this_genres.name = $this_genres_name)
 RETURN this { .actorCount } as this
 ```
 
@@ -490,7 +489,7 @@ RETURN this { .actorCount } as this
 
 ```graphql
 {
-    Movies(where: { genres_NOT: { name: "some genre" } }){
+    movies(where: { genres_NOT: { name: "some genre" } }) {
         actorCount
     }
 }
@@ -499,8 +498,8 @@ RETURN this { .actorCount } as this
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
-WHERE EXISTS((this)-[:IN_GENRE]->(:Genre)) AND NONE(this_genres_NOT IN [(this)-[:IN_GENRE]->(this_genres_NOT:Genre) | this_genres_NOT] WHERE this_genres_NOT.name = $this_genres_NOT_name) 
+MATCH (this:Movie)
+WHERE EXISTS((this)-[:IN_GENRE]->(:Genre)) AND NONE(this_genres_NOT IN [(this)-[:IN_GENRE]->(this_genres_NOT:Genre) | this_genres_NOT] WHERE this_genres_NOT.name = $this_genres_NOT_name)
 RETURN this { .actorCount } as this
 ```
 
@@ -520,7 +519,11 @@ RETURN this { .actorCount } as this
 
 ```graphql
 {
-    Movies(where: { genres_IN: [{ name: "first genre" }, { name: "second genre" }] }){
+    movies(
+        where: {
+            genres_IN: [{ name: "first genre" }, { name: "second genre" }]
+        }
+    ) {
         actorCount
     }
 }
@@ -529,7 +532,7 @@ RETURN this { .actorCount } as this
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 WHERE EXISTS((this)-[:IN_GENRE]->(:Genre)) AND ALL(this_genres_IN IN [(this)-[:IN_GENRE]->(this_genres_IN:Genre) | this_genres_IN] WHERE this_genres_IN.name = $this_genres_IN0_name OR this_genres_IN.name = $this_genres_IN1_name)
 RETURN this { .actorCount } as this
 ```
@@ -551,7 +554,7 @@ RETURN this { .actorCount } as this
 
 ```graphql
 {
-    Movies(where: { genres_NOT_IN: [{ name: "some genre" }] }){
+    movies(where: { genres_NOT_IN: [{ name: "some genre" }] }) {
         actorCount
     }
 }
@@ -560,7 +563,7 @@ RETURN this { .actorCount } as this
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 WHERE EXISTS((this)-[:IN_GENRE]->(:Genre)) AND ALL(this_genres_NOT_IN IN [(this)-[:IN_GENRE]->(this_genres_NOT_IN:Genre) | this_genres_NOT_IN] WHERE NOT(this_genres_NOT_IN.name = $this_genres_NOT_IN0_name))
 RETURN this { .actorCount } as this
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher-auth.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-auth.md
@@ -47,7 +47,7 @@ type Post @auth(
 
 ```graphql
 {
-    Posts(where: { id: "123" }) {
+    posts(where: { id: "123" }) {
         id
         title
     }

--- a/packages/graphql/tests/tck/tck-test-files/cypher-datetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-datetime.md
@@ -19,7 +19,7 @@ type Movie {
 
 ```graphql
 query {
-    Movies(where: { datetime: "1970-01-01T00:00:00.000Z" }) {
+    movies(where: { datetime: "1970-01-01T00:00:00.000Z" }) {
         datetime
     }
 }

--- a/packages/graphql/tests/tck/tck-test-files/cypher-directive.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-directive.md
@@ -38,7 +38,7 @@ type Movie {
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         topActor {
             name
@@ -75,7 +75,7 @@ RETURN this {
 
 ```graphql
 {
-    Actors {
+    actors {
         randomNumber
     }
 }
@@ -106,7 +106,7 @@ RETURN this {
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         topActor {
             name
@@ -150,7 +150,7 @@ RETURN this {
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         topActor {
             name
@@ -207,7 +207,7 @@ RETURN this {
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         topActor {
             name

--- a/packages/graphql/tests/tck/tck-test-files/cypher-pagination.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-pagination.md
@@ -19,7 +19,7 @@ type Movie {
 
 ```graphql
 {
-    Movies(options: { skip: 1 }) {
+    movies(options: { skip: 1 }) {
         title
     }
 }
@@ -52,7 +52,7 @@ SKIP $this_skip
 
 ```graphql
 {
-    Movies(options: { limit: 1 }) {
+    movies(options: { limit: 1 }) {
         title
     }
 }
@@ -85,7 +85,7 @@ LIMIT $this_limit
 
 ```graphql
 {
-    Movies(options: { limit: 1, skip: 2 }) {
+    movies(options: { limit: 1, skip: 2 }) {
         title
     }
 }
@@ -123,7 +123,7 @@ LIMIT $this_limit
 
 ```graphql
 query($skip: Int, $limit: Int) {
-    Movies(options: { limit: $limit, skip: $skip }) {
+    movies(options: { limit: $limit, skip: $skip }) {
         title
     }
 }
@@ -170,7 +170,7 @@ LIMIT $this_limit
 
 ```graphql
 query($skip: Int, $limit: Int, $title: String) {
-    Movies(options: { limit: $limit, skip: $skip }, where: { title: $title }) {
+    movies(options: { limit: $limit, skip: $skip }, where: { title: $title }) {
         title
     }
 }

--- a/packages/graphql/tests/tck/tck-test-files/cypher-relationship.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-relationship.md
@@ -26,7 +26,7 @@ type Movie {
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         topActor {
             name
@@ -38,7 +38,7 @@ type Movie {
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 RETURN this { .title, topActor: head([ (this)-[:TOP_ACTOR]->(this_topActor:Actor) | this_topActor { .name } ]) } as this
 ```
 
@@ -56,7 +56,7 @@ RETURN this { .title, topActor: head([ (this)-[:TOP_ACTOR]->(this_topActor:Actor
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         actors {
             name
@@ -68,7 +68,7 @@ RETURN this { .title, topActor: head([ (this)-[:TOP_ACTOR]->(this_topActor:Actor
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor) | this_actors { .name } ] } as this
 ```
 
@@ -86,7 +86,7 @@ RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor) | this_a
 
 ```graphql
 {
-    Movies {
+    movies {
         title
         topActor {
             name
@@ -101,12 +101,12 @@ RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor) | this_a
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
-RETURN this { 
+MATCH (this:Movie)
+RETURN this {
     .title,
-    topActor: head([ (this)-[:TOP_ACTOR]->(this_topActor:Actor) | this_topActor { 
+    topActor: head([ (this)-[:TOP_ACTOR]->(this_topActor:Actor) | this_topActor {
         .name,
-        movies: [ (this_topActor)-[:ACTED_IN]->(this_topActor_movies:Movie) | this_topActor_movies { 
+        movies: [ (this_topActor)-[:ACTED_IN]->(this_topActor_movies:Movie) | this_topActor_movies {
             .title
         } ]
     } ])
@@ -127,11 +127,11 @@ RETURN this {
 
 ```graphql
 {
-    Movies(where: {title: "some title"}) {
+    movies(where: { title: "some title" }) {
         title
-        topActor(where: {name: "top actor"}) {
+        topActor(where: { name: "top actor" }) {
             name
-            movies(where: {title: "top actor movie"}) {
+            movies(where: { title: "top actor movie" }) {
                 title
             }
         }
@@ -144,14 +144,14 @@ RETURN this {
 ```cypher
 MATCH (this:Movie)
 WHERE this.title = $this_title
-RETURN this { 
-    .title, 
+RETURN this {
+    .title,
     topActor: head([ (this)-[:TOP_ACTOR]->(this_topActor:Actor) WHERE this_topActor.name = $this_topActor_name | this_topActor {
-        .name, 
-        movies: [ (this_topActor)-[:ACTED_IN]->(this_topActor_movies:Movie) WHERE this_topActor_movies.title = $this_topActor_movies_title | this_topActor_movies { 
+        .name,
+        movies: [ (this_topActor)-[:ACTED_IN]->(this_topActor_movies:Movie) WHERE this_topActor_movies.title = $this_topActor_movies_title | this_topActor_movies {
             .title
-        } ] 
-    } ]) 
+        } ]
+    } ])
 } as this
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher-sort.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-sort.md
@@ -19,7 +19,7 @@ type Movie {
 
 ```graphql
 {
-    Movies(options: { sort: [id_DESC] }) {
+    movies(options: { sort: [id_DESC] }) {
         title
     }
 }
@@ -48,7 +48,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(options: { sort: [id_DESC, title_ASC] }) {
+    movies(options: { sort: [id_DESC, title_ASC] }) {
         title
     }
 }
@@ -77,7 +77,7 @@ RETURN this { .title } as this
 
 ```graphql
 query($title: String, $skip: Int, $limit: Int, $sort: [MovieSort]) {
-    Movies(
+    movies(
         options: { sort: $sort, skip: $skip, limit: $limit }
         where: { title: $title }
     ) {

--- a/packages/graphql/tests/tck/tck-test-files/cypher-union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-union.md
@@ -32,7 +32,7 @@ type Movie {
 
 ```graphql
 {
-    Movies(where: { title: "some title" }) {
+    movies(where: { title: "some title" }) {
         search(
             Movie: { title: "The Matrix" }
             Genre: { name: "Horror" }

--- a/packages/graphql/tests/tck/tck-test-files/cypher-where.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-where.md
@@ -26,7 +26,7 @@ type Movie {
 
 ```graphql
 query($title: String, $isFavorite: Boolean) {
-    Movies(where: { title: $title, isFavorite: $isFavorite }) {
+    movies(where: { title: $title, isFavorite: $isFavorite }) {
         title
     }
 }
@@ -62,7 +62,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { AND: [{ title: "some title" }] }) {
+    movies(where: { AND: [{ title: "some title" }] }) {
         title
     }
 }
@@ -92,7 +92,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { AND: [{ AND: [{ title: "some title" }] }] }) {
+    movies(where: { AND: [{ AND: [{ title: "some title" }] }] }) {
         title
     }
 }
@@ -122,7 +122,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { AND: [{ AND: [{ AND: [{ title: "some title" }] }] }] }) {
+    movies(where: { AND: [{ AND: [{ AND: [{ title: "some title" }] }] }] }) {
         title
     }
 }
@@ -152,7 +152,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { OR: [{ title: "some title" }] }) {
+    movies(where: { OR: [{ title: "some title" }] }) {
         title
     }
 }
@@ -182,7 +182,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { OR: [{ OR: [{ title: "some title" }] }] }) {
+    movies(where: { OR: [{ OR: [{ title: "some title" }] }] }) {
         title
     }
 }
@@ -212,7 +212,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { OR: [{ OR: [{ OR: [{ title: "some title" }] }] }] }) {
+    movies(where: { OR: [{ OR: [{ OR: [{ title: "some title" }] }] }] }) {
         title
     }
 }
@@ -242,7 +242,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: { title_IN: ["some title"] }) {
+    movies(where: { title_IN: ["some title"] }) {
         title
     }
 }

--- a/packages/graphql/tests/tck/tck-test-files/cypher.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher.md
@@ -19,7 +19,7 @@ type Movie {
 
 ```graphql
 {
-    Movies(where: {title: "River Runs Through It, A"}) {
+    movies(where: { title: "River Runs Through It, A" }) {
         title
     }
 }
@@ -28,7 +28,7 @@ type Movie {
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 WHERE this.title = $this_title
 RETURN this { .title } as this
 ```
@@ -47,7 +47,7 @@ RETURN this { .title } as this
 
 ```graphql
 {
-    Movies(where: {title: "River Runs Through It, A"}) {
+    movies(where: { title: "River Runs Through It, A" }) {
         id
         title
     }
@@ -57,7 +57,7 @@ RETURN this { .title } as this
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 WHERE this.title = $this_title
 RETURN this { .id, .title } as this
 ```
@@ -76,7 +76,7 @@ RETURN this { .id, .title } as this
 
 ```graphql
 query($title: String) {
-    Movies(where: {title: $title}) {
+    movies(where: { title: $title }) {
         id
         title
     }
@@ -92,7 +92,7 @@ query($title: String) {
 **Expected Cypher output**
 
 ```cypher
-MATCH (this:Movie) 
+MATCH (this:Movie)
 WHERE this.title = $this_title
 RETURN this { .id, .title } as this
 ```

--- a/packages/graphql/tests/tck/tck-test-files/schema-autogenerated.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-autogenerated.md
@@ -108,7 +108,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-custom-mutations.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-custom-mutations.md
@@ -132,7 +132,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
   testQuery(input: ExampleInput): String
   testCypherQuery(input: ExampleInput): String
 }

--- a/packages/graphql/tests/tck/tck-test-files/schema-cypher-directive.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-cypher-directive.md
@@ -200,8 +200,8 @@ type Mutation {
 }
 
 type Query {
-  Actors(where: ActorWhere, options: ActorOptions): [Actor]!
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-datetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-datetime.md
@@ -132,7 +132,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-directive-preserve.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-directive-preserve.md
@@ -114,7 +114,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-enum.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-enum.md
@@ -120,7 +120,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-exclude-directive.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-exclude-directive.md
@@ -183,7 +183,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 
@@ -284,7 +284,7 @@ type Mutation {
 }
 
 type Query {
-  Actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor]!
 }
 ```
 
@@ -398,7 +398,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 
@@ -521,7 +521,7 @@ type Mutation {
 
 type Query {
   customActorQuery: Actor
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 
@@ -754,7 +754,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 
@@ -864,7 +864,7 @@ type Mutation {
 }
 
 type Query {
-  Actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-extend.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-extend.md
@@ -150,7 +150,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-inputs.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-inputs.md
@@ -120,7 +120,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
   name(input: NodeInput): String
 }
 ```

--- a/packages/graphql/tests/tck/tck-test-files/schema-interfaces.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-interfaces.md
@@ -181,7 +181,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-relationship.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-relationship.md
@@ -243,8 +243,8 @@ type Mutation {
 }
 
 type Query {
-  Actors(where: ActorWhere, options: ActorOptions): [Actor]!
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 
@@ -554,8 +554,8 @@ type Mutation {
 }
 
 type Query {
-  Actors(where: ActorWhere, options: ActorOptions): [Actor]!
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-scalar.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-scalar.md
@@ -121,7 +121,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-simple.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-simple.md
@@ -180,7 +180,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-timestamps.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-timestamps.md
@@ -149,7 +149,7 @@ type Mutation {
 }
 
 type Query {
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema-unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-unions.md
@@ -271,8 +271,8 @@ type Mutation {
 }
 
 type Query {
-  Genres(where: GenreWhere, options: GenreOptions): [Genre]!
-  Movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  genres(where: GenreWhere, options: GenreOptions): [Genre]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie]!
 }
 
 input QueryOptions {

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -94,7 +94,12 @@ describe("TCK Generated tests", () => {
 
                         return {
                             ...res,
-                            [pluralize(def.name.value)]: (_root: any, _params: any, ctx: any, resolveInfo: any) => {
+                            [pluralize(camelCase(def.name.value))]: (
+                                _root: any,
+                                _params: any,
+                                ctx: any,
+                                resolveInfo: any
+                            ) => {
                                 ctx.neoSchema = neoSchema;
 
                                 compare(context, resolveInfo);

--- a/packages/graphql/tests/unit/schema/make-augmented-schema.unit.test.ts
+++ b/packages/graphql/tests/unit/schema/make-augmented-schema.unit.test.ts
@@ -1,3 +1,4 @@
+import camelCase from "camelcase";
 import { printSchema, parse, ObjectTypeDefinitionNode, NamedTypeNode, ListTypeNode, NonNullTypeNode } from "graphql";
 import { pluralize } from "graphql-compose";
 import { describe, test, expect } from "@jest/globals";
@@ -37,7 +38,7 @@ describe("makeAugmentedSchema", () => {
             expect(nodeObject).toBeTruthy();
 
             // Find
-            const nodeFindQuery = queryObject.fields?.find((x) => x.name.value === pluralize(type));
+            const nodeFindQuery = queryObject.fields?.find((x) => x.name.value === pluralize(camelCase(type)));
             const nodeFindQueryType = ((nodeFindQuery?.type as NonNullTypeNode).type as ListTypeNode)
                 .type as NamedTypeNode;
             expect(nodeFindQueryType.name.value === type);


### PR DESCRIPTION
Just a small refactor here (but once again touching loads of test files) to make our Query names more in line with common GraphQL conventions.

The following Query type:

```graphql
type Query {
    Movies...
}
```

Is now:

```graphql
type Query {
    movies...
}
```