### PR TITLE
Dependency upgrades

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -67,7 +67,7 @@
         "debug": "^4.3.2",
         "deep-equal": "^2.0.5",
         "dot-prop": "^6.0.1",
-        "graphql-compose": "^7.25.1",
+        "graphql-compose": "^8.1.0",
         "graphql-parse-resolve-info": "^4.12.0",
         "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -67,7 +67,7 @@
         "debug": "^4.3.2",
         "deep-equal": "^2.0.5",
         "dot-prop": "^6.0.1",
-        "graphql-compose": "^8.1.0",
+        "graphql-compose": "^9.0.2",
         "graphql-parse-resolve-info": "^4.12.0",
         "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -60,16 +60,16 @@
         "typescript": "3.9.7"
     },
     "dependencies": {
-        "@graphql-tools/merge": "^6.2.13",
-        "@graphql-tools/schema": "^7.1.3",
+        "@graphql-tools/merge": "6.2.14",
+        "@graphql-tools/schema": "^7.1.5",
         "@graphql-tools/utils": "^7.10.0",
         "camelcase": "^6.2.0",
-        "debug": "^4.3.1",
+        "debug": "^4.3.2",
         "deep-equal": "^2.0.5",
         "dot-prop": "^6.0.1",
         "graphql-compose": "^7.25.1",
-        "graphql-parse-resolve-info": "^4.11.0",
-        "graphql-relay": "^0.7.0",
+        "graphql-parse-resolve-info": "^4.12.0",
+        "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",
         "pluralize": "^8.0.0"
     },

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -411,9 +411,7 @@ function makeAugmentedSchema(
             name: node.name,
             fields: nodeFields,
             description: node.description,
-            extensions: {
-                directives: graphqlDirectivesToCompose(node.otherDirectives),
-            },
+            directives: graphqlDirectivesToCompose(node.otherDirectives),
             interfaces: node.interfaces.map((x) => x.name.value),
         });
 
@@ -1254,9 +1252,7 @@ function makeAugmentedSchema(
             name: inter.name.value,
             description: inter.description?.value,
             fields: objectComposeFields,
-            extensions: {
-                directives: graphqlDirectivesToCompose((inter.directives || []).filter((x) => x.name.value !== "auth")),
-            },
+            directives: graphqlDirectivesToCompose((inter.directives || []).filter((x) => x.name.value !== "auth")),
         });
     });
 

--- a/packages/graphql/src/schema/to-compose.ts
+++ b/packages/graphql/src/schema/to-compose.ts
@@ -18,7 +18,7 @@
  */
 
 import { InputValueDefinitionNode, DirectiveNode } from "graphql";
-import { ExtensionsDirective, DirectiveArgs, ObjectTypeComposerFieldConfigAsObjectDefinition } from "graphql-compose";
+import { DirectiveArgs, ObjectTypeComposerFieldConfigAsObjectDefinition, Directive } from "graphql-compose";
 import { isInt, Integer } from "neo4j-driver";
 import getFieldTypeMeta from "./get-field-type-meta";
 import parseValueNode from "./parse-value-node";
@@ -39,7 +39,7 @@ export function graphqlArgsToCompose(args: InputValueDefinitionNode[]) {
     }, {});
 }
 
-export function graphqlDirectivesToCompose(directives: DirectiveNode[]): ExtensionsDirective[] {
+export function graphqlDirectivesToCompose(directives: DirectiveNode[]): Directive[] {
     return directives.map((directive) => ({
         args: (directive.arguments || [])?.reduce(
             (r: DirectiveArgs, d) => ({ ...r, [d.name.value]: parseValueNode(d.value) }),
@@ -64,9 +64,7 @@ export function objectFieldsToComposeFields(
         } as ObjectTypeComposerFieldConfigAsObjectDefinition<any, any>;
 
         if (field.otherDirectives.length) {
-            newField.extensions = {
-                directives: graphqlDirectivesToCompose(field.otherDirectives),
-            };
+            newField.directives = graphqlDirectivesToCompose(field.otherDirectives);
         }
 
         if (["Int", "Float"].includes(field.typeMeta.name)) {

--- a/packages/ogm/package.json
+++ b/packages/ogm/package.json
@@ -26,7 +26,7 @@
     },
     "author": "Neo4j Inc.",
     "dependencies": {
-        "@graphql-tools/merge": "^6.2.13",
+        "@graphql-tools/merge": "6.2.14",
         "@neo4j/graphql": "^2.0.0-alpha.4",
         "camelcase": "^6.2.0",
         "pluralize": "^8.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,20 +599,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@graphql-tools/merge@npm:^6.2.13":
-  version: 6.2.13
-  resolution: "@graphql-tools/merge@npm:6.2.13"
+"@graphql-tools/merge@npm:6.2.14":
+  version: 6.2.14
+  resolution: "@graphql-tools/merge@npm:6.2.14"
   dependencies:
     "@graphql-tools/schema": ^7.0.0
     "@graphql-tools/utils": ^7.7.0
     tslib: ~2.2.0
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0
-  checksum: 19c977ebd6f918ec9ccdeb9cfd7cd4e818767c9f7fd19bd3d7d17888d9f98a977e63a9c111b254eb14ac420453fec84d2b336cc4d7a6a3c8a2e61f25af2f6b85
+  checksum: 98ee1c70394a881ca784577fbfbdc5253b291e6df4af77da70f9f6d9e01ad5831c57344a454136abd9eaeff4b513d0d9ab5d9e92e6fe80f9c07873a5ce0dc1d6
   languageName: node
   linkType: hard
 
-"@graphql-tools/schema@npm:^7.0.0, @graphql-tools/schema@npm:^7.1.3":
+"@graphql-tools/schema@npm:^7.0.0":
   version: 7.1.3
   resolution: "@graphql-tools/schema@npm:7.1.3"
   dependencies:
@@ -621,6 +621,19 @@ __metadata:
   peerDependencies:
     graphql: ^14.0.0 || ^15.0.0
   checksum: a0e0f9e5c746500702ed1316c6b97bb43ce171bb2fa865e7de38a5f958290094207172af4b9ba82dedf783ae42bcd7fd89b7d613affbe6717c40e758f04b77da
+  languageName: node
+  linkType: hard
+
+"@graphql-tools/schema@npm:^7.1.5":
+  version: 7.1.5
+  resolution: "@graphql-tools/schema@npm:7.1.5"
+  dependencies:
+    "@graphql-tools/utils": ^7.1.2
+    tslib: ~2.2.0
+    value-or-promise: 1.0.6
+  peerDependencies:
+    graphql: ^14.0.0 || ^15.0.0
+  checksum: 23b1e5443919a2d9abff535bfa9cd935e3ee3f0b2e3938d396af40ffcbf8d90bacf74fd3faf895845b1b0bf7cada5f7e0d1fd67f667ec02752884f25b1e19ac4
   languageName: node
   linkType: hard
 
@@ -916,7 +929,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@neo4j/graphql-ogm@workspace:packages/ogm"
   dependencies:
-    "@graphql-tools/merge": ^6.2.13
+    "@graphql-tools/merge": 6.2.14
     "@neo4j/graphql": ^2.0.0-alpha.4
     "@types/jest": 26.0.8
     "@types/node": 14.0.27
@@ -940,8 +953,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@neo4j/graphql@workspace:packages/graphql"
   dependencies:
-    "@graphql-tools/merge": ^6.2.13
-    "@graphql-tools/schema": ^7.1.3
+    "@graphql-tools/merge": 6.2.14
+    "@graphql-tools/schema": ^7.1.5
     "@graphql-tools/utils": ^7.10.0
     "@types/deep-equal": 1.0.1
     "@types/faker": 5.1.7
@@ -953,14 +966,14 @@ __metadata:
     "@types/randomstring": 1.1.6
     apollo-server: 2.21.0
     camelcase: ^6.2.0
-    debug: ^4.3.1
+    debug: ^4.3.2
     dedent: ^0.7.0
     deep-equal: ^2.0.5
     dot-prop: ^6.0.1
     faker: 5.2.0
     graphql-compose: ^7.25.1
-    graphql-parse-resolve-info: ^4.11.0
-    graphql-relay: ^0.7.0
+    graphql-parse-resolve-info: ^4.12.0
+    graphql-relay: ^0.8.0
     graphql-tag: 2.11.0
     is-uuid: 1.0.2
     jest: 26.2.2
@@ -4661,7 +4674,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1":
+"debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.2":
   version: 4.3.2
   resolution: "debug@npm:4.3.2"
   dependencies:
@@ -6648,24 +6661,24 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-parse-resolve-info@npm:^4.11.0":
-  version: 4.11.0
-  resolution: "graphql-parse-resolve-info@npm:4.11.0"
+"graphql-parse-resolve-info@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "graphql-parse-resolve-info@npm:4.12.0"
   dependencies:
     debug: ^4.1.1
     tslib: ^2.0.1
   peerDependencies:
     graphql: ">=0.9 <0.14 || ^14.0.2 || ^15.4.0"
-  checksum: ef41c34e647abbfeb720398012c559c4d3e4d3f78f6e5e994e55940bcfa5c48ad65274609bc22f1e8837c7b1027a897ef9c2334ec2152d3b52f1ba9f22dbc817
+  checksum: 995f76c99ef02116a802ccc02c64da848ef3facd55d894782a5a93097cf3074dc60bdeca932fa0de2b35b6788b93de504a18def5f5a236a6769ad3435eb6fe4e
   languageName: node
   linkType: hard
 
-"graphql-relay@npm:^0.7.0":
-  version: 0.7.0
-  resolution: "graphql-relay@npm:0.7.0"
+"graphql-relay@npm:^0.8.0":
+  version: 0.8.0
+  resolution: "graphql-relay@npm:0.8.0"
   peerDependencies:
-    graphql: ^15.5.0
-  checksum: 07a01d7325fddffd65fe3ff1c72d188af5f4b73e42268b7781e37725768489435b9e82bdaa6d4ef6af9da8b9ef7a02e0046b3e5039e5ef52422fabb8f55d028e
+    graphql: 15.5.1
+  checksum: 3986b64ca5126e2ad8cbfaf2c7c64161ce00a8f9832c70e226d096dcb47121a7adc652022a746706527661663537d6f721b313d0ad3ff651c8babe339b5b2469
   languageName: node
   linkType: hard
 
@@ -13765,6 +13778,13 @@ typescript@4.1.3:
   version: 1.0.1
   resolution: "value-equal@npm:1.0.1"
   checksum: ae8cc7bbb2bebcaf78ecbf7669944cfc6e23f50361d0d97dc903abbfb9ce5111ce1dc5cb2575646db69636a84b2a3b224e2191088edc3442fb4669c2365af874
+  languageName: node
+  linkType: hard
+
+"value-or-promise@npm:1.0.6":
+  version: 1.0.6
+  resolution: "value-or-promise@npm:1.0.6"
+  checksum: ea5fa311aad0c6f63feccb6891e162f847e9bb2b257813eef8fc945f9e48b3df5fe7402227309171f0b096b6c2d17e163d6384ec3de819f49743537bde078699
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,7 +971,7 @@ __metadata:
     deep-equal: ^2.0.5
     dot-prop: ^6.0.1
     faker: 5.2.0
-    graphql-compose: ^8.1.0
+    graphql-compose: ^9.0.2
     graphql-parse-resolve-info: ^4.12.0
     graphql-relay: ^0.8.0
     graphql-tag: 2.11.0
@@ -6643,16 +6643,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-compose@npm:^8.1.0":
-  version: 8.1.0
-  resolution: "graphql-compose@npm:8.1.0"
+"graphql-compose@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "graphql-compose@npm:9.0.2"
   dependencies:
     "@types/object-path": ^0.11.0
     graphql-type-json: 0.3.2
     object-path: 0.11.5
   peerDependencies:
-    graphql: ^14.2.0 || ^15.0.0
-  checksum: 9c660ed7c6500e4ff7d1e815884c5e197afb49b3a11d18f95f2d211e6744c54cbe9a2ba1b07c0aebc8cbbca1d6d03a7658c10809f61849f7b4e7459e583e28d5
+    graphql: ^14.2.0 || ^15.0.0 || ^16.0.0
+  checksum: 0c5c7967c1e8e6ea4fd7f65fb08212d65ddda980a9321a089599dd7e000b9d53a71be317abe6d16fb4079e6687b95470b383f6670a288322e7d1d16fdfcd2132
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -971,7 +971,7 @@ __metadata:
     deep-equal: ^2.0.5
     dot-prop: ^6.0.1
     faker: 5.2.0
-    graphql-compose: ^7.25.1
+    graphql-compose: ^8.1.0
     graphql-parse-resolve-info: ^4.12.0
     graphql-relay: ^0.8.0
     graphql-tag: 2.11.0
@@ -1763,6 +1763,13 @@ __metadata:
   version: 2.4.0
   resolution: "@types/normalize-package-data@npm:2.4.0"
   checksum: 6d077e73be7ac6227b678829c7bd765607136cdef537fd4ee7f368d9302a651aea924254d69826663322048436d90d6e7c679c9aa99c4824a687c568aab8ce4f
+  languageName: node
+  linkType: hard
+
+"@types/object-path@npm:^0.11.0":
+  version: 0.11.1
+  resolution: "@types/object-path@npm:0.11.1"
+  checksum: d0bdb453cb99e741fc99918889b0262e6ba0848b04c5c686f895de2cc22fde99414971adec6f33467a1c6150fcd624f6cc99eccdd47bffee3909f3883ad557d7
   languageName: node
   linkType: hard
 
@@ -6636,15 +6643,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-compose@npm:^7.25.1":
-  version: 7.25.1
-  resolution: "graphql-compose@npm:7.25.1"
+"graphql-compose@npm:^8.1.0":
+  version: 8.1.0
+  resolution: "graphql-compose@npm:8.1.0"
   dependencies:
+    "@types/object-path": ^0.11.0
     graphql-type-json: 0.3.2
     object-path: 0.11.5
   peerDependencies:
     graphql: ^14.2.0 || ^15.0.0
-  checksum: 96aa8a6ab9f2c3b2c97747bb2706aeaa4a88d90c10246d0d40caf8936aeea04e61267fb60db2651e59a6665e58a4a52c911259297c005a63900095dd3881e44f
+  checksum: 9c660ed7c6500e4ff7d1e815884c5e197afb49b3a11d18f95f2d211e6744c54cbe9a2ba1b07c0aebc8cbbca1d6d03a7658c10809f61849f7b4e7459e583e28d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Patch upgrades for most dependencies, holding off of upgrading `@graphql-tools/schema` and `@graphql-tools/utils` to 8.x because of _massively_ breaking changes.

Note that `@graphql-tools/merge` is pinned at 6.2.14 because 6.2.15 and higher depend on `@graphql-tools/schema` and `@graphql-tools/utils` 8.x, despite being a patch version upgrade.

`graphql-compose` upgraded to 9.x and bugs resulting from breaking changes fixed.