### PR TITLE
Custom Cypher and Union return type - preserve array return

### DIFF
--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -81,7 +81,7 @@ export default function cypherResolver({
         ) as { strs: string[]; params: any };
         const apocParamsStr = `{${apocParams.strs.length ? `${apocParams.strs.join(", ")}` : ""}}`;
 
-        const expectMultipleValues = referenceNode && field.typeMeta.array ? "true" : "false";
+        const expectMultipleValues = field.typeMeta.array ? "true" : "false";
         if (type === "Query") {
             cypherStrs.push(`
                 WITH apoc.cypher.runFirstColumn("${statement}", ${apocParamsStr}, ${expectMultipleValues}) as x

--- a/packages/graphql/tests/integration/issues/#315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/#315.int.test.ts
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/315", () => {
+    let driver: Driver;
+    const typeDefs = gql`
+        union Content = Post
+
+        type Post {
+            content: String!
+            modifiedDate: DateTime! @timestamp(operations: [CREATE, UPDATE])
+        }
+
+        type User {
+            id: ID!
+            friends: [User!]! @relationship(type: "HAS_FRIEND", direction: OUT)
+            posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+        }
+
+        type Query {
+            getContent(userID: ID): [Content]
+                @cypher(
+                    statement: """
+                    MATCH (myUser:User {id: $userID})
+                    OPTIONAL MATCH (myUser)-[:HAS_FRIEND]->(myFriends:User)
+                    CALL {
+                        WITH myUser, myFriends
+                        MATCH (myUser)-[:HAS_POST]->(post:Post)
+                        RETURN post
+                        UNION
+                        WITH myUser, myFriends
+                        MATCH (myFriends)-[:HAS_POST]->(post:Post)
+                        RETURN post
+                    }
+                    RETURN DISTINCT apoc.map.merge(properties(post), { __resolveType: 'Post' }) AS result ORDER BY result.modifiedDate DESC
+                    """
+                )
+        }
+    `;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("multiple entries are returned for custom cypher", async () => {
+        const session = driver.session();
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+
+        const userID = generate({ charset: "alphabetic" });
+
+        const input = [
+            {
+                id: userID,
+                friends: {
+                    create: [
+                        {
+                            id: generate({ charset: "alphabetic" }),
+                            posts: {
+                                create: [
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            id: generate({ charset: "alphabetic" }),
+                            posts: {
+                                create: [
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                ],
+                            },
+                        },
+                        {
+                            id: generate({ charset: "alphabetic" }),
+                            posts: {
+                                create: [
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                    {
+                                        content: generate({ charset: "alphabetic" }),
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+                posts: {
+                    create: [
+                        {
+                            content: generate({ charset: "alphabetic" }),
+                        },
+                        {
+                            content: generate({ charset: "alphabetic" }),
+                        },
+                        {
+                            content: generate({ charset: "alphabetic" }),
+                        },
+                    ],
+                },
+            },
+        ];
+
+        const mutation = `
+            mutation CreateUsers($input: [UserCreateInput!]!) {
+                createUsers(input: $input) {
+                    users {
+                        id
+                        friends {
+                            id
+                            posts {
+                                content
+                            }
+                        }
+                        posts {
+                            content
+                        }
+                    }
+                }
+            }
+        `;
+
+        const query = `
+            query GetContent($userID: ID) {
+                getContent(userID: $userID) {
+                    __typename
+                    ... on Post {
+                        content
+                    }
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { driver },
+                variableValues: { input },
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.createUsers?.users[0].id).toEqual(userID);
+            expect(mutationResult?.data?.createUsers?.users[0].friends).toHaveLength(3);
+            expect(mutationResult?.data?.createUsers?.users[0].posts).toHaveLength(3);
+
+            mutationResult?.data?.createUsers?.users[0].friends.forEach((friend) => {
+                expect(friend.posts).toHaveLength(3);
+            });
+
+            const queryResult = await graphql({
+                schema: neoSchema.schema,
+                source: query,
+                contextValue: { driver },
+                variableValues: {
+                    userID,
+                },
+            });
+
+            expect(queryResult.errors).toBeFalsy();
+
+            expect(queryResult?.data?.getContent).toHaveLength(12);
+        } finally {
+            await session.close();
+        }
+    });
+});


### PR DESCRIPTION
# Description

The recent changes to custom Cypher made it so that `expectMultipleReturns` of `apoc.cypher.runFirstColumn` is only set to `true` if a node match was found for the return type. Union return types did not meet this requirement, so `expectMultipleReturns` was set to `false` and only 1 record would ever be returned.

It should be clarified that Union returns for custom Cypher will not have relationships automatically projected, and this will only change when we work on querying Unions/Interfaces from the root Query type.

# Issue

#315 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
