### PR TITLE
Update documentation regarding query return types

### DIFF
--- a/docs/asciidoc/guides/migration-guide/queries.adoc
+++ b/docs/asciidoc/guides/migration-guide/queries.adoc
@@ -32,7 +32,7 @@ type Query {
 Changes to note for migration:
 
 * Query fields were previously named in the singular, and in _PascalCase_ - they are now pluralized and in _camelCase_
-* Query return types were previously in nullable arrays - the array is now non-nullable
+* Query return types were previously in nullable lists of nullable types - they are now non-nullable lists of non-nullable types, _e.g._ `[Movie]` is now `[Movie!]!`; ensuring either an array of defined `Movie` objects or an empty array.
 * In this example, the `_MovieFilter` type has essentially been renamed to `MovieWhere`, the `filter` arguments renamed to `where`, and the top-level field arguments `title` and `averageRating` removed - see <<migration-guide-queries-filtering>> below
 * The `first`, `offset` and `orderBy` have been collapsed into the `MovieOptions` type and renamed `limit`, `skip` and `sort`, respectively - see <<migration-guide-queries-options>> below
 


### PR DESCRIPTION
# Description

This changes the return type of the autogenerated queries to non-nullable lists of non-nullable types. 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
