### PR TITLE
Fix naming conflicts in create and update operations

### DIFF
--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -52,60 +52,62 @@ function createCreateAndParams({
         const _varName = `${varName}_${key}`;
         const relationField = node.relationFields.find((x) => key.startsWith(x.fieldName));
         const primitiveField = node.primitiveFields.find((x) => key === x.fieldName);
-        const pointField = node.pointFields.find((x) => key.startsWith(x.fieldName));
+        const pointField = node.pointFields.find((x) => key === x.fieldName);
 
         if (relationField) {
-            let refNode: Node;
+            let refNode: Node | undefined;
             let unionTypeName = "";
 
             if (relationField.union) {
                 [unionTypeName] = key.split(`${relationField.fieldName}_`).join("").split("_");
                 refNode = context.neoSchema.nodes.find((x) => x.name === unionTypeName) as Node;
-            } else {
+            } else if (relationField.fieldName === key) {
                 refNode = context.neoSchema.nodes.find((x) => x.name === relationField.typeMeta.name) as Node;
             }
 
-            if (value.create) {
-                const creates = relationField.typeMeta.array ? value.create : [value.create];
-                creates.forEach((create, index) => {
-                    const innerVarName = `${_varName}${index}`;
-                    res.creates.push(`\nWITH ${withVars.join(", ")}`);
+            if (refNode) {
+                if (value.create) {
+                    const creates = relationField.typeMeta.array ? value.create : [value.create];
+                    creates.forEach((create, index) => {
+                        const innerVarName = `${_varName}${index}`;
+                        res.creates.push(`\nWITH ${withVars.join(", ")}`);
 
-                    const recurse = createCreateAndParams({
-                        input: create,
-                        context,
-                        node: refNode,
-                        varName: innerVarName,
-                        withVars: [...withVars, innerVarName],
+                        const recurse = createCreateAndParams({
+                            input: create,
+                            context,
+                            node: refNode as Node,
+                            varName: innerVarName,
+                            withVars: [...withVars, innerVarName],
+                        });
+                        res.creates.push(recurse[0]);
+                        res.params = { ...res.params, ...recurse[1] };
+
+                        const inStr = relationField.direction === "IN" ? "<-" : "-";
+                        const outStr = relationField.direction === "OUT" ? "->" : "-";
+                        const relTypeStr = `[:${relationField.type}]`;
+                        res.creates.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${innerVarName})`);
                     });
-                    res.creates.push(recurse[0]);
-                    res.params = { ...res.params, ...recurse[1] };
+                }
 
-                    const inStr = relationField.direction === "IN" ? "<-" : "-";
-                    const outStr = relationField.direction === "OUT" ? "->" : "-";
-                    const relTypeStr = `[:${relationField.type}]`;
-                    res.creates.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${innerVarName})`);
-                });
+                if (value.connect) {
+                    const connectAndParams = createConnectAndParams({
+                        withVars,
+                        value: value.connect,
+                        varName: `${_varName}_connect`,
+                        parentVar: varName,
+                        relationField,
+                        context,
+                        refNode,
+                        labelOverride: unionTypeName,
+                        parentNode: node,
+                        fromCreate: true,
+                    });
+                    res.creates.push(connectAndParams[0]);
+                    res.params = { ...res.params, ...connectAndParams[1] };
+                }
+
+                return res;
             }
-
-            if (value.connect) {
-                const connectAndParams = createConnectAndParams({
-                    withVars,
-                    value: value.connect,
-                    varName: `${_varName}_connect`,
-                    parentVar: varName,
-                    relationField,
-                    context,
-                    refNode,
-                    labelOverride: unionTypeName,
-                    parentNode: node,
-                    fromCreate: true,
-                });
-                res.creates.push(connectAndParams[0]);
-                res.params = { ...res.params, ...connectAndParams[1] };
-            }
-
-            return res;
         }
 
         if (primitiveField?.auth) {

--- a/packages/graphql/tests/integration/issues/#288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/#288.int.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/288", () => {
+    let driver: Driver;
+    const typeDefs = gql`
+        type USER {
+            USERID: String
+            COMPANYID: String
+            COMPANY: [COMPANY] @relationship(type: "IS_PART_OF", direction: OUT)
+        }
+
+        type COMPANY {
+            USERS: [USER] @relationship(type: "IS_PART_OF", direction: IN)
+        }
+    `;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("COMPANYID can be populated on create and update", async () => {
+        const session = driver.session();
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+
+        const userid = generate({ charset: "alphabetic" });
+        const companyid1 = generate({ charset: "alphabetic" });
+        const companyid2 = generate({ charset: "alphabetic" });
+
+        const createMutation = `
+            mutation {
+                createUSERS(input: { USERID: "${userid}", COMPANYID: "${companyid1}" }) {
+                    users {
+                        USERID
+                        COMPANYID
+                    }
+                }
+            }
+        `;
+
+        const updateMutation = `
+            mutation {
+                updateUSERS(where: { USERID: "${userid}" }, update: { COMPANYID: "${companyid2}" }) {
+                    users {
+                        USERID
+                        COMPANYID
+                    }
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const createResult = await graphql({
+                schema: neoSchema.schema,
+                source: createMutation,
+                contextValue: { driver },
+            });
+
+            expect(createResult.errors).toBeFalsy();
+
+            expect(createResult?.data?.createUSERS?.users).toEqual([{ USERID: userid, COMPANYID: companyid1 }]);
+
+            const updateResult = await graphql({
+                schema: neoSchema.schema,
+                source: updateMutation,
+                contextValue: { driver },
+            });
+
+            expect(updateResult.errors).toBeFalsy();
+
+            expect(updateResult?.data?.updateUSERS?.users).toEqual([{ USERID: userid, COMPANYID: companyid2 }]);
+
+            await session.run(`MATCH (u:USER) WHERE u.USERID = "${userid}" DELETE u`);
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/issues/#288.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/issues/#288.md
@@ -1,0 +1,99 @@
+## #288
+
+<https://github.com/neo4j/graphql/issues/288>
+
+Type definitions:
+
+```schema
+type USER {
+    USERID: String
+    COMPANYID: String
+    COMPANY: [COMPANY] @relationship(type: "IS_PART_OF", direction: OUT)
+}
+
+type COMPANY {
+    USERS: [USER] @relationship(type: "IS_PART_OF", direction: IN)
+}
+```
+
+---
+
+### Can create a USER and COMPANYID is populated
+
+**GraphQL input**
+
+```graphql
+mutation {
+    createUSERS(input: { USERID: "userid", COMPANYID: "companyid" }) {
+        users {
+            USERID
+            COMPANYID
+        }
+    }
+}
+```
+
+**Expected Cypher output**
+
+```cypher
+CALL {
+    CREATE (this0:USER)
+    SET this0.USERID = $this0_USERID
+    SET this0.COMPANYID = $this0_COMPANYID
+    RETURN this0
+}
+
+RETURN
+this0 { .USERID, .COMPANYID } AS this0
+```
+
+**Expected Cypher params**
+
+```cypher-params
+{
+  "this0_USERID": "userid",
+  "this0_COMPANYID": "companyid"
+}
+```
+
+---
+
+### Can update a USER and COMPANYID is populated
+
+**GraphQL input**
+
+```graphql
+mutation {
+    updateUSERS(
+        where: { USERID: "userid" }
+        update: { COMPANYID: "companyid2" }
+    ) {
+        users {
+            USERID
+            COMPANYID
+        }
+    }
+}
+```
+
+**Expected Cypher output**
+
+```cypher
+MATCH (this:USER)
+WHERE this.USERID = $this_USERID
+
+SET this.COMPANYID = $this_update_COMPANYID
+
+RETURN this { .USERID, .COMPANYID } AS this
+```
+
+**Expected Cypher params**
+
+```cypher-params
+{
+  "this_USERID": "userid",
+  "this_update_COMPANYID": "companyid2"
+}
+```
+
+---


### PR DESCRIPTION
# Description

String `startsWith` is used for matching in a couple of places, which was causing naming conflicts.

Just as I'm writing this PR I've realised that this may be resolved in 2.0.0 due to the restructuring of input types for Union types!

# Issue

- #288 - confirmed and tested
- #268 - suspected, but unable to reproduce using the information given

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
