### PR TITLE
Fix for connection with multiple aliases

### DIFF
--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -132,7 +132,7 @@ function createConnectionAndParams({
                                 context,
                                 nodeVariable: relatedNodeVariable,
                                 parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                                    resolveTree.name
+                                    resolveTree.alias
                                 }.edges.node`,
                             });
                             nestedSubqueries.push(nestedConnection[0]);
@@ -141,7 +141,7 @@ function createConnectionAndParams({
                                 ...globalParams,
                                 ...Object.entries(nestedConnection[1]).reduce<Record<string, unknown>>(
                                     (res, [k, v]) => {
-                                        if (k !== `${relatedNodeVariable}_${connectionResolveTree.name}`) {
+                                        if (k !== `${relatedNodeVariable}_${connectionResolveTree.alias}`) {
                                             res[k] = v;
                                         }
                                         return res;
@@ -150,13 +150,15 @@ function createConnectionAndParams({
                                 ),
                             };
 
-                            if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`]) {
+                            if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.alias}`]) {
                                 if (!nestedConnectionFieldParams) nestedConnectionFieldParams = {};
                                 nestedConnectionFieldParams = {
                                     ...nestedConnectionFieldParams,
                                     ...{
-                                        [connectionResolveTree.name]:
-                                            nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`],
+                                        [connectionResolveTree.alias]:
+                                            nestedConnection[1][
+                                                `${relatedNodeVariable}_${connectionResolveTree.alias}`
+                                            ],
                                     },
                                 };
                             }
@@ -197,7 +199,7 @@ function createConnectionAndParams({
                         relationshipVariable,
                         context,
                         parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                            resolveTree.name
+                            resolveTree.alias
                         }.args.where.${n.name}`,
                     });
                     const [whereClause] = where;
@@ -268,7 +270,7 @@ function createConnectionAndParams({
                 relationshipVariable,
                 context,
                 parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                    resolveTree.name
+                    resolveTree.alias
                 }.args.where`,
             });
             const [whereClause] = where;
@@ -350,7 +352,7 @@ function createConnectionAndParams({
                         context,
                         nodeVariable: relatedNodeVariable,
                         parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                            resolveTree.name
+                            resolveTree.alias
                         }.edges.node`,
                     });
                     nestedSubqueries.push(nestedConnection[0]);
@@ -358,20 +360,20 @@ function createConnectionAndParams({
                     globalParams = {
                         ...globalParams,
                         ...Object.entries(nestedConnection[1]).reduce<Record<string, unknown>>((res, [k, v]) => {
-                            if (k !== `${relatedNodeVariable}_${connectionResolveTree.name}`) {
+                            if (k !== `${relatedNodeVariable}_${connectionResolveTree.alias}`) {
                                 res[k] = v;
                             }
                             return res;
                         }, {}),
                     };
 
-                    if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`]) {
+                    if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.alias}`]) {
                         if (!nestedConnectionFieldParams) nestedConnectionFieldParams = {};
                         nestedConnectionFieldParams = {
                             ...nestedConnectionFieldParams,
                             ...{
-                                [connectionResolveTree.name]:
-                                    nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`],
+                                [connectionResolveTree.alias]:
+                                    nestedConnection[1][`${parameterPrefix}_${connectionResolveTree.alias}`],
                             },
                         };
                     }
@@ -403,7 +405,7 @@ function createConnectionAndParams({
     const params = {
         ...globalParams,
         ...((whereInput || nestedConnectionFieldParams) && {
-            [`${nodeVariable}_${resolveTree.name}`]: {
+            [`${nodeVariable}_${resolveTree.alias}`]: {
                 ...(whereInput && { args: { where: whereInput } }),
                 ...(nestedConnectionFieldParams && { edges: { node: { ...nestedConnectionFieldParams } } }),
             },

--- a/packages/graphql/tests/integration/connections/alias.int.test.ts
+++ b/packages/graphql/tests/integration/connections/alias.int.test.ts
@@ -906,11 +906,11 @@ describe("Connections Alias", () => {
         try {
             await session.run(
                 `
-              CREATE (post:Post {title: "title"})
-              FOREACH(flag in $flags |
-                CREATE (:Comment {flag: flag})<-[:HAS_COMMENT]-(post)
-              )
-          `,
+                    CREATE (post:Post {title: "title"})
+                    FOREACH(flag in $flags |
+                        CREATE (:Comment {flag: flag})<-[:HAS_COMMENT]-(post)
+                    )
+                `,
                 {
                     flags,
                 }


### PR DESCRIPTION
# Description

Similar to #359, this adds the ability to have multiple aliases on connection fields without overwriting parameters by naming parameters after aliases and fields after names.

# Issue

- #392 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
