### PR TITLE
Incredibly slow linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ const baseExtends = [
     "plugin:jest/style",
     "plugin:import/errors",
     "plugin:import/warnings",
-    "plugin:prettier/recommended", // Enables eslint-plugin-prettier and eslint-config-prettier - ensure this is always last in the extends array
+    "prettier", // Ensure this is always last in the extends array
 ]; // Always spread at end of extends due to plugin:prettier/recommended
 
 const baseRules = {
@@ -37,7 +37,6 @@ const baseTypeScriptExtends = [
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
     "plugin:import/typescript",
-    "prettier/@typescript-eslint", // Disables ESLint rules from @typescript-eslint/eslint-plugin that conflict with Prettier
     ...baseExtends,
 ];
 
@@ -49,12 +48,6 @@ const baseTypeScriptRules = {
     "@typescript-eslint/no-use-before-define": "warn", // Unavoidable in some places, but a refactor should potentially happen and this rule switched on
     "@typescript-eslint/explicit-module-boundary-types": "off", // TODO We should really define what our functions return
     "@typescript-eslint/no-unused-vars": ["error"], // Additional rule enabled because we don't want unused variables hanging about!
-    "prettier/prettier": [
-        "error",
-        {
-            endOfLine: "auto",
-        },
-    ], // Support all operating system line endings
     /*
     start of @typescript-eslint/recommended-requiring-type-checking rules
     TODO Over the long term, reduce our usage of `any` and switch these rules on

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+    "endOfLine": "auto"
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
         "eslint-plugin-import": "2.22.0",
         "eslint-plugin-jest": "24.0.1",
         "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-prettier": "3.1.4",
         "eslint-plugin-react": "^7.23.1",
         "graphql": "^15.5.0",
         "husky": "4.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5585,18 +5585,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-prettier@npm:3.1.4":
-  version: 3.1.4
-  resolution: "eslint-plugin-prettier@npm:3.1.4"
-  dependencies:
-    prettier-linter-helpers: ^1.0.0
-  peerDependencies:
-    eslint: ">=5.0.0"
-    prettier: ">=1.13.0"
-  checksum: 4e4df155790a20a7ceef9008bbc22a677a8f7e790e9ef613a049a78dfe0b5dc3726afcd4bfd2a8ce41abc88c9a11db029819a722f70b940da32a03629e7f7832
-  languageName: node
-  linkType: hard
-
 "eslint-plugin-react@npm:^7.23.1":
   version: 7.23.2
   resolution: "eslint-plugin-react@npm:7.23.2"
@@ -6000,13 +5988,6 @@ __metadata:
   version: 3.1.3
   resolution: "fast-deep-equal@npm:3.1.3"
   checksum: 451526766b219503131d11e823eaadd1533080b0be4860e316670b039dcaf31cd1007c2fe036a9b922abba7c040dfad5e942ed79d21f2ff849e50049f36e0fb7
-  languageName: node
-  linkType: hard
-
-"fast-diff@npm:^1.1.2":
-  version: 1.2.0
-  resolution: "fast-diff@npm:1.2.0"
-  checksum: 9c5407d9c4869407854fe8838b8d9d26065ca747c9b80697957ae37482e982e880de823efa2c97ea1cba05dc06fce853a005e7557d10550c64c052cf7021ba9e
   languageName: node
   linkType: hard
 
@@ -9737,7 +9718,6 @@ fsevents@^1.2.7:
     eslint-plugin-import: 2.22.0
     eslint-plugin-jest: 24.0.1
     eslint-plugin-jsx-a11y: ^6.4.1
-    eslint-plugin-prettier: 3.1.4
     eslint-plugin-react: ^7.23.1
     graphql: ^15.5.0
     husky: 4.2.5
@@ -10829,15 +10809,6 @@ fsevents@^1.2.7:
   version: 2.0.0
   resolution: "prepend-http@npm:2.0.0"
   checksum: d39325775adce38e18213fd19656af4abd7672ef6b1e330437079bb237de011d49a70bfb56b35037603d30ef279cceddb33794f70168582d50845c2ade29968e
-  languageName: node
-  linkType: hard
-
-"prettier-linter-helpers@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "prettier-linter-helpers@npm:1.0.0"
-  dependencies:
-    fast-diff: ^1.1.2
-  checksum: 6d698b9c8dc28e52c8d69df520cde3410cc06cc40471acf81b4b7c18ca08e73d0efb0f878654985bb02fce4f8d3d64cdf64fe9f3ffad3e1dc7e17b837d4ddcb2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Switch eslint-plugin-prettier for eslint-config-prettier, this is recommended by Prettier, and the plugin was slowing linting right down. 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] CLA (https://neo4j.com/developer/cla/) has been signed
