### PR TITLE
Fix for field with multiple aliases

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -36,7 +36,6 @@
     },
     "author": "Neo4j Inc.",
     "devDependencies": {
-        "@graphql-tools/utils": "^7.7.3",
         "@types/deep-equal": "1.0.1",
         "@types/faker": "5.1.7",
         "@types/is-uuid": "1.0.0",
@@ -62,6 +61,7 @@
     "dependencies": {
         "@graphql-tools/merge": "^6.2.13",
         "@graphql-tools/schema": "^7.1.3",
+        "@graphql-tools/utils": "^7.7.3",
         "camelcase": "^6.2.0",
         "debug": "^4.3.1",
         "deep-equal": "^2.0.5",

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -19,6 +19,7 @@
 
 import { mergeTypeDefs } from "@graphql-tools/merge";
 import { IExecutableSchemaDefinition, makeExecutableSchema } from "@graphql-tools/schema";
+import { forEachField } from "@graphql-tools/utils";
 import camelCase from "camelcase";
 import {
     DefinitionNode,
@@ -44,7 +45,14 @@ import pluralize from "pluralize";
 import { Node, Exclude } from "../classes";
 import getAuth from "./get-auth";
 import { PrimitiveField, Auth } from "../types";
-import { findResolver, createResolver, deleteResolver, cypherResolver, updateResolver } from "./resolvers";
+import {
+    findResolver,
+    createResolver,
+    deleteResolver,
+    cypherResolver,
+    updateResolver,
+    defaultFieldResolver,
+} from "./resolvers";
 import checkNodeImplementsInterfaces from "./check-node-implements-interfaces";
 import * as Scalars from "./scalars";
 import parseExcludeDirective from "./parse-exclude-directive";
@@ -758,6 +766,14 @@ function makeAugmentedSchema(
         ...schemaDefinition,
         typeDefs: generatedTypeDefs,
         resolvers: generatedResolvers,
+    });
+
+    // Assign a default field resolver to account for aliasing of fields
+    forEachField(schema, (field) => {
+        if (!field.resolve) {
+            // eslint-disable-next-line no-param-reassign
+            field.resolve = defaultFieldResolver;
+        }
     });
 
     return {

--- a/packages/graphql/src/schema/resolvers/create.ts
+++ b/packages/graphql/src/schema/resolvers/create.ts
@@ -19,13 +19,14 @@
 
 import camelCase from "camelcase";
 import pluralize from "pluralize";
+import { FieldNode, GraphQLResolveInfo } from "graphql";
 import { execute } from "../../utils";
 import { translateCreate } from "../../translate";
 import { Node } from "../../classes";
 import { Context } from "../../types";
 
 export default function createResolver({ node }: { node: Node }) {
-    async function resolve(_root: any, _args: any, _context: unknown) {
+    async function resolve(_root: any, _args: any, _context: unknown, _info: GraphQLResolveInfo) {
         const context = _context as Context;
         const [cypher, params] = translateCreate({ context, node });
 
@@ -36,8 +37,14 @@ export default function createResolver({ node }: { node: Node }) {
             context,
         });
 
+        const responseField = _info.fieldNodes[0].selectionSet?.selections.find(
+            (selection) => selection.kind === "Field" && selection.name.value === pluralize(camelCase(node.name))
+        ) as FieldNode; // Field exist by construction and must be selected as it is the only field.
+
+        const responseKey = responseField.alias ? responseField.alias.value : responseField.name.value;
+
         return {
-            [pluralize(camelCase(node.name))]: Object.values(result[0] || {}),
+            [responseKey]: Object.values(result[0] || {}),
         };
     }
 

--- a/packages/graphql/src/schema/resolvers/create.ts
+++ b/packages/graphql/src/schema/resolvers/create.ts
@@ -26,7 +26,7 @@ import { Node } from "../../classes";
 import { Context } from "../../types";
 
 export default function createResolver({ node }: { node: Node }) {
-    async function resolve(_root: any, _args: any, _context: unknown, _info: GraphQLResolveInfo) {
+    async function resolve(_root: any, _args: any, _context: unknown, info: GraphQLResolveInfo) {
         const context = _context as Context;
         const [cypher, params] = translateCreate({ context, node });
 
@@ -37,7 +37,7 @@ export default function createResolver({ node }: { node: Node }) {
             context,
         });
 
-        const responseField = _info.fieldNodes[0].selectionSet?.selections.find(
+        const responseField = info.fieldNodes[0].selectionSet?.selections.find(
             (selection) => selection.kind === "Field" && selection.name.value === pluralize(camelCase(node.name))
         ) as FieldNode; // Field exist by construction and must be selected as it is the only field.
 

--- a/packages/graphql/src/schema/resolvers/defaultField.ts
+++ b/packages/graphql/src/schema/resolvers/defaultField.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLResolveInfo } from "graphql";
+
+/**
+ * Based on the default field resolver used by graphql-js that accounts for aliased fields
+ * @link https://github.com/graphql/graphql-js/blob/main/src/execution/execute.ts#L999-L1015
+ */
+// eslint-disable-next-line consistent-return
+export default function defaultFieldResolver(source: any, args: any, context: unknown, info: GraphQLResolveInfo) {
+    const responseKey = info.fieldNodes[0].alias ? info.fieldNodes[0].alias.value : info.fieldNodes[0].name.value;
+    if ((typeof source === "object" && source !== null) || typeof source === "function") {
+        const property = source[responseKey];
+        if (typeof property === "function") {
+            return source[responseKey](args, context, info);
+        }
+        return property;
+    }
+}

--- a/packages/graphql/src/schema/resolvers/index.ts
+++ b/packages/graphql/src/schema/resolvers/index.ts
@@ -22,3 +22,4 @@ export { default as findResolver } from "./read";
 export { default as updateResolver } from "./update";
 export { default as deleteResolver } from "./delete";
 export { default as cypherResolver } from "./cypher";
+export { default as defaultFieldResolver } from "./defaultField";

--- a/packages/graphql/src/schema/resolvers/update.ts
+++ b/packages/graphql/src/schema/resolvers/update.ts
@@ -26,7 +26,7 @@ import { Node } from "../../classes";
 import { Context } from "../../types";
 
 export default function updateResolver({ node }: { node: Node }) {
-    async function resolve(_root: any, _args: any, _context: unknown, _info: GraphQLResolveInfo) {
+    async function resolve(_root: any, _args: any, _context: unknown, info: GraphQLResolveInfo) {
         const context = _context as Context;
         const [cypher, params] = translateUpdate({ context, node });
         const result = await execute({
@@ -36,7 +36,7 @@ export default function updateResolver({ node }: { node: Node }) {
             context,
         });
 
-        const responseField = _info.fieldNodes[0].selectionSet?.selections.find(
+        const responseField = info.fieldNodes[0].selectionSet?.selections.find(
             (selection) => selection.kind === "Field" && selection.name.value === pluralize(camelCase(node.name))
         ) as FieldNode; // Field exist by construction and must be selected as it is the only field.
 

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -396,23 +396,23 @@ function createProjectionAndParams({
             // Sadly need to select the whole point object due to the risk of height/z
             // being selected on a 2D point, to which the database will throw an error
             if (point) {
-                fields.push(isArray ? "point:p" : `point: ${varName}.${key}`);
+                fields.push(isArray ? "point:p" : `point: ${varName}.${field.name}`);
             }
 
             if (crs) {
-                fields.push(isArray ? "crs: p.crs" : `crs: ${varName}.${key}.crs`);
+                fields.push(isArray ? "crs: p.crs" : `crs: ${varName}.${field.name}.crs`);
             }
 
             res.projection.push(
                 isArray
-                    ? `${key}: [p in ${varName}.${key} | { ${fields.join(", ")} }]`
+                    ? `${key}: [p in ${varName}.${field.name} | { ${fields.join(", ")} }]`
                     : `${key}: { ${fields.join(", ")} }`
             );
         } else if (dateTimeField) {
             res.projection.push(
                 dateTimeField.typeMeta.array
-                    ? `${key}: [ dt in ${varName}.${key} | apoc.date.convertFormat(toString(dt), "iso_zoned_date_time", "iso_offset_date_time") ]`
-                    : `${key}: apoc.date.convertFormat(toString(${varName}.${key}), "iso_zoned_date_time", "iso_offset_date_time")`
+                    ? `${key}: [ dt in ${varName}.${field.name} | apoc.date.convertFormat(toString(dt), "iso_zoned_date_time", "iso_offset_date_time") ]`
+                    : `${key}: apoc.date.convertFormat(toString(${varName}.${field.name}), "iso_zoned_date_time", "iso_offset_date_time")`
             );
         } else {
             // If field is aliased, rename projected field to alias and set to varName.fieldName

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -28,9 +28,12 @@ import { AUTH_FORBIDDEN_ERROR } from "../constants";
 function translateCreate({ context, node }: { context: Context; node: Node }): [string, any] {
     const { resolveTree } = context;
 
-    const { fieldsByTypeName } = resolveTree.fieldsByTypeName[`Create${pluralize(node.name)}MutationResponse`][
-        pluralize(camelCase(node.name))
-    ];
+    // Due to potential aliasing of returned object in response we look through fields of CreateMutationResponse
+    // and find field where field.name ~ node.name which exists by construction
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { fieldsByTypeName } = Object.values(
+        resolveTree.fieldsByTypeName[`Create${pluralize(node.name)}MutationResponse`]
+    ).find((field) => field.name === pluralize(camelCase(node.name)))!;
 
     const { createStrs, params } = (resolveTree.args.input as any[]).reduce(
         (res, input, index) => {

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -51,9 +51,13 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
     let projStr = "";
     let cypherParams: { [k: string]: any } = {};
     const whereStrs: string[] = [];
-    const { fieldsByTypeName } = resolveTree.fieldsByTypeName[`Update${pluralize(node.name)}MutationResponse`][
-        pluralize(camelCase(node.name))
-    ];
+
+    // Due to potential aliasing of returned object in response we look through fields of UpdateMutationResponse
+    // and find field where field.name ~ node.name which exists by construction
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { fieldsByTypeName } = Object.values(
+        resolveTree.fieldsByTypeName[`Update${pluralize(node.name)}MutationResponse`]
+    ).find((field) => field.name === pluralize(camelCase(node.name)))!;
 
     if (whereInput) {
         const where = createWhereAndParams({

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -80,17 +80,13 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
             charset: "alphabetic",
         });
 
-        const comment1Content = generate({
-            charset: "alphabetic",
-        });
+        const comment1Content = "comment 1 content";
 
         const comment2Id = generate({
             charset: "alphabetic",
         });
 
-        const comment2Content = generate({
-            charset: "alphabetic",
-        });
+        const comment2Content = "comment 2 content";
 
         const query = `
             query {

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/350", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+        const session = driver.session();
+        try {
+            await session.run(`
+                MATCH (n)
+                DETACH DELETE n
+            `);
+        } finally {
+            await session.close();
+        }
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("Retain attributes when aliasing the same field multiple times in a single query", async () => {
+        const session = driver.session();
+        const typeDefs = gql`
+            type Post {
+                id: ID!
+                title: String!
+                content: String!
+                comments: [Comment!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+            }
+            type Comment {
+                id: ID!
+                flagged: Boolean!
+                content: String!
+                post: Post! @relationship(type: "HAS_COMMENT", direction: IN)
+                canEdit: Boolean! @cypher(statement: "RETURN false")
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const postId = generate({
+            charset: "alphabetic",
+        });
+
+        const postTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const postContent = generate({
+            charset: "alphabetic",
+        });
+
+        const comment1Id = generate({
+            charset: "alphabetic",
+        });
+
+        const comment1Content = generate({
+            charset: "alphabetic",
+        });
+
+        const comment2Id = generate({
+            charset: "alphabetic",
+        });
+
+        const comment2Content = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            query {
+                posts {
+                    flaggedComments: comments(where: { flagged: true }) {
+                        content
+                        flagged
+                    }
+                    unflaggedComments: comments(where: {flagged: false}) {
+                        content
+                        flagged
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run(
+                `  
+                    CREATE (post:Post {id: $postId, title: $postTitle, content: $postContent})
+                    CREATE (comment1:Comment {id: $comment1Id, content: $comment1Content, flagged: true})
+                    CREATE (comment2:Comment {id: $comment2Id, content: $comment2Content, flagged: false})
+                    MERGE (post)-[:HAS_COMMENT]->(comment1)
+                    MERGE (post)-[:HAS_COMMENT]->(comment2)
+
+                `,
+                {
+                    postId,
+                    postTitle,
+                    postContent,
+                    comment1Id,
+                    comment1Content,
+                    comment2Id,
+                    comment2Content,
+                }
+            );
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: query,
+                contextValue: { driver },
+            });
+            expect(result.errors).toBeFalsy();
+            expect(result?.data?.posts[0].flaggedComments).toContainEqual({
+                content: comment1Content,
+                flagged: true,
+            });
+            expect(result?.data?.posts[0].unflaggedComments).toContainEqual({
+                content: comment2Content,
+                flagged: false,
+            });
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -29,15 +29,6 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
 
     beforeAll(async () => {
         driver = await neo4j();
-        const session = driver.session();
-        try {
-            await session.run(`
-                MATCH (n)
-                DETACH DELETE n
-            `);
-        } finally {
-            await session.close();
-        }
     });
 
     afterAll(async () => {

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -81,7 +81,7 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
 
         const query = `
             query {
-                posts {
+                posts(where: { id: "${postId}" }) {
                     flaggedComments: comments(where: { flagged: true }) {
                         content
                         flagged

--- a/packages/graphql/tests/tck/tck-test-files/cypher/alias.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/alias.md
@@ -6,13 +6,13 @@ Schema:
 
 ```schema
 type Actor {
-    name: String
+    name: String!
 }
 
 type Movie {
     id: ID
-    actors: [Actor] @relationship(type: "ACTED_IN", direction: IN)
-    custom: [Movie] @cypher(statement: """
+    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+    custom: [Movie!]! @cypher(statement: """
         MATCH (m:Movie)
         RETURN m
     """)
@@ -44,9 +44,9 @@ type Movie {
 ```cypher
 MATCH (this:Movie)
 RETURN this {
-    .id,
-    actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor) | this_actors { .name } ],
-    custom: [this_custom IN apoc.cypher.runFirstColumn("MATCH (m:Movie) RETURN m", {this: this, auth: $auth}, true) | this_custom { .id }]
+    movieId: this.id,
+    actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor) | this_actors { aliasActorsName: this_actors.name } ],
+    custom: [this_custom IN apoc.cypher.runFirstColumn("MATCH (m:Movie) RETURN m", {this: this, auth: $auth}, true) | this_custom { aliasCustomId: this_custom.id }]
 } as this
 ```
 
@@ -59,5 +59,48 @@ RETURN this {
        "roles": [],
        "jwt": {}
     }
+}
+```
+
+### Multiple aliases for single field with arguments
+
+**GraphQL input**
+
+```graphql
+{
+    movies {
+        id
+        keanu: actors(where: { name: "Keanu" }) {
+            name
+        }
+        carrie: actors(where: { name: "Carrie" }) {
+            name
+        }
+    }
+}
+```
+
+**Expected Cypher output**
+
+```cypher
+MATCH (this:Movie)
+RETURN this {
+    .id,
+    keanu: [ (this)<-[:ACTED_IN]-(this_keanu:Actor)  WHERE this_keanu.name = $this_keanu_name | this_keanu { .name } ],
+    carrie: [ (this)<-[:ACTED_IN]-(this_carrie:Actor)  WHERE this_carrie.name = $this_carrie_name | this_carrie { .name } ],
+} as this
+```
+
+**Expected Cypher params**
+
+```cypher-params
+{
+    "auth": {
+       "isAuthenticated": true,
+       "roles": [],
+       "jwt": {}
+    },
+    "this_keanu_name": "Keanu",
+    "this_carrie_name": "Carrie"
 }
 ```

--- a/packages/graphql/tests/tck/tck-test-files/cypher/alias.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/alias.md
@@ -11,6 +11,8 @@ type Actor {
 
 type Movie {
     id: ID
+    releaseDate: DateTime!
+    location: Point!
     actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
     custom: [Movie!]! @cypher(statement: """
         MATCH (m:Movie)
@@ -102,5 +104,75 @@ RETURN this {
     },
     "this_keanu_name": "Keanu",
     "this_carrie_name": "Carrie"
+}
+```
+
+### Alias datetime field
+
+**GraphQL input**
+
+```graphql
+{
+    movies {
+        d1: releaseDate
+        d2: releaseDate
+    }
+}
+```
+
+**Expected Cypher output**
+
+```cypher
+MATCH (this:Movie)
+RETURN this {
+    d1: apoc.date.convertFormat(toString(this.releaseDate), "iso_zoned_date_time", "iso_offset_date_time"),
+    d2: apoc.date.convertFormat(toString(this.releaseDate), "iso_zoned_date_time", "iso_offset_date_time")
+} as this
+```
+
+**Expected Cypher params**
+
+```cypher-params
+{
+    "auth": {
+       "isAuthenticated": true,
+       "roles": [],
+       "jwt": {}
+    }
+}
+```
+
+### Alias point field
+
+**GraphQL input**
+
+```graphql
+{
+    movies {
+        p1: location
+        p2: location
+    }
+}
+```
+
+**Expected Cypher output**
+
+```cypher
+MATCH (this:Movie)
+RETURN this {
+    p1: { point: this.location },
+    p2: { point: this.location }
+} as this
+```
+
+**Expected Cypher params**
+
+```cypher-params
+{
+    "auth": {
+       "isAuthenticated": true,
+       "roles": [],
+       "jwt": {}
+    }
 }
 ```


### PR DESCRIPTION
# Description

This pull request adds the ability to alias fields multiple times in queries. Currently when translating a graqhql request into a cypher query, the field name is used as opposed to the alias provided. Since the default field resolver also uses the field name this went unnoticed as long as any field was aliased at most one time during a query. However, as noted in #350 and described in detail in https://github.com/neo4j/graphql/issues/350#issuecomment-885957460; if a field is aliased multiple times, the use of the field name in the projection causes the last defined aliased field to override the others.

Aliasing of fields also requires to modify the returned object from the `create` and `update` resolver by making the key the aliased field.

# Issue

- #350 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
