### PR TITLE
return null for start and end cursors when the edges array is empty

### DIFF
--- a/packages/graphql/src/schema/pagination.test.ts
+++ b/packages/graphql/src/schema/pagination.test.ts
@@ -128,5 +128,20 @@ describe("cursor-pagination", () => {
                 },
             });
         });
+
+        test("it should return an empty array for edges when no results are returned (fix 327)", () => {
+            const args = {};
+            const totalCount = 0;
+            const result = createConnectionWithEdgeProperties([], args, totalCount);
+            expect(result).toStrictEqual({
+                edges: [],
+                pageInfo: {
+                    hasNextPage: false,
+                    hasPreviousPage: false,
+                    startCursor: null,
+                    endCursor: null,
+                },
+            });
+        });
     });
 });

--- a/packages/graphql/src/schema/pagination.ts
+++ b/packages/graphql/src/schema/pagination.ts
@@ -54,8 +54,8 @@ export function createConnectionWithEdgeProperties(
     return {
         edges,
         pageInfo: {
-            startCursor: firstEdge.cursor,
-            endCursor: lastEdge.cursor,
+            startCursor: firstEdge ? firstEdge.cursor : null,
+            endCursor: lastEdge ? lastEdge.cursor : null,
             hasPreviousPage: lastEdgeCursor > 0,
             hasNextPage: typeof first === "number" ? sliceEnd < totalCount : false,
         },


### PR DESCRIPTION
Fixes #327 

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [X] Integration tests have been updated
- [ ] Example applications have been updated
- [X] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
