### PR TITLE
Refactor/Rename `.verifyDatabase` -> `.checkNeo4jCompat`

### DIFF
--- a/docs/asciidoc/api-reference.adoc
+++ b/docs/asciidoc/api-reference.adoc
@@ -25,8 +25,8 @@ const neo4jGraphQL = new Neo4jGraphQL({
 
 === Methods
 
-==== `verifyDatabase`
-Reference: <<drivers-and-config-verifyDatabase>>
+==== `checkNeo4jCompat`
+Reference: <<drivers-and-config-checkNeo4jCompat>>
 
 == `OGM`
 Reference: <<ogm-api-reference>>

--- a/docs/asciidoc/driver-and-config.adoc
+++ b/docs/asciidoc/driver-and-config.adoc
@@ -50,16 +50,16 @@ const driver = neo4j.driver(
 const ogm = new OGM({ typeDefs, driver });
 ----
 
-[[drivers-and-config-verifyDatabase]]
-== `verifyDatabase`
-Use the `verifyDatabase` method available on either `Neo4jGraphQL` or the `OGM` to ensure the specified DBMS has the required; versions, functions and procedures.
+[[drivers-and-config-checkNeo4jCompat]]
+== `checkNeo4jCompat`
+Use the `checkNeo4jCompat` method available on either `Neo4jGraphQL` or the `OGM` to ensure the specified DBMS has the required; versions, functions and procedures.
 
 ==== `Neo4jGraphQL`
 
 [source, javascript]
 ----
 const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
-await neoSchema.verifyDatabase();
+await neoSchema.checkNeo4jCompat();
 ----
 
 ==== `OGM`
@@ -67,7 +67,7 @@ await neoSchema.verifyDatabase();
 [source, javascript]
 ----
 const ogm = new OGM({ typeDefs, driver });
-await ogm.verifyDatabase();
+await ogm.checkNeo4jCompat();
 ----
 
 == Specifying Neo4j Database

--- a/packages/graphql/src/classes/Neo4jGraphQL.test.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.test.ts
@@ -26,11 +26,11 @@ describe("Neo4jGraphQL", () => {
     });
 
     describe("methods", () => {
-        describe("verifyDatabase", () => {
+        describe("checkNeo4jCompat", () => {
             test("should throw neo4j-driver Driver missing", async () => {
                 const neoSchema = new Neo4jGraphQL({ typeDefs: "type User {id: ID}" });
 
-                await expect(neoSchema.verifyDatabase()).rejects.toThrow(`neo4j-driver Driver missing`);
+                await expect(neoSchema.checkNeo4jCompat()).rejects.toThrow(`neo4j-driver Driver missing`);
             });
         });
 

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -25,7 +25,7 @@ import { parseResolveInfo, ResolveTree } from "graphql-parse-resolve-info";
 import type { DriverConfig } from "../types";
 import { makeAugmentedSchema } from "../schema";
 import Node from "./Node";
-import { verifyDatabase } from "../utils";
+import { checkNeo4jCompat } from "../utils";
 import { getJWT } from "../auth/index";
 
 export type SchemaDirectives = IExecutableSchemaDefinition["schemaDirectives"];
@@ -117,7 +117,7 @@ class Neo4jGraphQL {
         });
     }
 
-    async verifyDatabase(input: { driver?: Driver; driverConfig?: DriverConfig } = {}): Promise<void> {
+    async checkNeo4jCompat(input: { driver?: Driver; driverConfig?: DriverConfig } = {}): Promise<void> {
         const driver = input.driver || this.driver;
         const driverConfig = input.driverConfig || this.driverConfig;
 
@@ -125,7 +125,7 @@ class Neo4jGraphQL {
             throw new Error("neo4j-driver Driver missing");
         }
 
-        return verifyDatabase({ driver, driverConfig });
+        return checkNeo4jCompat({ driver, driverConfig });
     }
 }
 

--- a/packages/graphql/src/utils/index.ts
+++ b/packages/graphql/src/utils/index.ts
@@ -19,5 +19,5 @@
 
 export { default as trimmer } from "./trimmer";
 export { default as execute } from "./execute";
-export { default as verifyDatabase } from "./verify-database";
+export { default as checkNeo4jCompat } from "./verify-database";
 export { default as upperFirstLetter } from "./upper-first-letter";

--- a/packages/graphql/src/utils/verify-database.test.ts
+++ b/packages/graphql/src/utils/verify-database.test.ts
@@ -18,11 +18,11 @@
  */
 
 import { Driver, Session } from "neo4j-driver";
-import verifyDatabase from "./verify-database";
+import checkNeo4jCompat from "./verify-database";
 import { MIN_NEO4J_VERSION, MIN_APOC_VERSION, REQUIRED_APOC_FUNCTIONS, REQUIRED_APOC_PROCEDURES } from "../constants";
 import { DriverConfig } from "../types";
 
-describe("verifyDatabase", () => {
+describe("checkNeo4jCompat", () => {
     test("should add driver config to session", async () => {
         // @ts-ignore
         const fakeSession: Session = {
@@ -60,7 +60,7 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        await verifyDatabase({ driver: fakeDriver, driverConfig });
+        await checkNeo4jCompat({ driver: fakeDriver, driverConfig });
     });
 
     test("should throw expected Neo4j version", async () => {
@@ -84,7 +84,7 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        await expect(verifyDatabase({ driver: fakeDriver })).rejects.toThrow(
+        await expect(checkNeo4jCompat({ driver: fakeDriver })).rejects.toThrow(
             `Expected minimum Neo4j version: '${MIN_NEO4J_VERSION}' received: '${invalidVersion}'`
         );
     });
@@ -110,7 +110,7 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        await expect(verifyDatabase({ driver: fakeDriver })).rejects.toThrow(
+        await expect(checkNeo4jCompat({ driver: fakeDriver })).rejects.toThrow(
             `Expected minimum APOC version: '${MIN_APOC_VERSION}' received: '${invalidApocVersion}'`
         );
     });
@@ -142,7 +142,7 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        await expect(verifyDatabase({ driver: fakeDriver })).rejects.toThrow(
+        await expect(checkNeo4jCompat({ driver: fakeDriver })).rejects.toThrow(
             `Missing APOC functions: [ ${REQUIRED_APOC_FUNCTIONS.join(", ")} ]`
         );
     });
@@ -175,7 +175,7 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        await expect(verifyDatabase({ driver: fakeDriver })).rejects.toThrow(
+        await expect(checkNeo4jCompat({ driver: fakeDriver })).rejects.toThrow(
             `Missing APOC procedures: [ ${REQUIRED_APOC_PROCEDURES.join(", ")} ]`
         );
     });
@@ -208,7 +208,7 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        expect(await verifyDatabase({ driver: fakeDriver })).toBeUndefined();
+        expect(await checkNeo4jCompat({ driver: fakeDriver })).toBeUndefined();
     });
 
     test("should throw no errors with valid DB (greater versions)", async () => {
@@ -239,6 +239,6 @@ describe("verifyDatabase", () => {
             verifyConnectivity: () => undefined,
         };
 
-        expect(await verifyDatabase({ driver: fakeDriver })).toBeUndefined();
+        expect(await checkNeo4jCompat({ driver: fakeDriver })).toBeUndefined();
     });
 });

--- a/packages/graphql/src/utils/verify-database.ts
+++ b/packages/graphql/src/utils/verify-database.ts
@@ -28,7 +28,7 @@ interface DBInfo {
     procedures: string[];
 }
 
-async function verifyDatabase({ driver, driverConfig }: { driver: Driver; driverConfig?: DriverConfig }) {
+async function checkNeo4jCompat({ driver, driverConfig }: { driver: Driver; driverConfig?: DriverConfig }) {
     await driver.verifyConnectivity();
 
     const sessionParams: {
@@ -89,4 +89,4 @@ async function verifyDatabase({ driver, driverConfig }: { driver: Driver; driver
     }
 }
 
-export default verifyDatabase;
+export default checkNeo4jCompat;

--- a/packages/graphql/tests/integration/find.int.test.ts
+++ b/packages/graphql/tests/integration/find.int.test.ts
@@ -65,7 +65,7 @@ describe("find", () => {
         `;
 
         try {
-            await neoSchema.verifyDatabase();
+            await neoSchema.checkNeo4jCompat();
 
             await session.run(
                 `

--- a/packages/ogm/src/classes/OGM.test.ts
+++ b/packages/ogm/src/classes/OGM.test.ts
@@ -37,12 +37,12 @@ describe("OGM", () => {
             });
         });
 
-        describe("verifyDatabase", () => {
+        describe("checkNeo4jCompat", () => {
             test("should neo4j-driver Driver missing", async () => {
                 // @ts-ignore
                 const ogm = new OGM({ typeDefs: "type User {id: ID}" });
 
-                await expect(ogm.verifyDatabase()).rejects.toThrow(`neo4j-driver Driver missing`);
+                await expect(ogm.checkNeo4jCompat()).rejects.toThrow(`neo4j-driver Driver missing`);
             });
         });
 

--- a/packages/ogm/src/classes/OGM.ts
+++ b/packages/ogm/src/classes/OGM.ts
@@ -69,10 +69,10 @@ class OGM {
         return found;
     }
 
-    async verifyDatabase(input: { driver?: Driver } = {}): Promise<void> {
+    async checkNeo4jCompat(input: { driver?: Driver } = {}): Promise<void> {
         const driver = input.driver || this.input.driver;
 
-        return this.neoSchema.verifyDatabase({ driver });
+        return this.neoSchema.checkNeo4jCompat({ driver });
     }
 }
 

--- a/packages/ogm/tests/integration/ogm.int.test.ts
+++ b/packages/ogm/tests/integration/ogm.int.test.ts
@@ -67,7 +67,7 @@ describe("OGM", () => {
             });
 
             try {
-                await ogm.verifyDatabase();
+                await ogm.checkNeo4jCompat();
 
                 await session.run(`
                     CREATE (:Movie {id: "${id}"})


### PR DESCRIPTION
Slightly more descriptive and correct naming.