### PR TITLE
Refactor/prefix env vars with NEO4J_GRAPHQL

### DIFF
--- a/docs/asciidoc/auth/authorization/roles.adoc
+++ b/docs/asciidoc/auth/authorization/roles.adoc
@@ -1,7 +1,7 @@
 [[auth-authorization-roles]]
 = Roles
 
-Use the roles property to specify the allowed roles for an operation. Use ENV `NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH` to specify a object path for JWT roles otherwise defaults to `jwt.roles`
+Use the roles property to specify the allowed roles for an operation. Use ENV `NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH` to specify a object path for JWT roles otherwise defaults to `jwt.roles`
 
 [source, graphql]
 ----

--- a/docs/asciidoc/auth/setup.adoc
+++ b/docs/asciidoc/auth/setup.adoc
@@ -16,13 +16,13 @@ content-type: application/json
 |===
 |Variable | Usage
 
-|`NEO4j_GRAPHQL_JWT_SECRET`
+|`NEO4J_GRAPHQL_JWT_SECRET`
 | Specify JWT secret
 
-|`NEO4j_GRAPHQL_JWT_NO_VERIFY`
+|`NEO4J_GRAPHQL_JWT_NO_VERIFY`
 | Disable the verification of the JW
 
-|`NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH`
+|`NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH`
 | Specify where on the JWT the roles key is
 |===
 
@@ -114,7 +114,7 @@ Specify the path in the environment;
 
 [source, bash]
 ----
-$ NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH="https://auth0.mysite.com/claims\\.https://auth0.mysite.com/claims/roles" node server
+$ NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH="https://auth0.mysite.com/claims\\.https://auth0.mysite.com/claims/roles" node server
 ----
 
 == Auth Value Plucking

--- a/examples/neo-push/README.md
+++ b/examples/neo-push/README.md
@@ -121,7 +121,7 @@ This application has two custom resolvers; sign in and sign up. In the resolvers
 }
 ```
 
-the `.sub` property is the users id. We use `NEO4j_GRAPHQL_JWT_SECRET` env var on the sever to configure the secret, this happens to be the same env `@neo4j/graphql` looks at too.
+the `.sub` property is the users id. We use `NEO4J_GRAPHQL_JWT_SECRET` env var on the sever to configure the secret, this happens to be the same env `@neo4j/graphql` looks at too.
 
 > Note to keep things simple... This application has no JWT expiry or refreshing mechanism. Patterns you would implement outside of `@neo4j/graphql` so we deemed it less important in this showcase.
 

--- a/examples/neo-push/server/.env.example
+++ b/examples/neo-push/server/.env.example
@@ -4,4 +4,4 @@ DEBUG=Server:*
 NEO_USER=admin
 NEO_PASSWORD=password
 NEO_URL=neo4j://localhost:7687/neo4j
-NEO4j_GRAPHQL_JWT_SECRET=supersecret
+NEO4J_GRAPHQL_JWT_SECRET=supersecret

--- a/examples/neo-push/server/src/config.ts
+++ b/examples/neo-push/server/src/config.ts
@@ -7,4 +7,4 @@ export const NODE_ENV = process.env.NODE_ENV as string;
 export const NEO_USER: string = (process.env.NEO_USER || "admin") as string;
 export const NEO_PASSWORD: string = (process.env.NEO_PASSWORD || "password") as string;
 export const NEO_URL: string = (process.env.NEO_URL || "neo4j://localhost:7687/neo4j") as string;
-export const NEO4j_GRAPHQL_JWT_SECRET: string = (process.env.NEO4j_GRAPHQL_JWT_SECRET || "secret") as string;
+export const NEO4J_GRAPHQL_JWT_SECRET: string = (process.env.NEO4J_GRAPHQL_JWT_SECRET || "secret") as string;

--- a/examples/neo-push/server/src/utils/create-jwt.ts
+++ b/examples/neo-push/server/src/utils/create-jwt.ts
@@ -3,7 +3,7 @@ import * as config from "../config";
 
 function createJWT(data: { sub: string }): Promise<string> {
     return new Promise((resolve, reject) => {
-        jwt.sign(data, config.NEO4j_GRAPHQL_JWT_SECRET, (err, token) => {
+        jwt.sign(data, config.NEO4J_GRAPHQL_JWT_SECRET, (err, token) => {
             if (err) {
                 return reject(err);
             }

--- a/examples/neo-push/server/src/utils/decode-jwt.ts
+++ b/examples/neo-push/server/src/utils/decode-jwt.ts
@@ -3,7 +3,7 @@ import * as config from "../config";
 
 function decodeJWT(token: string): Promise<{ sub: string }> {
     return new Promise((resolve, reject) => {
-        jwt.verify(token, config.NEO4j_GRAPHQL_JWT_SECRET, (err, decoded) => {
+        jwt.verify(token, config.NEO4J_GRAPHQL_JWT_SECRET, (err, decoded) => {
             if (err) {
                 reject(err);
             }

--- a/examples/neo-push/server/tests/integration/graphql/blog-auth.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/blog-auth.test.ts
@@ -11,12 +11,12 @@ describe("blog-auth", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -37,7 +37,7 @@ describe("blog-auth", () => {
             }
         `;
 
-        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);
@@ -76,7 +76,7 @@ describe("blog-auth", () => {
 
         `;
 
-        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/blog-custom.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/blog-custom.test.ts
@@ -11,12 +11,12 @@ describe("blog-custom", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -41,7 +41,7 @@ describe("blog-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -86,7 +86,7 @@ describe("blog-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -134,7 +134,7 @@ describe("blog-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -179,7 +179,7 @@ describe("blog-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/comment-auth.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/comment-auth.test.ts
@@ -11,12 +11,12 @@ describe("comment-auth", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -37,7 +37,7 @@ describe("comment-auth", () => {
             }
         `;
 
-        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/comment-custom.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/comment-custom.test.ts
@@ -11,12 +11,12 @@ describe("comment-custom", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -49,7 +49,7 @@ describe("comment-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -104,7 +104,7 @@ describe("comment-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -159,7 +159,7 @@ describe("comment-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -217,7 +217,7 @@ describe("comment-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/post-auth.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/post-auth.test.ts
@@ -11,12 +11,12 @@ describe("post-auth", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -41,7 +41,7 @@ describe("post-auth", () => {
             }
         `;
 
-        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);
@@ -79,7 +79,7 @@ describe("post-auth", () => {
             }
         `;
 
-        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/post-custom.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/post-custom.test.ts
@@ -11,12 +11,12 @@ describe("post-custom", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -45,7 +45,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -96,7 +96,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -147,7 +147,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -201,7 +201,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -254,7 +254,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -305,7 +305,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);
@@ -360,7 +360,7 @@ describe("post-custom", () => {
 
             `;
 
-            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             const socket = new Socket({ readable: true });
             const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/sign-in.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/sign-in.test.ts
@@ -8,12 +8,12 @@ describe("signIn", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 

--- a/examples/neo-push/server/tests/integration/graphql/sign-up.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/sign-up.test.ts
@@ -8,12 +8,12 @@ describe("signUp", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 

--- a/examples/neo-push/server/tests/integration/graphql/user-auth.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/user-auth.test.ts
@@ -11,12 +11,12 @@ describe("user-auth", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -39,7 +39,7 @@ describe("user-auth", () => {
             }
         `;
 
-        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);

--- a/examples/neo-push/server/tests/integration/graphql/workflow.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/workflow.test.ts
@@ -11,12 +11,12 @@ describe("workflow", () => {
     let driver: Driver;
 
     beforeAll(async () => {
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "supersecret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "supersecret";
         driver = await neo4j.connect();
     });
 
     afterAll(async () => {
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
         await driver.close();
     });
 
@@ -63,7 +63,7 @@ describe("workflow", () => {
             }),
         };
 
-        const token = jsonwebtoken.sign({ sub: user.id }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+        const token = jsonwebtoken.sign({ sub: user.id }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
         const socket = new Socket({ readable: true });
         const req = new IncomingMessage(socket);

--- a/packages/graphql/src/auth/get-jwt.ts
+++ b/packages/graphql/src/auth/get-jwt.ts
@@ -41,10 +41,10 @@ function getJWT(context: any): any {
     }
 
     try {
-        if (!environment.NEO4j_GRAPHQL_JWT_SECRET && environment.NEO4j_GRAPHQL_JWT_NO_VERIFY) {
+        if (!environment.NEO4J_GRAPHQL_JWT_SECRET && environment.NEO4J_GRAPHQL_JWT_NO_VERIFY) {
             result = jsonwebtoken.decode(token);
         } else {
-            result = jsonwebtoken.verify(token, environment.NEO4j_GRAPHQL_JWT_SECRET as string, {
+            result = jsonwebtoken.verify(token, environment.NEO4J_GRAPHQL_JWT_SECRET as string, {
                 algorithms: ["HS256", "RS256"],
             });
         }

--- a/packages/graphql/src/environment.ts
+++ b/packages/graphql/src/environment.ts
@@ -21,21 +21,21 @@
     https://stackoverflow.com/questions/45194598/using-process-env-in-typescript
     https://dev.to/isthatcentered/typing-process-env-and-dealing-with-nodeenv-3ilm
     If you just do;
-        exports const NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH = process.env.NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH;
+        exports const NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH = process.env.NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH;
     the const will be undefined.
 */
 const environment = {
-    get NEO4j_GRAPHQL_JWT_SECRET() {
-        return process.env.NEO4j_GRAPHQL_JWT_SECRET;
+    get NEO4J_GRAPHQL_JWT_SECRET() {
+        return process.env.NEO4J_GRAPHQL_JWT_SECRET;
     },
-    get NEO4j_GRAPHQL_JWT_NO_VERIFY() {
-        return Boolean(process.env.NEO4j_GRAPHQL_JWT_NO_VERIFY || false);
+    get NEO4J_GRAPHQL_JWT_NO_VERIFY() {
+        return Boolean(process.env.NEO4J_GRAPHQL_JWT_NO_VERIFY || false);
     },
     get NEO4J_GRAPHQL_DISABLE_REGEX() {
         return Boolean(process.env.NEO4J_GRAPHQL_DISABLE_REGEX || false);
     },
-    get NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH() {
-        return process.env.NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH;
+    get NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH() {
+        return process.env.NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH;
     },
     get NPM_PACKAGE_VERSION() {
         return process.env.NPM_PACKAGE_VERSION as string;

--- a/packages/graphql/src/translate/create-auth-param.ts
+++ b/packages/graphql/src/translate/create-auth-param.ts
@@ -33,8 +33,8 @@ function createAuthParam({ context }: { context: Context }) {
         return param;
     }
 
-    if (environment.NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH) {
-        param.roles = dotProp.get(jwt, environment.NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH);
+    if (environment.NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH) {
+        param.roles = dotProp.get(jwt, environment.NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH);
     } else if (jwt.roles) {
         param.roles = jwt.roles;
     }

--- a/packages/graphql/tests/integration/auth/allow.int.test.ts
+++ b/packages/graphql/tests/integration/auth/allow.int.test.ts
@@ -31,12 +31,12 @@ describe("auth/allow", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     describe("read", () => {
@@ -68,7 +68,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -124,7 +124,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -191,7 +191,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -260,7 +260,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -343,7 +343,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -402,7 +402,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -461,7 +461,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -530,7 +530,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -601,7 +601,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -659,7 +659,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -733,7 +733,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -804,7 +804,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -894,7 +894,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -967,7 +967,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -1058,7 +1058,7 @@ describe("auth/allow", () => {
                     roles: [],
                     sub: "invalid",
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });

--- a/packages/graphql/tests/integration/auth/bind.int.test.ts
+++ b/packages/graphql/tests/integration/auth/bind.int.test.ts
@@ -31,12 +31,12 @@ describe("auth/bind", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     describe("create", () => {
@@ -70,7 +70,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -138,7 +138,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -207,7 +207,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -265,7 +265,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -341,7 +341,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -402,7 +402,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -476,7 +476,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -550,7 +550,7 @@ describe("auth/bind", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });

--- a/packages/graphql/tests/integration/auth/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/auth/custom-resolvers.int.test.ts
@@ -31,12 +31,12 @@ describe("auth/custom-resolvers", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     describe("auth-injection", () => {
@@ -68,7 +68,7 @@ describe("auth/custom-resolvers", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({
@@ -122,7 +122,7 @@ describe("auth/custom-resolvers", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({
@@ -172,7 +172,7 @@ describe("auth/custom-resolvers", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({

--- a/packages/graphql/tests/integration/auth/is-authenticated.int.test.ts
+++ b/packages/graphql/tests/integration/auth/is-authenticated.int.test.ts
@@ -30,12 +30,12 @@ describe("auth/is-authenticated", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     describe("read", () => {

--- a/packages/graphql/tests/integration/auth/object-path.int.test.ts
+++ b/packages/graphql/tests/integration/auth/object-path.int.test.ts
@@ -31,12 +31,12 @@ describe("auth/object-path", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     test("should use object path with allow", async () => {
@@ -73,7 +73,7 @@ describe("auth/object-path", () => {
                     },
                 },
             },
-            process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+            process.env.NEO4J_GRAPHQL_JWT_SECRET as string
         );
 
         const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -138,7 +138,7 @@ describe("auth/object-path", () => {
             {
                 roles: [],
             },
-            process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+            process.env.NEO4J_GRAPHQL_JWT_SECRET as string
         );
 
         const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -168,7 +168,7 @@ describe("auth/object-path", () => {
     });
 
     test("should use object path with roles", async () => {
-        process.env.NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH =
+        process.env.NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH =
             "https://github\\.com/claims.https://github\\.com/claims/roles";
 
         const session = driver.session({ defaultAccessMode: "WRITE" });
@@ -195,7 +195,7 @@ describe("auth/object-path", () => {
 
         const token = jsonwebtoken.sign(
             { "https://github.com/claims": { "https://github.com/claims/roles": ["admin"] } },
-            process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+            process.env.NEO4J_GRAPHQL_JWT_SECRET as string
         );
 
         const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -221,7 +221,7 @@ describe("auth/object-path", () => {
             expect(user).toEqual({ id: userId });
         } finally {
             await session.close();
-            delete process.env.NEO4j_GRAPHQL_JWT_ROLES_OBJECT_PATH;
+            delete process.env.NEO4J_GRAPHQL_JWT_ROLES_OBJECT_PATH;
         }
     });
 });

--- a/packages/graphql/tests/integration/auth/roles.int.test.ts
+++ b/packages/graphql/tests/integration/auth/roles.int.test.ts
@@ -31,12 +31,12 @@ describe("auth/roles", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     describe("read", () => {
@@ -63,7 +63,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -102,7 +102,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -148,7 +148,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -192,7 +192,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -238,7 +238,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -282,7 +282,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -353,7 +353,7 @@ describe("auth/roles", () => {
             `;
 
             // missing super-admin
-            const token = jsonwebtoken.sign({ roles: ["admin"] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: ["admin"] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 await session.run(`
@@ -444,7 +444,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [""] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [""] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 await session.run(`
@@ -520,7 +520,7 @@ describe("auth/roles", () => {
             `;
 
             // missing super-admin
-            const token = jsonwebtoken.sign({ roles: ["admin"] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: ["admin"] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 await session.run(`
@@ -611,7 +611,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [""] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [""] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 await session.run(`
@@ -659,7 +659,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -715,7 +715,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 await session.run(`
@@ -764,7 +764,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -807,7 +807,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });
@@ -854,7 +854,7 @@ describe("auth/roles", () => {
                 }
             `;
 
-            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+            const token = jsonwebtoken.sign({ roles: [] }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
             try {
                 const socket = new Socket({ readable: true });

--- a/packages/graphql/tests/integration/auth/where.int.test.ts
+++ b/packages/graphql/tests/integration/auth/where.int.test.ts
@@ -31,12 +31,12 @@ describe("auth/where", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     describe("read", () => {
@@ -68,7 +68,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -138,7 +138,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -224,7 +224,7 @@ describe("auth/where", () => {
                         roles: [],
                         sub: userId,
                     },
-                    process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                    process.env.NEO4J_GRAPHQL_JWT_SECRET as string
                 );
 
                 const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -295,7 +295,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -354,7 +354,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -432,7 +432,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -503,7 +503,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -576,7 +576,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });
@@ -646,7 +646,7 @@ describe("auth/where", () => {
                     roles: [],
                     sub: userId,
                 },
-                process.env.NEO4j_GRAPHQL_JWT_SECRET as string
+                process.env.NEO4J_GRAPHQL_JWT_SECRET as string
             );
 
             const neoSchema = new Neo4jGraphQL({ typeDefs });

--- a/packages/graphql/tests/integration/custom-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/custom-resolvers-int.test.ts
@@ -32,12 +32,12 @@ describe("Custom Resolvers", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     test("should define a custom field resolver and resolve it", async () => {
@@ -455,7 +455,7 @@ describe("Custom Resolvers", () => {
                         charset: "alphabetic",
                     });
 
-                    const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+                    const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
                     const neoSchema = new Neo4jGraphQL({ typeDefs });
 
@@ -503,7 +503,7 @@ describe("Custom Resolvers", () => {
                         charset: "alphabetic",
                     });
 
-                    const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+                    const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
                     const neoSchema = new Neo4jGraphQL({ typeDefs });
 
@@ -550,7 +550,7 @@ describe("Custom Resolvers", () => {
                     charset: "alphabetic",
                 });
 
-                const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4j_GRAPHQL_JWT_SECRET as string);
+                const token = jsonwebtoken.sign({ sub: userId }, process.env.NEO4J_GRAPHQL_JWT_SECRET as string);
 
                 const neoSchema = new Neo4jGraphQL({ typeDefs });
 

--- a/packages/graphql/tests/integration/default-values.int.test.ts
+++ b/packages/graphql/tests/integration/default-values.int.test.ts
@@ -30,12 +30,12 @@ describe("Default values", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+        process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
     });
 
     afterAll(async () => {
         await driver.close();
-        delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+        delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
     });
 
     test("should allow default value on custom @cypher node field", async () => {

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -48,11 +48,11 @@ import createAuthParam from "../../src/translate/create-auth-param";
 const TCK_DIR = path.join(__dirname, "tck-test-files");
 
 beforeAll(() => {
-    process.env.NEO4j_GRAPHQL_JWT_SECRET = "secret";
+    process.env.NEO4J_GRAPHQL_JWT_SECRET = "secret";
 });
 
 afterAll(() => {
-    delete process.env.NEO4j_GRAPHQL_JWT_SECRET;
+    delete process.env.NEO4J_GRAPHQL_JWT_SECRET;
 });
 
 function generateCustomScalar(name: string): GraphQLScalarType {
@@ -94,7 +94,7 @@ describe("TCK Generated tests", () => {
                     if (!cypherParams.jwt) {
                         const socket = new Socket({ readable: true });
                         const req = new IncomingMessage(socket);
-                        const token = jsonwebtoken.sign(jwt, process.env.NEO4j_GRAPHQL_JWT_SECRET as string, {
+                        const token = jsonwebtoken.sign(jwt, process.env.NEO4J_GRAPHQL_JWT_SECRET as string, {
                             noTimestamp: true,
                         });
                         req.headers.authorization = `Bearer ${token}`;


### PR DESCRIPTION
Makes all env vars consistent with a prefix. 