### PR TITLE
Allow OGM selectionSet to be SelectionSetNode

### DIFF
--- a/packages/ogm/src/classes/Model.ts
+++ b/packages/ogm/src/classes/Model.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { DocumentNode, graphql, parse, print } from "graphql";
+import { DocumentNode, graphql, parse, print, SelectionSetNode } from "graphql";
 import pluralize from "pluralize";
 import camelCase from "camelcase";
 import { Neo4jGraphQL, upperFirst } from "@neo4j/graphql";
@@ -29,7 +29,7 @@ export interface ModelConstructor {
     neoSchema: Neo4jGraphQL;
 }
 
-function printSelectionSet(selectionSet: string | DocumentNode): string {
+function printSelectionSet(selectionSet: string | DocumentNode | SelectionSetNode): string {
     if (typeof selectionSet === "string") {
         return print(parse(selectionSet));
     }
@@ -70,7 +70,7 @@ class Model {
     }: {
         where?: GraphQLWhereArg;
         options?: GraphQLOptionsArg;
-        selectionSet?: string | DocumentNode;
+        selectionSet?: string | DocumentNode | SelectionSetNode;
         args?: any;
         context?: any;
         rootValue?: any;
@@ -142,7 +142,7 @@ class Model {
         rootValue = null,
     }: {
         input?: any;
-        selectionSet?: string | DocumentNode;
+        selectionSet?: string | DocumentNode | SelectionSetNode;
         args?: any;
         context?: any;
         rootValue?: any;
@@ -194,7 +194,7 @@ class Model {
         connect?: any;
         disconnect?: any;
         create?: any;
-        selectionSet?: string | DocumentNode;
+        selectionSet?: string | DocumentNode | SelectionSetNode;
         args?: any;
         context?: any;
         rootValue?: any;


### PR DESCRIPTION
# Description

Allow OGM selectionSet to be SelectionSetNode.

# Issue

#216

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
