### PR TITLE
Fix cypher params for update.create

### DIFF
--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -230,7 +230,7 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
                             operation: "CREATE",
                         });
                         createStrs.push(setA[0]);
-                        cypherParams = { ...cypherParams, ...createAndParams[1] };
+                        cypherParams = { ...cypherParams, ...setA[1] };
                     }
                 });
             });

--- a/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
@@ -217,4 +217,79 @@ describe("Relationship properties - read", () => {
             await session.close();
         }
     });
+    test("Create a relationship node with relationship properties on end node in a nested update (update -> create)", async () => {
+        const session = driver.session();
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+
+        const mutation = `
+            mutation {
+                updateMovies(
+                    where: { title: "${movieTitle}" }
+                    create: {
+                        actors: [
+                            {
+                                node: { name: "${actor3}" }
+                                relationship: { screenTime: 60 }
+                            }
+                        ]
+                    }
+                ) {
+                    movies {
+                        title
+                        actorsConnection {
+                            edges {
+                                screenTime
+                                node {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { driver },
+            });
+
+            expect(result.errors).toBeFalsy();
+
+            expect(result?.data?.updateMovies?.movies).toEqual([
+                {
+                    title: movieTitle,
+                    actorsConnection: {
+                        edges: [
+                            {
+                                screenTime: 60,
+                                node: {
+                                    name: actor3,
+                                },
+                            },
+                            {
+                                screenTime: 105,
+                                node: {
+                                    name: actor2,
+                                },
+                            },
+                            {
+                                screenTime: 105,
+                                node: {
+                                    name: actor1,
+                                },
+                            },
+                        ],
+                    },
+                },
+            ]);
+        } finally {
+            await session.close();
+        }
+    });
 });


### PR DESCRIPTION
# Description

Fixes #336 by adding the correct parameters from `createSetRelationshipPropertiesAndParams` to `cypherParams`

# Issue

- #336 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
