### PR TITLE
Update neo-push-server to enforce nodemon uses local ts-node install

### DIFF
--- a/examples/neo-push/server/package.json
+++ b/examples/neo-push/server/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "./dist/src/index.js",
     "scripts": {
-        "start": "nodemon --watch './src/**/*.ts' --exec ts-node -r tsconfig-paths/register --project ./src/tsconfig.json ./src/index.ts",
+        "start": "nodemon --watch './src/**/*.ts' --exec ./node_modules/.bin/ts-node -r tsconfig-paths/register --project ./src/tsconfig.json ./src/index.ts",
         "build": "tsc  --project src/",
         "seed": "ts-node -r tsconfig-paths/register --project ./src/tsconfig.json ./src/seeder.ts",
         "test": "jest"


### PR DESCRIPTION
# Description

Minor update to the neo-push demo's start script to explicitly call the local `ts-node` when using `nodemon`

# Issue

When attempting to run the neo-push demo for the first time after setup, I encountered an error within the runtime logs showing that `ts-node` could not be found. 

This was because the `start` script in neo-push-server's package.json used nodemon to execute the ts-node process, but had not set the `--exec` flag to a relative/absolute path, meaning nodemon was implicitly expecting to find the provided argument on a user's $PATH (and I did not have a global ts-node installed). Since ts-node is a dev dependency, the script should be using the locally installed version.

Note: There's a subtle difference in the `test` script, which also calls ts-node without a relative path, because the yarn/npm execution environment is different from the nested nodemon process, and so yarn finds the ts-node executable from within `node_modules/.bin` without issue.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] CLA (https://neo4j.com/developer/cla/) has been signed
