### PR TITLE
fix: temporarily disable validateTypeDefs 

### DIFF
--- a/docs/asciidoc/auth/auth.adoc
+++ b/docs/asciidoc/auth/auth.adoc
@@ -3,6 +3,8 @@
 
 In this section you will learn more about how to secure your GraphQL API using Neo4j GraphQL's inbuilt auth mechanics. 
 
+Using auth requires various APOC functions and producers, one being https://neo4j.com/labs/apoc/4.1/overview/apoc.util/apoc.util.validatePredicate/[apoc.util.validatePredicate] that is not currently in Neo4j Aura. Run the <<drivers-and-config-checkNeo4jCompat>> method to ensure your Graph has all the requirements.
+
 == Preview
 
 

--- a/docs/asciidoc/auth/auth.adoc
+++ b/docs/asciidoc/auth/auth.adoc
@@ -5,8 +5,6 @@ In this section you will learn more about how to secure your GraphQL API using N
 
 > Using auth requires various APOC functions and procedures, one being https://neo4j.com/labs/apoc/4.1/overview/apoc.util/apoc.util.validatePredicate/[apoc.util.validatePredicate] that is not currently in Neo4j Aura. Run the <<drivers-and-config-checkNeo4jCompat>> method to ensure your Graph has all the requirements.
 
-Using auth requires various APOC functions and producers, one being https://neo4j.com/labs/apoc/4.1/overview/apoc.util/apoc.util.validatePredicate/[apoc.util.validatePredicate] that is not currently in Neo4j Aura. Run the <<drivers-and-config-checkNeo4jCompat>> method to ensure your Graph has all the requirements.
-
 == Preview
 
 

--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -152,25 +152,28 @@ describe("makeAugmentedSchema", () => {
         expect(() => makeAugmentedSchema({ typeDefs })).toThrow("cannot auto-generate an array");
     });
 
-    test("should throw timestamp operations must be an array", () => {
-        const typeDefs = `
-                type Movie  {
-                    name: DateTime @timestamp(operations: "read")
-                }
-            `;
+    /*
+        Removal of validateTypeDefs function
+    */
+    // test("should throw timestamp operations must be an array", () => {
+    //     const typeDefs = `
+    //             type Movie  {
+    //                 name: DateTime @timestamp(operations: "read")
+    //             }
+    //         `;
 
-        expect(() => makeAugmentedSchema({ typeDefs })).toThrow('Argument "operations" has invalid value "read".');
-    });
+    //     expect(() => makeAugmentedSchema({ typeDefs })).toThrow('Argument "operations" has invalid value "read".');
+    // });
 
-    test("should throw timestamp operations[0] invalid", () => {
-        const typeDefs = `
-                type Movie  {
-                    name: DateTime @timestamp(operations: ["read"])
-                }
-            `;
+    // test("should throw timestamp operations[0] invalid", () => {
+    //     const typeDefs = `
+    //             type Movie  {
+    //                 name: DateTime @timestamp(operations: ["read"])
+    //             }
+    //         `;
 
-        expect(() => makeAugmentedSchema({ typeDefs })).toThrow('Argument "operations" has invalid value ["read"].');
-    });
+    //     expect(() => makeAugmentedSchema({ typeDefs })).toThrow('Argument "operations" has invalid value ["read"].');
+    // });
 
     test("should throw cannot have auth directive on a relationship", () => {
         const typeDefs = `

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -53,7 +53,7 @@ import getCustomResolvers from "./get-custom-resolvers";
 import getObjFieldMeta from "./get-obj-field-meta";
 import * as point from "./point";
 import { graphqlDirectivesToCompose, objectFieldsToComposeFields } from "./to-compose";
-import validateTypeDefs from "./validation";
+// import validateTypeDefs from "./validation";
 
 function makeAugmentedSchema(
     { typeDefs, resolvers, ...schemaDefinition }: IExecutableSchemaDefinition,
@@ -61,7 +61,12 @@ function makeAugmentedSchema(
 ): { schema: GraphQLSchema; nodes: Node[] } {
     const document = mergeTypeDefs(Array.isArray(typeDefs) ? (typeDefs as string[]) : [typeDefs as string]);
 
-    validateTypeDefs(document);
+    /*
+        Issue caused by a combination of GraphQL Compose removing types and 
+        that we are not adding Points to the validation schema. This should be a
+        temporary fix and does not detriment usability of the library. 
+    */
+    // validateTypeDefs(document);
 
     const composer = new SchemaComposer();
 


### PR DESCRIPTION
# Description

The typeDefs validation was causing too many issues and after @darrellwarde and I spent some time debugging we realised it would be detrimental to include it! This pr comments out the typedef validation :O. Removing the validation has no effect on the usability of the library and the only side effect would be users get a lesser defined error when they give us some invalid typeDefs. 

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
