### PR TITLE
Change minimum database version to 4.1.5

### DIFF
--- a/docs/asciidoc/introduction.adoc
+++ b/docs/asciidoc/introduction.adoc
@@ -63,7 +63,7 @@ Additionally, prerelease version numbers may have additional suffixes, for examp
 
 == Requirements
 
-1. https://neo4j.com/[Neo4j Database] 4.1.0+
+1. https://neo4j.com/[Neo4j Database] 4.1.5+
 2. https://neo4j.com/developer/neo4j-apoc/[APOC] 4.1.0+
 3. https://nodejs.org/en/[Node.js] 12+
 

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -54,7 +54,6 @@
         "npm-run-all": "4.1.5",
         "randomstring": "1.1.5",
         "rimraf": "3.0.2",
-        "semver": "7.3.5",
         "ts-jest": "26.1.4",
         "ts-node": "^10.0.0",
         "typescript": "3.9.7"
@@ -71,7 +70,8 @@
         "graphql-parse-resolve-info": "^4.12.0",
         "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",
-        "pluralize": "^8.0.0"
+        "pluralize": "^8.0.0",
+        "semver": "^7.3.5"
     },
     "peerDependencies": {
         "graphql": "^15.0.0",

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -21,7 +21,7 @@ const DEBUG_PREFIX = "@neo4j/graphql";
 
 export const AUTH_FORBIDDEN_ERROR = "@neo4j/graphql/FORBIDDEN";
 export const AUTH_UNAUTHENTICATED_ERROR = "@neo4j/graphql/UNAUTHENTICATED";
-export const MIN_NEO4J_VERSION = "4.1.0";
+export const MIN_NEO4J_VERSION = "4.1.5";
 export const MIN_APOC_VERSION = "4.1.0";
 export const REQUIRED_APOC_FUNCTIONS = [
     "apoc.util.validatePredicate",

--- a/packages/graphql/src/utils/verify-database.test.ts
+++ b/packages/graphql/src/utils/verify-database.test.ts
@@ -129,6 +129,37 @@ describe("checkNeo4jCompat", () => {
         await expect(checkNeo4jCompat({ driver: fakeDriver })).resolves.not.toThrow();
     });
 
+    test("should not throw Error for Aura version numbers", async () => {
+        // @ts-ignore
+        const fakeSession: Session = {
+            // @ts-ignore
+            run: () => ({
+                records: [
+                    {
+                        toObject: () => ({
+                            version: "4.2-aura",
+                            apocVersion: MIN_APOC_VERSION,
+                            functions: REQUIRED_APOC_FUNCTIONS,
+                            procedures: REQUIRED_APOC_PROCEDURES,
+                        }),
+                    },
+                ],
+            }),
+            // @ts-ignore
+            close: () => undefined,
+        };
+
+        // @ts-ignore
+        const fakeDriver: Driver = {
+            // @ts-ignore
+            session: () => fakeSession,
+            // @ts-ignore
+            verifyConnectivity: () => undefined,
+        };
+
+        await expect(checkNeo4jCompat({ driver: fakeDriver })).resolves.not.toThrow();
+    });
+
     test("should throw expected APOC version", async () => {
         const invalidApocVersion = "2.3.1";
 

--- a/packages/graphql/src/utils/verify-database.ts
+++ b/packages/graphql/src/utils/verify-database.ts
@@ -69,7 +69,7 @@ async function checkNeo4jCompat({ driver, driverConfig }: { driver: Driver; driv
         const info = result.records[0].toObject() as DBInfo;
         const errors: string[] = [];
 
-        if (semver.lt(info.version, MIN_NEO4J_VERSION)) {
+        if (semver.lt(semver.coerce(info.version), MIN_NEO4J_VERSION)) {
             errors.push(`Expected minimum Neo4j version: '${MIN_NEO4J_VERSION}' received: '${info.version}'`);
         }
 

--- a/packages/graphql/src/utils/verify-database.ts
+++ b/packages/graphql/src/utils/verify-database.ts
@@ -18,6 +18,7 @@
  */
 
 import { Driver } from "neo4j-driver";
+import semver from "semver";
 import { MIN_NEO4J_VERSION, MIN_APOC_VERSION, REQUIRED_APOC_FUNCTIONS, REQUIRED_APOC_PROCEDURES } from "../constants";
 import { DriverConfig } from "../types";
 
@@ -66,23 +67,28 @@ async function checkNeo4jCompat({ driver, driverConfig }: { driver: Driver; driv
     try {
         const result = await session.run(cypher);
         const info = result.records[0].toObject() as DBInfo;
+        const errors: string[] = [];
 
-        if (info.version < MIN_NEO4J_VERSION) {
-            throw new Error(`Expected minimum Neo4j version: '${MIN_NEO4J_VERSION}' received: '${info.version}'`);
+        if (semver.lt(info.version, MIN_NEO4J_VERSION)) {
+            errors.push(`Expected minimum Neo4j version: '${MIN_NEO4J_VERSION}' received: '${info.version}'`);
         }
 
-        if (info.apocVersion < MIN_APOC_VERSION) {
-            throw new Error(`Expected minimum APOC version: '${MIN_APOC_VERSION}' received: '${info.apocVersion}'`);
+        if (semver.lt(semver.coerce(info.apocVersion), MIN_APOC_VERSION)) {
+            errors.push(`Expected minimum APOC version: '${MIN_APOC_VERSION}' received: '${info.apocVersion}'`);
         }
 
         const missingFunctions = REQUIRED_APOC_FUNCTIONS.filter((f) => !info.functions.includes(f));
         if (missingFunctions.length) {
-            throw new Error(`Missing APOC functions: [ ${missingFunctions.join(", ")} ]`);
+            errors.push(`Missing APOC functions: [ ${missingFunctions.join(", ")} ]`);
         }
 
         const missingProcedures = REQUIRED_APOC_PROCEDURES.filter((p) => !info.procedures.includes(p));
         if (missingProcedures.length) {
-            throw new Error(`Missing APOC procedures: [ ${missingProcedures.join(", ")} ]`);
+            errors.push(`Missing APOC procedures: [ ${missingProcedures.join(", ")} ]`);
+        }
+
+        if (errors.length) {
+            throw new Error(`Encountered the following DBMS compatiblility issues:\n${errors.join("\n")}`);
         }
     } finally {
         await session.close();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,7 +1076,7 @@ __metadata:
     pluralize: ^8.0.0
     randomstring: 1.1.5
     rimraf: 3.0.2
-    semver: 7.3.5
+    semver: ^7.3.5
     ts-jest: 26.1.4
     ts-node: ^10.0.0
     typescript: 3.9.7


### PR DESCRIPTION
# Description

Following reports that our changes to connect operations no longer work on 4.1.0, I iterated through versions to find the minimum which we now support - 4.1.5 is where all tests start passing.

Also fixes version checking, now uses `semver` package for comparison. For non-semantic APOC version, strips off the trailing number.

Also, now throws all compatibility issues in one error, rather than throwing as soon as it hits each.

Worthwhile adding an integration test pipeline for 4.1.5 exactly (rather than 4.1.x as current, I'm assuming 4.1.9) so we can easily tell if and when we break compatibility? 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
