### PR TITLE
Reserved properties

### DIFF
--- a/docs/asciidoc/ogm/selection-set.adoc
+++ b/docs/asciidoc/ogm/selection-set.adoc
@@ -36,11 +36,15 @@ When using the OGM, you do not have to provide a selection set by default. Doing
 
 [source, graphql]
 ----
-type Node {
+type Movie {
     id: ID
     name: String
-    relatedNodes: [Node] @relationship(type: "HAS_NODE", direction: OUT)
+    genres: [Genre] @relationship(type: "IN_GENRE", direction: OUT)
     customCypher: String! @cypher(statement: "RETURN someCustomData")
+}
+
+type Genre {
+    name: String
 }
 ----
 
@@ -71,33 +75,36 @@ const driver = neo4j.driver(
 );
 
 const typeDefs = `
-    type Node {
+    type Movie {
         id: ID
         name: String
-        relatedNodes: [Node] @relationship(type: "HAS_NODE", direction: OUT)
+        genres: [Genre] @relationship(type: "IN_GENRE", direction: OUT)
         customCypher: String! @cypher(statement: "RETURN someCustomData")
+    }
+
+    type Genre {
+        name: String
     }
 `;
 
 const ogm = new OGM({ typeDefs, driver });
-const Node = ogm.model("Node");
+const Movie = ogm.model("Movie");
 
 const selectionSet = `
     {
         id
         name
-        relatedNodes {
-            id
+        genres {
             name
         }
         customCypher
     }
 `;
 
-const nodes = await Node.find({ selectionSet });
+const movies = await Movie.find({ selectionSet });
 ----
 
-Note that  the argument `selectionSet` is passed every invocation of the `Node.find()` function.
+Note that  the argument `selectionSet` is passed every invocation of the `Movie.find()` function.
 
 ==  Selection set as a static
 
@@ -114,32 +121,35 @@ const driver = neo4j.driver(
 );
 
 const typeDefs = `
-    type Node {
+    type Movie {
         id: ID
         name: String
-        relatedNodes: [Node] @relationship(type: "HAS_NODE", direction: OUT)
+        genres: [Genre] @relationship(type: "IN_GENRE", direction: OUT)
         customCypher: String! @cypher(statement: "RETURN someCustomData")
+    }
+
+    type Genre {
+        name: String
     }
 `;
 
 const ogm = new OGM({ typeDefs, driver });
-const Node = ogm.model("Node");
+const Movie = ogm.model("Movie");
 
 const selectionSet = `
     {
         id
         name
-        relatedNodes {
-            id
+        genres {
             name
         }
         customCypher
     }
 `;
 
-Node.setSelectionSet(selectionSet)
+Movie.setSelectionSet(selectionSet)
 
-const nodes = await Node.find();
+const movies = await Movie.find();
 ----
 
-Note that despite not passing this selection set into `Node.find()`, the requested fields will be returned on each request.
+Note that despite not passing this selection set into `Movie.find()`, the requested fields will be returned on each request.

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -34,3 +34,27 @@ export const REQUIRED_APOC_PROCEDURES = ["apoc.util.validate", "apoc.do.when", "
 export const DEBUG_AUTH = `${DEBUG_PREFIX}:auth`;
 export const DEBUG_GRAPHQL = `${DEBUG_PREFIX}:graphql`;
 export const DEBUG_EXECUTE = `${DEBUG_PREFIX}:execute`;
+
+// [0]Property [1]Error
+export const RESERVED_NODE_LABELS = [
+    [
+        "PageInfo",
+        "Type name `PageInfo` reserved to support the pagination model of connections. See https://relay.dev/graphql/connections.htm#sec-Reserved-Types for more information.",
+    ],
+    [
+        "Connection",
+        'Type names ending "Connection" are reserved to support the pagination model of connections. See https://relay.dev/graphql/connections.htm#sec-Reserved-Types for more information.',
+    ],
+    ["Node", "Type name 'Node' reserved to support relay See https://relay.dev/graphql/"],
+];
+
+// [0]Property [1]Error
+export const RESERVED_INTERFACE_NAMES = [
+    ["Node", "Interface name 'Node' reserved to support relay See https://relay.dev/graphql/"],
+];
+
+// [0]Property [1]Error
+export const RESERVED_INTERFACE_PROPERTIES = [
+    ["node", "Interface field name 'node' reserved to support relay See https://relay.dev/graphql/"],
+    ["cursor", "Interface field name 'cursor' reserved to support relay See https://relay.dev/graphql/"],
+];

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -35,26 +35,21 @@ export const DEBUG_AUTH = `${DEBUG_PREFIX}:auth`;
 export const DEBUG_GRAPHQL = `${DEBUG_PREFIX}:graphql`;
 export const DEBUG_EXECUTE = `${DEBUG_PREFIX}:execute`;
 
-// [0]Property [1]Error
-export const RESERVED_NODE_LABELS = [
+// [0]Name [1]Error
+export const RESERVED_TYPE_NAMES = [
     [
         "PageInfo",
-        "Type name `PageInfo` reserved to support the pagination model of connections. See https://relay.dev/graphql/connections.htm#sec-Reserved-Types for more information.",
+        "Type or Interface with name `PageInfo` reserved to support the pagination model of connections. See https://relay.dev/graphql/connections.htm#sec-Reserved-Types for more information.",
     ],
     [
         "Connection",
-        'Type names ending "Connection" are reserved to support the pagination model of connections. See https://relay.dev/graphql/connections.htm#sec-Reserved-Types for more information.',
+        'Type or Interface with name ending "Connection" are reserved to support the pagination model of connections. See https://relay.dev/graphql/connections.htm#sec-Reserved-Types for more information.',
     ],
-    ["Node", "Type name 'Node' reserved to support relay See https://relay.dev/graphql/"],
+    ["Node", "Type or Interface with name 'Node' reserved to support relay See https://relay.dev/graphql/"],
 ];
 
-// [0]Property [1]Error
-export const RESERVED_INTERFACE_NAMES = [
-    ["Node", "Interface name 'Node' reserved to support relay See https://relay.dev/graphql/"],
-];
-
-// [0]Property [1]Error
-export const RESERVED_INTERFACE_PROPERTIES = [
+// [0]Field [1]Error
+export const RESERVED_INTERFACE_FIELDS = [
     ["node", "Interface field name 'node' reserved to support relay See https://relay.dev/graphql/"],
     ["cursor", "Interface field name 'cursor' reserved to support relay See https://relay.dev/graphql/"],
 ];

--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -311,42 +311,84 @@ describe("makeAugmentedSchema", () => {
         describe("Node", () => {
             test("should throw when using PageInfo as node name", () => {
                 const typeDefs = `
-                type PageInfo {
-                    id: ID
-                }
-            `;
+                    type PageInfo {
+                        id: ID
+                    }
+                `;
 
                 expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
-                    (constants.RESERVED_NODE_LABELS.find((x) => x[0] === "PageInfo") as string[])[1]
+                    (constants.RESERVED_TYPE_NAMES.find((x) => x[0] === "PageInfo") as string[])[1]
                 );
             });
 
             test("should throw when using Connection in a node name", () => {
                 const typeDefs = `
-                type NodeConnection {
-                    id: ID
-                }
-            `;
+                    type NodeConnection {
+                        id: ID
+                    }
+                `;
 
                 expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
-                    (constants.RESERVED_NODE_LABELS.find((x) => x[0] === "Connection") as string[])[1]
+                    (constants.RESERVED_TYPE_NAMES.find((x) => x[0] === "Connection") as string[])[1]
                 );
             });
 
             test("should throw when using Node as node name", () => {
                 const typeDefs = `
-                type Node {
-                    id: ID
-                }
-            `;
+                    type Node {
+                        id: ID
+                    }
+                `;
 
                 expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
-                    (constants.RESERVED_NODE_LABELS.find((x) => x[0] === "Node") as string[])[1]
+                    (constants.RESERVED_TYPE_NAMES.find((x) => x[0] === "Node") as string[])[1]
                 );
             });
         });
 
         describe("Interface", () => {
+            test("should throw when using PageInfo as relationship properties interface name", () => {
+                const typeDefs = `
+                    type Movie {
+                        id: ID
+                        actors: [Actor] @relationship(type: "ACTED_IN", direction: OUT, properties: "PageInfo")
+                    }
+
+                    interface PageInfo {
+                        screenTime: Int
+                    }
+
+                    type Actor {
+                        name: String
+                    }
+                `;
+
+                expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                    (constants.RESERVED_TYPE_NAMES.find((x) => x[0] === "PageInfo") as string[])[1]
+                );
+            });
+
+            test("should throw when using Connection in a properties interface name", () => {
+                const typeDefs = `
+                    type Movie {
+                        id: ID
+                        actors: [Actor] @relationship(type: "ACTED_IN", direction: OUT, properties: "NodeConnection")
+                    }
+
+                    interface NodeConnection {
+                        screenTime: Int
+                    }
+
+                    type Actor {
+                        name: String
+                    }
+                `;
+
+                expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                    (constants.RESERVED_TYPE_NAMES.find((x) => x[0] === "Connection") as string[])[1]
+                );
+            });
+
             test("should throw when using Node as relationship properties interface name", () => {
                 const typeDefs = `
                     type Movie {
@@ -364,7 +406,7 @@ describe("makeAugmentedSchema", () => {
                 `;
 
                 expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
-                    (constants.RESERVED_INTERFACE_NAMES.find((x) => x[0] === "Node") as string[])[1]
+                    (constants.RESERVED_TYPE_NAMES.find((x) => x[0] === "Node") as string[])[1]
                 );
             });
 
@@ -386,7 +428,7 @@ describe("makeAugmentedSchema", () => {
                     `;
 
                     expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
-                        (constants.RESERVED_INTERFACE_PROPERTIES.find((x) => x[0] === "node") as string[])[1]
+                        (constants.RESERVED_INTERFACE_FIELDS.find((x) => x[0] === "node") as string[])[1]
                     );
                 });
 
@@ -407,7 +449,7 @@ describe("makeAugmentedSchema", () => {
                     `;
 
                     expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
-                        (constants.RESERVED_INTERFACE_PROPERTIES.find((x) => x[0] === "cursor") as string[])[1]
+                        (constants.RESERVED_INTERFACE_FIELDS.find((x) => x[0] === "cursor") as string[])[1]
                     );
                 });
             });

--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -30,6 +30,7 @@ import {
 import { pluralize } from "graphql-compose";
 import makeAugmentedSchema from "./make-augmented-schema";
 import { Node } from "../classes";
+import * as constants from "../constants";
 
 describe("makeAugmentedSchema", () => {
     test("should be a function", () => {
@@ -136,8 +137,8 @@ describe("makeAugmentedSchema", () => {
 
     test("should throw cannot have auth directive on a relationship", () => {
         const typeDefs = `
-                type Node {
-                    node: Node @relationship(type: "NODE", direction: OUT) @auth(rules: [{operations: [CREATE]}])
+                type Movie {
+                    movie: Movie @relationship(type: "NODE", direction: OUT) @auth(rules: [{operations: [CREATE]}])
                 }
             `;
 
@@ -147,7 +148,7 @@ describe("makeAugmentedSchema", () => {
     describe("REGEX", () => {
         test("should remove the MATCHES filter by default", () => {
             const typeDefs = `
-                    type Node {
+                    type Movie {
                         name: String
                     }
                 `;
@@ -157,7 +158,7 @@ describe("makeAugmentedSchema", () => {
             const document = parse(printSchema(neoSchema.schema));
 
             const nodeWhereInput = document.definitions.find(
-                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "NodeWhere"
+                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "MovieWhere"
             ) as InputObjectTypeDefinitionNode;
 
             const matchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("_MATCHES"));
@@ -167,7 +168,7 @@ describe("makeAugmentedSchema", () => {
 
         test("should add the MATCHES filter when NEO4J_GRAPHQL_ENABLE_REGEX is set", () => {
             const typeDefs = `
-                    type Node {
+                    type User {
                         name: String
                     }
                 `;
@@ -177,7 +178,7 @@ describe("makeAugmentedSchema", () => {
             const document = parse(printSchema(neoSchema.schema));
 
             const nodeWhereInput = document.definitions.find(
-                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "NodeWhere"
+                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "UserWhere"
             ) as InputObjectTypeDefinitionNode;
 
             const matchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("_MATCHES"));
@@ -191,12 +192,12 @@ describe("makeAugmentedSchema", () => {
             // https://github.com/neo4j/graphql/issues/158
 
             const typeDefs = `
-                type Node {
+                type Movie {
                     createdAt: DateTime
                 }
 
                 type Query {
-                  nodes: [Node] @cypher(statement: "")
+                  movies: [Movie] @cypher(statement: "")
                 }
             `;
 
@@ -304,5 +305,112 @@ describe("makeAugmentedSchema", () => {
         expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
             "Cannot have @cypher directive on relationship property"
         );
+    });
+
+    describe("Reserved Names", () => {
+        describe("Node", () => {
+            test("should throw when using PageInfo as node name", () => {
+                const typeDefs = `
+                type PageInfo {
+                    id: ID
+                }
+            `;
+
+                expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                    (constants.RESERVED_NODE_LABELS.find((x) => x[0] === "PageInfo") as string[])[1]
+                );
+            });
+
+            test("should throw when using Connection in a node name", () => {
+                const typeDefs = `
+                type NodeConnection {
+                    id: ID
+                }
+            `;
+
+                expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                    (constants.RESERVED_NODE_LABELS.find((x) => x[0] === "Connection") as string[])[1]
+                );
+            });
+
+            test("should throw when using Node as node name", () => {
+                const typeDefs = `
+                type Node {
+                    id: ID
+                }
+            `;
+
+                expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                    (constants.RESERVED_NODE_LABELS.find((x) => x[0] === "Node") as string[])[1]
+                );
+            });
+        });
+
+        describe("Interface", () => {
+            test("should throw when using Node as relationship properties interface name", () => {
+                const typeDefs = `
+                    type Movie {
+                        id: ID
+                        actors: [Actor] @relationship(type: "ACTED_IN", direction: OUT, properties: "Node")
+                    }
+
+                    interface Node {
+                        screenTime: Int
+                    }
+
+                    type Actor {
+                        name: String
+                    }
+                `;
+
+                expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                    (constants.RESERVED_INTERFACE_NAMES.find((x) => x[0] === "Node") as string[])[1]
+                );
+            });
+
+            describe("Fields", () => {
+                test("should throw when using 'node' as a relationship property", () => {
+                    const typeDefs = `
+                        type Movie {
+                            id: ID
+                            actors: [Actor] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                        }
+
+                        interface ActedIn {
+                            node: ID
+                        }
+
+                        type Actor {
+                            name: String
+                        }
+                    `;
+
+                    expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                        (constants.RESERVED_INTERFACE_PROPERTIES.find((x) => x[0] === "node") as string[])[1]
+                    );
+                });
+
+                test("should throw when using 'cursor' as a relationship property", () => {
+                    const typeDefs = `
+                        type Movie {
+                            id: ID
+                            actors: [Actor] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                        }
+
+                        interface ActedIn {
+                            cursor: ID
+                        }
+
+                        type Actor {
+                            name: String
+                        }
+                    `;
+
+                    expect(() => makeAugmentedSchema({ typeDefs })).toThrow(
+                        (constants.RESERVED_INTERFACE_PROPERTIES.find((x) => x[0] === "cursor") as string[])[1]
+                    );
+                });
+            });
+        });
     });
 });

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -177,7 +177,7 @@ function makeAugmentedSchema(
     Object.keys(Scalars).forEach((scalar) => composer.addTypeDefs(`scalar ${scalar}`));
 
     const nodes = objectNodes.map((definition) => {
-        constants.RESERVED_NODE_LABELS.forEach(([label, message]) => {
+        constants.RESERVED_TYPE_NAMES.forEach(([label, message]) => {
             let toThrowError = false;
 
             if (label === "Connection" && definition.name.value.endsWith("Connection")) {
@@ -259,8 +259,18 @@ function makeAugmentedSchema(
     const relationshipFields = new Map<string, ObjectFields>();
 
     relationshipProperties.forEach((relationship) => {
-        constants.RESERVED_INTERFACE_NAMES.forEach(([label, message = ""]) => {
+        constants.RESERVED_TYPE_NAMES.forEach(([label, message]) => {
+            let toThrowError = false;
+
+            if (label === "Connection" && relationship.name.value.endsWith("Connection")) {
+                toThrowError = true;
+            }
+
             if (relationship.name.value === label) {
+                toThrowError = true;
+            }
+
+            if (toThrowError) {
                 throw new Error(message);
             }
         });
@@ -271,7 +281,7 @@ function makeAugmentedSchema(
         }
 
         relationship.fields?.forEach((field) => {
-            constants.RESERVED_INTERFACE_PROPERTIES.forEach(([fieldName, message]) => {
+            constants.RESERVED_INTERFACE_FIELDS.forEach(([fieldName, message]) => {
                 if (field.name.value === fieldName) {
                     throw new Error(message);
                 }


### PR DESCRIPTION
# Description

Throws error when the user uses reserved names on types, interfaces and interface fields. This is mainly to stop any conflicts with Relay. 

