### PR TITLE
Fix multiple connections being returned from custom Cypher

### DIFF
--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -42,7 +42,7 @@ export default function cypherResolver({
         const cypherStrs: string[] = [];
         let params = { ...args, auth: createAuthParam({ context }), cypherParams: context.cypherParams };
         let projectionStr = "";
-        let connectionProjectionStr = "";
+        const connectionProjectionStrs: string[] = [];
         let projectionAuthStr = "";
         const isPrimitive = ["ID", "String", "Boolean", "Float", "Int", "DateTime", "BigInt"].includes(
             field.typeMeta.name
@@ -89,7 +89,7 @@ export default function cypherResolver({
                         nodeVariable: "this",
                     });
                     const [nestedStr, nestedP] = nestedConnection;
-                    connectionProjectionStr = nestedStr;
+                    connectionProjectionStrs.push(nestedStr);
                     params = { ...params, ...nestedP };
                 });
             }
@@ -127,9 +127,7 @@ export default function cypherResolver({
             );
         }
 
-        if (connectionProjectionStr) {
-            cypherStrs.push(connectionProjectionStr);
-        }
+        cypherStrs.push(connectionProjectionStrs.join("\n"));
 
         if (isPrimitive || isEnum || isScalar) {
             cypherStrs.push(`RETURN this`);


### PR DESCRIPTION
# Description

Fix multiple connections being returned from custom Cypher

Variable being reassigned in a loop. 😞 

# Issue

Reported in Discord: https://discord.com/channels/787399249741479977/818578492723036210/873251861648515122

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
