### PR TITLE
Feat/remove-directives-from-fields

### DIFF
--- a/docs/asciidoc/ogm/index.adoc
+++ b/docs/asciidoc/ogm/index.adoc
@@ -8,3 +8,15 @@ Common applications won't just expose a single API. On the same instance as the 
 * <<ogm-methods>>
 * <<ogm-private>>
 * <<ogm-selection-set>>
+
+
+== Directives
+The following directives are excluded from the OGM's schema; 
+
+* `@auth`
+* `@exclude`
+* `@private`
+* `@readonly`
+* `@writeonly`
+
+See also <<ogm-private>>

--- a/packages/ogm/src/classes/OGM.test.ts
+++ b/packages/ogm/src/classes/OGM.test.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { printSchema } from "graphql";
 import OGM from "./OGM";
 
 describe("OGM", () => {
@@ -26,6 +27,16 @@ describe("OGM", () => {
     });
 
     describe("methods", () => {
+        describe("constructor", () => {
+            test("should evoke the filterDocument method", () => {
+                const ogm = new OGM({ typeDefs: `type User @auth {id:ID}` });
+
+                const printed = printSchema(ogm.neoSchema.schema);
+
+                expect(printed.includes("@auth")).toBeFalsy();
+            });
+        });
+
         describe("verifyDatabase", () => {
             test("should neo4j-driver Driver missing", async () => {
                 // @ts-ignore
@@ -34,6 +45,7 @@ describe("OGM", () => {
                 await expect(ogm.verifyDatabase()).rejects.toThrow(`neo4j-driver Driver missing`);
             });
         });
+
         describe("model", () => {
             test("should throw cannot find model", () => {
                 const ogm = new OGM({ typeDefs: `type User {id:ID}` });

--- a/packages/ogm/src/classes/OGM.ts
+++ b/packages/ogm/src/classes/OGM.ts
@@ -17,46 +17,10 @@
  * limitations under the License.
  */
 
-import { DefinitionNode, FieldDefinitionNode } from "graphql";
 import { Driver } from "neo4j-driver";
-import { mergeTypeDefs } from "@graphql-tools/merge";
 import { Neo4jGraphQL, Neo4jGraphQLConstructor } from "@neo4j/graphql";
 import Model from "./Model";
-
-function filterTypeDefs(typeDefs: Neo4jGraphQLConstructor["typeDefs"]) {
-    const merged = mergeTypeDefs(Array.isArray(typeDefs) ? (typeDefs as string[]) : [typeDefs as string]);
-
-    return {
-        ...merged,
-        definitions: merged.definitions.reduce((res: DefinitionNode[], def) => {
-            if (def.kind !== "ObjectTypeDefinition" && def.kind !== "InterfaceTypeDefinition") {
-                return [...res, def];
-            }
-
-            if (["Query", "Subscription", "Mutation"].includes(def.name.value)) {
-                return [...res, def];
-            }
-
-            return [
-                ...res,
-                {
-                    ...def,
-                    directives: def.directives?.filter((x) => !["auth", "exclude"].includes(x.name.value)),
-                    fields: def.fields?.reduce(
-                        (r: FieldDefinitionNode[], f) => [
-                            ...r,
-                            {
-                                ...f,
-                                directives: f.directives?.filter((x) => !["private", "ignore"].includes(x.name.value)),
-                            },
-                        ],
-                        []
-                    ),
-                },
-            ];
-        }, []),
-    };
-}
+import { filterDocument } from "../utils";
 
 class OGM {
     public neoSchema: Neo4jGraphQL;
@@ -68,10 +32,8 @@ class OGM {
     constructor(input: Neo4jGraphQLConstructor) {
         this.input = input;
 
-        const typeDefs = filterTypeDefs(input.typeDefs);
-
         this.neoSchema = new Neo4jGraphQL({
-            typeDefs,
+            typeDefs: filterDocument(input.typeDefs),
             driver: input.driver,
             resolvers: input.resolvers,
             schemaDirectives: input.schemaDirectives,

--- a/packages/ogm/src/utils/filter-document.test.ts
+++ b/packages/ogm/src/utils/filter-document.test.ts
@@ -1,0 +1,32 @@
+import { parse, print } from "graphql";
+import filterDocument from "./filter-document";
+
+describe("filterDocument", () => {
+    test("should remove all directives", () => {
+        const initial = `
+            type User @auth @exclude {
+                id: ID @auth @private @readonly @writeonly
+                name: String @auth @private @readonly @writeonly
+                email: String @auth @private @readonly @writeonly
+                password: String @auth @private @readonly @writeonly
+            }
+
+
+        `;
+
+        const filtered = filterDocument(initial);
+
+        expect(print(filtered)).toEqual(
+            print(
+                parse(`
+                    type User {
+                        id: ID
+                        name: String
+                        email: String
+                        password: String
+                    }
+                `)
+            )
+        );
+    });
+});

--- a/packages/ogm/src/utils/filter-document.ts
+++ b/packages/ogm/src/utils/filter-document.ts
@@ -1,0 +1,42 @@
+import { DefinitionNode, DocumentNode, FieldDefinitionNode } from "graphql";
+import { Neo4jGraphQLConstructor } from "@neo4j/graphql";
+import { mergeTypeDefs } from "@graphql-tools/merge";
+
+const excludedDirectives = ["auth", "exclude", "private", "readonly", "writeonly"];
+
+function filterDocument(typeDefs: Neo4jGraphQLConstructor["typeDefs"]): DocumentNode {
+    const merged = mergeTypeDefs(Array.isArray(typeDefs) ? (typeDefs as string[]) : [typeDefs as string]);
+
+    return {
+        ...merged,
+        definitions: merged.definitions.reduce((res: DefinitionNode[], def) => {
+            if (def.kind !== "ObjectTypeDefinition" && def.kind !== "InterfaceTypeDefinition") {
+                return [...res, def];
+            }
+
+            if (["Query", "Subscription", "Mutation"].includes(def.name.value)) {
+                return [...res, def];
+            }
+
+            return [
+                ...res,
+                {
+                    ...def,
+                    directives: def.directives?.filter((x) => !excludedDirectives.includes(x.name.value)),
+                    fields: def.fields?.reduce(
+                        (r: FieldDefinitionNode[], f) => [
+                            ...r,
+                            {
+                                ...f,
+                                directives: f.directives?.filter((x) => !excludedDirectives.includes(x.name.value)),
+                            },
+                        ],
+                        []
+                    ),
+                },
+            ];
+        }, []),
+    };
+}
+
+export default filterDocument;

--- a/packages/ogm/src/utils/index.ts
+++ b/packages/ogm/src/utils/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as filterDocument } from "./filter-document";


### PR DESCRIPTION
Some field directives we were not removed from the OGM - when they probably should have... seeming the OGM is designed to be private. This PR adds ; 

* `@auth`
* `@exclude`
* `@private`
* `@readonly`
* `@writeonly`

to the OGM exclude list. 