### PR TITLE
fix: losing params while creating Auth Predicate

### DIFF
--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -548,4 +548,146 @@ describe("createAuthAndParams", () => {
             });
         });
     });
+
+    describe("params", () => {
+        test("should convert undefined $jwt parameters to null", () => {
+            const idField = {
+                fieldName: "id",
+                typeMeta: {
+                    name: "ID",
+                    array: false,
+                    required: false,
+                    pretty: "String",
+                    input: {
+                        where: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        create: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        update: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                    },
+                },
+                otherDirectives: [],
+                arguments: [],
+            };
+
+            // @ts-ignore
+            const node: Node = {
+                name: "Movie",
+                relationFields: [],
+                cypherFields: [],
+                enumFields: [],
+                scalarFields: [],
+                primitiveFields: [idField],
+                dateTimeFields: [],
+                interfaceFields: [],
+                objectFields: [],
+                pointFields: [],
+                authableFields: [idField],
+                auth: {
+                    rules: [
+                        { allow: { id: "$jwt.sub" } },
+                        { operations: ["CREATE"], roles: ["admin"] },
+                        { roles: ["admin"] },
+                    ],
+                    type: "JWT",
+                },
+            };
+
+            // @ts-ignore
+            const neoSchema: Neo4jGraphQL = {
+                nodes: [node],
+            };
+
+            // @ts-ignore
+            const context: Context = { neoSchema, jwt: {} };
+
+            const result = createAuthAndParams({
+                context,
+                entity: node,
+                operation: "READ",
+                allow: { parentNode: node, varName: "this" },
+            });
+
+            expect(result[1]).toMatchObject({
+                this_auth_allow0_id: null,
+            });
+        });
+
+        test("should convert undefined $context parameters to null", () => {
+            const idField = {
+                fieldName: "id",
+                typeMeta: {
+                    name: "ID",
+                    array: false,
+                    required: false,
+                    pretty: "String",
+                    input: {
+                        where: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        create: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        update: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                    },
+                },
+                otherDirectives: [],
+                arguments: [],
+            };
+
+            // @ts-ignore
+            const node: Node = {
+                name: "Movie",
+                relationFields: [],
+                cypherFields: [],
+                enumFields: [],
+                scalarFields: [],
+                primitiveFields: [idField],
+                dateTimeFields: [],
+                interfaceFields: [],
+                objectFields: [],
+                pointFields: [],
+                authableFields: [idField],
+                auth: {
+                    rules: [
+                        { allow: { id: "$context.nop" } },
+                        { operations: ["CREATE"], roles: ["admin"] },
+                        { roles: ["admin"] },
+                    ],
+                    type: "JWT",
+                },
+            };
+
+            // @ts-ignore
+            const neoSchema: Neo4jGraphQL = {
+                nodes: [node],
+            };
+
+            // @ts-ignore
+            const context: Context = { neoSchema, jwt: {} };
+
+            const result = createAuthAndParams({
+                context,
+                entity: node,
+                operation: "READ",
+                allow: { parentNode: node, varName: "this" },
+            });
+
+            expect(result[1]).toMatchObject({
+                this_auth_allow0_id: null,
+            });
+        });
+    });
 });

--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -93,12 +93,16 @@ function createAuthPredicate({
             if (authableField) {
                 const [, jwtPath] = (value as string).split("$jwt.");
                 const [, ctxPath] = (value as string).split("$context.");
-                let paramValue: string = value as string;
+                let paramValue: string | null = value as string;
 
                 if (jwtPath) {
                     paramValue = dotProp.get({ value: jwt }, `value.${jwtPath}`) as string;
                 } else if (ctxPath) {
                     paramValue = dotProp.get({ value: context }, `value.${ctxPath}`) as string;
+                }
+                // To avoid loosing param on query execution
+                if ((jwtPath || ctxPath) && paramValue === undefined) {
+                    paramValue = null
                 }
 
                 const param = `${chainStr}_${key}`;

--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -100,7 +100,7 @@ function createAuthPredicate({
                 } else if (ctxPath) {
                     paramValue = dotProp.get({ value: context }, `value.${ctxPath}`) as string;
                 }
-                // To avoid loosing params on query execution
+                // To avoid losing params on query execution
                 if ((jwtPath || ctxPath) && paramValue === undefined) {
                     paramValue = null;
                 }

--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -100,9 +100,9 @@ function createAuthPredicate({
                 } else if (ctxPath) {
                     paramValue = dotProp.get({ value: context }, `value.${ctxPath}`) as string;
                 }
-                // To avoid loosing param on query execution
+                // To avoid loosing params on query execution
                 if ((jwtPath || ctxPath) && paramValue === undefined) {
-                    paramValue = null
+                    paramValue = null;
                 }
 
                 const param = `${chainStr}_${key}`;


### PR DESCRIPTION
# Description

Avoid `createAuthPredicate` to lose params when no values attached to them.
In the case of a non authed request for example `$jwt.sub` return undefined.

To fix this I just check `paramValue` before setting it to the `params` object, if it's `undefined` set it to `null`.

# Issue

Fix: https://github.com/neo4j/graphql/issues/280

# Checklist

- [x] ~~Documentation has been updated~~ (Not applicable)
- [x] ~~TCK tests have been updated~~ (Not applicable)
- [x] Integration tests have been updated
- [x] ~~Example applications have been updated~~ (Not applicable)
- [x] ~~New files have copyright header~~ (Not applicable)
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
