### PR TITLE
Fix the use of custom scalar/enum values as return type for custom Cypher

### DIFF
--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -82,9 +82,9 @@ export default function cypherResolver({
                         context,
                         nodeVariable: "this",
                     });
-                    const [str, p] = nestedConnection;
-                    connectionProjectionStr = str;
-                    params = { ...params, ...p };
+                    const [nestedStr, nestedP] = nestedConnection;
+                    connectionProjectionStr = nestedStr;
+                    params = { ...params, ...nestedP };
                 });
             }
         }

--- a/packages/graphql/tests/integration/issues/387.int.test.ts
+++ b/packages/graphql/tests/integration/issues/387.int.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/387", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should return custom scalars from custom Cypher fields", async () => {
+        const session = driver.session();
+
+        const name = generate({
+            charset: "alphabetic",
+        });
+        const url = generate({
+            charset: "alphabetic",
+        });
+
+        const typeDefs = gql`
+            scalar URL
+
+            type Place {
+                name: String
+                url: URL
+                    @cypher(
+                        statement: """
+                        return '${url}'
+                        """
+                    )
+                url_array: [URL]
+                    @cypher(
+                        statement: """
+                        return ['${url}', '${url}']
+                        """
+                    )
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const query = `
+            {
+                places(where: { name: "${name}" }) {
+                    name
+                    url
+                    url_array
+                }
+            }
+        `;
+
+        try {
+            await session.run(`CREATE (:Place { name: "${name}" })`);
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: query,
+                contextValue: { driver },
+            });
+
+            expect(result.errors).toBeFalsy();
+
+            expect(result.data as any).toEqual({
+                places: [
+                    {
+                        name,
+                        url,
+                        url_array: [url, url],
+                    },
+                ],
+            });
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/issues/387.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/issues/387.md
@@ -1,0 +1,78 @@
+# #387
+
+<https://github.com/neo4j/graphql/issues/387>
+
+Schema:
+
+```graphql
+scalar URL
+
+type Place {
+    name: String
+    url_works: String
+        @cypher(
+            statement: """
+            return '' + ''
+            """
+        )
+    url_fails: URL
+        @cypher(
+            statement: """
+            return '' + ''
+            """
+        )
+    url_array_works: [String]
+        @cypher(
+            statement: """
+            return ['' + '']
+            """
+        )
+    url_array_fails: [URL]
+        @cypher(
+            statement: """
+            return ['' + '']
+            """
+        )
+}
+```
+
+---
+
+## Should project custom scalars from custom Cypher correctly
+
+### GraphQL Input
+
+```graphql
+{
+    places {
+        url_works
+        url_fails
+        url_array_works
+        url_array_fails
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Place)
+RETURN this {
+    url_works: apoc.cypher.runFirstColumn("return '' + ''", {this: this, auth: $auth}, false),
+    url_fails: apoc.cypher.runFirstColumn("return '' + ''", {this: this, auth: $auth}, false),
+    url_array_works: apoc.cypher.runFirstColumn("return ['' + '']", {this: this, auth: $auth}, false),
+    url_array_fails: apoc.cypher.runFirstColumn("return ['' + '']", {this: this, auth: $auth}, false)
+} as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "auth": {
+        "isAuthenticated": true,
+        "jwt": {},
+        "roles": []
+    }
+}
+```

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -112,20 +112,20 @@ describe("TCK Generated tests", () => {
                     }
 
                     function compare(
-                        cypher: { expected: string; recived: string },
-                        params: { expected: any; recived: any },
+                        cypher: { expected: string; received: string },
+                        params: { expected: any; received: any },
                         context: any
                     ) {
                         if (
-                            cypher.recived.includes("$auth.") ||
-                            cypher.recived.includes("auth: $auth") ||
-                            cypher.recived.includes("auth:$auth")
+                            cypher.received.includes("$auth.") ||
+                            cypher.received.includes("auth: $auth") ||
+                            cypher.received.includes("auth:$auth")
                         ) {
                             params.expected.auth = createAuthParam({ context });
                         }
 
-                        expect(trimmer(cypher.expected)).toEqual(trimmer(cypher.recived));
-                        expect(params.expected).toEqual(params.recived);
+                        expect(trimmer(cypher.expected)).toEqual(trimmer(cypher.received));
+                        expect(params.expected).toEqual(params.received);
                     }
 
                     const queries = document.definitions.reduce((res, def) => {
@@ -154,8 +154,8 @@ describe("TCK Generated tests", () => {
                                 });
 
                                 compare(
-                                    { expected: cQuery, recived: cypherQuery },
-                                    { expected: cQueryParams, recived: cypherParams },
+                                    { expected: cQuery, received: cypherQuery },
+                                    { expected: cQueryParams, received: cypherParams },
                                     mergedContext
                                 );
 
@@ -180,8 +180,8 @@ describe("TCK Generated tests", () => {
                                 });
 
                                 compare(
-                                    { expected: cQuery, recived: cypherQuery },
-                                    { expected: cQueryParams, recived: cypherParams },
+                                    { expected: cQuery, received: cypherQuery },
+                                    { expected: cQueryParams, received: cypherParams },
                                     mergedContext
                                 );
 
@@ -216,8 +216,8 @@ describe("TCK Generated tests", () => {
                                 });
 
                                 compare(
-                                    { expected: cQuery, recived: cypherQuery },
-                                    { expected: cQueryParams, recived: cypherParams },
+                                    { expected: cQuery, received: cypherQuery },
+                                    { expected: cQueryParams, received: cypherParams },
                                     mergedContext
                                 );
 
@@ -244,8 +244,8 @@ describe("TCK Generated tests", () => {
                                 });
 
                                 compare(
-                                    { expected: cQuery, recived: cypherQuery },
-                                    { expected: cQueryParams, recived: cypherParams },
+                                    { expected: cQuery, received: cypherQuery },
+                                    { expected: cQueryParams, received: cypherParams },
                                     mergedContext
                                 );
 
@@ -267,8 +267,8 @@ describe("TCK Generated tests", () => {
                                 });
 
                                 compare(
-                                    { expected: cQuery, recived: cypherQuery },
-                                    { expected: cQueryParams, recived: cypherParams },
+                                    { expected: cQuery, received: cypherQuery },
+                                    { expected: cQueryParams, received: cypherParams },
                                     mergedContext
                                 );
 


### PR DESCRIPTION
# Description

Fix the use of custom scalar/enum values as return type for custom Cypher

# Issue

#387 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
