### PR TITLE
Manually add schemaDirectives after resolvers

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -36,7 +36,6 @@
     },
     "author": "Neo4j Inc.",
     "devDependencies": {
-        "@graphql-tools/utils": "^7.7.3",
         "@types/deep-equal": "1.0.1",
         "@types/faker": "5.1.7",
         "@types/is-uuid": "1.0.0",
@@ -63,6 +62,7 @@
     "dependencies": {
         "@graphql-tools/merge": "^6.2.13",
         "@graphql-tools/schema": "^7.1.3",
+        "@graphql-tools/utils": "^7.10.0",
         "camelcase": "^6.2.0",
         "debug": "^4.3.1",
         "deep-equal": "^2.0.5",

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -77,8 +77,15 @@ class Neo4jGraphQL {
         this.nodes = nodes;
         this.relationships = relationships;
         this.schema = schema;
+
         /*
-            addResolversToSchema must be first, so that custom resolvers also get schema level resolvers
+            Order must be:
+
+                addResolversToSchema -> visitSchemaDirectives -> createWrappedSchema
+
+            addResolversToSchema breaks schema directives added before it
+
+            createWrappedSchema must come last so that all requests have context prepared correctly
         */
         if (resolvers) {
             if (Array.isArray(resolvers)) {
@@ -91,11 +98,7 @@ class Neo4jGraphQL {
         }
 
         if (schemaDirectives) {
-            SchemaDirectiveVisitor.visitSchemaDirectives(
-                this.schema,
-                schemaDirectives
-                // (schemaDirectives as unknown) as Record<string, typeof SchemaDirectiveVisitor>
-            );
+            SchemaDirectiveVisitor.visitSchemaDirectives(this.schema, schemaDirectives);
         }
 
         this.schema = this.createWrappedSchema({ schema: this.schema, config });

--- a/packages/graphql/tests/integration/issues/349.int.test.ts
+++ b/packages/graphql/tests/integration/issues/349.int.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import neo4j from "neo4j-driver";
 import { SchemaDirectiveVisitor } from "@graphql-tools/utils";
 import { graphql } from "graphql";

--- a/packages/graphql/tests/integration/issues/349.int.test.ts
+++ b/packages/graphql/tests/integration/issues/349.int.test.ts
@@ -1,0 +1,196 @@
+import neo4j from "neo4j-driver";
+import { SchemaDirectiveVisitor } from "@graphql-tools/utils";
+import { graphql } from "graphql";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/349", () => {
+    type Field = Parameters<SchemaDirectiveVisitor["visitFieldDefinition"]>[0];
+
+    class DisallowDirective extends SchemaDirectiveVisitor {
+        // eslint-disable-next-line class-methods-use-this
+        public visitFieldDefinition(field: Field) {
+            field.resolve = function () {
+                // Disallow any and all access, all the time
+                throw new Error("go away");
+            };
+        }
+    }
+
+    const schemaDirectives = {
+        disallow: DisallowDirective,
+    };
+
+    describe("https://github.com/neo4j/graphql/issues/349#issuecomment-885295157", () => {
+        const neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs: /* GraphQL */ `
+                directive @disallow on FIELD_DEFINITION
+
+                type Mutation {
+                    doStuff: String! @disallow
+                }
+
+                type Query {
+                    noop: Boolean
+                }
+            `,
+
+            driver: neo4j.driver("bolt://localhost:7687"),
+            resolvers: { Mutation: { doStuff: () => "OK" } },
+            schemaDirectives,
+        });
+
+        test("DisallowDirective", async () => {
+            const gqlResult = await graphql({
+                schema: neo4jGraphQL.schema,
+                source: /* GraphQL */ `
+                    mutation {
+                        doStuff
+                    }
+                `,
+                contextValue: { driver: neo4j.driver("bolt://localhost:7687") },
+            });
+
+            expect(gqlResult.data).toBeNull();
+            expect(gqlResult.errors).toBeTruthy();
+        });
+    });
+
+    describe("https://github.com/neo4j/graphql/issues/349#issuecomment-885311918", () => {
+        const neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs: /* GraphQL */ `
+                directive @disallow on FIELD_DEFINITION
+
+                type NestedResult {
+                    stuff: String! @disallow
+                }
+
+                type Mutation {
+                    doStuff: String! @disallow
+                    doNestedStuff: NestedResult!
+                }
+
+                type Query {
+                    getStuff: String! @disallow
+                    getNestedStuff: NestedResult!
+                }
+            `,
+
+            driver: neo4j.driver("bolt://localhost:7687"),
+            resolvers: {
+                NestedResult: {
+                    stuff: (parent: string) => parent,
+                },
+
+                Mutation: {
+                    doStuff: () => "OK",
+                    doNestedStuff: () => "OK",
+                },
+
+                Query: {
+                    getStuff: () => "OK",
+                    getNestedStuff: () => "OK",
+                },
+            },
+            schemaDirectives,
+        });
+
+        test("mutation top - DisallowDirective", async () => {
+            const gqlResult = await graphql({
+                schema: neo4jGraphQL.schema,
+                source: /* GraphQL */ `
+                    mutation {
+                        doStuff
+                    }
+                `,
+                contextValue: { driver: neo4j.driver("bolt://localhost:7687") },
+            });
+
+            expect(gqlResult.data).toBeNull();
+            expect(gqlResult.errors && gqlResult.errors[0].message).toBe("go away");
+        });
+
+        test("query top - DisallowDirective", async () => {
+            const gqlResult = await graphql({
+                schema: neo4jGraphQL.schema,
+                source: /* GraphQL */ `
+                    query {
+                        getStuff
+                    }
+                `,
+                contextValue: { driver: neo4j.driver("bolt://localhost:7687") },
+            });
+
+            expect(gqlResult.data).toBeNull();
+            expect(gqlResult.errors && gqlResult.errors[0].message).toBe("go away");
+        });
+
+        test("mutation nested - DisallowDirective", async () => {
+            const gqlResult = await graphql({
+                schema: neo4jGraphQL.schema,
+                source: /* GraphQL */ `
+                    mutation {
+                        doNestedStuff {
+                            stuff
+                        }
+                    }
+                `,
+                contextValue: { driver: neo4j.driver("bolt://localhost:7687") },
+            });
+
+            expect(gqlResult.data).toBeNull();
+            expect(gqlResult.errors && gqlResult.errors[0].message).toBe("go away");
+        });
+
+        test("query nested - DisallowDirective", async () => {
+            const gqlResult = await graphql({
+                schema: neo4jGraphQL.schema,
+                source: /* GraphQL */ `
+                    query {
+                        getNestedStuff {
+                            stuff
+                        }
+                    }
+                `,
+                contextValue: { driver: neo4j.driver("bolt://localhost:7687") },
+            });
+
+            expect(gqlResult.data).toBeNull();
+            expect(gqlResult.errors && gqlResult.errors[0].message).toBe("go away");
+        });
+    });
+
+    describe("schemaDirectives can be an empty object", () => {
+        const neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs: /* GraphQL */ `
+                directive @disallow on FIELD_DEFINITION
+
+                type Mutation {
+                    doStuff: String! @disallow
+                }
+
+                type Query {
+                    noop: Boolean
+                }
+            `,
+
+            driver: neo4j.driver("bolt://localhost:7687"),
+            resolvers: { Mutation: { doStuff: () => "OK" } },
+            schemaDirectives: {},
+        });
+
+        test("DisallowDirective", async () => {
+            const gqlResult = await graphql({
+                schema: neo4jGraphQL.schema,
+                source: /* GraphQL */ `
+                    mutation {
+                        doStuff
+                    }
+                `,
+                contextValue: { driver: neo4j.driver("bolt://localhost:7687") },
+            });
+
+            expect(gqlResult.data?.doStuff).toEqual("OK");
+            expect(gqlResult.errors).toBeFalsy();
+        });
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,7 +624,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/utils@npm:^7.1.2, @graphql-tools/utils@npm:^7.7.0, @graphql-tools/utils@npm:^7.7.3":
+"@graphql-tools/utils@npm:^7.1.2, @graphql-tools/utils@npm:^7.7.0":
   version: 7.8.0
   resolution: "@graphql-tools/utils@npm:7.8.0"
   dependencies:
@@ -634,6 +634,19 @@ __metadata:
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0
   checksum: 8b9b38c26318a034199d705f43968bb82da7263652ada46908fb63288872d96e5dfcb4036105fbdaeb8521805635b3e306487c6ab3b418c44d93b38281d43ac6
+  languageName: node
+  linkType: hard
+
+"@graphql-tools/utils@npm:^7.10.0":
+  version: 7.10.0
+  resolution: "@graphql-tools/utils@npm:7.10.0"
+  dependencies:
+    "@ardatan/aggregate-error": 0.0.6
+    camel-case: 4.1.2
+    tslib: ~2.2.0
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0
+  checksum: 8b8e674f344e825c27816ead8a66edca5aed2eac26b601bb028350837ae39fee3ca9241255b918b8199d60bff41884a4814f98df465a0a8a5db5b91428ce2aa9
   languageName: node
   linkType: hard
 
@@ -929,7 +942,7 @@ __metadata:
   dependencies:
     "@graphql-tools/merge": ^6.2.13
     "@graphql-tools/schema": ^7.1.3
-    "@graphql-tools/utils": ^7.7.3
+    "@graphql-tools/utils": ^7.10.0
     "@types/deep-equal": 1.0.1
     "@types/faker": 5.1.7
     "@types/is-uuid": 1.0.0


### PR DESCRIPTION
# Description

It appears that despite promising to be fixed in version 6.0.10 (https://github.com/ardatan/graphql-tools/releases/tag/v6.0.10), `addResolversToSchema` in `@graphql-tools/schema` breaks schema directives. So this is a workaround for that bug, adding schema directives after resolvers have been added.

Also changed constructor types around for this field so hopefully `SchemaDirectiveVisitor` can be used directly from `@graphql-tools/utils` without recasting.

# Issue

#349

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
