### PR TITLE
Fix for custom type resolvers on unions.

### DIFF
--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -760,7 +760,9 @@ function makeAugmentedSchema(
 
     unions.forEach((union) => {
         // eslint-disable-next-line no-underscore-dangle
-        generatedResolvers[union.name.value] = { __resolveType: (root) => root.__resolveType };
+        if (!generatedResolvers[union.name.value]) {
+            generatedResolvers[union.name.value] = { __resolveType: (root) => root.__resolveType };
+        }
     });
 
     const schema = makeExecutableSchema({


### PR DESCRIPTION
Partial fix for  #207 .  Prevents non null union resolvers from being overwritten with a __resolveType.