### PR TITLE
Return totalCount if no edges, and prevent errors for accessing undefined properties

### DIFF
--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -121,8 +121,8 @@ function makeAugmentedSchema(
         fields: {
             hasNextPage: "Boolean!",
             hasPreviousPage: "Boolean!",
-            startCursor: "String!",
-            endCursor: "String!",
+            startCursor: "String",
+            endCursor: "String",
         },
     });
 

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -1130,9 +1130,20 @@ function makeAugmentedSchema(
 
                         const totalCount = isInt(count) ? count.toNumber() : count;
 
+                        const unionEdges = edges?.filter((edge) => {
+                            if (
+                                Object.keys(edge.node).length === 1 &&
+                                Object.prototype.hasOwnProperty.call(edge.node, "__resolveType")
+                            ) {
+                                return false;
+                            }
+
+                            return true;
+                        });
+
                         return {
                             totalCount,
-                            ...createConnectionWithEdgeProperties(edges, args, totalCount),
+                            ...createConnectionWithEdgeProperties(unionEdges, args, totalCount),
                         };
                     },
                 },

--- a/packages/graphql/src/schema/pagination.ts
+++ b/packages/graphql/src/schema/pagination.ts
@@ -24,7 +24,7 @@ import { Integer, isInt } from "neo4j-driver";
  * Adapted from graphql-relay-js ConnectionFromArraySlice
  */
 export function createConnectionWithEdgeProperties(
-    arraySlice: { node: Record<string, any>; [key: string]: any }[],
+    arraySlice: { node: Record<string, any>; [key: string]: any }[] = [],
     args: { after?: string; first?: number } = {},
     totalCount: number
 ) {
@@ -54,8 +54,8 @@ export function createConnectionWithEdgeProperties(
     return {
         edges,
         pageInfo: {
-            startCursor: firstEdge.cursor,
-            endCursor: lastEdge.cursor,
+            startCursor: firstEdge?.cursor,
+            endCursor: lastEdge?.cursor,
             hasPreviousPage: lastEdgeCursor > 0,
             hasNextPage: typeof first === "number" ? sliceEnd < totalCount : false,
         },

--- a/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
@@ -306,7 +306,7 @@ describe("createConnectionAndParams", () => {
             WITH this
             MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
             WITH collect({ screenTime: this_acted_in.screenTime }) AS edges
-            WITH edges, size(edges) AS totalCount, edges[11..21] AS limitedSelection
+            WITH size(edges) AS totalCount, edges[11..21] AS limitedSelection
             RETURN { edges: limitedSelection, totalCount: totalCount } AS actorsConnection
             }`);
     });

--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -89,10 +89,6 @@ function createConnectionAndParams({
         const unionSubqueries: string[] = [];
 
         unionNodes.forEach((n) => {
-            // if (!node?.fieldsByTypeName[n.name]) {
-            //     return;
-            // }
-
             const relatedNodeVariable = `${nodeVariable}_${n.name}`;
             const nodeOutStr = `(${relatedNodeVariable}:${n.name})`;
 

--- a/packages/graphql/tests/integration/connection-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/connection-resolvers-int.test.ts
@@ -344,7 +344,7 @@ describe("Connection Resolvers", () => {
         }
     });
 
-    test("should return a total count of zero if no edges", async () => {
+    test("should return a total count of zero and correct pageInfo if no edges", async () => {
         const session = driver.session();
 
         const typeDefs = `
@@ -374,6 +374,12 @@ describe("Connection Resolvers", () => {
                     id
                     actorsConnection {
                         totalCount
+                        pageInfo {
+                            startCursor
+                            endCursor
+                            hasNextPage
+                            hasPreviousPage
+                        }
                     }
                 }
             }
@@ -395,7 +401,15 @@ describe("Connection Resolvers", () => {
 
             expect(gqlResult.errors).toBeUndefined();
 
-            expect((gqlResult.data as any).movies).toEqual([{ id: movieId, actorsConnection: { totalCount: 0 } }]);
+            expect((gqlResult.data as any).movies).toEqual([
+                {
+                    id: movieId,
+                    actorsConnection: {
+                        totalCount: 0,
+                        pageInfo: { startCursor: null, endCursor: null, hasNextPage: false, hasPreviousPage: false },
+                    },
+                },
+            ]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/connection-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/connection-resolvers-int.test.ts
@@ -142,6 +142,7 @@ describe("Connection Resolvers", () => {
             await session.close();
         }
     });
+
     test("it should provide an after offset that correctly results in the next batch of items", async () => {
         const session = driver.session();
 
@@ -338,6 +339,63 @@ describe("Connection Resolvers", () => {
                     },
                 },
             });
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should return a total count of zero if no edges", async () => {
+        const session = driver.session();
+
+        const typeDefs = `
+            type Actor {
+                id: ID
+                movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT)
+            }
+
+            type Movie {
+                id: ID
+                actors: [Actor]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+        });
+
+        const query = `
+            query GetMovie($movieId: ID) {
+                movies(where: { id: $movieId }) {
+                    id
+                    actorsConnection {
+                        totalCount
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run("CREATE (:Movie { id: $movieId })", { movieId });
+
+            const gqlResult = await graphql({
+                schema: neoSchema.schema,
+                source: query,
+                contextValue: { driver },
+                variableValues: { movieId },
+            });
+
+            if (gqlResult.errors) {
+                console.log(JSON.stringify(gqlResult.errors, null, 2));
+            }
+
+            expect(gqlResult.errors).toBeUndefined();
+
+            expect((gqlResult.data as any).movies).toEqual([{ id: movieId, actorsConnection: { totalCount: 0 } }]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/connections/unions.int.test.ts
+++ b/packages/graphql/tests/integration/connections/unions.int.test.ts
@@ -141,7 +141,7 @@ describe("Connections -> Unions", () => {
         }
     });
 
-    test("With `where` argument on node", async () => {
+    test("With where argument on node", async () => {
         const session = driver.session();
 
         const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
@@ -195,7 +195,7 @@ describe("Connections -> Unions", () => {
         }
     });
 
-    test("With `where` argument on relationship", async () => {
+    test("With where argument on relationship", async () => {
         const session = driver.session();
 
         const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
@@ -249,7 +249,7 @@ describe("Connections -> Unions", () => {
         }
     });
 
-    test("With `where` argument on relationship and node", async () => {
+    test("With where argument on relationship and node", async () => {
         const session = driver.session();
 
         const neoSchema = new Neo4jGraphQL({ typeDefs, driver });

--- a/packages/graphql/tests/tck/tck-test-files/.markdownlint.json
+++ b/packages/graphql/tests/tck/tck-test-files/.markdownlint.json
@@ -1,5 +1,5 @@
 {
     "default": true,
-    "MD013": { "code_blocks": false },
+    "MD013": false,
     "MD024": { "siblings_only": true }
 }

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/projections.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/projections.md
@@ -1,0 +1,339 @@
+# Relay Cursor Connection projections
+
+Ensure that `totalCount` and `edges` are always returned so that `pageInfo` can be calculated. `edges` should always be minimal if not specifically requested.
+
+Schema:
+
+```graphql
+union Production = Movie | Series
+
+type Movie {
+    title: String!
+    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+}
+
+type Series {
+    title: String!
+    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+}
+
+type Actor {
+    name: String!
+    productions: [Production!]! @relationship(type: "ACTED_IN", direction: OUT)
+}
+```
+
+---
+
+## edges not returned if not asked for
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { title: "Forrest Gump" }) {
+        title
+        actorsConnection {
+            totalCount
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.title = $this_title
+CALL {
+    WITH this
+    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ }) AS edges
+    RETURN { totalCount: size(edges) } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_title": "Forrest Gump"
+}
+```
+
+---
+
+## edges and totalCount returned if pageInfo asked for
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { title: "Forrest Gump" }) {
+        title
+        actorsConnection {
+            pageInfo {
+                startCursor
+                endCursor
+                hasNextPage
+                hasPreviousPage
+            }
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.title = $this_title
+CALL {
+    WITH this
+    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ }) AS edges
+    RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_title": "Forrest Gump"
+}
+```
+
+---
+
+## Minimal edges returned if not asked for with pagination arguments
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { title: "Forrest Gump" }) {
+        title
+        actorsConnection(first: 5) {
+            totalCount
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.title = $this_title
+CALL {
+    WITH this
+    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ }) AS edges
+    WITH size(edges) AS totalCount, edges[..5] AS limitedSelection
+    RETURN { edges: limitedSelection, totalCount: totalCount } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_title": "Forrest Gump"
+}
+```
+
+---
+
+## edges not returned if not asked for on a union
+
+### GraphQL Input
+
+```graphql
+query {
+    actors(where: { name: "Tom Hanks" }) {
+        name
+        productionsConnection {
+            totalCount
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Actor)
+WHERE this.name = $this_name
+CALL {
+    WITH this
+    CALL {
+        WITH this
+        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Movie:Movie)
+        WITH { node: { __resolveType: "Movie" } } AS edge
+        RETURN edge
+        UNION
+        WITH this
+        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Series:Series)
+        WITH { node: { __resolveType: "Series" } } AS edge
+        RETURN edge
+    }
+    WITH count(edge) as totalCount
+    RETURN { totalCount: totalCount } AS productionsConnection
+}
+RETURN this { .name, productionsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_name": "Tom Hanks"
+}
+```
+
+---
+
+## edges and totalCount returned if pageInfo asked for on a union
+
+### GraphQL Input
+
+```graphql
+query {
+    actors(where: { name: "Tom Hanks" }) {
+        name
+        productionsConnection {
+            pageInfo {
+                startCursor
+                endCursor
+                hasNextPage
+                hasPreviousPage
+            }
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Actor)
+WHERE this.name = $this_name
+CALL {
+    WITH this
+    CALL {
+        WITH this
+        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Movie:Movie)
+        WITH { node: { __resolveType: "Movie" } } AS edge
+        RETURN edge
+        UNION
+        WITH this
+        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Series:Series)
+        WITH { node: { __resolveType: "Series" } } AS edge
+        RETURN edge
+    }
+    WITH collect(edge) as edges, count(edge) as totalCount
+    RETURN { edges: edges, totalCount: totalCount } AS productionsConnection
+}
+RETURN this { .name, productionsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_name": "Tom Hanks"
+}
+```
+
+---
+
+## totalCount is calculated and returned if asked for with edges
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { title: "Forrest Gump" }) {
+        title
+        actorsConnection {
+            totalCount
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.title = $this_title
+CALL {
+    WITH this
+    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ node: { name: this_actor.name } }) AS edges
+    RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_title": "Forrest Gump"
+}
+```
+
+---
+
+## totalCount is calculated and returned if asked for with edges with pagination arguments
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { title: "Forrest Gump" }) {
+        title
+        actorsConnection(first: 5) {
+            totalCount
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.title = $this_title
+CALL {
+    WITH this
+    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ node: { name: this_actor.name } }) AS edges
+    WITH size(edges) AS totalCount, edges[..5] AS limitedSelection
+    RETURN { edges: limitedSelection, totalCount: totalCount } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_title": "Forrest Gump"
+}
+```

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
@@ -383,6 +383,11 @@ CALL {
         OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Book:Book)
         WITH { words: this_wrote.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
         RETURN edge
+        UNION
+        WITH this
+        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Journal:Journal)
+        WITH { words: this_wrote.words, node: { __resolveType: "Journal" } } AS edge
+        RETURN edge
     }
     WITH collect(edge) as edges, count(edge) as totalCount
     RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection

--- a/packages/graphql/tests/tck/tck-test-files/schema/connections/enums.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/connections/enums.md
@@ -390,8 +390,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/connections/sort.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/connections/sort.md
@@ -299,8 +299,8 @@ input Node2Where {
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/connections/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/connections/unions.md
@@ -613,8 +613,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 union Publication = Book | Journal

--- a/packages/graphql/tests/tck/tck-test-files/schema/directives/exclude.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/directives/exclude.md
@@ -662,8 +662,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/interfaces.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/interfaces.md
@@ -210,8 +210,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/issues/162.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/issues/162.md
@@ -89,8 +89,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/relationship-properties.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/relationship-properties.md
@@ -384,8 +384,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/relationship.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/relationship.md
@@ -235,8 +235,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {
@@ -618,8 +618,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {

--- a/packages/graphql/tests/tck/tck-test-files/schema/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/unions.md
@@ -325,8 +325,8 @@ Pagination information (Relay)
 type PageInfo {
     hasNextPage: Boolean!
     hasPreviousPage: Boolean!
-    startCursor: String!
-    endCursor: String!
+    startCursor: String
+    endCursor: String
 }
 
 type Query {


### PR DESCRIPTION
# Description

Addresses some bugs introduced with cursor-based pagination, and adds more test cases.

- No longer assume that `edges` in the resolve tree - this was safe to assume before, but now `totalCount` or `pageInfo` can be present instead
- Project `__resolveType` for unions to allow for calculation of `totalCount`, but filter out before return to match fragments in the selection set
- Don't return `edges` in Cypher unless it's necessary - this is when either `edges` or `pageInfo` have been asked for

Problems still to discuss and address:

- ~~`startCursor` and `endCursor` - nullable or non-nullable? The spec says that they are non-nullable (https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo.Fields), but there is a longstanding PR to change this (https://github.com/facebook/relay/pull/2655), so do we go with what is currently accurate, or what it "should" be?~~
- Pagination on union connection fields - currently the `first` and `after` arguments are not added to union fields, and if they are, what should the behaviour be?

# Issue

- #327
- #332 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
