### PR TITLE
feat(graphql): add allowUnauthenticated parameter to auth rules

### DIFF
--- a/docs/asciidoc/auth/authentication.adoc
+++ b/docs/asciidoc/auth/authentication.adoc
@@ -96,7 +96,7 @@ extend type Todo @auth(rules: [{ isAuthenticated: true }])
 == `allowUnauthenticated`
 In some cases, you may want to allow unauthenticated requests while also having auth-based rules. You can use the `allowUnauthenticated` parameter to avoid throwing an exception if no auth is present in the context.
 
-In the example below, only the publisher can see his blog posts even if it is not published yet. Once the blog post is published, anyone can see it.
+In the example below, only the publisher can see his blog posts if it is not published yet. Once the blog post is published, anyone can see it.
 
 [source, graphql]
 ----

--- a/docs/asciidoc/auth/authentication.adoc
+++ b/docs/asciidoc/auth/authentication.adoc
@@ -92,3 +92,26 @@ type Todo {
 
 extend type Todo @auth(rules: [{ isAuthenticated: true }])
 ----
+
+== `allowUnauthenticated`
+In some cases, you may want to allow unauthenticated requests while also having auth-based rules. You can use the `allowUnauthenticated` parameter to avoid throwing an exception if no auth is present in the context.
+
+In the example below, only the publisher can see his blog posts even if it is not published yet. Once the blog post is published, anyone can see it.
+
+[source, graphql]
+----
+type BlogPost {
+    id: ID!
+    publisher: User!
+    published: Boolean!
+}
+
+extend type BlogPost {
+    password: String! @auth(rules: [
+        { operations: [READ], where: { OR: [
+            { publisher: "$jwt.sub" },
+            { published: true },
+        ] }, allowUnauthenticated: true }
+    ])
+}
+----

--- a/docs/asciidoc/auth/authentication.adoc
+++ b/docs/asciidoc/auth/authentication.adoc
@@ -98,22 +98,20 @@ In some cases, you may want to allow unauthenticated requests while also having 
 
 In the example below, only the publisher can see his blog posts even if it is not published yet. Once the blog post is published, anyone can see it.
 
-WARNING: In case of unauthenticated requests, auth parameters will be replaced by `null` in the cypher query. In this case, `publisher: "$jwt.sub"` will become `publisher: null`; This can lead to unwanted results if the field used for querying is nullable in Neo4J.
-
 [source, graphql]
 ----
-type BlogPost {
+type BlogPost
+    @auth(
+        rules: [
+            {
+                operations: [READ]
+                where: { OR: [{ publisher: "$jwt.sub" }, { published: true }] }
+                allowUnauthenticated: true
+            }
+        ]
+    ) {
     id: ID!
-    publisher: User!
+    publisher: String!
     published: Boolean!
-}
-
-extend type BlogPost {
-    password: String! @auth(rules: [
-        { operations: [READ], where: { OR: [
-            { publisher: "$jwt.sub" },
-            { published: true },
-        ] }, allowUnauthenticated: true }
-    ])
 }
 ----

--- a/docs/asciidoc/auth/authentication.adoc
+++ b/docs/asciidoc/auth/authentication.adoc
@@ -98,6 +98,8 @@ In some cases, you may want to allow unauthenticated requests while also having 
 
 In the example below, only the publisher can see his blog posts even if it is not published yet. Once the blog post is published, anyone can see it.
 
+WARNING: In case of unauthenticated requests, auth parameters will be replaced by `null` in the cypher query. In this case, `publisher: "$jwt.sub"` will become `publisher: null`; This can lead to unwanted results if the field used for querying is nullable in Neo4J.
+
 [source, graphql]
 ----
 type BlogPost {

--- a/packages/graphql/src/schema/get-auth.ts
+++ b/packages/graphql/src/schema/get-auth.ts
@@ -21,13 +21,7 @@ import { DirectiveNode, valueFromASTUntyped } from "graphql";
 import { Auth, AuthRule, AuthOperations } from "../types";
 
 const validOperations: AuthOperations[] = ["CREATE", "READ", "UPDATE", "DELETE", "CONNECT", "DISCONNECT"];
-const validFields = [
-    "operations",
-    "AND", "OR",
-    "allow", "where", "bind",
-    "isAuthenticated", "allowUnauthenticated",
-    "roles"
-];
+const validFields = ["operations", "AND", "OR", "allow", "where", "bind", "isAuthenticated", "allowUnauthenticated", "roles"];
 
 function getAuth(directive: DirectiveNode): Auth {
     const auth: Auth = { rules: [], type: "JWT" };

--- a/packages/graphql/src/schema/get-auth.ts
+++ b/packages/graphql/src/schema/get-auth.ts
@@ -21,7 +21,13 @@ import { DirectiveNode, valueFromASTUntyped } from "graphql";
 import { Auth, AuthRule, AuthOperations } from "../types";
 
 const validOperations: AuthOperations[] = ["CREATE", "READ", "UPDATE", "DELETE", "CONNECT", "DISCONNECT"];
-const validFields = ["operations", "AND", "OR", "allow", "where", "bind", "isAuthenticated", "roles"];
+const validFields = [
+    "operations",
+    "AND", "OR",
+    "allow", "where", "bind",
+    "isAuthenticated", "allowUnauthenticated",
+    "roles"
+];
 
 function getAuth(directive: DirectiveNode): Auth {
     const auth: Auth = { rules: [], type: "JWT" };

--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -685,5 +685,141 @@ describe("createAuthAndParams", () => {
                 });
             }).toThrow("Unauthenticated");
         });
+
+        test("should showcase the allowUnauthenticated behavior with undefined $jwt", () => {
+            const idField = {
+                fieldName: "id",
+                typeMeta: {
+                    name: "ID",
+                    array: false,
+                    required: false,
+                    pretty: "String",
+                    input: {
+                        where: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        create: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        update: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                    },
+                },
+                otherDirectives: [],
+                arguments: [],
+            };
+
+            // @ts-ignore
+            const node: Node = {
+                name: "Movie",
+                relationFields: [],
+                cypherFields: [],
+                enumFields: [],
+                scalarFields: [],
+                primitiveFields: [idField],
+                dateTimeFields: [],
+                interfaceFields: [],
+                objectFields: [],
+                pointFields: [],
+                authableFields: [idField],
+                auth: {
+                    rules: [
+                        { allow: { id: "$jwt.sub" }, allowUnauthenticated: true },
+                        { operations: ["CREATE"], roles: ["admin"] },
+                        { roles: ["admin"] },
+                    ],
+                    type: "JWT",
+                },
+            };
+
+            // @ts-ignore
+            const neoSchema: Neo4jGraphQL = {
+                nodes: [node],
+            };
+
+            // @ts-ignore
+            const context: Context = { neoSchema, jwt: {} };
+
+            const result = createAuthAndParams({
+                context,
+                entity: node,
+                operation: "READ",
+                allow: { parentNode: node, varName: "this" },
+            });
+
+            expect(result).toContainEqual({ this_auth_allow0_id: null });
+        });
+
+        test("should showcase the allowUnauthenticated behavior with undefined $context", () => {
+            const idField = {
+                fieldName: "id",
+                typeMeta: {
+                    name: "ID",
+                    array: false,
+                    required: false,
+                    pretty: "String",
+                    input: {
+                        where: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        create: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                        update: {
+                            type: "String",
+                            pretty: "String",
+                        },
+                    },
+                },
+                otherDirectives: [],
+                arguments: [],
+            };
+
+            // @ts-ignore
+            const node: Node = {
+                name: "Movie",
+                relationFields: [],
+                cypherFields: [],
+                enumFields: [],
+                scalarFields: [],
+                primitiveFields: [idField],
+                dateTimeFields: [],
+                interfaceFields: [],
+                objectFields: [],
+                pointFields: [],
+                authableFields: [idField],
+                auth: {
+                    rules: [
+                        { allow: { id: "$context.nop" }, allowUnauthenticated: true },
+                        { operations: ["CREATE"], roles: ["admin"] },
+                        { roles: ["admin"] },
+                    ],
+                    type: "JWT",
+                },
+            };
+
+            // @ts-ignore
+            const neoSchema: Neo4jGraphQL = {
+                nodes: [node],
+            };
+
+            // @ts-ignore
+            const context: Context = { neoSchema, jwt: {} };
+
+            const result = createAuthAndParams({
+                context,
+                entity: node,
+                operation: "READ",
+                allow: { parentNode: node, varName: "this" },
+            });
+
+            expect(result).toContainEqual({ this_auth_allow0_id: null });
+        });
     });
 });

--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -751,6 +751,7 @@ describe("createAuthAndParams", () => {
                 allow: { parentNode: node, varName: "this" },
             });
 
+            expect(trimmer(result[0])).toEqual(trimmer('false OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))'));
             expect(result[1]).toEqual({});
         });
 
@@ -819,6 +820,7 @@ describe("createAuthAndParams", () => {
                 allow: { parentNode: node, varName: "this" },
             });
 
+            expect(trimmer(result[0])).toEqual(trimmer('false OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))'));
             expect(result[1]).toEqual({});
         });
     });

--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -95,7 +95,7 @@ describe("createAuthAndParams", () => {
 
             expect(trimmer(result[0])).toEqual(
                 trimmer(`
-                    EXISTS(this.id) AND this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    this.id IS NOT NULL AND this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 `)
             );
 
@@ -175,7 +175,7 @@ describe("createAuthAndParams", () => {
 
             expect(trimmer(result[0])).toEqual(
                 trimmer(`
-                    EXISTS(this.id) AND this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    this.id IS NOT NULL AND this.id = $this_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 `)
             );
 
@@ -253,7 +253,7 @@ describe("createAuthAndParams", () => {
 
             expect(trimmer(result[0])).toEqual(
                 trimmer(`
-                     ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND EXISTS(this.id) AND this.id = $this_auth_allow0_id
+                     ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND this.id IS NOT NULL AND this.id = $this_auth_allow0_id
                 `)
             );
 
@@ -334,7 +334,7 @@ describe("createAuthAndParams", () => {
 
                 expect(trimmer(result[0])).toEqual(
                     trimmer(`
-                        EXISTS(this.id) AND this.id = $this${key}0_auth_allow0_id ${key} ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                        this.id IS NOT NULL AND this.id = $this${key}0_auth_allow0_id ${key} ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                     `)
                 );
 
@@ -422,11 +422,11 @@ describe("createAuthAndParams", () => {
                 trimmer(`
                     ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 AND
-                    EXISTS(this.id) AND this.id = $this_auth_allow0_id
+                    this.id IS NOT NULL AND this.id = $this_auth_allow0_id
                 AND
-                    EXISTS(this.id) AND this.id = $thisAND0_auth_allow0_id AND ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    this.id IS NOT NULL AND this.id = $thisAND0_auth_allow0_id AND ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 AND
-                    EXISTS(this.id) AND this.id = $thisOR0_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
+                    this.id IS NOT NULL AND this.id = $thisOR0_auth_allow0_id OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
                 `)
             );
 
@@ -536,7 +536,7 @@ describe("createAuthAndParams", () => {
 
                 expect(trimmer(result[0])).toEqual(
                     trimmer(`
-                        (EXISTS(this.id) AND this.id = $this_auth_allow0_${key}0_id ${key} EXISTS(this.id) AND this.id = $this_auth_allow0_${key}1_id ${key} EXISTS(this.id) AND this.id = $this_auth_allow0_${key}2_id)
+                        (this.id IS NOT NULL AND this.id = $this_auth_allow0_${key}0_id ${key} this.id IS NOT NULL AND this.id = $this_auth_allow0_${key}1_id ${key} this.id IS NOT NULL AND this.id = $this_auth_allow0_${key}2_id)
                     `)
                 );
 
@@ -751,7 +751,7 @@ describe("createAuthAndParams", () => {
                 allow: { parentNode: node, varName: "this" },
             });
 
-            expect(result).toContainEqual({ this_auth_allow0_id: null });
+            expect(result[1]).toEqual({});
         });
 
         test("should showcase the allowUnauthenticated behavior with undefined $context", () => {
@@ -819,7 +819,7 @@ describe("createAuthAndParams", () => {
                 allow: { parentNode: node, varName: "this" },
             });
 
-            expect(result).toContainEqual({ this_auth_allow0_id: null });
+            expect(result[1]).toEqual({});
         });
     });
 });

--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -67,7 +67,7 @@ function createAuthPredicate({
     }
 
     const { jwt } = context;
-    const allowUnauthenticated = rule.allowUnauthenticated
+    const { allowUnauthenticated } = rule;
 
     const result = Object.entries(rule[kind] as any).reduce(
         (res: Res, [key, value]) => {
@@ -113,7 +113,7 @@ function createAuthPredicate({
                 if (paramValue === undefined) {
                     res.strs.push("false");
                 } else if (paramValue === null) {
-                    res.strs.push(`${varName}.${key} IS null`);
+                    res.strs.push(`${varName}.${key} IS NULL`);
                 } else {
                     const param = `${chainStr}_${key}`;
                     res.params[param] = paramValue;

--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -102,8 +102,10 @@ function createAuthPredicate({
                     paramValue = dotProp.get({ value: context }, `value.${ctxPath}`) as string;
                 }
 
-                if (paramValue === undefined) {
+                if (paramValue === undefined && rule.allowUnauthenticated !== true) {
                     throw new Neo4jGraphQLAuthenticationError("Unauthenticated");
+                } else if (paramValue === undefined) {
+                    paramValue = null;
                 }
 
                 const param = `${chainStr}_${key}`;

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -47,6 +47,7 @@ export interface Context {
 
 export interface BaseAuthRule {
     isAuthenticated?: boolean;
+    allowUnauthenticated?: boolean;
     allow?: { [k: string]: any } | "*";
     bind?: { [k: string]: any } | "*";
     where?: { [k: string]: any } | "*";

--- a/packages/graphql/tests/integration/auth/allow-unauthenticated.int.test.ts
+++ b/packages/graphql/tests/integration/auth/allow-unauthenticated.int.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Socket } from "net";
+import { graphql } from "graphql";
+import { Driver } from "neo4j-driver";
+import { IncomingMessage } from "http";
+import { generate } from "randomstring";
+
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+// Reference: https://github.com/neo4j/graphql/pull/355
+// Reference: https://github.com/neo4j/graphql/issues/345
+// Reference: https://github.com/neo4j/graphql/pull/342#issuecomment-884061188
+describe("auth/allow-unauthenticated", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    describe("allowUnauthenticated with allow", () => {
+        test("should return a Post without errors", async () => {
+            const typeDefs = `
+                type Post {
+                    id: ID!
+                    publisher: String!
+                    published: Boolean!
+                }
+    
+                extend type Post @auth(rules: [
+                    { allow: { OR: [
+                        { publisher: "$jwt.sub" },
+                        { published: true },
+                    ] }, allowUnauthenticated: true }
+                ])
+            `;
+    
+            const postId = generate({ charset: "alphabetic" });
+    
+            const query = `
+                {
+                    posts(where: { id: ${postId} }) {
+                        id
+                    }
+                }
+            `;
+    
+            const secret = "secret";
+            const session = driver.session({ defaultAccessMode: "WRITE" });
+            const neoSchema = new Neo4jGraphQL({ typeDefs, config: { jwt: { secret } } });
+    
+            await session.run(`
+                CREATE (:Post {id: "${postId}", publisher: "nop", published: true})
+            `);
+    
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+    
+            const gqlResult = await graphql({
+                contextValue: { driver, req },
+                schema: neoSchema.schema,
+                source: query,
+            });
+
+            // Check that no errors have been throwed
+            expect(gqlResult.errors).toBeUndefined();
+
+            // Check if returned data is what we really want
+            expect(gqlResult.data?.posts?.[0]?.id).toBe(postId);
+        });
+
+        test("should throw a Forbidden error", async () => {
+            const typeDefs = `
+                type Post {
+                    id: ID!
+                    publisher: String!
+                    published: Boolean!
+                }
+    
+                extend type Post @auth(rules: [
+                    { allow: { OR: [
+                        { publisher: "$jwt.sub" },
+                        { published: true },
+                    ] }, allowUnauthenticated: true }
+                ])
+            `;
+    
+            const postId = generate({ charset: "alphabetic" });
+    
+            const query = `
+                {
+                    posts(where: { id: ${postId} }) {
+                        id
+                    }
+                }
+            `;
+    
+            const secret = "secret";
+            const session = driver.session({ defaultAccessMode: "WRITE" });
+            const neoSchema = new Neo4jGraphQL({ typeDefs, config: { jwt: { secret } } });
+    
+            await session.run(`
+                CREATE (:Post {id: "${postId}", publisher: "nop", published: false})
+            `);
+    
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+    
+            const gqlResult = await graphql({
+                contextValue: { driver, req },
+                schema: neoSchema.schema,
+                source: query,
+            });
+    
+            // Check that a Forbidden error have been throwed
+            expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
+            expect((gqlResult.errors as any[])).toHaveLength(1);
+    
+            // Check if returned data is what we really want
+            expect(gqlResult.data?.posts).toBeUndefined();
+        });
+    });
+
+    describe("allowUnauthenticated with where", () => {
+        test("should return a Post without errors", async () => {
+            const typeDefs = `
+                type Post {
+                    id: ID!
+                    publisher: String!
+                    published: Boolean!
+                }
+    
+                extend type Post @auth(rules: [
+                    { where: { OR: [
+                        { publisher: "$jwt.sub" },
+                        { published: true },
+                    ] }, allowUnauthenticated: true }
+                ])
+            `;
+    
+            const postId = generate({ charset: "alphabetic" });
+    
+            const query = `
+                {
+                    posts(where: { id: ${postId} }) {
+                        id
+                    }
+                }
+            `;
+    
+            const secret = "secret";
+            const session = driver.session({ defaultAccessMode: "WRITE" });
+            const neoSchema = new Neo4jGraphQL({ typeDefs, config: { jwt: { secret } } });
+    
+            await session.run(`
+                CREATE (:Post {id: "${postId}", publisher: "nop", published: true})
+            `);
+    
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+    
+            const gqlResult = await graphql({
+                contextValue: { driver, req },
+                schema: neoSchema.schema,
+                source: query,
+            });
+
+            // Check that no errors have been throwed
+            expect(gqlResult.errors).toBeUndefined();
+
+            // Check if returned data is what we really want
+            expect(gqlResult.data?.posts?.[0]?.id).toBe(postId);
+        });
+
+        test("should return an empty array without errors", async () => {
+            const typeDefs = `
+                type Post {
+                    id: ID!
+                    publisher: String!
+                    published: Boolean!
+                }
+    
+                extend type Post @auth(rules: [
+                    { where: { OR: [
+                        { publisher: "$jwt.sub" },
+                        { published: true },
+                    ] }, allowUnauthenticated: true }
+                ])
+            `;
+    
+            const postId = generate({ charset: "alphabetic" });
+    
+            const query = `
+                {
+                    posts(where: { id: ${postId} }) {
+                        id
+                    }
+                }
+            `;
+    
+            const secret = "secret";
+            const session = driver.session({ defaultAccessMode: "WRITE" });
+            const neoSchema = new Neo4jGraphQL({ typeDefs, config: { jwt: { secret } } });
+    
+            await session.run(`
+                CREATE (:Post {id: "${postId}", publisher: "nop", published: false})
+            `);
+    
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+    
+            const gqlResult = await graphql({
+                contextValue: { driver, req },
+                schema: neoSchema.schema,
+                source: query,
+            });
+    
+            // Check that no errors have been throwed
+            expect(gqlResult.errors).toBeUndefined();
+    
+            // Check if returned data is what we really want
+            expect(gqlResult.data?.posts).toStrictEqual([]);
+        });
+    });
+
+    describe("allowUnauthenticated with bind", () => {
+        test("should throw only a Forbiden error", async () => {
+            const typeDefs = `
+                type User {
+                    id: ID
+                }
+    
+                extend type User @auth(rules: [{ 
+                    operations: [CREATE],
+                    bind: { id: "$jwt.sub" },
+                    allowUnauthenticated: true
+                }])
+            `;
+    
+            const query = `
+                mutation {
+                    createUsers(input: [{id: "not bound"}]) {
+                        users {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const secret = "secret";
+            const neoSchema = new Neo4jGraphQL({ typeDefs, config: { jwt: { secret } } });
+    
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+    
+            const gqlResult = await graphql({
+                contextValue: { driver, req },
+                schema: neoSchema.schema,
+                source: query,
+            });
+
+            // Check that a Forbidden error have been throwed
+            expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
+            expect((gqlResult.errors as any[])).toHaveLength(1);
+    
+            // Check if returned data is what we really want
+            expect(gqlResult.data?.posts).toBeUndefined();
+        });
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/allow.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/allow.md
@@ -86,7 +86,7 @@ extend type Comment
 
 ```cypher
 MATCH (this:User)
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this { .id } as this
 ```
 
@@ -125,9 +125,9 @@ RETURN this { .id } as this
 
 ```cypher
 MATCH (this:User)
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this { .password } as this
 ```
 
@@ -170,10 +170,10 @@ RETURN this { .password } as this
 
 ```cypher
 MATCH (this:User)
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { .content } ]
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { .content } ]
 } as this
 ```
 
@@ -215,12 +215,12 @@ RETURN this {
 
 ```cypher
 MATCH (this:Post)
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this {
     creator: head([
         (this)<-[:HAS_POST]-(this_creator:User)
-        WHERE apoc.util.validatePredicate(NOT(EXISTS(this_creator.id) AND this_creator.id = $this_creator_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0]) AND apoc.util.validatePredicate(NOT(EXISTS(this_creator.id) AND this_creator.id = $this_creator_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0]) | this_creator {
+        WHERE apoc.util.validatePredicate(NOT(this_creator.id IS NOT NULL AND this_creator.id = $this_creator_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0]) AND apoc.util.validatePredicate(NOT(this_creator.id IS NOT NULL AND this_creator.id = $this_creator_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0]) | this_creator {
             .password
         } ])
 } as this
@@ -269,10 +269,10 @@ RETURN this {
 ```cypher
 MATCH (this:User)
 WHERE this.id = $this_id
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE this_posts.id = $this_posts_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { comments: [ (this_posts)-[:HAS_COMMENT]->(this_posts_comments:Comment) WHERE this_posts_comments.id = $this_posts_comments_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts_comments)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_posts_comments)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_comments_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts_comments {
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE this_posts.id = $this_posts_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts { comments: [ (this_posts)-[:HAS_COMMENT]->(this_posts_comments:Comment) WHERE this_posts_comments.id = $this_posts_comments_id AND apoc.util.validatePredicate(NOT(EXISTS((this_posts_comments)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_posts_comments)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_comments_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) | this_posts_comments {
         .content
     } ] } ]
 } as this
@@ -323,7 +323,7 @@ MATCH (this:User)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 SET this.id = $this_update_id
 
@@ -372,7 +372,7 @@ MATCH (this:User)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id AND EXISTS(this.id) AND this.id = $this_update_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id AND this.id IS NOT NULL AND this.id = $this_update_password_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 SET this.password = $this_update_password
 
@@ -425,12 +425,12 @@ MATCH (this:Post)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 WITH this
 OPTIONAL MATCH (this)<-[:HAS_POST]-(this_creator0:User)
 CALL apoc.do.when(this_creator0 IS NOT NULL, "
     WITH this, this_creator0
-    CALL apoc.util.validate(NOT(EXISTS(this_creator0.id) AND this_creator0.id = $this_creator0_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
+    CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
     SET this_creator0.id = $this_update_creator0_id
     RETURN count(*) ",
     "",
@@ -498,11 +498,11 @@ MATCH (this:Post)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) WITH this OPTIONAL MATCH (this)<-[:HAS_POST]-(this_creator0:User)
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0]) WITH this OPTIONAL MATCH (this)<-[:HAS_POST]-(this_creator0:User)
 
 CALL apoc.do.when(this_creator0 IS NOT NULL, "
     WITH this, this_creator0
-    CALL apoc.util.validate(NOT(EXISTS(this_creator0.id) AND this_creator0.id = $this_creator0_auth_allow0_id AND EXISTS(this_creator0.id) AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
+    CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id AND this_creator0.id IS NOT NULL AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
     SET this_creator0.password = $this_update_creator0_password
     RETURN count(*)
     ",
@@ -563,7 +563,7 @@ mutation {
 ```cypher
 MATCH (this:User)
 WHERE this.id = $this_id WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 DETACH DELETE this
 ```
 
@@ -611,13 +611,13 @@ WITH this
 OPTIONAL MATCH (this)-[:HAS_POST]->(this_posts0:Post)
 WHERE this_posts0.id = $this_posts0_id
 WITH this, this_posts0
-CALL apoc.util.validate(NOT(EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_posts0 WHEN NULL THEN [] ELSE [1] END |
     DETACH DELETE this_posts0
 )
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 DETACH DELETE this
 ```
 
@@ -671,7 +671,7 @@ WHERE this_disconnect_posts0.id = $this_disconnect_posts0_id
 
 WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
 
-CALL apoc.util.validate(NOT(EXISTS(this_disconnect_posts0.id) AND this_disconnect_posts0.id = $this_disconnect_posts0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this_disconnect_posts0.id IS NOT NULL AND this_disconnect_posts0.id = $this_disconnect_posts0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_disconnect_posts0_rel
@@ -732,13 +732,13 @@ MATCH (this:Comment)
 WHERE this.id = $this_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 WITH this
 OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
 WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
 
-CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_post0_disconnect0Comment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Comment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_post0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_post0_disconnect0_rel
@@ -749,7 +749,7 @@ OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HA
 WHERE this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0_id
 WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
 
-CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0_creator0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id) AND EXISTS(this_post0_disconnect0_creator0.id) AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0_creator0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id) AND this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 FOREACH(_ IN CASE this_post0_disconnect0_creator0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_post0_disconnect0_creator0_rel
@@ -813,7 +813,7 @@ CALL {
     WHERE this_connect_posts0.id = $this_connect_posts0_id
 
     WITH this, this_connect_posts0
-    CALL apoc.util.validate(NOT(EXISTS(this_connect_posts0.id) AND this_connect_posts0.id = $this_connect_posts0User0_allow_auth_allow0_id AND EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_connect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(this_connect_posts0.id IS NOT NULL AND this_connect_posts0.id = $this_connect_posts0User0_allow_auth_allow0_id AND EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0Post1_allow_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
     FOREACH(_ IN CASE this_connect_posts0 WHEN NULL THEN [] ELSE [1] END |
         MERGE (this)-[:HAS_POST]->(this_connect_posts0)

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/bind.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/bind.md
@@ -61,7 +61,7 @@ CALL {
     SET this0.id = $this0_id
     SET this0.name = $this0_name
     WITH this0
-    CALL apoc.util.validate(NOT(EXISTS(this0.id) AND this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(this0.id IS NOT NULL AND this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
     RETURN this0
 }
 RETURN this0 { .id } AS this0
@@ -134,17 +134,17 @@ CALL {
     SET this0_posts0_creator0.id = $this0_posts0_creator0_id
 
     WITH this0, this0_posts0, this0_posts0_creator0
-    CALL apoc.util.validate(NOT(EXISTS(this0_posts0_creator0.id) AND this0_posts0_creator0.id = $this0_posts0_creator0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(this0_posts0_creator0.id IS NOT NULL AND this0_posts0_creator0.id = $this0_posts0_creator0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
     MERGE (this0_posts0)<-[:HAS_POST]-(this0_posts0_creator0)
 
     WITH this0, this0_posts0
-    CALL apoc.util.validate(NOT(EXISTS((this0_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this0_posts0_auth_bind0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(EXISTS((this0_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this0_posts0_auth_bind0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
 
     MERGE (this0)-[:HAS_POST]->(this0_posts0)
 
     WITH this0
-    CALL apoc.util.validate(NOT(EXISTS(this0.id) AND this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(this0.id IS NOT NULL AND this0.id = $this0_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
     RETURN this0
 }
@@ -199,7 +199,7 @@ WHERE this.id = $this_id
 SET this.id = $this_update_id
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```
@@ -264,7 +264,7 @@ CALL apoc.do.when(this_posts0 IS NOT NULL,
         SET this_posts0_creator0.id = $this_update_posts0_creator0_id
 
         WITH this, this_posts0, this_posts0_creator0
-        CALL apoc.util.validate(NOT(EXISTS(this_posts0_creator0.id) AND this_posts0_creator0.id = $this_posts0_creator0_auth_bind0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
+        CALL apoc.util.validate(NOT(this_posts0_creator0.id IS NOT NULL AND this_posts0_creator0.id = $this_posts0_creator0_auth_bind0_id), \"@neo4j/graphql/FORBIDDEN\", [0])
 
         RETURN count(*)
     \",
@@ -276,7 +276,7 @@ CALL apoc.do.when(this_posts0 IS NOT NULL,
 {this:this, this_posts0:this_posts0, auth:$auth,this_update_posts0_creator0_id:$this_update_posts0_creator0_id,this_posts0_creator0_auth_bind0_id:$this_posts0_creator0_auth_bind0_id}) YIELD value as _
 
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```
@@ -345,7 +345,7 @@ CALL {
     )
 
     WITH this, this_connect_creator0
-    CALL apoc.util.validate(NOT(EXISTS((this_connect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_connect_creator0Post0_bind_auth_bind0_creator_id) AND EXISTS(this_connect_creator0.id) AND this_connect_creator0.id = $this_connect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+    CALL apoc.util.validate(NOT(EXISTS((this_connect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_creator0Post0_bind_auth_bind0_creator_id) AND this_connect_creator0.id IS NOT NULL AND this_connect_creator0.id = $this_connect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
     RETURN count(*)
 }
@@ -406,7 +406,7 @@ FOREACH(_ IN CASE this_disconnect_creator0 WHEN NULL THEN [] ELSE [1] END |
 )
 
 WITH this, this_disconnect_creator0
-CALL apoc.util.validate(NOT(EXISTS((this_disconnect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_disconnect_creator0Post0_bind_auth_bind0_creator_id) AND EXISTS(this_disconnect_creator0.id) AND this_disconnect_creator0.id = $this_disconnect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(EXISTS((this_disconnect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_creator0Post0_bind_auth_bind0_creator_id) AND this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0User1_bind_auth_bind0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this { .id } AS this
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/where.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/where.md
@@ -83,7 +83,7 @@ extend type Post
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 RETURN this { .id } as this
 ```
 
@@ -122,7 +122,7 @@ RETURN this { .id } as this
 
 ```cypher
 MATCH (this:User)
-WHERE this.name = $this_name AND EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.name = $this_name AND this.id IS NOT NULL AND this.id = $this_auth_where0_id
 RETURN this { .id } as this
 ```
 
@@ -165,10 +165,10 @@ RETURN this { .id } as this
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .content } ]
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .content } ]
 } as this
 ```
 
@@ -211,11 +211,11 @@ RETURN this {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE this_posts.content = $this_posts_content AND EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .content } ]
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE this_posts.content = $this_posts_content AND EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .content } ]
 } as this
 ```
 
@@ -261,10 +261,10 @@ RETURN this {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 RETURN this {
     .id,
-    content: [(this)-[:HAS_POST]->(this_content) WHERE "Post" IN labels(this_content) | head( [ this_content IN [this_content] WHERE "Post" IN labels (this_content) AND EXISTS((this_content)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_content)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_content_Post_auth_where0_creator_id) | this_content { __resolveType: "Post", .id } ] ) ]
+    content: [(this)-[:HAS_POST]->(this_content) WHERE "Post" IN labels(this_content) | head( [ this_content IN [this_content] WHERE "Post" IN labels (this_content) AND EXISTS((this_content)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_content)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_content_Post_auth_where0_creator_id) | this_content { __resolveType: "Post", .id } ] ) ]
 } as this
 ```
 
@@ -306,7 +306,7 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 SET this.name = $this_update_name
 RETURN this { .id } AS this
 ```
@@ -349,7 +349,7 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE this.name = $this_name AND EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.name = $this_name AND this.id IS NOT NULL AND this.id = $this_auth_where0_id
 SET this.name = $this_update_name
 RETURN this { .id } AS this
 ```
@@ -396,16 +396,16 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this OPTIONAL MATCH (this)-[:HAS_POST]->(this_posts0:Post)
-WHERE EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_auth_where0_creator_id)
+WHERE EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_auth_where0_creator_id)
 
 CALL apoc.do.when(this_posts0 IS NOT NULL, " SET this_posts0.id = $this_update_posts0_id RETURN count(*) ", "", {this:this, this_posts0:this_posts0, auth:$auth,this_update_posts0_id:$this_update_posts0_id}) YIELD value as _
 
 RETURN this {
     .id,
-    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .id } ]
+    posts: [ (this)-[:HAS_POST]->(this_posts:Post) WHERE EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .id } ]
 } AS this
 ```
 
@@ -459,7 +459,7 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 DETACH DELETE this
 ```
 
@@ -498,7 +498,7 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE this.name = $this_name AND EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.name = $this_name AND this.id IS NOT NULL AND this.id = $this_auth_where0_id
 DETACH DELETE this
 ```
 
@@ -538,11 +538,11 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
 OPTIONAL MATCH (this)-[:HAS_POST]->(this_posts0:Post)
-WHERE EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_auth_where0_creator_id)
+WHERE EXISTS((this_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_auth_where0_creator_id)
 
 FOREACH(_ IN CASE this_posts0 WHEN NULL THEN [] ELSE [1] END | DETACH DELETE this_posts0 )
 
@@ -605,7 +605,7 @@ CALL {
     CALL {
         WITH this0
         OPTIONAL MATCH (this0_posts_connect0:Post)
-        WHERE EXISTS((this0_posts_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this0_posts_connect0_auth_where0_creator_id)
+        WHERE EXISTS((this0_posts_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this0_posts_connect0_auth_where0_creator_id)
 
         FOREACH(_ IN CASE this0_posts_connect0 WHEN NULL THEN [] ELSE [1] END | MERGE (this0)-[:HAS_POST]->(this0_posts_connect0) )
 
@@ -675,7 +675,7 @@ CALL {
     CALL {
         WITH this0
         OPTIONAL MATCH (this0_posts_connect0:Post)
-        WHERE this0_posts_connect0.id = $this0_posts_connect0_id AND EXISTS((this0_posts_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this0_posts_connect0_auth_where0_creator_id)
+        WHERE this0_posts_connect0.id = $this0_posts_connect0_id AND EXISTS((this0_posts_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this0_posts_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this0_posts_connect0_auth_where0_creator_id)
 
         FOREACH(_ IN CASE this0_posts_connect0 WHEN NULL THEN [] ELSE [1] END | MERGE (this0)-[:HAS_POST]->(this0_posts_connect0) )
 
@@ -729,16 +729,16 @@ mutation {
 ```cypher
 MATCH (this:User)
 
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
 CALL {
     WITH this
     OPTIONAL MATCH (this_posts0_connect0:Post)
-    WHERE EXISTS((this_posts0_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_connect0_auth_where0_creator_id)
+    WHERE EXISTS((this_posts0_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_connect0_auth_where0_creator_id)
 
     FOREACH(_ IN CASE this_posts0_connect0 WHEN NULL THEN [] ELSE [1] END | MERGE (this)-[:HAS_POST]->(this_posts0_connect0) )
 
@@ -786,16 +786,16 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
 CALL {
     WITH this
     OPTIONAL MATCH (this_posts0_connect0:Post)
-    WHERE this_posts0_connect0.id = $this_posts0_connect0_id AND EXISTS((this_posts0_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_connect0_auth_where0_creator_id)
+    WHERE this_posts0_connect0.id = $this_posts0_connect0_id AND EXISTS((this_posts0_connect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_connect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_connect0_auth_where0_creator_id)
 
     FOREACH(_ IN CASE this_posts0_connect0 WHEN NULL THEN [] ELSE [1] END | MERGE (this)-[:HAS_POST]->(this_posts0_connect0) )
 
@@ -844,16 +844,16 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
 CALL {
     WITH this
     OPTIONAL MATCH (this_connect_posts0:Post)
-    WHERE EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_connect_posts0_auth_where0_creator_id)
+    WHERE EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_auth_where0_creator_id)
 
     FOREACH(_ IN CASE this_connect_posts0 WHEN NULL THEN [] ELSE [1] END | MERGE (this)-[:HAS_POST]->(this_connect_posts0) )
 
@@ -901,16 +901,16 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
 CALL {
     WITH this
     OPTIONAL MATCH (this_connect_posts0:Post)
-    WHERE this_connect_posts0.id = $this_connect_posts0_id AND EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_connect_posts0_auth_where0_creator_id)
+    WHERE this_connect_posts0.id = $this_connect_posts0_id AND EXISTS((this_connect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_auth_where0_creator_id)
 
     FOREACH(_ IN CASE this_connect_posts0 WHEN NULL THEN [] ELSE [1] END | MERGE (this)-[:HAS_POST]->(this_connect_posts0) )
 
@@ -959,14 +959,14 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
 OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-WHERE EXISTS((this_posts0_disconnect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_disconnect0_auth_where0_creator_id)
+WHERE EXISTS((this_posts0_disconnect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_disconnect0_auth_where0_creator_id)
 
 FOREACH(_ IN CASE this_posts0_disconnect0 WHEN NULL THEN [] ELSE [1] END | DELETE this_posts0_disconnect0_rel )
 
@@ -1013,13 +1013,13 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post) WHERE this_posts0_disconnect0.id = $this_posts0_disconnect0_id AND EXISTS((this_posts0_disconnect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_posts0_disconnect0_auth_where0_creator_id)
+OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post) WHERE this_posts0_disconnect0.id = $this_posts0_disconnect0_id AND EXISTS((this_posts0_disconnect0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts0_disconnect0_auth_where0_creator_id)
 
 FOREACH(_ IN CASE this_posts0_disconnect0 WHEN NULL THEN [] ELSE [1] END | DELETE this_posts0_disconnect0_rel )
 
@@ -1065,10 +1065,10 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id WITH this OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post) WHERE EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_disconnect_posts0_auth_where0_creator_id)
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id WITH this OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post) WHERE EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0_auth_where0_creator_id)
 
 FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_disconnect_posts0_rel
@@ -1115,9 +1115,9 @@ mutation {
 
 ```cypher
 MATCH (this:User)
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 WITH this
-WHERE EXISTS(this.id) AND this.id = $this_auth_where0_id WITH this OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post) WHERE this_disconnect_posts0.id = $this_disconnect_posts0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE EXISTS(creator.id) AND creator.id = $this_disconnect_posts0_auth_where0_creator_id)
+WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id WITH this OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post) WHERE this_disconnect_posts0.id = $this_disconnect_posts0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0_auth_where0_creator_id)
 
 FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
     DELETE this_disconnect_posts0_rel

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/projection.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/projection.md
@@ -36,10 +36,10 @@ mutation {
 ```cypher
 MATCH (this:User)
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_update_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_update_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 SET this.id = $this_update_id
 WITH this
-CALL apoc.util.validate(NOT(EXISTS(this.id) AND this.id = $this_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 RETURN this { .id } AS this
 ```
 
@@ -93,8 +93,8 @@ CALL {
     RETURN this1
 }
 
-CALL apoc.util.validate(NOT(EXISTS(this0.id) AND this0.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
-CALL apoc.util.validate(NOT(EXISTS(this1.id) AND this1.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this0.id IS NOT NULL AND this0.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
+CALL apoc.util.validate(NOT(this1.id IS NOT NULL AND this1.id = $projection_id_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 
 RETURN this0 { .id } AS this0, this1 { .id } AS this1
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher/union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/union.md
@@ -62,7 +62,7 @@ RETURN this {
             [ this_search IN [this_search]
                 WHERE "Genre" IN labels (this_search) AND
                 this_search.name = $this_search_Genre_name AND
-                apoc.util.validatePredicate(NOT(EXISTS(this_search.name) AND this_search.name = $this_search_Genre_auth_allow0_name), "@neo4j/graphql/FORBIDDEN", [0])  |
+                apoc.util.validatePredicate(NOT(this_search.name IS NOT NULL AND this_search.name = $this_search_Genre_auth_allow0_name), "@neo4j/graphql/FORBIDDEN", [0])  |
                 this_search {
                     __resolveType: "Genre",
                      .name


### PR DESCRIPTION
# Description

Add allowUnauthenticated parameter in auth rules to avoid throwing exceptions if no auth is provided.

**Changes:**
- Update documentation `auth/authentication`.
- If `paramValue` is `undefined` inject `false` instead of the previous condition `key = $param`, as it should always be falsy
- Fix a small issue: if a `paramValue` is `null`, `apoc.validate` raise an exception if the check is done like this `value = null`. So I just replaced the condition for it to be `value IS null` ([more infos](https://community.neo4j.com/t/neo-clienterror-procedure-procedurecallfailed-with-apoc-do-when/14017/12))
- Fix the 4.3.0 Neo4J deprecation of `EXISTS()` with recommanded `IS NOT NULL`. ([more infos](https://neo4j.com/docs/cypher-manual/current/deprecations-additions-removals-compatibility/#:~:text=ASSERT%20exists(node.property)))

# Issue

https://github.com/neo4j/graphql/issues/345

# Checklist

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
