### PR TITLE
config: remove codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-* @danstarns @darrellwarde


### PR DESCRIPTION
# Description

Removes code owners so team members don't get spam on holidays. As the team grows I would say this is unnecessary for Darrell and me to **both** review everything going in. 

