### PR TITLE
Integration test causal consistency

### DIFF
--- a/packages/graphql/tests/integration/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/advanced-filtering.int.test.ts
@@ -86,7 +86,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -148,7 +148,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -216,7 +216,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -290,7 +290,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -356,7 +356,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -425,7 +425,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -491,7 +491,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -562,7 +562,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -631,7 +631,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -700,7 +700,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -775,7 +775,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -855,7 +855,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -937,7 +937,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -1004,7 +1004,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -1071,7 +1071,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -1137,7 +1137,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -1204,7 +1204,7 @@ describe("Advanced Filtering", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         if (gqlResult.errors) {
@@ -1261,7 +1261,7 @@ describe("Advanced Filtering", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 if (gqlResult.errors) {
@@ -1314,7 +1314,7 @@ describe("Advanced Filtering", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 if (gqlResult.errors) {
@@ -1397,7 +1397,7 @@ describe("Advanced Filtering", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1461,7 +1461,7 @@ describe("Advanced Filtering", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1533,7 +1533,7 @@ describe("Advanced Filtering", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1605,7 +1605,7 @@ describe("Advanced Filtering", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1694,7 +1694,7 @@ describe("Advanced Filtering", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1777,7 +1777,7 @@ describe("Advanced Filtering", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1884,7 +1884,7 @@ Params:
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     if (gqlResult.errors) {
@@ -1968,7 +1968,7 @@ Params:
                 const nullResult = await graphql({
                     schema: neoSchema.schema,
                     source: nullQuery,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 if (nullResult.errors) {
@@ -1995,7 +1995,7 @@ Params:
                 const notNullResult = await graphql({
                     schema: neoSchema.schema,
                     source: notNullQuery,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 if (notNullResult.errors) {
@@ -2070,7 +2070,7 @@ Params:
                 const nullResult = await graphql({
                     schema: neoSchema.schema,
                     source: nullQuery,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 if (nullResult.errors) {
@@ -2096,7 +2096,7 @@ Params:
                 const notNullResult = await graphql({
                     schema: neoSchema.schema,
                     source: notNullQuery,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 if (notNullResult.errors) {

--- a/packages/graphql/tests/integration/auth/allow-unauthenticated.int.test.ts
+++ b/packages/graphql/tests/integration/auth/allow-unauthenticated.int.test.ts
@@ -79,7 +79,7 @@ describe("auth/allow-unauthenticated", () => {
             const req = new IncomingMessage(socket);
 
             const gqlResult = await graphql({
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 schema: neoSchema.schema,
                 source: query,
             });
@@ -129,7 +129,7 @@ describe("auth/allow-unauthenticated", () => {
             const req = new IncomingMessage(socket);
 
             const gqlResult = await graphql({
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 schema: neoSchema.schema,
                 source: query,
             });
@@ -182,7 +182,7 @@ describe("auth/allow-unauthenticated", () => {
             const req = new IncomingMessage(socket);
 
             const gqlResult = await graphql({
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 schema: neoSchema.schema,
                 source: query,
             });
@@ -235,7 +235,7 @@ describe("auth/allow-unauthenticated", () => {
             const req = new IncomingMessage(socket);
 
             const gqlResult = await graphql({
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 schema: neoSchema.schema,
                 source: query,
             });
@@ -285,7 +285,7 @@ describe("auth/allow-unauthenticated", () => {
             const req = new IncomingMessage(socket);
 
             const gqlResult = await graphql({
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 schema: neoSchema.schema,
                 source: query,
             });
@@ -337,7 +337,7 @@ describe("auth/allow-unauthenticated", () => {
             const req = new IncomingMessage(socket);
 
             const gqlResult = await graphql({
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 schema: neoSchema.schema,
                 source: query,
             });

--- a/packages/graphql/tests/integration/auth/allow.int.test.ts
+++ b/packages/graphql/tests/integration/auth/allow.int.test.ts
@@ -85,7 +85,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -143,7 +143,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -212,7 +212,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -285,7 +285,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -356,7 +356,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -431,7 +431,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -516,7 +516,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -577,7 +577,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -638,7 +638,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -709,7 +709,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -782,7 +782,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -842,7 +842,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -920,7 +920,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -993,7 +993,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -1087,7 +1087,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -1161,7 +1161,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -1254,7 +1254,7 @@ describe("auth/allow", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");

--- a/packages/graphql/tests/integration/auth/bind.int.test.ts
+++ b/packages/graphql/tests/integration/auth/bind.int.test.ts
@@ -83,7 +83,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -155,7 +155,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -230,7 +230,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -290,7 +290,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -370,7 +370,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -433,7 +433,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -509,7 +509,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -585,7 +585,7 @@ describe("auth/bind", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");

--- a/packages/graphql/tests/integration/auth/custom-cypher.int.test.ts
+++ b/packages/graphql/tests/integration/auth/custom-cypher.int.test.ts
@@ -72,7 +72,7 @@ describe("should inject the auth into cypher directive", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query as string,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();
@@ -166,7 +166,7 @@ describe("should inject the auth into cypher directive", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query as string,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();
@@ -268,7 +268,7 @@ describe("should inject the auth into cypher directive", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();

--- a/packages/graphql/tests/integration/auth/is-authenticated.int.test.ts
+++ b/packages/graphql/tests/integration/auth/is-authenticated.int.test.ts
@@ -70,7 +70,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -109,7 +109,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -155,7 +155,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -199,7 +199,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -245,7 +245,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -289,7 +289,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -365,7 +365,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -441,7 +441,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -485,7 +485,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -545,7 +545,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -590,7 +590,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -633,7 +633,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");
@@ -680,7 +680,7 @@ describe("auth/is-authenticated", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Unauthenticated");

--- a/packages/graphql/tests/integration/auth/object-path.int.test.ts
+++ b/packages/graphql/tests/integration/auth/object-path.int.test.ts
@@ -90,7 +90,7 @@ describe("auth/object-path", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();
@@ -218,7 +218,7 @@ describe("auth/object-path", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();

--- a/packages/graphql/tests/integration/auth/roles.int.test.ts
+++ b/packages/graphql/tests/integration/auth/roles.int.test.ts
@@ -71,7 +71,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -110,7 +110,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -156,7 +156,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -200,7 +200,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -246,7 +246,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -290,7 +290,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -366,7 +366,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -459,7 +459,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -535,7 +535,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -627,7 +627,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -671,7 +671,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -730,7 +730,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -775,7 +775,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -818,7 +818,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -865,7 +865,7 @@ describe("auth/roles", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");

--- a/packages/graphql/tests/integration/auth/where.int.test.ts
+++ b/packages/graphql/tests/integration/auth/where.int.test.ts
@@ -85,7 +85,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -161,7 +161,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -251,7 +251,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -339,7 +339,7 @@ describe("auth/where", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver, req },
+                        contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
                     expect(gqlResult.errors).toBeUndefined();
                     const posts = (gqlResult.data as any).users[0].content as any[];
@@ -430,7 +430,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
                 expect(gqlResult.errors).toBeUndefined();
                 const posts = (gqlResult.data as any).users[0].contentConnection as {
@@ -500,7 +500,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -561,7 +561,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -642,7 +642,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -715,7 +715,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -789,7 +789,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();
@@ -861,7 +861,7 @@ describe("auth/where", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver, req },
+                    contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeUndefined();

--- a/packages/graphql/tests/integration/autogenerate.int.test.ts
+++ b/packages/graphql/tests/integration/autogenerate.int.test.ts
@@ -61,7 +61,7 @@ describe("autogenerate", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -120,7 +120,7 @@ describe("autogenerate", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/composite-where.int.test.ts
+++ b/packages/graphql/tests/integration/composite-where.int.test.ts
@@ -42,7 +42,7 @@ describe("composite-where", () => {
                 type Actor {
                     name: String
                 }
-    
+
                 type Movie {
                     id: ID!
                     actors: [Actor] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
@@ -104,7 +104,7 @@ describe("composite-where", () => {
                     schema: neoSchema.schema,
                     source: query,
                     variableValues: { movieId, actorName, screenTime },
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -124,7 +124,7 @@ describe("composite-where", () => {
                 type Actor {
                     name: String
                 }
-    
+
                 type Movie {
                     id: ID!
                     actors: [Actor] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
@@ -186,7 +186,7 @@ describe("composite-where", () => {
                     schema: neoSchema.schema,
                     source: query,
                     variableValues: { movieId, actorName, screenTime },
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/connection-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/connection-resolvers-int.test.ts
@@ -112,7 +112,7 @@ describe("Connection Resolvers", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -216,7 +216,7 @@ describe("Connection Resolvers", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: {
                     input: [
                         {
@@ -282,7 +282,7 @@ describe("Connection Resolvers", () => {
             const result2 = await graphql({
                 schema: neoSchema.schema,
                 source: secondQuery,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: {
                     movieId,
                     endCursor: result?.data?.createMovies.movies[0].actorsConnection.pageInfo.endCursor,
@@ -312,7 +312,7 @@ describe("Connection Resolvers", () => {
             const result3 = await graphql({
                 schema: neoSchema.schema,
                 source: secondQuery,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: {
                     movieId,
                     endCursor: result2?.data?.movies[0].actorsConnection.pageInfo.endCursor,
@@ -391,7 +391,7 @@ describe("Connection Resolvers", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieId },
             });
 

--- a/packages/graphql/tests/integration/connections/alias.int.test.ts
+++ b/packages/graphql/tests/integration/connections/alias.int.test.ts
@@ -20,9 +20,9 @@
 import { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
+import { gql } from "apollo-server";
 import neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { gql } from "apollo-server";
 
 describe("Connections Alias", () => {
     let driver: Driver;
@@ -69,7 +69,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
@@ -83,7 +83,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -129,7 +129,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
@@ -143,7 +143,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -192,7 +192,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
@@ -206,7 +206,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -254,7 +254,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
@@ -268,7 +268,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -314,7 +314,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
@@ -328,7 +328,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -374,7 +374,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
                     CREATE (m)<-[:ACTED_IN]-(:Actor)
@@ -388,7 +388,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -434,7 +434,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
@@ -448,7 +448,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -494,7 +494,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
@@ -508,7 +508,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -554,7 +554,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
@@ -568,7 +568,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -616,7 +616,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
@@ -630,7 +630,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -678,7 +678,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
                     CREATE (m)<-[:ACTED_IN]-(:Actor {name: randomUUID()})
@@ -692,7 +692,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -742,7 +742,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN {roles: [randomUUID()]}]-(:Actor {name: randomUUID()})
                     CREATE (m)<-[:ACTED_IN {roles: [randomUUID()]}]-(:Actor {name: randomUUID()})
@@ -756,7 +756,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();
@@ -821,7 +821,7 @@ describe("Connections Alias", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (m:Movie {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN {roles: $roles}]-(:Actor {name: $actorName})
                 `,
@@ -835,7 +835,7 @@ describe("Connections Alias", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeUndefined();

--- a/packages/graphql/tests/integration/connections/enums.int.test.ts
+++ b/packages/graphql/tests/integration/connections/enums.int.test.ts
@@ -112,7 +112,7 @@ describe("Enum Relationship Properties", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { title, name },
             });
 

--- a/packages/graphql/tests/integration/connections/unions.int.test.ts
+++ b/packages/graphql/tests/integration/connections/unions.int.test.ts
@@ -110,7 +110,7 @@ describe("Connections -> Unions", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -170,7 +170,7 @@ describe("Connections -> Unions", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -228,7 +228,7 @@ describe("Connections -> Unions", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -282,7 +282,7 @@ describe("Connections -> Unions", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -336,7 +336,7 @@ describe("Connections -> Unions", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/count.int.test.ts
+++ b/packages/graphql/tests/integration/count.int.test.ts
@@ -20,13 +20,13 @@
 import { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import neo4j from "./neo4j";
-import { Neo4jGraphQL } from "../../src/classes";
 import pluralize from "pluralize";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
 import jsonwebtoken from "jsonwebtoken";
 import camelCase from "camelcase";
+import neo4j from "./neo4j";
+import { Neo4jGraphQL } from "../../src/classes";
 
 describe("count", () => {
     let driver: Driver;
@@ -74,7 +74,7 @@ describe("count", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             if (gqlResult.errors) {
@@ -126,7 +126,7 @@ describe("count", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             if (gqlResult.errors) {
@@ -205,7 +205,7 @@ describe("count", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             if (gqlResult.errors) {
@@ -268,7 +268,7 @@ describe("count", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");

--- a/packages/graphql/tests/integration/create.int.test.ts
+++ b/packages/graphql/tests/integration/create.int.test.ts
@@ -68,7 +68,7 @@ describe("create", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -126,7 +126,7 @@ describe("create", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id1, id2 },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -284,7 +284,7 @@ describe("create", () => {
                     },
                 ],
             },
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
         });
 
         expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/custom-directives.int.test.ts
+++ b/packages/graphql/tests/integration/custom-directives.int.test.ts
@@ -84,7 +84,7 @@ describe("Custom Directives", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/custom-resolvers.int.test.ts
@@ -72,7 +72,7 @@ describe("Custom Resolvers", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -353,7 +353,7 @@ describe("Custom Resolvers", () => {
                         const gqlResult = await graphql({
                             schema: neoSchema.schema,
                             source: query,
-                            contextValue: { driver },
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         });
 
                         expect(gqlResult.errors).toBeFalsy();
@@ -421,7 +421,7 @@ describe("Custom Resolvers", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: mutation,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -462,7 +462,7 @@ describe("Custom Resolvers", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -514,7 +514,7 @@ describe("Custom Resolvers", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -571,7 +571,7 @@ describe("Custom Resolvers", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/cypher.int.test.ts
+++ b/packages/graphql/tests/integration/cypher.int.test.ts
@@ -95,7 +95,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { title: movieTitle },
                     });
 
@@ -165,7 +165,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { title: movieTitle, name: actorName },
                     });
 
@@ -248,7 +248,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver, req },
+                        contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { title: movieTitle, name: actorName },
                     });
 
@@ -326,7 +326,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { titles: [movieTitle1, movieTitle2, movieTitle3] },
                     });
 
@@ -408,7 +408,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { title: movieTitle },
                     });
 
@@ -478,7 +478,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { title: movieTitle },
                     });
 
@@ -548,7 +548,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { title: movieTitle },
                     });
 
@@ -623,7 +623,7 @@ describe("cypher", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                         variableValues: { id: townId },
                     });
 

--- a/packages/graphql/tests/integration/default-values.int.test.ts
+++ b/packages/graphql/tests/integration/default-values.int.test.ts
@@ -76,7 +76,7 @@ describe("Default values", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -122,7 +122,7 @@ describe("Default values", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -266,7 +266,7 @@ describe("Default values", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/delete.int.test.ts
+++ b/packages/graphql/tests/integration/delete.int.test.ts
@@ -71,7 +71,7 @@ describe("delete", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -128,7 +128,7 @@ describe("delete", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id: "NOT FOUND" },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -200,7 +200,7 @@ describe("delete", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id, name },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -292,7 +292,7 @@ describe("delete", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id1, name, id2 },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -383,7 +383,7 @@ describe("delete", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { name },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/enums.int.test.ts
+++ b/packages/graphql/tests/integration/enums.int.test.ts
@@ -72,7 +72,7 @@ describe("enums", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/field-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/field-filtering.int.test.ts
@@ -96,7 +96,7 @@ describe("field-filtering", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             if (gqlResult.errors) {

--- a/packages/graphql/tests/integration/find.int.test.ts
+++ b/packages/graphql/tests/integration/find.int.test.ts
@@ -78,7 +78,7 @@ describe("find", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -131,7 +131,7 @@ describe("find", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -190,7 +190,7 @@ describe("find", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { ids: [id1, id2, id3] },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -255,7 +255,7 @@ describe("find", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { ids: [id1, id2, id3], title },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -347,7 +347,7 @@ describe("find", () => {
                     movieIds: [movieId1, movieId2, movieId3],
                     actorIds: [actorId1, actorId2, actorId3],
                 },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -485,7 +485,7 @@ describe("find", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { movieIds: [movieId1, movieId2, movieId3], actorIds: [actorId1, actorId2, actorId3] },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -550,7 +550,7 @@ describe("find", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { movieWhere: { OR: [{ title, id }] } },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/floats.int.test.ts
+++ b/packages/graphql/tests/integration/floats.int.test.ts
@@ -73,7 +73,7 @@ describe("floats", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -135,7 +135,7 @@ describe("floats", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: {
                     imdbRating_float: imdbRatingFloat,
                     imdbRating_int: imdbRatingInt,
@@ -206,7 +206,7 @@ describe("floats", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: {
                     float,
                     floats,
@@ -269,7 +269,7 @@ describe("floats", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/ignore-directive.int.test.ts
+++ b/packages/graphql/tests/integration/ignore-directive.int.test.ts
@@ -77,7 +77,7 @@ describe("@ignore directive", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: usersQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { username },
         });
 

--- a/packages/graphql/tests/integration/issues/190.int.test.ts
+++ b/packages/graphql/tests/integration/issues/190.int.test.ts
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -165,7 +165,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/issues/207.int.test.ts
+++ b/packages/graphql/tests/integration/issues/207.int.test.ts
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/207", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/issues/283.int.test.ts
+++ b/packages/graphql/tests/integration/issues/283.int.test.ts
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/283", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/issues/288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/288.int.test.ts
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
             const createResult = await graphql({
                 schema: neoSchema.schema,
                 source: createMutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(createResult.errors).toBeFalsy();
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
             const updateResult = await graphql({
                 schema: neoSchema.schema,
                 source: updateMutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(updateResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/issues/315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/315.int.test.ts
@@ -213,7 +213,7 @@ describe("https://github.com/neo4j/graphql/issues/315", () => {
             const mutationResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { input },
             });
 
@@ -230,7 +230,7 @@ describe("https://github.com/neo4j/graphql/issues/315", () => {
             const queryResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: {
                     userID,
                 },

--- a/packages/graphql/tests/integration/issues/326.int.test.ts
+++ b/packages/graphql/tests/integration/issues/326.int.test.ts
@@ -20,11 +20,11 @@
 import { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import neo4j from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
 import { IncomingMessage } from "http";
 import jsonwebtoken from "jsonwebtoken";
 import { Socket } from "net";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("326", () => {
     let driver: Driver;
@@ -97,7 +97,7 @@ describe("326", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id },
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");
@@ -166,7 +166,7 @@ describe("326", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id },
-                contextValue: { driver, req },
+                contextValue: { driver, req, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect((gqlResult.errors as any[])[0].message).toEqual("Forbidden");

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -96,7 +96,7 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
 
         try {
             await session.run(
-                `  
+                `
                     CREATE (post:Post {id: $postId, title: $postTitle, content: $postContent})
                     CREATE (comment1:Comment {id: $comment1Id, content: $comment1Content, flagged: true})
                     CREATE (comment2:Comment {id: $comment2Id, content: $comment2Content, flagged: false})
@@ -118,7 +118,7 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
             expect(result.errors).toBeFalsy();
             expect(result?.data?.posts[0].flaggedComments).toContainEqual({

--- a/packages/graphql/tests/integration/issues/360.int.test.ts
+++ b/packages/graphql/tests/integration/issues/360.int.test.ts
@@ -80,7 +80,7 @@ describe("360", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();
@@ -134,7 +134,7 @@ describe("360", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeUndefined();
@@ -192,7 +192,7 @@ describe("360", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { rangeStart, rangeEnd },
             });
 

--- a/packages/graphql/tests/integration/issues/369.int.test.ts
+++ b/packages/graphql/tests/integration/issues/369.int.test.ts
@@ -90,7 +90,7 @@ describe("369", () => {
         `;
         try {
             await session.run(
-                `  
+                `
                     CREATE (:Dato {uuid: $datoUUID})-[:DEPENDE {uuid: $relUUID}]->(:Dato {uuid: $datoToUUID})
                 `,
                 {
@@ -103,7 +103,7 @@ describe("369", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -174,7 +174,7 @@ describe("369", () => {
         `;
         try {
             await session.run(
-                `  
+                `
                     CREATE (d:Dato {uuid: $datoUUID})-[:DEPENDE {uuid: $relUUID}]->(:Dato {uuid: $datoToUUID})
                     CREATE (d)-[:DEPENDE {uuid: randomUUID()}]->(:Dato {uuid: randomUUID()})
                     CREATE (d)-[:DEPENDE {uuid: randomUUID()}]->(:Dato {uuid: randomUUID()})
@@ -189,7 +189,7 @@ describe("369", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/nested-unions.int.test.ts
+++ b/packages/graphql/tests/integration/nested-unions.int.test.ts
@@ -114,7 +114,7 @@ describe("Nested unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
             expect(gqlResult.errors).toBeFalsy();
             expect(gqlResult.data?.updateMovies.movies[0].title).toEqual(movieTitle);
@@ -178,7 +178,7 @@ describe("Nested unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
             expect(gqlResult.errors).toBeFalsy();
             expect(gqlResult.data?.updateMovies.movies).toEqual([
@@ -263,7 +263,7 @@ describe("Nested unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
             expect(gqlResult.errors).toBeFalsy();
             expect(gqlResult.data?.updateMovies.movies).toEqual([
@@ -364,7 +364,7 @@ describe("Nested unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
             expect(gqlResult.errors).toBeFalsy();
             expect(gqlResult.data?.updateMovies.movies[0].title).toEqual(movieTitle);
@@ -463,7 +463,7 @@ describe("Nested unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
             expect(gqlResult.errors).toBeFalsy();
             // expect(gqlResult.data?.createMovies.movies).toEqual([

--- a/packages/graphql/tests/integration/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/query-options.int.test.ts
@@ -83,7 +83,7 @@ describe("query options", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
@@ -102,7 +102,7 @@ describe("Relationship properties - connect", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName, screenTime },
             });
             expect(gqlResult.errors).toBeFalsy();
@@ -194,7 +194,7 @@ describe("Relationship properties - connect", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName, screenTime },
             });
             expect(gqlResult.errors).toBeFalsy();
@@ -282,7 +282,7 @@ describe("Relationship properties - connect", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName, screenTime },
             });
             expect(gqlResult.errors).toBeFalsy();
@@ -367,7 +367,7 @@ describe("Relationship properties - connect", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName, screenTime },
             });
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
@@ -94,7 +94,7 @@ describe("Relationship properties - create", () => {
         const result = await graphql({
             schema: neoSchema.schema,
             source,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { movieTitle, actorName, screenTime },
         });
         expect(result.errors).toBeFalsy();
@@ -179,7 +179,7 @@ describe("Relationship properties - create", () => {
         const result = await graphql({
             schema: neoSchema.schema,
             source,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { movieTitle, actorName, words },
         });
         expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
@@ -88,7 +88,7 @@ describe("Relationship properties - delete", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName },
             });
             expect(gqlResult.errors).toBeFalsy();
@@ -176,7 +176,7 @@ describe("Relationship properties - delete", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { actorName, screenTime },
             });
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
@@ -88,7 +88,7 @@ describe("Relationship properties - disconnect", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName },
             });
             expect(gqlResult.errors).toBeFalsy();
@@ -178,7 +178,7 @@ describe("Relationship properties - disconnect", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { actorName, screenTime },
             });
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
@@ -113,7 +113,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -188,7 +188,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -249,7 +249,7 @@ describe("Relationship properties - read", () => {
             const ascResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { nameSort: "ASC" },
             });
 
@@ -290,7 +290,7 @@ describe("Relationship properties - read", () => {
             const descResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { nameSort: "DESC" },
             });
 
@@ -366,7 +366,7 @@ describe("Relationship properties - read", () => {
             const ascResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { nameSort: "ASC" },
             });
 
@@ -401,7 +401,7 @@ describe("Relationship properties - read", () => {
             const descResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { nameSort: "DESC" },
             });
 
@@ -467,7 +467,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -539,7 +539,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
@@ -114,7 +114,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -187,7 +187,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -217,7 +217,7 @@ describe("Relationship properties - read", () => {
             await session.close();
         }
     });
-      
+
     test("Create relationship node through update field on end node in a nested update (update -> update)", async () => {
         const session = driver.session();
 
@@ -259,7 +259,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();
@@ -295,7 +295,7 @@ describe("Relationship properties - read", () => {
             await session.close();
         }
     });
-      
+
     test("Create a relationship node with relationship properties on end node in a nested update (update -> create)", async () => {
         const session = driver.session();
 
@@ -335,7 +335,7 @@ describe("Relationship properties - read", () => {
             const result = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(result.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/scalars.init.test.ts
+++ b/packages/graphql/tests/integration/scalars.init.test.ts
@@ -91,7 +91,7 @@ describe("scalars", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: create,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -139,7 +139,7 @@ describe("scalars", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/sort.int.test.ts
+++ b/packages/graphql/tests/integration/sort.int.test.ts
@@ -81,7 +81,7 @@ describe("sort", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     expect(gqlResult.errors).toBeUndefined();
@@ -152,7 +152,7 @@ describe("sort", () => {
                     const gqlResult = await graphql({
                         schema: neoSchema.schema,
                         source: query,
-                        contextValue: { driver },
+                        contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                     });
 
                     expect(gqlResult.errors).toBeUndefined();

--- a/packages/graphql/tests/integration/timestamps.int.test.ts
+++ b/packages/graphql/tests/integration/timestamps.int.test.ts
@@ -67,7 +67,7 @@ describe("TimeStamps", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -127,7 +127,7 @@ describe("TimeStamps", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -183,7 +183,7 @@ describe("TimeStamps", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -241,7 +241,7 @@ describe("TimeStamps", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -297,7 +297,7 @@ describe("TimeStamps", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -355,7 +355,7 @@ describe("TimeStamps", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/types/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/types/bigint.int.test.ts
@@ -68,7 +68,7 @@ describe("BigInt", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -129,7 +129,7 @@ describe("BigInt", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -183,7 +183,7 @@ describe("BigInt", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/types/date.int.test.ts
+++ b/packages/graphql/tests/integration/types/date.int.test.ts
@@ -71,7 +71,7 @@ describe("Date", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -130,7 +130,7 @@ describe("Date", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -200,7 +200,7 @@ describe("Date", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -253,7 +253,7 @@ describe("Date", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/types/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/datetime.int.test.ts
@@ -71,7 +71,7 @@ describe("DateTime", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -127,7 +127,7 @@ describe("DateTime", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -197,7 +197,7 @@ describe("DateTime", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -247,7 +247,7 @@ describe("DateTime", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: query,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();
@@ -298,7 +298,7 @@ describe("DateTime", () => {
                 const gqlResult = await graphql({
                     schema: neoSchema.schema,
                     source: create,
-                    contextValue: { driver },
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 });
 
                 expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
@@ -75,7 +75,7 @@ describe("CartesianPoint", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { serial, x, y },
         });
 
@@ -125,7 +125,7 @@ describe("CartesianPoint", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { serial, x, y, z },
         });
 
@@ -191,7 +191,7 @@ describe("CartesianPoint", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { serial, x, y: newY },
         });
 
@@ -258,7 +258,7 @@ describe("CartesianPoint", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { serial, x, y: newY, z },
         });
 
@@ -321,7 +321,7 @@ describe("CartesianPoint", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: partsQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { serial },
         });
 
@@ -376,7 +376,7 @@ describe("CartesianPoint", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: partsQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { serial },
         });
 

--- a/packages/graphql/tests/integration/types/point.int.test.ts
+++ b/packages/graphql/tests/integration/types/point.int.test.ts
@@ -90,7 +90,7 @@ describe("Point", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, size, longitude, latitude },
         });
 
@@ -157,7 +157,7 @@ describe("Point", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, size, longitude, latitude, height },
         });
 
@@ -230,7 +230,7 @@ describe("Point", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, longitude, latitude: newLatitude },
         });
 
@@ -304,7 +304,7 @@ describe("Point", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, longitude, latitude: newLatitude, height },
         });
 
@@ -373,7 +373,7 @@ describe("Point", () => {
         const equalsResult = await graphql({
             schema: neoSchema.schema,
             source: photographsEqualsQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { longitude, latitude },
         });
 
@@ -408,7 +408,7 @@ describe("Point", () => {
         const inResult = await graphql({
             schema: neoSchema.schema,
             source: photographsInQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: [
                 { longitude, latitude },
                 { longitude: parseFloat(faker.address.longitude()), latitude: parseFloat(faker.address.latitude()) },
@@ -446,7 +446,7 @@ describe("Point", () => {
         const notInResult = await graphql({
             schema: neoSchema.schema,
             source: photographsNotInQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: [
                 { longitude: parseFloat(faker.address.longitude()), latitude: parseFloat(faker.address.latitude()) },
                 { longitude: parseFloat(faker.address.longitude()), latitude: parseFloat(faker.address.latitude()) },
@@ -486,7 +486,7 @@ describe("Point", () => {
         const lessThanResult = await graphql({
             schema: neoSchema.schema,
             source: photographsLessThanQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { longitude, latitude: latitude + 1 },
         });
 
@@ -523,7 +523,7 @@ describe("Point", () => {
         const greaterThanResult = await graphql({
             schema: neoSchema.schema,
             source: photographsGreaterThanQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { longitude, latitude: latitude + 1 },
         });
 
@@ -582,7 +582,7 @@ describe("Point", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: photographsQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { longitude, latitude, height },
         });
 

--- a/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
@@ -77,7 +77,7 @@ describe("[CartesianPoint]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, locations },
         });
 
@@ -132,7 +132,7 @@ describe("[CartesianPoint]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, locations },
         });
 
@@ -218,7 +218,7 @@ describe("[CartesianPoint]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, locations: newLocations },
         });
 
@@ -306,7 +306,7 @@ describe("[CartesianPoint]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, locations: newLocations },
         });
 
@@ -374,7 +374,7 @@ describe("[CartesianPoint]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: partsQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id },
         });
 
@@ -425,7 +425,7 @@ describe("[CartesianPoint]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: partsQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id },
         });
 

--- a/packages/graphql/tests/integration/types/points.int.test.ts
+++ b/packages/graphql/tests/integration/types/points.int.test.ts
@@ -77,7 +77,7 @@ describe("[Point]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, waypoints },
         });
 
@@ -132,7 +132,7 @@ describe("[Point]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: create,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, waypoints },
         });
 
@@ -218,7 +218,7 @@ describe("[Point]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, waypoints: newWaypoints },
         });
 
@@ -306,7 +306,7 @@ describe("[Point]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: update,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id, waypoints: newWaypoints },
         });
 
@@ -376,7 +376,7 @@ describe("[Point]", () => {
         const routesResult = await graphql({
             schema: neoSchema.schema,
             source: routesQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { waypoints },
         });
 
@@ -404,7 +404,7 @@ describe("[Point]", () => {
         const routesIncludesResult = await graphql({
             schema: neoSchema.schema,
             source: routesIncludesQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { waypoint: waypoints[0] },
         });
 
@@ -432,7 +432,7 @@ describe("[Point]", () => {
         const routesNotIncludesResult = await graphql({
             schema: neoSchema.schema,
             source: routesNotIncludesQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: {
                 waypoint: {
                     longitude: parseFloat(faker.address.longitude()),
@@ -488,7 +488,7 @@ describe("[Point]", () => {
         const gqlResult = await graphql({
             schema: neoSchema.schema,
             source: routesQuery,
-            contextValue: { driver },
+            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             variableValues: { id },
         });
 

--- a/packages/graphql/tests/integration/unions.int.test.ts
+++ b/packages/graphql/tests/integration/unions.int.test.ts
@@ -89,7 +89,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -160,7 +160,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: query,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -233,7 +233,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -320,7 +320,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -409,7 +409,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -491,7 +491,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -591,7 +591,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -674,7 +674,7 @@ describe("unions", () => {
             const gqlResult = await graphql({
                 schema: neoSchema.schema,
                 source: mutation,
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();

--- a/packages/graphql/tests/integration/update.int.test.ts
+++ b/packages/graphql/tests/integration/update.int.test.ts
@@ -71,7 +71,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id, name: updatedName },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -132,7 +132,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id, name: updatedName },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -205,7 +205,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { updatedMovieId, actorName },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -267,7 +267,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { id1, id2, name: updatedName },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -350,7 +350,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { movieId, updatedName, initialName },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -418,7 +418,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id, name },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -486,7 +486,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id, name },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -566,7 +566,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id1, name, id2 },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -661,7 +661,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: mutation,
                 variableValues: { id, name1, name3 },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -740,7 +740,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -807,7 +807,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -886,7 +886,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: { movieId, seriesId },
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -952,7 +952,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -1044,7 +1044,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -1190,7 +1190,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -1308,7 +1308,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();
@@ -1409,7 +1409,7 @@ describe("update", () => {
                 schema: neoSchema.schema,
                 source: query,
                 variableValues: {},
-                contextValue: { driver },
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
             });
 
             expect(gqlResult.errors).toBeFalsy();


### PR DESCRIPTION
# Description

Integration tests don't work against Aura Professional due to causal clustering. This is an attempt at passing the last bookmark into GraphQL execution so that test data is available. 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
