### PR TITLE
doc(readme) badges for discord chat and graphql forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,14 @@
 💡 Welcome to the Monorepo for [Neo4j](https://neo4j.com/) + [GraphQL](https://graphql.org/).
 
 ![Neo4j + GraphQL](./docs/images/banner.png)
+<p align="center">
+  <a href="https://discord.gg/neo4j">
+    <img alt="Discord" src="https://img.shields.io/discord/787399249741479977?logo=discord&logoColor=white">
+  </a>
+  <a href="https://community.neo4j.com/c/drivers-stacks/graphql/33">
+    <img alt="Discourse users" src="https://img.shields.io/discourse/users?logo=discourse&server=https%3A%2F%2Fcommunity.neo4j.com">
+  </a>
+</p>
 
 ## Contributing
 


### PR DESCRIPTION

# Description

Adds badges for discord chat and graphql forum on community.neo4j.com to the readme.

# Issue

There's not a graphql specific issue related to this change. This is part of a broader dev-rel initiative to improve cross-linking and awareness of our community channels.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
