### PR TITLE
fix: use package json for useragent name and version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ packages/package-tests/**/package-lock.json
 !.yarn/sdks
 !.yarn/versions
 .pnp.*
+
+tsconfig.tsbuildinfo

--- a/packages/graphql/src/environment.ts
+++ b/packages/graphql/src/environment.ts
@@ -17,9 +17,11 @@
  * limitations under the License.
  */
 
+import * as pack from "../package.json";
+
 const environment = {
-    NPM_PACKAGE_VERSION: process.env.NPM_PACKAGE_VERSION as string,
-    NPM_PACKAGE_NAME: process.env.NPM_PACKAGE_NAME as string,
+    NPM_PACKAGE_VERSION: pack.version,
+    NPM_PACKAGE_NAME: pack.name,
 };
 
 export default environment;

--- a/packages/graphql/src/tsconfig.build.json
+++ b/packages/graphql/src/tsconfig.build.json
@@ -3,5 +3,8 @@
     "compilerOptions": {
         "outDir": "../dist"
     },
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts"],
+    "references": [
+        { "path": "../" } // for package.json import
+    ]
 }

--- a/packages/graphql/src/tsconfig.json
+++ b/packages/graphql/src/tsconfig.json
@@ -2,5 +2,8 @@
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
         "outDir": "../dist"
-    }
+    },
+    "references": [
+        { "path": "../" } // for package.json import
+    ]
 }

--- a/packages/graphql/src/utils/execute.test.ts
+++ b/packages/graphql/src/utils/execute.test.ts
@@ -67,6 +67,8 @@ describe("execute", () => {
                             close: () => true,
                         };
                     },
+                    // @ts-ignore
+                    _config: {},
                 };
 
                 // @ts-ignore
@@ -85,6 +87,10 @@ describe("execute", () => {
                 expect(result).toEqual([{ title }]);
                 // @ts-ignore
                 expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
+                // @ts-ignore
+                expect(driver._config.userAgent).toEqual(
+                    `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`
+                );
             })
         );
     });

--- a/packages/graphql/src/utils/execute.test.ts
+++ b/packages/graphql/src/utils/execute.test.ts
@@ -21,6 +21,7 @@ import { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../classes";
 import { Context } from "../types";
 import execute from "./execute";
+import environment from "../environment";
 
 describe("execute", () => {
     test("should execute return records.toObject", async () => {
@@ -82,6 +83,8 @@ describe("execute", () => {
                 });
 
                 expect(result).toEqual([{ title }]);
+                // @ts-ignore
+                expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
             })
         );
     });

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -53,7 +53,7 @@ async function execute(input: {
     }
 
     // @ts-ignore: Required to set connection user agent
-    input.context.driver._userAgent = `${environment.NPM_PACKAGE_VERSION}/${environment.NPM_PACKAGE_NAME}`; // eslint-disable-line no-underscore-dangle
+    input.context.driver._userAgent = `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`; // eslint-disable-line no-underscore-dangle
 
     const session = input.context.driver.session(sessionParams);
 

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -52,8 +52,16 @@ async function execute(input: {
         }
     }
 
-    // @ts-ignore: Required to set connection user agent
-    input.context.driver._userAgent = `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`; // eslint-disable-line no-underscore-dangle
+    const userAgent = `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`;
+
+    // @ts-ignore: below
+    if (input.context.driver?._config) {
+        // @ts-ignore: (driver >= 4.3)
+        input.context.driver._config.userAgent = userAgent; // eslint-disable-line no-underscore-dangle
+    }
+
+    // @ts-ignore: (driver <= 4.2)
+    input.context.driver._userAgent = userAgent; // eslint-disable-line no-underscore-dangle
 
     const session = input.context.driver.session(sessionParams);
 
@@ -67,7 +75,6 @@ async function execute(input: {
     }
 
     try {
-        // input.context.neoSchema.debug(`Cypher: ${input.cypher}\nParams: ${JSON.stringify(input.params, null, 2)}`);
         debug(
             "%s",
             `About to execute Cypher:\nCypher:\n${input.cypher}\nParams:\n${JSON.stringify(input.params, null, 2)}`

--- a/packages/graphql/tests/tsconfig.json
+++ b/packages/graphql/tests/tsconfig.json
@@ -1,7 +1,8 @@
 {
     "extends": "../../../tsconfig.base.json",
     "compilerOptions": {
-        "types": ["node", "jest"]
+        "types": ["node", "jest"],
+        "resolveJsonModule": true
     },
     "references": [{ "path": "../src/tsconfig.json" }]
 }

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.base.json",
+    "compilerOptions": {
+        "rootDir": ".",
+        "outDir": ".",
+        "composite": true
+    },
+    "files": ["package.json"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
         "strict": true,
         "target": "es6",
         // TODO Refactor so that noImplicitAny is no longer needed
-        "noImplicitAny": false
+        "noImplicitAny": false,
+        "resolveJsonModule": true
     }
 }


### PR DESCRIPTION
# Description

Uses `package.json` to grab the version and package name vs using the environment variable. Changes to ts-config can be explained here: https://stackoverflow.com/a/61467483/10687857

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
