### PR TITLE
Remove surplus _IN and _NOT_IN filters for relationships

### DIFF
--- a/docs/asciidoc/guides/2.0.0-migration/miscellaneous.adoc
+++ b/docs/asciidoc/guides/2.0.0-migration/miscellaneous.adoc
@@ -46,3 +46,44 @@ const neoSchema = new Neo4jGraphQL({
 ----
 
 If you need to do this, please report the scenario as an issue on GitHub.
+
+== `_IN` and `_NOT_IN` filters on relationships removed
+
+There were previously `_IN` and `_NOT_IN` filters for one-to-many and one-to-one relationships, but these were surplus to requirements, and didn't match for all cardinalities (many-to-many relationships don't have `_INCLUDES` and `_NOT_INCLUDES`). These may be added back in the future if and when we look more holistically at distinguishing between different relationship cardinalities.
+
+You can still achieve identical filters through different routes. For example, if you had the following schema:
+
+[source, graphql]
+----
+type Movie {
+    title: String!
+    director: Director @relationship(type: "DIRECTED", direction: IN)
+}
+
+type Director {
+    name: String!
+    movies: [Movie!]! @relationship(type: "DIRECTED", direction: OUT)
+}
+----
+
+You would have been able to run the following query:
+
+[source, graphql]
+----
+query {
+    movies(where: { director_IN: [{ name: "A" }, { name: "B" }] }) {
+        title
+    }
+}
+----
+
+You can still achieve exactly the same filter with the following:
+
+[source, graphql]
+----
+query {
+    movies(where: { director: { OR: [{ name: "A" }, { name: "B" }]} }) {
+        title
+    }
+}
+----

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -820,12 +820,6 @@ function makeAugmentedSchema(
 
             whereInput.addFields({
                 ...{ [rel.fieldName]: `${n.name}Where`, [`${rel.fieldName}_NOT`]: `${n.name}Where` },
-                ...(rel.typeMeta.array
-                    ? {}
-                    : {
-                          [`${rel.fieldName}_IN`]: `[${n.name}Where!]`,
-                          [`${rel.fieldName}_NOT_IN`]: `[${n.name}Where!]`,
-                      }),
             });
 
             let anyNonNullRelProperties = false;

--- a/packages/graphql/tests/tck/tck-test-files/schema/issues/162.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/issues/162.md
@@ -361,8 +361,6 @@ input TigerJawLevel2Part1Where {
     tiger_NOT: TigerWhere
     tigerConnection: TigerJawLevel2Part1TigerConnectionWhere
     tigerConnection_NOT: TigerJawLevel2Part1TigerConnectionWhere
-    tiger_IN: [TigerWhere!]
-    tiger_NOT_IN: [TigerWhere!]
 }
 
 input TigerJawLevel2RelationInput {
@@ -398,8 +396,6 @@ input TigerJawLevel2Where {
     part1_NOT: TigerJawLevel2Part1Where
     part1Connection: TigerJawLevel2Part1ConnectionWhere
     part1Connection_NOT: TigerJawLevel2Part1ConnectionWhere
-    part1_IN: [TigerJawLevel2Part1Where!]
-    part1_NOT_IN: [TigerJawLevel2Part1Where!]
 }
 
 input TigerOptions {


### PR DESCRIPTION
# Description

Let's take the opportunity of this breaking release to remove some surplus requirements, `_IN` and `_NOT_IN` for one-to-many and one-to-one relationships. We don't currently treat these relationship cardinalities differently anywhere else, the filters are completely untested, and the same filters can be achieved through other means (see migration guide for example).

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
