### PR TITLE
Adds a simple util file which can be called to teardown database

### DIFF
--- a/packages/graphql/tests/integration/teardown.ts
+++ b/packages/graphql/tests/integration/teardown.ts
@@ -1,3 +1,28 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * File not imported in project, and to be used in test pipelines to teardown target database.
+ *
+ *   `ts-node tests/integration/teardown.ts`
+ */
+
 import neo4j from "./neo4j";
 
 const teardown = async () => {
@@ -7,14 +32,13 @@ const teardown = async () => {
     try {
         console.log("Clearing down database...");
         await session.run("MATCH (n) DETACH DELETE n");
-    } catch (e) {
-        console.log("Encountered an error whilst clearing down database!");
-        throw e;
     } finally {
         await session.close();
         await driver.close();
     }
 };
 
-// eslint-disable-next-line no-void
-void teardown().then(() => console.log("Successfully cleared down database."));
+teardown().then(
+    () => console.log("Successfully cleared down database."),
+    (reason) => console.log(`Error encountered whilst clearing down database: ${reason}`)
+);

--- a/packages/graphql/tests/integration/teardown.ts
+++ b/packages/graphql/tests/integration/teardown.ts
@@ -1,0 +1,20 @@
+import neo4j from "./neo4j";
+
+const teardown = async () => {
+    const driver = await neo4j();
+    const session = driver.session();
+
+    try {
+        console.log("Clearing down database...");
+        await session.run("MATCH (n) DETACH DELETE n");
+    } catch (e) {
+        console.log("Encountered an error whilst clearing down database!");
+        throw e;
+    } finally {
+        await session.close();
+        await driver.close();
+    }
+};
+
+// eslint-disable-next-line no-void
+void teardown().then(() => console.log("Successfully cleared down database."));


### PR DESCRIPTION
# Description

Will need to be used to avoid hitting the 50,000 node limit when testing against Aura Free (would take a while, but would be a nuisance).
