### PR TITLE
fix(example/login): avoid confusion caused by secondary button

### DIFF
--- a/examples/neo-push/client/src/components/SignIn.tsx
+++ b/examples/neo-push/client/src/components/SignIn.tsx
@@ -74,9 +74,6 @@ function SignIn() {
                                 onChange={(e) => setPassword(e.target.value)}
                             />
                         </Form.Group>
-                        <Button block variant="outline-secondary" onClick={() => history.push(constants.SIGN_UP_PAGE)}>
-                            Sign Up
-                        </Button>
                         <Button className="mt-3" variant="primary" type="submit">
                             Sign In
                         </Button>
@@ -90,6 +87,13 @@ function SignIn() {
                                 {error}
                             </Alert>
                         )}
+                        <hr />
+                        <p>
+                            Go to{" "}
+                            <Alert.Link onClick={() => history.push(constants.SIGN_UP_PAGE)}>
+                                Sign Up
+                            </Alert.Link> instead
+                        </p>
                     </Card>
                 </Form>
             </Row>

--- a/examples/neo-push/client/src/components/SignUp.tsx
+++ b/examples/neo-push/client/src/components/SignUp.tsx
@@ -87,9 +87,6 @@ function SignUp() {
                                 onChange={(e) => setPasswordConfirm(e.target.value)}
                             />
                         </Form.Group>
-                        <Button block variant="outline-secondary" onClick={() => history.push(constants.SIGN_IN_PAGE)}>
-                            Sign In
-                        </Button>
                         <Button className="mt-3" variant="primary" type="submit">
                             Sign Up
                         </Button>
@@ -103,6 +100,13 @@ function SignUp() {
                                 {error}
                             </Alert>
                         )}
+                        <hr />
+                        <p>
+                            Go to{" "}
+                            <Alert.Link onClick={() => history.push(constants.SIGN_IN_PAGE)}>
+                                Sign In
+                            </Alert.Link> instead
+                        </p>
                     </Card>
                 </Form>
             </Row>


### PR DESCRIPTION
# Description

enhanced a little bit sign-in and sign-up modals ui in the neo-push example
<img width="246" alt="signin" src="https://user-images.githubusercontent.com/597067/122222786-df40d280-ceb2-11eb-9e07-1163e1a879e7.png">


# Issue

The link between sign in and sign up modals was made by a secondary button placed just next to the submit button and was prone to confusion.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [x] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
