### PR TITLE
Refactor/remove-or-and-types

### DIFF
--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -194,8 +194,8 @@ function makeAugmentedSchema(
         }
 
         const queryFields = {
-            OR: `[${node.name}OR]`,
-            AND: `[${node.name}AND]`,
+            OR: `[${node.name}Where]`,
+            AND: `[${node.name}Where]`,
             // Custom scalar fields only support basic equality
             ...node.scalarFields.reduce((res, f) => {
                 res[f.fieldName] = f.typeMeta.array ? `[${f.typeMeta.name}]` : f.typeMeta.name;
@@ -258,11 +258,9 @@ function makeAugmentedSchema(
             ),
         };
 
-        const [andInput, orInput, whereInput] = ["AND", "OR", "Where"].map((value) => {
-            return composer.createInputTC({
-                name: `${node.name}${value}`,
-                fields: queryFields,
-            });
+        const whereInput = composer.createInputTC({
+            name: `${node.name}Where`,
+            fields: queryFields,
         });
 
         const nodeInput = composer.createInputTC({
@@ -474,13 +472,11 @@ function makeAugmentedSchema(
                 : `${n.name}DisconnectFieldInput`;
             const deleteField = rel.typeMeta.array ? `[${n.name}DeleteFieldInput]` : `${n.name}DeleteFieldInput`;
 
-            [whereInput, andInput, orInput].forEach((inputType) => {
-                inputType.addFields({
-                    [rel.fieldName]: `${n.name}Where`,
-                    [`${rel.fieldName}_NOT`]: `${n.name}Where`,
-                    [`${rel.fieldName}_IN`]: `[${n.name}Where]`,
-                    [`${rel.fieldName}_NOT_IN`]: `[${n.name}Where]`,
-                });
+            whereInput.addFields({
+                [rel.fieldName]: `${n.name}Where`,
+                [`${rel.fieldName}_NOT`]: `${n.name}Where`,
+                [`${rel.fieldName}_IN`]: `[${n.name}Where]`,
+                [`${rel.fieldName}_NOT_IN`]: `[${n.name}Where]`,
             });
 
             composeNode.addFields({

--- a/packages/graphql/tests/tck/tck-test-files/schema-arrays.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-arrays.md
@@ -30,34 +30,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  ratings: [Float]
-  ratings_NOT: [Float]
-  ratings_IN: Float
-  ratings_NOT_IN: Float
-  averageRating: Float
-  averageRating_IN: [Float]
-  averageRating_NOT: Float
-  averageRating_NOT_IN: [Float]
-  averageRating_LT: Float
-  averageRating_LTE: Float
-  averageRating_GT: Float
-  averageRating_GTE: Float
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
   ratings: [Float]
@@ -68,34 +40,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  ratings: [Float]
-  ratings_NOT: [Float]
-  ratings_IN: Float
-  ratings_NOT_IN: Float
-  averageRating: Float
-  averageRating_IN: [Float]
-  averageRating_NOT: Float
-  averageRating_NOT_IN: [Float]
-  averageRating_LT: Float
-  averageRating_LTE: Float
-  averageRating_GT: Float
-  averageRating_GTE: Float
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -129,8 +73,8 @@ input MovieWhere {
   averageRating_LTE: Float
   averageRating_GT: Float
   averageRating_GTE: Float
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-autogenerated.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-autogenerated.md
@@ -26,22 +26,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID = "autogenerate"
 }
@@ -50,22 +34,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -85,8 +53,8 @@ input MovieWhere {
   id_ENDS_WITH: ID
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-comments.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-comments.md
@@ -76,45 +76,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  actorCount: Int
-  actorCount_IN: [Int]
-  actorCount_NOT: Int
-  actorCount_NOT_IN: [Int]
-  actorCount_LT: Int
-  actorCount_LTE: Int
-  actorCount_GT: Int
-  actorCount_GTE: Int
-  averageRating: Float
-  averageRating_IN: [Float]
-  averageRating_NOT: Float
-  averageRating_NOT_IN: [Float]
-  customScalar: CustomScalar
-  genre: Genre
-  genre_IN: [Genre]
-  genre_NOT: Genre
-  genre_NOT_IN: [Genre]
-  averageRating_LT: Float
-  averageRating_LTE: Float
-  averageRating_GT: Float
-  averageRating_GTE: Float
-  isActive: Boolean
-  isActive_NOT: Boolean
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
   actorCount: Int
@@ -128,45 +89,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  actorCount: Int
-  actorCount_IN: [Int]
-  actorCount_NOT: Int
-  actorCount_NOT_IN: [Int]
-  actorCount_LT: Int
-  actorCount_LTE: Int
-  actorCount_GT: Int
-  actorCount_GTE: Int
-  averageRating: Float
-  averageRating_IN: [Float]
-  averageRating_NOT: Float
-  averageRating_NOT_IN: [Float]
-  customScalar: CustomScalar
-  genre: Genre
-  genre_IN: [Genre]
-  genre_NOT: Genre
-  genre_NOT_IN: [Genre]
-  averageRating_LT: Float
-  averageRating_LTE: Float
-  averageRating_GT: Float
-  averageRating_GTE: Float
-  isActive: Boolean
-  isActive_NOT: Boolean
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -219,8 +141,8 @@ input MovieWhere {
   averageRating_GTE: Float
   isActive: Boolean
   isActive_NOT: Boolean
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-custom-mutations.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-custom-mutations.md
@@ -48,22 +48,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
 }
@@ -72,22 +56,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -107,8 +75,8 @@ input MovieWhere {
   id_ENDS_WITH: ID
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-cypher-directive.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-cypher-directive.md
@@ -30,22 +30,6 @@ type Actor {
   name: String
 }
 
-input ActorAND {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-}
-
 input ActorCreateInput {
   name: String
 }
@@ -54,22 +38,6 @@ input ActorOptions {
   sort: [ActorSort]
   limit: Int
   skip: Int
-}
-
-input ActorOR {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
 }
 
 enum ActorSort {
@@ -82,8 +50,8 @@ input ActorUpdateInput {
 }
 
 input ActorWhere {
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
   name: String
   name_IN: [String]
   name_NOT: String
@@ -107,22 +75,6 @@ type Movie {
   actors(title: String): [Actor]
 }
 
-input MovieAND {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-}
-
 input MovieCreateInput {
   id: ID
 }
@@ -133,21 +85,6 @@ input MovieOptions {
   skip: Int
 }
 
-input MovieOR {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-}
 
 enum MovieSort {
   id_DESC
@@ -159,8 +96,8 @@ input MovieUpdateInput {
 }
 
 input MovieWhere {
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   id: ID
   id_IN: [ID]
   id_NOT: ID

--- a/packages/graphql/tests/tck/tck-test-files/schema-datetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-datetime.md
@@ -31,29 +31,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  datetime: DateTime
-  datetime_NOT: DateTime
-  datetime_IN: [DateTime]
-  datetime_NOT_IN: [DateTime]
-  datetime_LT: DateTime
-  datetime_LTE: DateTime
-  datetime_GT: DateTime
-  datetime_GTE: DateTime
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
 
 input MovieCreateInput {
   id: ID
@@ -64,30 +41,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  datetime: DateTime
-  datetime_NOT: DateTime
-  datetime_IN: [DateTime]
-  datetime_NOT_IN: [DateTime]
-  datetime_LT: DateTime
-  datetime_LTE: DateTime
-  datetime_GT: DateTime
-  datetime_GTE: DateTime
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -117,8 +70,8 @@ input MovieWhere {
   datetime_LTE: DateTime
   datetime_GT: DateTime
   datetime_GTE: DateTime
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-directive-preserve.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-directive-preserve.md
@@ -32,22 +32,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
 }
@@ -56,22 +40,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -91,8 +59,8 @@ input MovieWhere {
   id_ENDS_WITH: ID
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-enum.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-enum.md
@@ -38,15 +38,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  status: Status
-  status_IN: [Status]
-  status_NOT: Status
-  status_NOT_IN: [Status]
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   status: Status
 }
@@ -55,15 +46,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  status: Status
-  status_IN: [Status]
-  status_NOT: Status
-  status_NOT_IN: [Status]
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -76,8 +58,8 @@ input MovieWhere {
   status_IN: [Status]
   status_NOT: Status
   status_NOT_IN: [Status]
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-exclude-directive.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-exclude-directive.md
@@ -25,40 +25,8 @@ type Actor {
   name: String
 }
 
-input ActorAND {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-}
-
 input ActorCreateInput {
   name: String
-}
-
-input ActorOR {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
 }
 
 input ActorUpdateInput {
@@ -66,8 +34,8 @@ input ActorUpdateInput {
 }
 
 input ActorWhere {
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
   name: String
   name_IN: [String]
   name_NOT: String
@@ -90,22 +58,6 @@ type Movie {
   title: String
 }
 
-input MovieAND {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
-}
-
 input MovieCreateInput {
   title: String
 }
@@ -114,22 +66,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
 }
 
 enum MovieSort {
@@ -142,8 +78,8 @@ input MovieUpdateInput {
 }
 
 input MovieWhere {
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   title: String
   title_IN: [String]
   title_NOT: String
@@ -206,42 +142,10 @@ type Actor {
   name: String
 }
 
-input ActorAND {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-}
-
 input ActorOptions {
   sort: [ActorSort]
   limit: Int
   skip: Int
-}
-
-input ActorOR {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
 }
 
 enum ActorSort {
@@ -254,8 +158,8 @@ input ActorUpdateInput {
 }
 
 input ActorWhere {
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
   name: String
   name_IN: [String]
   name_NOT: String
@@ -316,22 +220,6 @@ type Movie {
   title: String
 }
 
-input MovieAND {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
-}
-
 input MovieCreateInput {
   title: String
 }
@@ -340,22 +228,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
 }
 
 enum MovieSort {
@@ -368,8 +240,8 @@ input MovieUpdateInput {
 }
 
 input MovieWhere {
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   title: String
   title_IN: [String]
   title_NOT: String
@@ -438,22 +310,6 @@ type Movie {
   title: String
 }
 
-input MovieAND {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
-}
-
 input MovieCreateInput {
   title: String
 }
@@ -462,22 +318,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
 }
 
 enum MovieSort {
@@ -490,8 +330,8 @@ input MovieUpdateInput {
 }
 
 input MovieWhere {
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   title: String
   title_IN: [String]
   title_NOT: String
@@ -549,22 +389,6 @@ type Actor {
   name: String
 }
 
-input ActorAND {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-}
-
 input ActorConnectFieldInput {
   where: ActorWhere
 }
@@ -583,22 +407,6 @@ input ActorOptions {
   skip: Int
 }
 
-input ActorOR {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-}
-
 enum ActorSort {
   name_DESC
   name_ASC
@@ -609,8 +417,8 @@ input ActorUpdateInput {
 }
 
 input ActorWhere {
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
   name: String
   name_IN: [String]
   name_NOT: String
@@ -652,26 +460,6 @@ input MovieActorsUpdateFieldInput {
   delete: [ActorDeleteFieldInput]
 }
 
-input MovieAND {
-  actors: ActorWhere
-  actors_IN: [ActorWhere]
-  actors_NOT: ActorWhere
-  actors_NOT_IN: [ActorWhere]
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
-}
-
 input MovieConnectInput {
   actors: [ActorConnectFieldInput]
 }
@@ -703,26 +491,6 @@ input MovieDeleteInput {
   actors: [MovieActorsDeleteInput]
 }
 
-input MovieOR {
-  actors: ActorWhere
-  actors_IN: [ActorWhere]
-  actors_NOT: ActorWhere
-  actors_NOT_IN: [ActorWhere]
-  OR: [MovieOR]
-  AND: [MovieAND]
-  title: String
-  title_IN: [String]
-  title_NOT: String
-  title_NOT_IN: [String]
-  title_CONTAINS: String
-  title_NOT_CONTAINS: String
-  title_STARTS_WITH: String
-  title_NOT_STARTS_WITH: String
-  title_ENDS_WITH: String
-  title_NOT_ENDS_WITH: String
-  title_REGEX: String
-}
-
 enum MovieSort {
   title_DESC
   title_ASC
@@ -738,8 +506,8 @@ input MovieWhere {
   actors_IN: [ActorWhere]
   actors_NOT: ActorWhere
   actors_NOT_IN: [ActorWhere]
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   title: String
   title_IN: [String]
   title_NOT: String
@@ -801,22 +569,6 @@ type Actor {
   name: String
 }
 
-input ActorAND {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-}
-
 input ActorCreateInput {
   name: String
 }
@@ -825,22 +577,6 @@ input ActorOptions {
   sort: [ActorSort]
   limit: Int
   skip: Int
-}
-
-input ActorOR {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
 }
 
 enum ActorSort {
@@ -853,8 +589,8 @@ input ActorUpdateInput {
 }
 
 input ActorWhere {
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
   name: String
   name_IN: [String]
   name_NOT: String

--- a/packages/graphql/tests/tck/tck-test-files/schema-extend.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-extend.md
@@ -31,33 +31,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
   name: String
@@ -67,33 +40,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -126,8 +72,8 @@ input MovieWhere {
   name_ENDS_WITH: String
   name_NOT_ENDS_WITH: String
   name_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-inputs.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-inputs.md
@@ -38,22 +38,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
 }
@@ -62,22 +46,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -97,8 +65,8 @@ input MovieWhere {
   id_ENDS_WITH: ID
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-interfaces.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-interfaces.md
@@ -50,26 +50,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  movies: MovieWhere
-  movies_IN: [MovieWhere]
-  movies_NOT: MovieWhere
-  movies_NOT_IN: [MovieWhere]
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
   movies: MovieMoviesFieldInput
@@ -79,26 +59,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  movies: MovieWhere
-  movies_IN: [MovieWhere]
-  movies_NOT: MovieWhere
-  movies_NOT_IN: [MovieWhere]
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -122,8 +82,8 @@ input MovieWhere {
   movies_IN: [MovieWhere]
   movies_NOT: MovieWhere
   movies_NOT_IN: [MovieWhere]
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieDisconnectFieldInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-points.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-points.md
@@ -46,19 +46,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  filmedAt: PointInput
-  filmedAt_NOT: PointInput
-  filmedAt_IN: [PointInput]
-  filmedAt_NOT_IN: [PointInput]
-  filmedAt_LT: PointDistance
-  filmedAt_LTE: PointDistance
-  filmedAt_GT: PointDistance
-  filmedAt_GTE: PointDistance
-  filmedAt_DISTANCE: PointDistance
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
 
 input MovieCreateInput {
   filmedAt: PointInput
@@ -68,20 +55,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  filmedAt: PointInput
-  filmedAt_NOT: PointInput
-  filmedAt_IN: [PointInput]
-  filmedAt_NOT_IN: [PointInput]
-  filmedAt_LT: PointDistance
-  filmedAt_LTE: PointDistance
-  filmedAt_GT: PointDistance
-  filmedAt_GTE: PointDistance
-  filmedAt_DISTANCE: PointDistance
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -99,8 +72,8 @@ input MovieWhere {
   filmedAt_GT: PointDistance
   filmedAt_GTE: PointDistance
   filmedAt_DISTANCE: PointDistance
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {
@@ -169,20 +142,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MachineAND {
-  partLocation: CartesianPointInput
-  partLocation_NOT: CartesianPointInput
-  partLocation_IN: [CartesianPointInput]
-  partLocation_NOT_IN: [CartesianPointInput]
-  partLocation_LT: CartesianPointDistance
-  partLocation_LTE: CartesianPointDistance
-  partLocation_GT: CartesianPointDistance
-  partLocation_GTE: CartesianPointDistance
-  partLocation_DISTANCE: CartesianPointDistance
-  OR: [MachineOR]
-  AND: [MachineAND]
-}
-
 input MachineCreateInput {
   partLocation: CartesianPointInput
 }
@@ -191,20 +150,6 @@ input MachineOptions {
   sort: [MachineSort]
   limit: Int
   skip: Int
-}
-
-input MachineOR {
-  partLocation: CartesianPointInput
-  partLocation_NOT: CartesianPointInput
-  partLocation_IN: [CartesianPointInput]
-  partLocation_NOT_IN: [CartesianPointInput]
-  partLocation_LT: CartesianPointDistance
-  partLocation_LTE: CartesianPointDistance
-  partLocation_GT: CartesianPointDistance
-  partLocation_GTE: CartesianPointDistance
-  partLocation_DISTANCE: CartesianPointDistance
-  OR: [MachineOR]
-  AND: [MachineAND]
 }
 
 enum MachineSort {
@@ -222,8 +167,8 @@ input MachineWhere {
   partLocation_GT: CartesianPointDistance
   partLocation_GTE: CartesianPointDistance
   partLocation_DISTANCE: CartesianPointDistance
-  OR: [MachineOR]
-  AND: [MachineAND]
+  OR: [MachineWhere]
+  AND: [MachineWhere]
 }
 
 input MachineUpdateInput {
@@ -287,15 +232,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  filmedAt: [PointInput]
-  filmedAt_NOT: [PointInput]
-  filmedAt_IN: PointInput
-  filmedAt_NOT_IN: PointInput
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   filmedAt: [PointInput]
 }
@@ -305,22 +241,13 @@ input MovieOptions {
   skip: Int
 }
 
-input MovieOR {
-  filmedAt: [PointInput]
-  filmedAt_NOT: [PointInput]
-  filmedAt_IN: PointInput
-  filmedAt_NOT_IN: PointInput
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieWhere {
   filmedAt: [PointInput]
   filmedAt_NOT: [PointInput]
   filmedAt_IN: PointInput
   filmedAt_NOT_IN: PointInput
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {
@@ -384,15 +311,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MachineAND {
-  partLocations: [CartesianPointInput]
-  partLocations_NOT: [CartesianPointInput]
-  partLocations_IN: CartesianPointInput
-  partLocations_NOT_IN: CartesianPointInput
-  OR: [MachineOR]
-  AND: [MachineAND]
-}
-
 input MachineCreateInput {
   partLocations: [CartesianPointInput]
 }
@@ -402,22 +320,13 @@ input MachineOptions {
   skip: Int
 }
 
-input MachineOR {
-  partLocations: [CartesianPointInput]
-  partLocations_NOT: [CartesianPointInput]
-  partLocations_IN: CartesianPointInput
-  partLocations_NOT_IN: CartesianPointInput
-  OR: [MachineOR]
-  AND: [MachineAND]
-}
-
 input MachineWhere {
   partLocations: [CartesianPointInput]
   partLocations_NOT: [CartesianPointInput]
   partLocations_IN: CartesianPointInput
   partLocations_NOT_IN: CartesianPointInput
-  OR: [MachineOR]
-  AND: [MachineAND]
+  OR: [MachineWhere]
+  AND: [MachineWhere]
 }
 
 input MachineUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-private.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-private.md
@@ -27,22 +27,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input UserAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [UserOR]
-  AND: [UserAND]
-}
-
 input UserCreateInput {
   id: ID
 }
@@ -51,22 +35,6 @@ input UserOptions {
   sort: [UserSort]
   limit: Int
   skip: Int
-}
-
-input UserOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [UserOR]
-  AND: [UserAND]
 }
 
 enum UserSort {
@@ -86,8 +54,8 @@ input UserWhere {
   id_ENDS_WITH: ID
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
-  OR: [UserOR]
-  AND: [UserAND]
+  OR: [UserWhere]
+  AND: [UserWhere]
 }
 
 input UserUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-relationship.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-relationship.md
@@ -31,22 +31,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input ActorAND {
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-  OR: [ActorOR]
-  AND: [ActorAND]
-}
-
 input ActorCreateInput {
   name: String
 }
@@ -55,22 +39,6 @@ input ActorOptions {
   sort: [ActorSort]
   limit: Int
   skip: Int
-}
-
-input ActorOR {
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-  OR: [ActorOR]
-  AND: [ActorAND]
 }
 
 enum ActorSort {
@@ -90,8 +58,8 @@ input ActorWhere {
   name_ENDS_WITH: String
   name_NOT_ENDS_WITH: String
   name_REGEX: String
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
 }
 
 input ActorConnectFieldInput {
@@ -116,26 +84,6 @@ input MovieRelationInput {
   actors: [ActorCreateInput]
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-  actors: ActorWhere
-  actors_NOT: ActorWhere
-  actors_IN: [ActorWhere]
-  actors_NOT_IN: [ActorWhere]
-}
-
 input MovieCreateInput {
   id: ID
   actors: MovieActorsFieldInput
@@ -145,26 +93,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
-  actors: ActorWhere
-  actors_NOT: ActorWhere
-  actors_IN: [ActorWhere]
-  actors_NOT_IN: [ActorWhere]
 }
 
 enum MovieSort {
@@ -184,8 +112,8 @@ input MovieWhere {
   id_ENDS_WITH: ID
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   actors: ActorWhere
   actors_NOT: ActorWhere
   actors_IN: [ActorWhere]
@@ -290,26 +218,6 @@ type Actor {
   movies(where: MovieWhere, options: MovieOptions): [Movie]
 }
 
-input ActorAND {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-  movies: MovieWhere
-  movies_NOT: MovieWhere
-  movies_IN: [MovieWhere]
-  movies_NOT_IN: [MovieWhere]
-}
-
 input ActorConnectFieldInput {
   where: ActorWhere
   connect: ActorConnectInput
@@ -357,26 +265,6 @@ input ActorOptions {
   skip: Int
 }
 
-input ActorOR {
-  OR: [ActorOR]
-  AND: [ActorAND]
-  name: String
-  name_IN: [String]
-  name_NOT: String
-  name_NOT_IN: [String]
-  name_CONTAINS: String
-  name_NOT_CONTAINS: String
-  name_STARTS_WITH: String
-  name_NOT_STARTS_WITH: String
-  name_ENDS_WITH: String
-  name_NOT_ENDS_WITH: String
-  name_REGEX: String
-  movies: MovieWhere
-  movies_NOT: MovieWhere
-  movies_IN: [MovieWhere]
-  movies_NOT_IN: [MovieWhere]
-}
-
 enum ActorSort {
   name_DESC
   name_ASC
@@ -388,8 +276,8 @@ input ActorUpdateInput {
 }
 
 input ActorWhere {
-  OR: [ActorOR]
-  AND: [ActorAND]
+  OR: [ActorWhere]
+  AND: [ActorWhere]
   name: String
   name_IN: [String]
   name_NOT: String
@@ -431,26 +319,6 @@ input MovieActorsUpdateFieldInput {
   delete: [ActorDeleteFieldInput]
 }
 
-input MovieAND {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  actors: ActorWhere
-  actors_NOT: ActorWhere
-  actors_IN: [ActorWhere]
-  actors_NOT_IN: [ActorWhere]
-}
-
 input MovieConnectFieldInput {
   where: MovieWhere
   connect: MovieConnectInput
@@ -478,26 +346,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  actors: ActorWhere
-  actors_NOT: ActorWhere
-  actors_IN: [ActorWhere]
-  actors_NOT_IN: [ActorWhere]
 }
 
 input MovieRelationInput {
@@ -543,8 +391,8 @@ input MovieUpdateInput {
 }
 
 input MovieWhere {
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   id: ID
   id_IN: [ID]
   id_NOT: ID

--- a/packages/graphql/tests/tck/tck-test-files/schema-scalar.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-scalar.md
@@ -32,23 +32,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  myCustomScalar: CustomScalar
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
   myCustomScalar: CustomScalar
@@ -58,23 +41,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  myCustomScalar: CustomScalar
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -97,8 +63,8 @@ input MovieWhere {
   id_NOT_ENDS_WITH: ID
   id_REGEX: String
   myCustomScalar: CustomScalar
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-simple.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-simple.md
@@ -32,40 +32,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  actorCount: Int
-  actorCount_IN: [Int]
-  actorCount_NOT: Int
-  actorCount_NOT_IN: [Int]
-  actorCount_LT: Int
-  actorCount_LTE: Int
-  actorCount_GT: Int
-  actorCount_GTE: Int
-  averageRating: Float
-  averageRating_IN: [Float]
-  averageRating_NOT: Float
-  averageRating_NOT_IN: [Float]
-  averageRating_LT: Float
-  averageRating_LTE: Float
-  averageRating_GT: Float
-  averageRating_GTE: Float
-  isActive: Boolean
-  isActive_NOT: Boolean
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
   actorCount: Int
@@ -77,40 +43,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  actorCount: Int
-  actorCount_IN: [Int]
-  actorCount_NOT: Int
-  actorCount_NOT_IN: [Int]
-  actorCount_LT: Int
-  actorCount_LTE: Int
-  actorCount_GT: Int
-  actorCount_GTE: Int
-  averageRating: Float
-  averageRating_IN: [Float]
-  averageRating_NOT: Float
-  averageRating_NOT_IN: [Float]
-  averageRating_LT: Float
-  averageRating_LTE: Float
-  averageRating_GT: Float
-  averageRating_GTE: Float
-  isActive: Boolean
-  isActive_NOT: Boolean
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -154,8 +86,8 @@ input MovieWhere {
   averageRating_GTE: Float
   isActive: Boolean
   isActive_NOT: Boolean
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-timestamps.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-timestamps.md
@@ -33,38 +33,6 @@ type DeleteInfo {
   relationshipsDeleted: Int!
 }
 
-input MovieAND {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  createdAt: DateTime
-  createdAt_NOT: DateTime
-  createdAt_IN: [DateTime]
-  createdAt_NOT_IN: [DateTime]
-  createdAt_LT: DateTime
-  createdAt_LTE: DateTime
-  createdAt_GT: DateTime
-  createdAt_GTE: DateTime
-  updatedAt: DateTime
-  updatedAt_NOT: DateTime
-  updatedAt_IN: [DateTime]
-  updatedAt_NOT_IN: [DateTime]
-  updatedAt_LT: DateTime
-  updatedAt_LTE: DateTime
-  updatedAt_GT: DateTime
-  updatedAt_GTE: DateTime
-  OR: [MovieOR]
-  AND: [MovieAND]
-}
-
 input MovieCreateInput {
   id: ID
 }
@@ -73,38 +41,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-  createdAt: DateTime
-  createdAt_NOT: DateTime
-  createdAt_IN: [DateTime]
-  createdAt_NOT_IN: [DateTime]
-  createdAt_LT: DateTime
-  createdAt_LTE: DateTime
-  createdAt_GT: DateTime
-  createdAt_GTE: DateTime
-  updatedAt: DateTime
-  updatedAt_NOT: DateTime
-  updatedAt_IN: [DateTime]
-  updatedAt_NOT_IN: [DateTime]
-  updatedAt_LT: DateTime
-  updatedAt_LTE: DateTime
-  updatedAt_GT: DateTime
-  updatedAt_GTE: DateTime
-  OR: [MovieOR]
-  AND: [MovieAND]
 }
 
 enum MovieSort {
@@ -144,8 +80,8 @@ input MovieWhere {
   updatedAt_LTE: DateTime
   updatedAt_GT: DateTime
   updatedAt_GTE: DateTime
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
 }
 
 input MovieUpdateInput {

--- a/packages/graphql/tests/tck/tck-test-files/schema-unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema-unions.md
@@ -36,22 +36,6 @@ type Genre {
   id: ID
 }
 
-input GenreAND {
-  OR: [GenreOR]
-  AND: [GenreAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-}
-
 input GenreConnectFieldInput {
   where: GenreWhere
 }
@@ -70,22 +54,6 @@ input GenreOptions {
   skip: Int
 }
 
-input GenreOR {
-  OR: [GenreOR]
-  AND: [GenreAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
-}
-
 enum GenreSort {
   id_DESC
   id_ASC
@@ -96,8 +64,8 @@ input GenreUpdateInput {
 }
 
 input GenreWhere {
-  OR: [GenreOR]
-  AND: [GenreAND]
+  OR: [GenreWhere]
+  AND: [GenreWhere]
   id: ID
   id_IN: [ID]
   id_NOT: ID
@@ -115,22 +83,6 @@ type Movie {
   id: ID
   search(options: QueryOptions, Genre: GenreWhere, Movie: MovieWhere): [Search]
   searchNoDirective: Search
-}
-
-input MovieAND {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
 }
 
 input MovieConnectFieldInput {
@@ -163,22 +115,6 @@ input MovieOptions {
   sort: [MovieSort]
   limit: Int
   skip: Int
-}
-
-input MovieOR {
-  OR: [MovieOR]
-  AND: [MovieAND]
-  id: ID
-  id_IN: [ID]
-  id_NOT: ID
-  id_NOT_IN: [ID]
-  id_CONTAINS: ID
-  id_NOT_CONTAINS: ID
-  id_STARTS_WITH: ID
-  id_NOT_STARTS_WITH: ID
-  id_ENDS_WITH: ID
-  id_NOT_ENDS_WITH: ID
-  id_REGEX: String
 }
 
 input MovieRelationInput {
@@ -249,8 +185,8 @@ input MovieDeleteInput {
 }
 
 input MovieWhere {
-  OR: [MovieOR]
-  AND: [MovieAND]
+  OR: [MovieWhere]
+  AND: [MovieWhere]
   id: ID
   id_IN: [ID]
   id_NOT: ID

--- a/packages/graphql/tests/unit/schema/make-augmented-schema.unit.test.ts
+++ b/packages/graphql/tests/unit/schema/make-augmented-schema.unit.test.ts
@@ -56,18 +56,6 @@ describe("makeAugmentedSchema", () => {
             );
             expect(where).toBeTruthy();
 
-            // OR
-            const or = document.definitions.find(
-                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === `${type}OR`
-            );
-            expect(or).toBeTruthy();
-
-            // AND
-            const and = document.definitions.find(
-                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === `${type}AND`
-            );
-            expect(and).toBeTruthy();
-
             // SORT
             const sort = document.definitions.find(
                 (x) => x.kind === "EnumTypeDefinition" && x.name.value === `${type}Sort`


### PR DESCRIPTION
We don't need to repeat ourselves with the `AND` `OR` types. This PR removes them & generally frees up a lot of space in test files and the output schema. 