### PR TITLE
feat: export auth errors from index

### DIFF
--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -35,4 +35,9 @@ export {
     CypherRuntime,
     CypherUpdateStrategy,
 } from "./types";
-export { Neo4jGraphQL, Neo4jGraphQLConstructor } from "./classes";
+export {
+    Neo4jGraphQL,
+    Neo4jGraphQLConstructor,
+    Neo4jGraphQLAuthenticationError,
+    Neo4jGraphQLForbiddenError,
+} from "./classes";


### PR DESCRIPTION
# Description

Exports the auth error classes so one can override the messages, reference https://discord.com/channels/787399249741479977/818578492723036210/872962949445193748 

