### PR TITLE
Docs/Update playbook for 1.0.0-beta release

### DIFF
--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -1,13 +1,6 @@
 name: graphql-manual
 title: Neo4j GraphQL
-version: '1.0-preview'
-prerelease: true
+version: '1.0.0-beta'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc
-asciidoc:
-  attributes:
-    neo4j-version: '4.2'
-    neo4j-version-exact: '4.2.2'
-    neo4j-buildnumber: '4.2'
-    docs-version: '1.0'


### PR DESCRIPTION
This PR updates the version number in the Antora playbook for the 1.0.0-beta release.

The `prerelease` attribute has been removed (along with the redundant asciidoc attributes).

