### PR TITLE
Fix optional cookie

### DIFF
--- a/packages/graphql/src/auth/get-jwt.ts
+++ b/packages/graphql/src/auth/get-jwt.ts
@@ -49,7 +49,7 @@ function getJWT(context: Context): any {
         return result;
     }
 
-    const authorization = (req.headers.authorization || req.headers.Authorization || req.cookies.token) as string;
+    const authorization = (req.headers.authorization || req.headers.Authorization || req.cookies?.token) as string;
     if (!authorization) {
         debug("Could not get .authorization, .Authorization or .cookies.token from req");
 


### PR DESCRIPTION
# Description

prevent app crash with errors `Cannot read property 'token' of undefined`

# Issue

1. start the neo-push server
`yarn workspace neo-push-server start`
2. query anything

### what happens

it triggers an error `Cannot read property 'token' of undefined`
<img width="1193" alt="token-property-error" src="https://user-images.githubusercontent.com/597067/122247589-c0007000-cec7-11eb-8852-5279a4a9d60b.png">

### expected result

it should run smoothly

<img width="1197" alt="itworksfine" src="https://user-images.githubusercontent.com/597067/122247981-0bb31980-cec8-11eb-9c6f-760e295e98ab.png">

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
