### PR TITLE
feat: Resolve union type in custom cypher

### DIFF
--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -18,6 +18,8 @@
  */
 
 import { isInt } from "neo4j-driver";
+import { UnionTypeDefinitionNode } from "graphql/language/ast";
+import { ResolveTree } from "graphql-parse-resolve-info";
 import { execute } from "../../utils";
 import { BaseField, ConnectionField, Context } from "../../types";
 import { graphqlArgsToCompose } from "../to-compose";
@@ -26,6 +28,7 @@ import createAuthParam from "../../translate/create-auth-param";
 import { AUTH_FORBIDDEN_ERROR } from "../../constants";
 import createProjectionAndParams from "../../translate/create-projection-and-params";
 import createConnectionAndParams from "../../translate/connection/create-connection-and-params";
+import { Node } from "../../classes";
 
 export default function cypherResolver({
     field,
@@ -36,59 +39,54 @@ export default function cypherResolver({
     statement: string;
     type: "Query" | "Mutation";
 }) {
-    async function resolve(_root: any, args: any, _context: unknown) {
-        const context = _context as Context;
-        const { resolveTree } = context;
-        const cypherStrs: string[] = [];
-        let params = { ...args, auth: createAuthParam({ context }), cypherParams: context.cypherParams };
-        let projectionStr = "";
-        let connectionProjectionStr = "";
+    // Separate previos logic to reuse in simple and union node
+    function getNodeProjection(referenceNode: Node, resolveTree: ResolveTree, context: Context, resolveType: boolean) {
         let projectionAuthStr = "";
-        const isPrimitive = ["ID", "String", "Boolean", "Float", "Int", "DateTime", "BigInt"].includes(
-            field.typeMeta.name
-        );
+        let connectionProjectionStr = "";
+        let params: any;
+        const recurse = createProjectionAndParams({
+            fieldsByTypeName: resolveTree.fieldsByTypeName,
+            node: referenceNode,
+            resolveType,
+            context,
+            varName: `this`,
+        });
+        const [str, p, meta] = recurse;
+        const projectionStr = str;
+        params = p;
 
-        const preAuth = createAuthAndParams({ entity: field, context });
-        if (preAuth[0]) {
-            params = { ...params, ...preAuth[1] };
-            cypherStrs.push(`CALL apoc.util.validate(NOT(${preAuth[0]}), "${AUTH_FORBIDDEN_ERROR}", [0])`);
+        if (meta?.authValidateStrs?.length) {
+            projectionAuthStr = meta.authValidateStrs.join(" AND ");
         }
 
-        const referenceNode = context.neoSchema.nodes.find((x) => x.name === field.typeMeta.name);
-        if (referenceNode) {
-            const recurse = createProjectionAndParams({
-                fieldsByTypeName: resolveTree.fieldsByTypeName,
-                node: referenceNode,
-                context,
-                varName: `this`,
-            });
-            const [str, p, meta] = recurse;
-            projectionStr = str;
-            params = { ...params, ...p };
+        if (meta?.connectionFields?.length) {
+            meta.connectionFields.forEach((connectionResolveTree) => {
+                const connectionField = referenceNode.connectionFields.find(
+                    (x) => x.fieldName === connectionResolveTree.name
+                ) as ConnectionField;
 
-            if (meta?.authValidateStrs?.length) {
-                projectionAuthStr = meta.authValidateStrs.join(" AND ");
-            }
-
-            if (meta?.connectionFields?.length) {
-                meta.connectionFields.forEach((connectionResolveTree) => {
-                    const connectionField = referenceNode.connectionFields.find(
-                        (x) => x.fieldName === connectionResolveTree.name
-                    ) as ConnectionField;
-
-                    const nestedConnection = createConnectionAndParams({
-                        resolveTree: connectionResolveTree,
-                        field: connectionField,
-                        context,
-                        nodeVariable: "this",
-                    });
-                    const [str, p] = nestedConnection;
-                    connectionProjectionStr = str;
-                    params = { ...params, ...p };
+                const nestedConnection = createConnectionAndParams({
+                    resolveTree: connectionResolveTree,
+                    field: connectionField,
+                    context,
+                    nodeVariable: "this",
                 });
-            }
+                const [strc, pc] = nestedConnection;
+                connectionProjectionStr = strc;
+                params = { ...params, ...pc };
+            });
         }
-
+        return { projectionStr, params, connectionProjectionStr, projectionAuthStr };
+    }
+    // Separate previos logic to reuse in simple and union node
+    function addSecurityAndConnection(
+        context: Context,
+        args: any,
+        params: any,
+        projectionAuthStr: string,
+        connectionProjectionStr: string
+    ) {
+        const cypherStrs: string[] = [];
         const initApocParamsStrs = ["auth: $auth", ...(context.cypherParams ? ["cypherParams: $cypherParams"] : [])];
         const apocParams = Object.entries(args).reduce(
             (r: { strs: string[]; params: any }, entry) => {
@@ -124,8 +122,109 @@ export default function cypherResolver({
         if (connectionProjectionStr) {
             cypherStrs.push(connectionProjectionStr);
         }
+        return cypherStrs;
+    }
+    async function resolve(_root: any, args: any, _context: unknown) {
+        const context = _context as Context;
+        const { resolveTree } = context;
+        const cypherStrs: string[] = [];
+        let params = { ...args, auth: createAuthParam({ context }), cypherParams: context.cypherParams };
+        let projectionStr = "";
+        let connectionProjectionStr = "";
+        let projectionAuthStr = "";
+        const isPrimitive = ["ID", "String", "Boolean", "Float", "Int", "DateTime", "BigInt"].includes(
+            field.typeMeta.name
+        );
 
-        if (!isPrimitive) {
+        const preAuth = createAuthAndParams({ entity: field, context });
+        if (preAuth[0]) {
+            params = { ...params, ...preAuth[1] };
+            cypherStrs.push(`CALL apoc.util.validate(NOT(${preAuth[0]}), "${AUTH_FORBIDDEN_ERROR}", [0])`);
+        }
+
+        const referenceNode = context.neoSchema.nodes.find((x) => x.name === field.typeMeta.name);
+        const unions = context.neoSchema.document.definitions.filter(
+            (x) => x.kind === "UnionTypeDefinition"
+        ) as UnionTypeDefinitionNode[];
+        const referenceUnion = unions.find((u) => u.name.value === field.typeMeta.name);
+        const subresolves: {
+            projectionStr: string;
+            params: any;
+            connectionProjectionStr: string;
+            projectionAuthStr: string;
+            nodeName: string;
+            cypherStrs: string[];
+        }[] = [];
+        if (referenceNode) {
+            const {
+                projectionStr: ps,
+                params: p,
+                connectionProjectionStr: cps,
+                projectionAuthStr: pas,
+            } = getNodeProjection(referenceNode, resolveTree, context, false);
+            projectionAuthStr = pas;
+            params = { ...p, ...params };
+            connectionProjectionStr = cps;
+            projectionStr = ps;
+        }
+        if (referenceUnion) {
+            const referencedNodes = referenceUnion?.types?.map((u) =>
+                context.neoSchema.nodes.find((n) => n.name === u.name.value)
+            );
+            if (referencedNodes) {
+                referencedNodes
+                    .filter((b) => b !== undefined)
+                    .filter((n) => Object.keys(resolveTree.fieldsByTypeName).includes(n?.name ?? ""))
+                    .forEach((node) => {
+                        // Build cypher for every node in union type
+                        if (node) {
+                            const clonests = JSON.parse(JSON.stringify(cypherStrs)); // clone original sentence array to each child node union type
+                            const unionNodeProjection = getNodeProjection(
+                                node,
+                                {
+                                    fieldsByTypeName: { [node.name]: resolveTree.fieldsByTypeName[node.name] },
+                                } as ResolveTree,
+                                context,
+                                true
+                            );
+                            addSecurityAndConnection(
+                                context,
+                                args,
+                                (params = { ...unionNodeProjection.params, ...params }),
+                                unionNodeProjection.projectionAuthStr,
+                                unionNodeProjection.connectionProjectionStr
+                            ).forEach((a) => clonests.push(a));
+
+                            subresolves.push({
+                                ...unionNodeProjection,
+                                nodeName: node.name,
+                                cypherStrs: clonests,
+                            });
+                        }
+                    });
+            }
+        } else {
+            addSecurityAndConnection(context, args, params, projectionAuthStr, connectionProjectionStr).forEach((a) =>
+                cypherStrs.push(a)
+            );
+        }
+        if (referenceUnion) {
+            cypherStrs.splice(0, cypherStrs.length);
+            cypherStrs.push("call {\n");
+            const subquerys = subresolves.map(
+                (sub) => `${sub.cypherStrs.join("\n")}
+            match(thisnode:${sub.nodeName})
+
+            where thisnode=this or apoc.map.merge(properties(thisnode), { __resolveType: '${
+                sub.nodeName
+            }' })=properties(this)
+            return thisnode ${sub.projectionStr} as this`
+            );
+            cypherStrs.push(subquerys.join("\nunion\n"));
+            cypherStrs.push("}");
+            cypherStrs.push(`with this AS this
+            RETURN this`);
+        } else if (!isPrimitive) {
             cypherStrs.push(`RETURN this ${projectionStr} AS this`);
         } else {
             cypherStrs.push(`RETURN this`);


### PR DESCRIPTION
It allows to solve custom cypher with results of type union,  currently this query crashes. 

An example of this is the following:

                type Movie {
                    title: String!
                    actors: [Actor] @relationship(type: "ACTED_IN", direction: IN)
                    directors: [Actor] @relationship(type: "DIRECTED", direction: IN)
                }
                type Director {
                    name: String!
                    movies: [Movie] @relationship(type: "DIRECTED", direction: OUT)
                }
                type Actor {
                    name: String!
                    movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT)
                }
                union Person = Director | Actor
                type Query {

                    personInMovie(title: String!): [Person] @cypher(statement: """
                        MATCH (m:Movie {title: $title})<-[:ACTED_IN|DIRECTED]-(p)
                        RETURN p
                    """)
                }
