### PR TITLE
Return totalCount if no edges are requested (Fix 332)

### DIFF
--- a/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
@@ -375,7 +375,7 @@ describe("createConnectionAndParams", () => {
             WITH this
             MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
             WITH collect({  }) AS edges
-            RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
+            RETURN { totalCount: size(edges) } AS actorsConnection
             }`);
     });
 });

--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -66,7 +66,7 @@ function createConnectionAndParams({
     const connection = resolveTree.fieldsByTypeName[field.typeMeta.name];
     const { edges } = connection;
 
-    const relationshipFieldsByTypeName = edges.fieldsByTypeName[field.relationshipTypeName];
+    const relationshipFieldsByTypeName = edges ? edges.fieldsByTypeName[field.relationshipTypeName] : {};
 
     const relationshipProperties = Object.values(relationshipFieldsByTypeName).filter((v) => v.name !== "node");
     const node = Object.values(relationshipFieldsByTypeName).find((v) => v.name === "node") as ResolveTree;

--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -372,18 +372,39 @@ function createConnectionAndParams({
     }
 
     if (!firstInput && !afterInput) {
-        subquery.push(
-            `RETURN { edges: edges, totalCount: ${field.relationship.union ? "totalCount" : "size(edges)"} } AS ${
-                resolveTree.alias
-            }`
-        );
+        const returnString = [
+            "RETURN",
+            "{",
+            edges && "edges: edges,",
+            `totalCount: ${field.relationship.union ? "totalCount" : "size(edges)"}`,
+            "}",
+            "AS",
+            resolveTree.alias,
+        ]
+            .filter(Boolean)
+            .join(" ");
+
+        subquery.push(returnString);
     } else {
         const offsetLimitStr = createOffsetLimitStr({
             offset: typeof afterInput === "string" ? cursorToOffset(afterInput) + 1 : undefined,
             limit: firstInput as Integer | number | undefined,
         });
         subquery.push(`WITH edges, size(edges) AS totalCount, edges${offsetLimitStr} AS limitedSelection`);
-        subquery.push(`RETURN { edges: limitedSelection, totalCount: totalCount } AS ${resolveTree.alias}`);
+
+        const returnString = [
+            "RETURN",
+            "{",
+            edges && "edges: limitedSelection,",
+            "totalCount: totalCount",
+            "}",
+            "AS",
+            resolveTree.alias,
+        ]
+            .filter(Boolean)
+            .join(" ");
+
+        subquery.push(returnString);
     }
     subquery.push("}");
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
@@ -421,7 +421,7 @@ CALL {
     WITH this
     CALL { }
     WITH collect(edge) as edges, count(edge) as totalCount
-    RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
+    RETURN { totalCount: totalCount } AS publicationsConnection
 }
 RETURN this { .name, publicationsConnection } as this
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
@@ -397,3 +397,37 @@ RETURN this { .name, publicationsConnection } as this
 ```
 
 ---
+
+## Projecting only the totalCount of the union connection when no edges are requested (fix-332)
+
+### GraphQL Input
+
+```graphql
+query {
+    authors {
+        name
+        publicationsConnection {
+            totalCount
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Author)
+CALL {
+    WITH this
+    CALL { }
+    WITH collect(edge) as edges, count(edge) as totalCount
+    RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
+}
+RETURN this { .name, publicationsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{}
+```


### PR DESCRIPTION
~This is a naive fix for #332. Specifically, it returns an empty object for "edges" in the `create-connection-and-params.ts` function instead of undefined. This allows the rest of the function to continue without erring but it also means that the database is still returning the edges to the server; the server just ignores it.~

~A full fix would be to rewrite the cypher so that only the totalCount is returned. But that's trickier, so I'll defer to what @darrellwarde and @danstarns want to do.~

**Update**: Cypher should now request only totalCount if that's the only field requested in the tree.

**But** see [this comment](https://github.com/neo4j/graphql/issues/332#issuecomment-882124477) about a possible error in the projection of edges on a connection field that resolves to a union

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [X] TCK tests have been updated
- [X] Integration tests have been updated
- [ ] Example applications have been updated
- [X] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
