### PR TITLE
Docs/Update antora.yml version attribute to 1.0

### DIFF
--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -1,6 +1,6 @@
 name: graphql-manual
 title: Neo4j GraphQL
-version: '1.0.0-beta'
+version: '1.0'
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
# Description

Updates the version attribute in the docs `antora.yml` file to `1.0`.
When the docs are next published they will be published as neo4j.com/docs/graphql-manual/1.0 and he docs publish process will be updated so that neo4j.com/docs/graphql-manual/current displays the same content as neo4j.com/docs/graphql-manual/1.0
