### PR TITLE
Test/add-docker-for-testing

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,20 @@
+FROM node:14.16
+
+WORKDIR /app
+
+RUN npm install -g --force yarn
+
+COPY ./package.json ./package.json
+
+COPY ./ ./
+
+WORKDIR /app/examples/neo-push/server
+
+# Invalid ELF header, 
+# Ensures we install bcrypt based on this machine
+RUN yarn add bcrypt
+
+WORKDIR /app
+RUN yarn install
+
+CMD ["yarn", "test"]

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,33 @@
+version: "3"
+
+services:
+    neo4j:
+        image: neo4j
+        ports:
+            - 7474:7474
+            - 7687:7687
+        environment:
+            - NEO4J_AUTH=neo4j/test
+            - NEO4J_dbms_security_procedures_unrestricted=apoc.*
+        volumes:
+            - $HOME/neo4j/data:/data
+            - $HOME/neo4j/logs:/logs
+            - $HOME/neo4j/import:/var/lib/neo4j/import
+            - $HOME/neo4j/plugins:/plugins
+        healthcheck:
+            test: wget http://localhost:7474/browser -O -
+            interval: 1s
+            timeout: 1s
+            retries: 25
+
+    test:
+        build:
+            context: .
+            dockerfile: Dockerfile.test
+        depends_on:
+            neo4j:
+                condition: service_healthy
+        environment:
+            - NEO_USER=neo4j
+            - NEO_PASSWORD=test
+            - NEO_URL=bolt://host.docker.internal:7687/neo4j

--- a/docs/markdown/CONTRIBUTING.md
+++ b/docs/markdown/CONTRIBUTING.md
@@ -76,6 +76,26 @@ $ yarn
 
 This library uses eslint with AirBnb style. Please use either use a IDE or format your code before submitting a PR. The recommend setup would be VSCode and Prettier.
 
+### Testing
+
+You will need a running neo4j instance unless your using Docker.
+
+#### Local Neo4j
+
+From the root run
+
+```
+cross-env NEO_USER=YOUR_USER NEO_PASSWORD_YOUR_PASSWORD NEO_URL=YOUR_URL yarn run test
+```
+
+#### Docker 🐋
+
+From the root run
+
+```
+docker-compose -f ./docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test
+```
+
 ## Further reading
 
 If you want to find out more about how you can contribute, head over to our website for [more information](http://neo4j.com/developer/contributing-code/).

--- a/examples/neo-push/server/tests/integration/neo4j.ts
+++ b/examples/neo-push/server/tests/integration/neo4j.ts
@@ -1,4 +1,5 @@
 import * as neo4j from "neo4j-driver";
+import * as util from "util";
 
 export async function connect(): Promise<neo4j.Driver> {
     const { NEO_USER = "admin", NEO_PASSWORD = "password", NEO_URL = "neo4j://localhost:7687/neo4j" } = process.env;
@@ -6,6 +7,10 @@ export async function connect(): Promise<neo4j.Driver> {
     const auth = neo4j.auth.basic(NEO_USER, NEO_PASSWORD);
 
     const driver = neo4j.driver(NEO_URL, auth);
+
+    if (process.env.NEO_WAIT && !driver) {
+        await util.promisify(setTimeout)(Number(process.env.NEO_WAIT));
+    }
 
     try {
         await driver.verifyConnectivity();


### PR DESCRIPTION
Adds docker file and a compose for testing. Make sure you turn off your local neo4j instance and run; 

```
docker-compose -f ./docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test
```

Did it work? 