### PR TITLE
Config/Simplify "exports" field in package.json

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -12,9 +12,7 @@
         "url": "https://github.com/neo4j/graphql-tracker-temp/issues"
     },
     "homepage": "https://github.com/neo4j/graphql-tracker-temp/blob/master/README.md",
-    "exports": {
-        "require": "./dist/index.js"
-    },
+    "exports": "./dist/index.js",
     "main": "./dist/index.js",
     "types": "./dist/index.d.ts",
     "files": [


### PR DESCRIPTION
I was trying to bundle a small application using webpack (don't ask), but it was flat-out refusing to compile due to the fact that "." didn't exist in our "exports" field of our `package.json` file. I've lost the exact error in my terminal history, but I don't imagine I'll be the only person suffering from this.

The "exports" field can be quite powerful from the sounds of the limited reading I've done, but for now I've simplified it right down to essentially mirror the "main" field. 