### PR TITLE
Fixed nullability of Query return type

### DIFF
--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -65,8 +65,8 @@ describe("makeAugmentedSchema", () => {
 
             // Find
             const nodeFindQuery = queryObject.fields?.find((x) => x.name.value === pluralize(camelCase(type)));
-            const nodeFindQueryType = ((nodeFindQuery?.type as NonNullTypeNode).type as ListTypeNode)
-                .type as NamedTypeNode;
+            const nodeFindQueryType = (((nodeFindQuery?.type as NonNullTypeNode).type as ListTypeNode)
+                .type as NonNullTypeNode).type as NamedTypeNode;
             expect(nodeFindQueryType.name.value).toEqual(type);
 
             // Options
@@ -235,7 +235,7 @@ describe("makeAugmentedSchema", () => {
                 type Node {
                     createdAt: DateTime
                 }
-              
+
                 type Query {
                   nodes: [Node] @cypher(statement: "")
                 }

--- a/packages/graphql/src/schema/resolvers/read.test.ts
+++ b/packages/graphql/src/schema/resolvers/read.test.ts
@@ -29,7 +29,7 @@ describe("Read resolver", () => {
         };
 
         const result = findResolver({ node });
-        expect(result.type).toEqual(`[Movie]!`);
+        expect(result.type).toEqual(`[Movie!]!`);
         expect(result.resolve).toBeInstanceOf(Function);
         expect(result.args).toMatchObject({
             where: `MovieWhere`,

--- a/packages/graphql/src/schema/resolvers/read.ts
+++ b/packages/graphql/src/schema/resolvers/read.ts
@@ -37,7 +37,7 @@ export default function findResolver({ node }: { node: Node }) {
     }
 
     return {
-        type: `[${node.name}]!`,
+        type: `[${node.name}!]!`,
         resolve,
         args: { where: `${node.name}Where`, options: `${node.name}Options` },
     };

--- a/packages/graphql/tests/tck/tck-test-files/schema/arrays.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/arrays.md
@@ -105,7 +105,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/comments.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/comments.md
@@ -172,7 +172,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/custom-mutations.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/custom-mutations.md
@@ -108,7 +108,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
   testQuery(input: ExampleInput): String
   testCypherQuery(input: ExampleInput): String
 }

--- a/packages/graphql/tests/tck/tck-test-files/schema/directive-preserve.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directive-preserve.md
@@ -90,7 +90,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/access-directives.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/access-directives.md
@@ -112,7 +112,7 @@ type Mutation {
 }
 
 type Query {
-  users(where: UserWhere, options: UserOptions): [User]!
+  users(where: UserWhere, options: UserOptions): [User!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/autogenerate.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/autogenerate.md
@@ -97,7 +97,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/cypher.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/cypher.md
@@ -144,8 +144,8 @@ type Mutation {
 }
 
 type Query {
-  actors(where: ActorWhere, options: ActorOptions): [Actor]!
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor!]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/default.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/default.md
@@ -147,7 +147,7 @@ type Mutation {
 }
 
 type Query {
-  users(where: UserWhere, options: UserOptions): [User]!
+  users(where: UserWhere, options: UserOptions): [User!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/exclude.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/exclude.md
@@ -126,7 +126,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -202,7 +202,7 @@ type Mutation {
 }
 
 type Query {
-  actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor!]!
 }
 ```
 
@@ -291,7 +291,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -389,7 +389,7 @@ type Mutation {
 
 type Query {
   customActorQuery: Actor
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -579,7 +579,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -664,7 +664,7 @@ type Mutation {
 }
 
 type Query {
-  actors(where: ActorWhere, options: ActorOptions): [Actor]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/ignore.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/ignore.md
@@ -115,7 +115,7 @@ type Mutation {
 }
 
 type Query {
-  users(where: UserWhere, options: UserOptions): [User]!
+  users(where: UserWhere, options: UserOptions): [User!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/private.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/private.md
@@ -84,7 +84,7 @@ type Mutation {
 }
 
 type Query {
-  users(where: UserWhere, options: UserOptions): [User]!
+  users(where: UserWhere, options: UserOptions): [User!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/timestamps.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/timestamps.md
@@ -109,7 +109,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/enum.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/enum.md
@@ -90,7 +90,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/extend.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/extend.md
@@ -101,7 +101,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/inputs.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/inputs.md
@@ -95,7 +95,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
   name(input: NodeInput): String
 }
 ```

--- a/packages/graphql/tests/tck/tck-test-files/schema/interfaces.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/interfaces.md
@@ -168,7 +168,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/issues/#162.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/issues/#162.md
@@ -67,9 +67,9 @@ type Mutation {
 }
 
 type Query {
-    tigers(where: TigerWhere, options: TigerOptions): [Tiger]!
-    tigerJawLevel2s(where: TigerJawLevel2Where, options: TigerJawLevel2Options): [TigerJawLevel2]!
-    tigerJawLevel2Part1s(where: TigerJawLevel2Part1Where, options: TigerJawLevel2Part1Options): [TigerJawLevel2Part1]!
+    tigers(where: TigerWhere, options: TigerOptions): [Tiger!]!
+    tigerJawLevel2s(where: TigerJawLevel2Where, options: TigerJawLevel2Options): [TigerJawLevel2!]!
+    tigerJawLevel2Part1s(where: TigerJawLevel2Part1Where, options: TigerJawLevel2Part1Options): [TigerJawLevel2Part1!]!
 }
 
 enum SortDirection {

--- a/packages/graphql/tests/tck/tck-test-files/schema/issues/#200.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/issues/#200.md
@@ -112,7 +112,7 @@ type Mutation {
 }
 
 type Query {
-  categories(where: CategoryWhere, options: CategoryOptions): [Category]!
+  categories(where: CategoryWhere, options: CategoryOptions): [Category!]!
 }
 
 enum SortDirection {

--- a/packages/graphql/tests/tck/tck-test-files/schema/null.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/null.md
@@ -227,7 +227,7 @@ input PointInput {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 
 type UpdateMoviesMutationResponse {

--- a/packages/graphql/tests/tck/tck-test-files/schema/relationship.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/relationship.md
@@ -192,8 +192,8 @@ type Mutation {
 }
 
 type Query {
-  actors(where: ActorWhere, options: ActorOptions): [Actor]!
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor!]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -464,8 +464,8 @@ type Mutation {
 }
 
 type Query {
-  actors(where: ActorWhere, options: ActorOptions): [Actor]!
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  actors(where: ActorWhere, options: ActorOptions): [Actor!]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/scalar.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/scalar.md
@@ -93,7 +93,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/simple.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/simple.md
@@ -116,7 +116,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/types/bigint.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/types/bigint.md
@@ -99,7 +99,7 @@ type Mutation {
 }
 
 type Query {
-  files(where: FileWhere, options: FileOptions): [File]!
+  files(where: FileWhere, options: FileOptions): [File!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/types/datetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/types/datetime.md
@@ -100,7 +100,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/types/points.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/types/points.md
@@ -102,7 +102,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -205,7 +205,7 @@ type Mutation {
 }
 
 type Query {
-  machines(where: MachineWhere, options: MachineOptions): [Machine]!
+  machines(where: MachineWhere, options: MachineOptions): [Machine!]!
 }
 ```
 
@@ -284,7 +284,7 @@ type Mutation {
 }
 
 type Query {
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 ```
 
@@ -363,7 +363,7 @@ type Mutation {
 }
 
 type Query {
-  machines(where: MachineWhere, options: MachineOptions): [Machine]!
+  machines(where: MachineWhere, options: MachineOptions): [Machine!]!
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/schema/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/unions.md
@@ -243,8 +243,8 @@ type Mutation {
 }
 
 type Query {
-  genres(where: GenreWhere, options: GenreOptions): [Genre]!
-  movies(where: MovieWhere, options: MovieOptions): [Movie]!
+  genres(where: GenreWhere, options: GenreOptions): [Genre!]!
+  movies(where: MovieWhere, options: MovieOptions): [Movie!]!
 }
 
 input QueryOptions {


### PR DESCRIPTION
# Description

Query return type was previously `[Type]!`, now `[Type!]!` as it should be.

# Issue

Raised on Discord and tracked in Trello.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
