### PR TITLE
feat: Resolve union type in custom cypher resolver

### DIFF
--- a/packages/graphql/tests/integration/cypher.int.test.ts
+++ b/packages/graphql/tests/integration/cypher.int.test.ts
@@ -257,6 +257,94 @@ describe("cypher", () => {
                     await session.close();
                 }
             });
+            test("should query custom query and return union type", async () => {
+                const session = driver.session();
+
+                const movieTitle = generate({
+                    charset: "alphabetic",
+                });
+                const actorName = generate({
+                    charset: "alphabetic",
+                });
+                const directorName = generate({
+                    charset: "alphabetic",
+                });
+
+                const typeDefs = `
+                    type Movie {
+                        title: String!
+                        actors: [Actor] @relationship(type: "ACTED_IN", direction: IN)
+                        directors: [Actor] @relationship(type: "DIRECTED", direction: IN)
+                    }
+                    type Director {
+                        name: String!
+                        movies: [Movie] @relationship(type: "DIRECTED", direction: OUT)
+                    }
+                    type Actor {
+                        name: String!
+                        movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT)
+                    }
+                    union Person = Director | Actor
+                    type Query {
+
+                        personInMovie(title: String!): [Person] @cypher(statement: """
+                            MATCH (m:Movie {title: $title})<-[:ACTED_IN|DIRECTED]-(p)
+                            RETURN p
+                        """)
+                    }
+                `;
+
+                const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+                const source = `
+                    query($title: String!) {
+                        personInMovie(title: $title) {
+                            ... on Actor {
+                                name
+                            }
+                            ... on Director{
+                                name
+                            }
+                        }
+                    }
+                `;
+
+                try {
+                    await session.run(
+                        `
+                            CREATE (:Movie {title: $title})<-[:ACTED_IN]-(:Actor {name: $name})
+                        `,
+                        {
+                            title: movieTitle,
+                            name: actorName,
+                        }
+                    );
+                    await session.run(
+                        `
+                            CREATE (:Movie {title: $title})<-[:DIRECTED]-(:Director {name: $name})
+                        `,
+                        {
+                            title: movieTitle,
+                            name: directorName,
+                        }
+                    );
+
+                    const gqlResult = await graphql({
+                        schema: neoSchema.schema,
+                        source,
+                        contextValue: { driver },
+                        variableValues: { title: movieTitle },
+                    });
+
+                    expect(gqlResult.errors).toBeFalsy();
+                    expect((gqlResult?.data as any).personInMovie).toEqual([
+                        { name: actorName },
+                        { name: directorName },
+                    ]);
+                } finally {
+                    await session.close();
+                }
+            });
 
             test("should query multiple nodes and return relationship data", async () => {
                 const session = driver.session();


### PR DESCRIPTION
allows solving cypher with union type results, in the current behavior graphql crashes.

An example of this is the following:

                 type Movie {
                        title: String!
                        actors: [Actor] @relationship(type: "ACTED_IN", direction: IN)
                        directors: [Actor] @relationship(type: "DIRECTED", direction: IN)
                    }
                    type Director {
                        name: String!
                        movies: [Movie] @relationship(type: "DIRECTED", direction: OUT)
                    }
                    type Actor {
                        name: String!
                        movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT)
                    }
                    union Person = Director | Actor
                    type Query {

                        personInMovie(title: String!): [Person] @cypher(statement: """
                            MATCH (m:Movie {title: $title})<-[:ACTED_IN|DIRECTED]-(p)
                            RETURN p
                        """)
                    }