### PR TITLE
Fix/property-exists-on-auth

### DIFF
--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -77,15 +77,16 @@ function createAuthPredicate({
                 const _param = `${chainStr}_${key}`;
                 const [, jwtPath] = (value as string).split("$jwt.");
                 const [, ctxPath] = (value as string).split("$context.");
+                const existsStr = `EXISTS(${varName}.${key})`;
 
                 if (jwtPath) {
                     res.params[_param] = dotProp.get({ value: jwt }, `value.${jwtPath}`);
-                    res.strs.push(`${varName}.${key} = $${_param}`);
+                    res.strs.push(`${existsStr} AND ${varName}.${key} = $${_param}`);
                 }
 
                 if (ctxPath) {
                     res.params[_param] = dotProp.get({ value: context.graphQLContext }, `value.${ctxPath}`);
-                    res.strs.push(`${varName}.${key} = $${_param}`);
+                    res.strs.push(`${existsStr} AND ${varName}.${key} = $${_param}`);
                 }
             }
 

--- a/packages/graphql/tests/tck/tck-test-files/auth/cypher-auth-allow.md
+++ b/packages/graphql/tests/tck/tck-test-files/auth/cypher-auth-allow.md
@@ -86,7 +86,7 @@ extend type Comment
 
 ```cypher
 MATCH (this:User)
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this { .id } as this
 ```
 
@@ -125,9 +125,9 @@ RETURN this { .id } as this
 
 ```cypher
 MATCH (this:User)
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this { .password } as this
 ```
 
@@ -170,10 +170,10 @@ RETURN this { .password } as this
 
 ```cypher
 MATCH (this:User)
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { .content } ]
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { .content } ]
 } as this
 ```
 
@@ -215,9 +215,9 @@ RETURN this {
 
 ```cypher
 MATCH (this:Post)
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this {
-    creator: head([ (this)<-[:HAS_POST]-(this_creator:User) WHERE apoc.util.validatePredicate(NOT(this_creator.id = $this_creator_auth_allow0_id AND this_creator.id = $this_creator_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0]) | this_creator {
+    creator: head([ (this)<-[:HAS_POST]-(this_creator:User) WHERE apoc.util.validatePredicate(NOT(EXISTS(this_creator.id) AND this_creator.id = $this_creator_auth_allow0_id AND EXISTS(this_creator.id) AND this_creator.id = $this_creator_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0]) | this_creator {
         .password
     } ])
 } as this
@@ -266,10 +266,10 @@ RETURN this {
 ```cypher
 MATCH (this:User)
 WHERE this.id = $this_id
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE this_posts.id = $this_posts_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { comments: [ (this_posts)-[:HAS_COMMENT]->(this_posts_comments:Comment) WHERE this_posts_comments.id = $this_posts_comments_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts_comments)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_posts_comments)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id = $this_posts_comments_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts_comments {
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE this_posts.id = $this_posts_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { comments: [ (this_posts)-[:HAS_COMMENT]->(this_posts_comments:Comment) WHERE this_posts_comments.id = $this_posts_comments_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts_comments)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_posts_comments)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_comments_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts_comments {
         .content
     } ] } ]
 } as this
@@ -320,7 +320,7 @@ MATCH (this:User)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 SET this.id = $this_update_id
 
@@ -369,7 +369,7 @@ MATCH (this:User)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id AND this.id = $this_update_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id AND EXISTS(this.id) AND this.id = $this_update_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 SET this.password = $this_update_password
 
@@ -422,12 +422,12 @@ MATCH (this:Post)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 WITH this
 OPTIONAL MATCH (this)<-[:HAS_POST]-(this_creator0:User)
 CALL apoc.do.when(this_creator0 IS NOT NULL, "
     WITH this, this_creator0
-    CALL apoc.util.validate(NOT(this_creator0.id = $this_creator0_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
+    CALL apoc.util.validate(NOT(EXISTS(this_creator0.id) AND this_creator0.id = $this_creator0_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
     SET this_creator0.id = $this_update_creator0_id
     RETURN count(*) ",
     "",
@@ -495,11 +495,11 @@ MATCH (this:Post)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) WITH this OPTIONAL MATCH (this)<-[:HAS_POST]-(this_creator0:User)
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) WITH this OPTIONAL MATCH (this)<-[:HAS_POST]-(this_creator0:User)
 
 CALL apoc.do.when(this_creator0 IS NOT NULL, "
     WITH this, this_creator0
-    CALL apoc.util.validate(NOT(this_creator0.id = $this_creator0_auth_allow0_id AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
+    CALL apoc.util.validate(NOT(EXISTS(this_creator0.id) AND this_creator0.id = $this_creator0_auth_allow0_id AND EXISTS(this_creator0.id) AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
     SET this_creator0.password = $this_update_creator0_password
     RETURN count(*)
     ",
@@ -560,7 +560,7 @@ mutation {
 ```cypher
 MATCH (this:User)
 WHERE this.id = $this_id WITH this
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 DETACH DELETE this
 ```
 
@@ -608,13 +608,13 @@ WITH this
 OPTIONAL MATCH (this)-[:HAS_POST]->(this_posts0:Post)
 WHERE this_posts0.id = $this_posts0_id
 WITH this, this_posts0
-CALL apoc.util.validate(NOT(EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_posts0_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_posts0 WHEN NULL THEN [] ELSE [1] END |
     DETACH DELETE this_posts0
 )
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 DETACH DELETE this
 ```
 
@@ -668,7 +668,7 @@ WHERE this_disconnect_posts0.id = $this_disconnect_posts0_id
 
 WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
 
-CALL apoc.util.validate(NOT(this_disconnect_posts0.id = $this_disconnect_posts0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this_disconnect_posts0.id) AND this_disconnect_posts0.id = $this_disconnect_posts0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_disconnect_posts0_rel
@@ -729,13 +729,13 @@ MATCH (this:Comment)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 WITH this
 OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
 WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
 
-CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id = $this_post0_disconnect0Comment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_post0_disconnect0Comment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_post0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_post0_disconnect0_rel
@@ -746,7 +746,7 @@ OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HA
 WHERE this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0_id
 WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
 
-CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0_creator0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id) AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0_creator0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id) AND EXISTS(this_post0_disconnect0_creator0.id) AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_post0_disconnect0_creator0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_post0_disconnect0_creator0_rel
@@ -808,7 +808,7 @@ OPTIONAL MATCH (this_connect_posts0:Post)
 WHERE this_connect_posts0.id = $this_connect_posts0_id
 
 WITH this, this_connect_posts0
-CALL apoc.util.validate(NOT(this_connect_posts0.id = $this_connect_posts0User0_allow_auth_allow0_id AND EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_connect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this_connect_posts0.id) AND this_connect_posts0.id = $this_connect_posts0User0_allow_auth_allow0_id AND EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_connect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_connect_posts0 WHEN NULL THEN [] ELSE [1] END |
     MERGE (this)-[:HAS_POST]->(this_connect_posts0)

--- a/packages/graphql/tests/tck/tck-test-files/auth/cypher-auth-bind.md
+++ b/packages/graphql/tests/tck/tck-test-files/auth/cypher-auth-bind.md
@@ -61,7 +61,7 @@ CALL {
     SET this0.id = $this0_id
     SET this0.name = $this0_name
     WITH this0
-    CALL apoc.util.validate(NOT(this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(EXISTS(this0.id) AND this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
     RETURN this0
 }
 RETURN this0 { .id } AS this0
@@ -134,17 +134,17 @@ CALL {
     SET this0_posts0_creator0.id = $this0_posts0_creator0_id
 
     WITH this0, this0_posts0, this0_posts0_creator0
-    CALL apoc.util.validate(NOT(this0_posts0_creator0.id = $this0_posts0_creator0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(EXISTS(this0_posts0_creator0.id) AND this0_posts0_creator0.id = $this0_posts0_creator0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
     MERGE (this0_posts0)<-[:HAS_POST]-(this0_posts0_creator0)
 
     WITH this0, this0_posts0
-    CALL apoc.util.validate(NOT(EXISTS((this0_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this0_posts0_auth_bind0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(EXISTS((this0_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this0_posts0_auth_bind0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
     MERGE (this0)-[:HAS_POST]->(this0_posts0)
 
     WITH this0
-    CALL apoc.util.validate(NOT(this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(EXISTS(this0.id) AND this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
     RETURN this0
 }
@@ -199,7 +199,7 @@ WHERE this.id = $this_id
 SET this.id = $this_update_id
 
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```
@@ -264,7 +264,7 @@ CALL apoc.do.when(this_posts0 IS NOT NULL,
         SET this_posts0_creator0.id = $this_update_posts0_creator0_id
 
         WITH this, this_posts0, this_posts0_creator0
-        CALL apoc.util.validate(NOT(this_posts0_creator0.id = $this_posts0_creator0_auth_bind0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
+        CALL apoc.util.validate(NOT(EXISTS(this_posts0_creator0.id) AND this_posts0_creator0.id = $this_posts0_creator0_auth_bind0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
 
         RETURN count(*)
     \",
@@ -276,7 +276,7 @@ CALL apoc.do.when(this_posts0 IS NOT NULL,
 {this:this, this_posts0:this_posts0, auth:$auth,this_update_posts0_creator0_id:$this_update_posts0_creator0_id,this_posts0_creator0_auth_bind0_id:$this_posts0_creator0_auth_bind0_id}) YIELD value as _
 
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```
@@ -343,7 +343,7 @@ FOREACH(_ IN CASE this_connect_creator0 WHEN NULL THEN [] ELSE [1] END |
 )
 
 WITH this, this_connect_creator0
-CALL apoc.util.validate(NOT(EXISTS((this_connect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_connect_creator0Post0_bind_auth_bind0_creator_id) AND this_connect_creator0.id = $this_connect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_connect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_connect_creator0Post0_bind_auth_bind0_creator_id) AND EXISTS(this_connect_creator0.id) AND this_connect_creator0.id = $this_connect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```
@@ -402,7 +402,7 @@ FOREACH(_ IN CASE this_disconnect_creator0 WHEN NULL THEN [] ELSE [1] END |
 )
 
 WITH this, this_disconnect_creator0
-CALL apoc.util.validate(NOT(EXISTS((this_disconnect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id = $this_disconnect_creator0Post0_bind_auth_bind0_creator_id) AND this_disconnect_creator0.id = $this_disconnect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_disconnect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_disconnect_creator0Post0_bind_auth_bind0_creator_id) AND EXISTS(this_disconnect_creator0.id) AND this_disconnect_creator0.id = $this_disconnect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```

--- a/packages/graphql/tests/tck/tck-test-files/auth/cypher-projection.md
+++ b/packages/graphql/tests/tck/tck-test-files/auth/cypher-projection.md
@@ -36,10 +36,10 @@ mutation {
 ```cypher
 MATCH (this:User)
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_update_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_update_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 SET this.id = $this_update_id
 WITH this
-CALL apoc.util.validate(NOT(this.id = $this_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this { .id } AS this
 ```
 
@@ -93,8 +93,8 @@ CALL {
     RETURN this1
 }
 
-CALL apoc.util.validate(NOT(this0.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
-CALL apoc.util.validate(NOT(this1.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this0.id) AND this0.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS(this1.id) AND this1.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this0 { .id } AS this0, this1 { .id } AS this1
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher-union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher-union.md
@@ -62,7 +62,7 @@ RETURN this {
             [ this_search IN [this_search]
                 WHERE "Genre" IN labels (this_search) AND
                 this_search.name = $this_search_Genre_name AND
-                apoc.util.validatePredicate(NOT(this_search.name = $this_search_Genre_auth_allow0_name), "@neo4j/graphql/FORBIDDEN", [0])  |
+                apoc.util.validatePredicate(NOT(EXISTS(this_search.name) AND this_search.name = $this_search_Genre_auth_allow0_name), "@neo4j/graphql/FORBIDDEN", [0])  |
                 this_search {
                     __resolveType: "Genre",
                      .name

--- a/packages/graphql/tests/unit/translate/create-auth-and-params.unit.test.ts
+++ b/packages/graphql/tests/unit/translate/create-auth-and-params.unit.test.ts
@@ -70,7 +70,7 @@ describe("createAuthAndParams", () => {
 
             expect(trimmer(result[0])).toEqual(
                 trimmer(`
-                    this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    EXISTS(this.id) AND this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 `)
             );
 
@@ -140,7 +140,7 @@ describe("createAuthAndParams", () => {
 
             expect(trimmer(result[0])).toEqual(
                 trimmer(`
-                    this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    EXISTS(this.id) AND this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 `)
             );
 
@@ -208,7 +208,7 @@ describe("createAuthAndParams", () => {
 
             expect(trimmer(result[0])).toEqual(
                 trimmer(`
-                    ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND this.id = $this_auth_allow0_id
+                     ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND EXISTS(this.id) AND this.id = $this_auth_allow0_id
                 `)
             );
 
@@ -279,8 +279,8 @@ describe("createAuthAndParams", () => {
 
                 expect(trimmer(result[0])).toEqual(
                     trimmer(`
-                    this.id = $this${key}0_auth_allow0_id ${key} ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
-                `)
+                        EXISTS(this.id) AND this.id = $this${key}0_auth_allow0_id ${key} ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    `)
                 );
 
                 expect(result[1]).toMatchObject({
@@ -357,11 +357,11 @@ describe("createAuthAndParams", () => {
                 trimmer(`
                     ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) 
                 AND 
-                    this.id = $this_auth_allow0_id 
+                    EXISTS(this.id) AND this.id = $this_auth_allow0_id 
                 AND 
-                    this.id = $thisAND0_auth_allow0_id AND ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) 
+                    EXISTS(this.id) AND this.id = $thisAND0_auth_allow0_id AND ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) 
                 AND 
-                    this.id = $thisOR0_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    EXISTS(this.id) AND this.id = $thisOR0_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 `)
             );
 
@@ -451,7 +451,7 @@ describe("createAuthAndParams", () => {
 
                 expect(trimmer(result[0])).toEqual(
                     trimmer(`
-                        (this.id = $this_auth_allow0_${key}0_id ${key} this.id = $this_auth_allow0_${key}1_id ${key} this.id = $this_auth_allow0_${key}2_id)
+                        (EXISTS(this.id) AND this.id = $this_auth_allow0_${key}0_id ${key} EXISTS(this.id) AND this.id = $this_auth_allow0_${key}1_id ${key} EXISTS(this.id) AND this.id = $this_auth_allow0_${key}2_id)
                     `)
                 );
 


### PR DESCRIPTION
Where we use the predicate on `apoc.util.validate` when a property doesn't exist(null) and we try to cast it to a boolean neo4j throws. This PR adds the `EXISTS` predicate before the property check, to stop the auto casting of null to a boolean. 