### PR TITLE
Allow for the optional setting of Cypher query options

### DIFF
--- a/docs/asciidoc/troubleshooting.adoc
+++ b/docs/asciidoc/troubleshooting.adoc
@@ -16,3 +16,50 @@ Alternatively, if you are debugging a particular functionality, you can specify 
 2. `@neo4j/graphql:auth` - Logs the status of authorization header and token extraction, and decoding of JWT
 3. `@neo4j/graphql:graphql` - Logs the GraphQL query and variables
 4. `@neo4j/graphql:execute` - Logs the Cypher and Cypher paramaters before execution, and summary of execution
+
+== Query Tuning
+
+Hopefully you won't need to perform any query tuning, but if you do, the Neo4j GraphQL Library allows you to set the full array of query options on construction of the library.
+
+You can read more about the available query options at https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/#cypher-query-options.
+
+_Please only set these options if you know what you are doing._
+
+For example, in order to set the Cypher runtime to "interpreted":
+
+[source, javascript]
+----
+const { Neo4jGraphQL, CypherRuntime } = require("@neo4j/graphql");
+const neo4j = require("neo4j-driver");
+const { ApolloServer } = require("apollo-server");
+
+const typeDefs = `
+    type Movie {
+        title: String!
+    }
+`;
+
+const driver = neo4j.driver(
+    "bolt://localhost:7687",
+    neo4j.auth.basic("neo4j", "password")
+);
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    config: {
+        queryOptions: {
+            runtime: CypherRuntime.INTERPRETED,
+        },
+    },
+});
+
+const server = new ApolloServer({
+    schema: neoSchema.schema,
+    context: ({ req }) => ({ req }),
+});
+
+server.listen().then(({ url }) => {
+  console.log(`Server ready at ${url}`);
+});
+----

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -21,7 +21,7 @@ import Debug from "debug";
 import { Driver } from "neo4j-driver";
 import { DocumentNode, GraphQLResolveInfo, GraphQLSchema, parse, printSchema, print } from "graphql";
 import { addResolversToSchema, addSchemaLevelResolver, IExecutableSchemaDefinition } from "@graphql-tools/schema";
-import type { DriverConfig } from "../types";
+import type { DriverConfig, CypherQueryOptions } from "../types";
 import { makeAugmentedSchema } from "../schema";
 import Node from "./Node";
 import { checkNeo4jCompat } from "../utils";
@@ -42,6 +42,7 @@ export interface Neo4jGraphQLConfig {
     driverConfig?: DriverConfig;
     jwt?: Neo4jGraphQLJWT;
     enableRegex?: boolean;
+    queryOptions?: CypherQueryOptions;
 }
 
 export interface Neo4jGraphQLConstructor extends IExecutableSchemaDefinition {
@@ -136,6 +137,8 @@ class Neo4jGraphQL {
             }
 
             context.auth = createAuthParam({ context });
+
+            context.queryOptions = config.queryOptions;
         });
     }
 

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -20,5 +20,19 @@
 import { upperFirst } from "graphql-compose";
 
 export { upperFirst };
-export { DriverConfig, GraphQLOptionsArg, GraphQLWhereArg, DeleteInfo, GraphQLSortArg } from "./types";
+export {
+    DriverConfig,
+    GraphQLOptionsArg,
+    GraphQLWhereArg,
+    DeleteInfo,
+    GraphQLSortArg,
+    CypherConnectComponentsPlanner,
+    CypherExpressionEngine,
+    CypherInterpretedPipesFallback,
+    CypherOperatorEngine,
+    CypherPlanner,
+    CypherReplanning,
+    CypherRuntime,
+    CypherUpdateStrategy,
+} from "./types";
 export { Neo4jGraphQL, Neo4jGraphQLConstructor } from "./classes";

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -41,6 +41,7 @@ export interface Context {
     neoSchema: Neo4jGraphQL;
     jwt?: JwtPayload;
     auth?: AuthContext;
+    queryOptions?: CypherQueryOptions;
     [k: string]: any;
 }
 
@@ -187,3 +188,64 @@ export interface DeleteInfo {
 }
 
 export type TimeStampOperations = "CREATE" | "UPDATE";
+
+export enum CypherRuntime {
+    INTERPRETED = "interpreted",
+    SLOTTED = "slotted",
+    PIPELINED = "pipelined",
+}
+
+export enum CypherPlanner {
+    COST = "cost",
+    IDP = "idp",
+    DP = "dp",
+}
+
+export enum CypherConnectComponentsPlanner {
+    GREEDY = "greedy",
+    IDP = "idp",
+}
+
+export enum CypherUpdateStrategy {
+    DEFAULT = "default",
+    EAGER = "eager",
+}
+
+export enum CypherExpressionEngine {
+    DEFAULT = "default",
+    INTERPRETED = "interpreted",
+    COMPILED = "compiled",
+}
+
+export enum CypherOperatorEngine {
+    DEFAULT = "default",
+    INTERPRETED = "interpreted",
+    COMPILED = "compiled",
+}
+
+export enum CypherInterpretedPipesFallback {
+    DEFAULT = "default",
+    DISABLED = "disabled",
+    WHITELISTED_PLANS_ONLY = "whitelisted_plans_only",
+    ALL = "all",
+}
+
+export enum CypherReplanning {
+    DEFAULT = "default",
+    FORCE = "force",
+    SKIP = "skip",
+}
+
+/*
+  Object keys and enum values map to values at https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/#cypher-query-options
+*/
+export interface CypherQueryOptions {
+    runtime?: CypherRuntime;
+    planner?: CypherPlanner;
+    connectComponentsPlanner?: CypherConnectComponentsPlanner;
+    updateStrategy?: CypherUpdateStrategy;
+    expressionEngine?: CypherExpressionEngine;
+    operatorEngine?: CypherOperatorEngine;
+    interpretedPipesFallback?: CypherInterpretedPipesFallback;
+    replan?: CypherReplanning;
+}

--- a/packages/graphql/src/utils/execute.test.ts
+++ b/packages/graphql/src/utils/execute.test.ts
@@ -19,9 +19,20 @@
 
 import { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../classes";
-import { Context } from "../types";
+import {
+    Context,
+    CypherConnectComponentsPlanner,
+    CypherExpressionEngine,
+    CypherInterpretedPipesFallback,
+    CypherOperatorEngine,
+    CypherPlanner,
+    CypherReplanning,
+    CypherRuntime,
+    CypherUpdateStrategy,
+} from "../types";
 import execute from "./execute";
 import environment from "../environment";
+import { trimmer } from ".";
 
 describe("execute", () => {
     test("should execute return records.toObject", async () => {
@@ -93,5 +104,166 @@ describe("execute", () => {
                 );
             })
         );
+    });
+
+    describe("should set query options", () => {
+        test("no query options if object is empty", async () => {
+            const defaultAccessMode = "READ";
+
+            const cypher = trimmer(`
+                CREATE (u:User {title: $title})
+                RETURN u { .title } as u
+            `);
+
+            const title = "some title";
+            const params = { title };
+            const records = [{ toObject: () => ({ title }) }];
+            const database = "neo4j";
+            const bookmarks = ["test"];
+
+            // @ts-ignore
+            const driver: Driver = {
+                // @ts-ignore
+                session: (options) => {
+                    expect(options).toMatchObject({ defaultAccessMode, database, bookmarks });
+
+                    const tx = {
+                        run: (paramCypher, paramParams) => {
+                            expect(trimmer(paramCypher)).toEqual(cypher);
+                            expect(paramParams).toEqual(params);
+
+                            return { records };
+                        },
+                    };
+
+                    return {
+                        readTransaction: (fn) => {
+                            // @ts-ignore
+                            return fn(tx);
+                        },
+                        writeTransaction: (fn) => {
+                            // @ts-ignore
+                            return fn(tx);
+                        },
+                        close: () => true,
+                    };
+                },
+                // @ts-ignore
+                _config: {},
+            };
+
+            // @ts-ignore
+            const neoSchema: Neo4jGraphQL = {
+                // @ts-ignore
+                options: {},
+            };
+
+            const result = await execute({
+                cypher,
+                params,
+                defaultAccessMode,
+                context: {
+                    driverConfig: { database, bookmarks },
+                    neoSchema,
+                    driver,
+                    queryOptions: {},
+                } as Context,
+            });
+
+            expect(result).toEqual([{ title }]);
+            // @ts-ignore
+            expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
+            // @ts-ignore
+            expect(driver._config.userAgent).toEqual(
+                `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`
+            );
+        });
+
+        test("one of each query option", async () => {
+            const defaultAccessMode = "READ";
+
+            const inputCypher = trimmer(`
+            CREATE (u:User {title: $title})
+            RETURN u { .title } as u
+        `);
+
+            const expectedCypher = trimmer(`
+            CYPHER runtime=interpreted planner=cost connectComponentsPlanner=greedy updateStrategy=default expressionEngine=compiled operatorEngine=compiled interpretedPipesFallback=all replan=default
+            CREATE (u:User {title: $title})
+            RETURN u { .title } as u
+        `);
+
+            const title = "some title";
+            const params = { title };
+            const records = [{ toObject: () => ({ title }) }];
+            const database = "neo4j";
+            const bookmarks = ["test"];
+
+            // @ts-ignore
+            const driver: Driver = {
+                // @ts-ignore
+                session: (options) => {
+                    expect(options).toMatchObject({ defaultAccessMode, database, bookmarks });
+
+                    const tx = {
+                        run: (paramCypher, paramParams) => {
+                            expect(trimmer(paramCypher)).toEqual(expectedCypher);
+                            expect(paramParams).toEqual(params);
+
+                            return { records };
+                        },
+                    };
+
+                    return {
+                        readTransaction: (fn) => {
+                            // @ts-ignore
+                            return fn(tx);
+                        },
+                        writeTransaction: (fn) => {
+                            // @ts-ignore
+                            return fn(tx);
+                        },
+                        close: () => true,
+                    };
+                },
+                // @ts-ignore
+                _config: {},
+            };
+
+            // @ts-ignore
+            const neoSchema: Neo4jGraphQL = {
+                // @ts-ignore
+                options: {},
+            };
+
+            const result = await execute({
+                cypher: inputCypher,
+                params,
+                defaultAccessMode,
+                context: {
+                    driverConfig: { database, bookmarks },
+                    neoSchema,
+                    driver,
+                    queryOptions: {
+                        runtime: CypherRuntime.INTERPRETED,
+                        planner: CypherPlanner.COST,
+                        connectComponentsPlanner: CypherConnectComponentsPlanner.GREEDY,
+                        updateStrategy: CypherUpdateStrategy.DEFAULT,
+                        expressionEngine: CypherExpressionEngine.COMPILED,
+                        operatorEngine: CypherOperatorEngine.COMPILED,
+                        interpretedPipesFallback: CypherInterpretedPipesFallback.ALL,
+                        replan: CypherReplanning.DEFAULT,
+                    },
+                } as Context,
+            });
+
+            expect(result).toEqual([{ title }]);
+            // @ts-ignore
+            expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
+            // @ts-ignore
+            expect(driver._config.userAgent).toEqual(
+                `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`
+            );
+        });
     });
 });

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -74,14 +74,18 @@ async function execute(input: {
         input.params.auth = createAuthParam({ context: input.context });
     }
 
+    const cypher =
+        input.context.queryOptions && Object.keys(input.context.queryOptions).length
+            ? `CYPHER ${Object.entries(input.context.queryOptions)
+                  .map(([key, value]) => `${key}=${value}`)
+                  .join(" ")}\n${input.cypher}`
+            : input.cypher;
+
     try {
-        debug(
-            "%s",
-            `About to execute Cypher:\nCypher:\n${input.cypher}\nParams:\n${JSON.stringify(input.params, null, 2)}`
-        );
+        debug("%s", `About to execute Cypher:\nCypher:\n${cypher}\nParams:\n${JSON.stringify(input.params, null, 2)}`);
 
         const result = await session[`${input.defaultAccessMode.toLowerCase()}Transaction`]((tx) =>
-            tx.run(input.cypher, input.params)
+            tx.run(cypher, input.params)
         );
 
         if (input.statistics) {


### PR DESCRIPTION
# Description

Allows for optional setting of Cypher query options from https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/#cypher-query-options

Needs documentation - either https://neo4j.com/docs/graphql-manual/current/drivers-and-config/ or https://neo4j.com/docs/graphql-manual/current/troubleshooting/?

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
