### PR TITLE
Fix missing params from update.create mutation

### DIFF
--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -230,7 +230,7 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
                             operation: "CREATE",
                         });
                         createStrs.push(setA[0]);
-                        cypherParams = { ...cypherParams, ...createAndParams[1] };
+                        cypherParams = { ...cypherParams, ...createAndParams[1], ...setA[1] };
                     }
                 });
             });


### PR DESCRIPTION
# Description

Fixes #336. Adds `params` from `createSetRelationshipPropertiesAndParams` to cypher query

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
