### PR TITLE
bugfix/datetime-with-timezone

### DIFF
--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -46,6 +46,7 @@ function createProjectionAndParams({
         const optionsInput = field.args.options as GraphQLOptionsArg;
         const fieldFields = (field.fieldsByTypeName as unknown) as FieldsByTypeName;
         const cypherField = node.cypherFields.find((x) => x.fieldName === key);
+        const dateTimeField = node.dateTimeFields.find((x) => x.fieldName === key);
 
         if (cypherField) {
             let projectionStr = "";
@@ -307,7 +308,15 @@ function createProjectionAndParams({
             return res;
         }
 
-        res.projection.push(`.${key}`);
+        if (dateTimeField) {
+            res.projection.push(
+                dateTimeField.typeMeta.array
+                    ? `${key}: [ dt in ${varName}.${key} | apoc.date.convertFormat(toString(dt), "iso_zoned_date_time", "iso_offset_date_time") ]`
+                    : `${key}: apoc.date.convertFormat(toString(${varName}.${key}), "iso_zoned_date_time", "iso_offset_date_time")`
+            );
+        } else {
+            res.projection.push(`.${key}`);
+        }
 
         return res;
     }

--- a/packages/graphql/tests/tck/tck-test-files/cypher-datetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-datetime.md
@@ -30,7 +30,7 @@ query {
 ```cypher
 MATCH (this:Movie)
 WHERE this.datetime = $this_datetime
-RETURN this { .datetime } as this
+RETURN this { datetime: apoc.date.convertFormat(toString(this.datetime), "iso_zoned_date_time", "iso_offset_date_time") } as this
 ```
 
 **Expected Cypher params**
@@ -65,7 +65,7 @@ CALL {
     SET this0.datetime = $this0_datetime
     RETURN this0
 }
-RETURN this0 { .datetime } AS this0
+RETURN this0 { datetime: apoc.date.convertFormat(toString(this0.datetime), "iso_zoned_date_time", "iso_offset_date_time") } AS this0
 ```
 
 **Expected Cypher params**
@@ -98,7 +98,7 @@ mutation {
 ```cypher
 MATCH (this:Movie)
 SET this.datetime = $this_update_datetime
-RETURN this { .id, .datetime } AS this
+RETURN this { .id, datetime: apoc.date.convertFormat(toString(this.datetime), "iso_zoned_date_time", "iso_offset_date_time") } AS this
 ```
 
 **Expected Cypher params**


### PR DESCRIPTION
Bug fixed by ensuring that the datetime string returned from the database is already in ISO 8601 format for parsing.

A bit of background on the solution here:

My initial thinking was to simply update the `serialize` function so that it could parse the timestamp with IANA timezone. But it quickly dawned upon me that support for IANA timezones in Javascript is ropey at best. To use the native solution, Node.js must have been compiled with an option for internationalisation (`Intl`) support, which we obviously can't depend on for a library. So my thoughts moved to Cypher where I was going to select every component of the datetime individually and then concatenate into a string. Luckily @danstarns stepped in and recommend checking out `apoc.date`, and here we are!