### PR TITLE
test: add NEO4J_GRAPHQL_ENABLE_REGEX flag to broken test

### DIFF
--- a/packages/graphql/tests/integration/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/advanced-filtering.int.test.ts
@@ -30,10 +30,12 @@ describe("Advanced Filtering", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
+        process.env.NEO4J_GRAPHQL_ENABLE_REGEX = "true";
     });
 
     afterAll(async () => {
         await driver.close();
+        delete process.env.NEO4J_GRAPHQL_ENABLE_REGEX;
     });
 
     describe("String/ID Filtering", () => {


### PR DESCRIPTION
Fixes broken test adding env flag. 