### PR TITLE
Docs/mark-release-as-preview-and-prerelease

### DIFF
--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -1,6 +1,7 @@
 name: graphql-manual
 title: Neo4j GraphQL
-version: '1.0'
+version: '1.0-preview'
+prerelease: true
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
The ultimate path for the docs on neo4j.com/docs derives from the values in _/antora/antora.yml_.

This PR updates the version to '1.0-preview' and adds a prerelease attribute, which displays a preview notice on every page, as shown on https://neo4j.com/docs/getting-started/4.3-preview/