### PR TITLE
Remove prerelease marker

### DIFF
--- a/docs/antora/antora.yml
+++ b/docs/antora/antora.yml
@@ -1,7 +1,6 @@
 name: graphql-manual
 title: Neo4j GraphQL Library
 version: '2.0'
-prerelease: true
 start_page: ROOT:index.adoc
 nav:
 - modules/ROOT/content-nav.adoc


### PR DESCRIPTION
# Description

Removes the prerelease marker from the Antora component descriptor, which means 2.0 is included as the latest release in the version drop-down.