### PR TITLE
Test/add-set-tz-jest-globals

### DIFF
--- a/jest-global.setup.js
+++ b/jest-global.setup.js
@@ -1,3 +1,9 @@
+const setTZ = require("set-tz");
+
+const TZ = "Etc/UTC";
+
 module.exports = function globalSetup() {
     process.env.NODE_ENV = "test";
+
+    setTZ(TZ);
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "lint-staged": "10.2.11",
         "npm-run-all": "4.1.5",
         "prettier": "2.1.2",
+        "set-tz": "0.2.0",
         "typescript": "3.9.7"
     }
 }

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -26,7 +26,7 @@
         "test": "run-s test:unit test:int test:tck",
         "test:unit": "jest src/ --coverage=true",
         "test:unit:watch": "jest unit --watchAll",
-        "test:tck": "TZ=Etc/UTC jest tck",
+        "test:tck": "jest tck",
         "test:tck:watch": "jest tck --watchAll",
         "test:int": "jest int",
         "test:int:watch": "jest int --watch",

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -49,7 +49,6 @@ const TCK_DIR = path.join(__dirname, "tck-test-files");
 
 beforeAll(() => {
     process.env.JWT_SECRET = "secret";
-    process.env.TZ = "Etc/UTC";
 });
 
 afterAll(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11871,6 +11871,7 @@ fsevents@^1.2.7:
     lint-staged: 10.2.11
     npm-run-all: 4.1.5
     prettier: 2.1.2
+    set-tz: 0.2.0
     typescript: 3.9.7
   languageName: unknown
   linkType: soft
@@ -14579,6 +14580,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"set-tz@npm:0.2.0":
+  version: 0.2.0
+  resolution: "set-tz@npm:0.2.0"
+  dependencies:
+    windows-iana: ^3.0.0
+  checksum: dc6ac8f87488c117a9d178b3dbca9499944e8f33de44b36b7dad050608e3a312adeae33d4c2a97614165475e4bdfd8114d141a7992d7f42540b5b9a3b811da14
+  languageName: node
+  linkType: hard
+
 "set-value@npm:^2.0.0, set-value@npm:^2.0.1":
   version: 2.0.1
   resolution: "set-value@npm:2.0.1"
@@ -17055,6 +17065,13 @@ typescript@4.1.3:
   version: 2.0.0
   resolution: "wildcard@npm:2.0.0"
   checksum: 207baede4d6d41fc1aefcc4727c95ca6f29eaaf4d66478665fe0ac17232709637426ae96fd79deb3b68da3564e7bde7f2be63e5c3665ac8f63ee92364c0a2dd3
+  languageName: node
+  linkType: hard
+
+"windows-iana@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "windows-iana@npm:3.1.0"
+  checksum: 305bb360a082c11b791df38072fcfe41bbc06ca9d5896e14791b4be61eba357d107ebcc57131210185a9854ff4bb4c87cbefc01bd45c8fdde5a38f76cea12567
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Turns out when you set `process.env.TZ` it will change the windows underlying timezone too, I just missed my buss because I though I had a extra hour. `set-tz` seems like a well vetted packaged and "works on my machine". 