### PR TITLE
Error auth relationship properties

### DIFF
--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -208,4 +208,42 @@ describe("makeAugmentedSchema", () => {
             expect(document.kind).toEqual("Document");
         });
     });
+
+    test("should throw error if auth is used on relationship properties interface", () => {
+        const typeDefs = `
+            type Movie {
+                actors: Actor @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type Actor {
+                name: String
+            }
+
+            interface ActedIn @auth(rules: [{ operations: [CREATE], roles: ["admin"] }]) {
+                screenTime: Int
+            }
+        `;
+
+        expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+            "Cannot have @auth directive on relationship properties interface"
+        );
+    });
+
+    test("should throw error if auth is used on relationship property", () => {
+        const typeDefs = `
+            type Movie {
+                actors: Actor @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type Actor {
+                name: String
+            }
+
+            interface ActedIn {
+                screenTime: Int @auth(rules: [{ operations: [CREATE], roles: ["admin"] }])
+            }
+        `;
+
+        expect(() => makeAugmentedSchema({ typeDefs })).toThrow("Cannot have @auth directive on relationship property");
+    });
 });

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -258,6 +258,11 @@ function makeAugmentedSchema(
     const relationshipFields = new Map<string, RelationshipField[]>();
 
     relationshipProperties.forEach((relationship) => {
+        const authDirective = (relationship.directives || []).find((x) => x.name.value === "auth");
+        if (authDirective) {
+            throw new Error("Cannot have @auth directive on relationship properties interface");
+        }
+
         const relationshipFieldMeta = getRelationshipFieldMeta({ relationship, enums });
 
         if (!pointInTypeDefs) {
@@ -269,34 +274,38 @@ function makeAugmentedSchema(
 
         relationshipFields.set(relationship.name.value, relationshipFieldMeta);
 
-        const propertiesInterface = composer.createInterfaceTC({
-            name: relationship.name.value,
-            fields: {
-                ...relationship.fields?.reduce((res, f) => {
-                    const typeMeta = getFieldTypeMeta(f);
+        const fields = {};
 
-                    const newField = {
-                        description: f.description?.value,
-                        type: typeMeta.pretty,
-                    } as ObjectTypeComposerFieldConfigAsObjectDefinition<any, any>;
+        relationship.fields?.forEach((field) => {
+            const authDirective = (field.directives || []).find((x) => x.name.value === "auth");
+            if (authDirective) {
+                throw new Error("Cannot have @auth directive on relationship property");
+            }
 
-                    if (["Int", "Float"].includes(typeMeta.name)) {
-                        newField.resolve = (source) => {
-                            // @ts-ignore: outputValue is unknown, and to cast to object would be an antipattern
-                            if (isInt(source[f.name.value])) {
-                                return (source[f.name.value] as Integer).toNumber();
-                            }
+            const typeMeta = getFieldTypeMeta(field);
 
-                            return source[f.name.value];
-                        };
+            const newField = {
+                description: field.description?.value,
+                type: typeMeta.pretty,
+            } as ObjectTypeComposerFieldConfigAsObjectDefinition<any, any>;
+
+            if (["Int", "Float"].includes(typeMeta.name)) {
+                newField.resolve = (source) => {
+                    // @ts-ignore: outputValue is unknown, and to cast to object would be an antipattern
+                    if (isInt(source[field.name.value])) {
+                        return (source[field.name.value] as Integer).toNumber();
                     }
 
-                    return {
-                        ...res,
-                        [f.name.value]: newField,
-                    };
-                }, {}),
-            },
+                    return source[field.name.value];
+                };
+            }
+
+            fields[field.name.value] = newField;
+        });
+
+        const propertiesInterface = composer.createInterfaceTC({
+            name: relationship.name.value,
+            fields,
         });
 
         composer.createInputTC({


### PR DESCRIPTION
# Description

Throws error when `@auth` is used on relationship props. This is not supported and we assume that the parent nodes auth is sufficient enough. 