### PR TITLE
Fix for aliasing connection multiple times

### DIFF
--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -132,7 +132,7 @@ function createConnectionAndParams({
                                 context,
                                 nodeVariable: relatedNodeVariable,
                                 parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                                    resolveTree.name
+                                    resolveTree.alias
                                 }.edges.node`,
                             });
                             nestedSubqueries.push(nestedConnection[0]);
@@ -141,7 +141,7 @@ function createConnectionAndParams({
                                 ...globalParams,
                                 ...Object.entries(nestedConnection[1]).reduce<Record<string, unknown>>(
                                     (res, [k, v]) => {
-                                        if (k !== `${relatedNodeVariable}_${connectionResolveTree.name}`) {
+                                        if (k !== `${relatedNodeVariable}_${connectionResolveTree.alias}`) {
                                             res[k] = v;
                                         }
                                         return res;
@@ -150,13 +150,15 @@ function createConnectionAndParams({
                                 ),
                             };
 
-                            if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`]) {
+                            if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.alias}`]) {
                                 if (!nestedConnectionFieldParams) nestedConnectionFieldParams = {};
                                 nestedConnectionFieldParams = {
                                     ...nestedConnectionFieldParams,
                                     ...{
-                                        [connectionResolveTree.name]:
-                                            nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`],
+                                        [connectionResolveTree.alias]:
+                                            nestedConnection[1][
+                                                `${relatedNodeVariable}_${connectionResolveTree.alias}`
+                                            ],
                                     },
                                 };
                             }
@@ -197,7 +199,7 @@ function createConnectionAndParams({
                         relationshipVariable,
                         context,
                         parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                            resolveTree.name
+                            resolveTree.alias
                         }.args.where.${n.name}`,
                     });
                     const [whereClause] = where;
@@ -268,7 +270,7 @@ function createConnectionAndParams({
                 relationshipVariable,
                 context,
                 parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                    resolveTree.name
+                    resolveTree.alias
                 }.args.where`,
             });
             const [whereClause] = where;
@@ -350,7 +352,7 @@ function createConnectionAndParams({
                         context,
                         nodeVariable: relatedNodeVariable,
                         parameterPrefix: `${parameterPrefix ? `${parameterPrefix}.` : `${nodeVariable}_`}${
-                            resolveTree.name
+                            resolveTree.alias
                         }.edges.node`,
                     });
                     nestedSubqueries.push(nestedConnection[0]);
@@ -358,20 +360,20 @@ function createConnectionAndParams({
                     globalParams = {
                         ...globalParams,
                         ...Object.entries(nestedConnection[1]).reduce<Record<string, unknown>>((res, [k, v]) => {
-                            if (k !== `${relatedNodeVariable}_${connectionResolveTree.name}`) {
+                            if (k !== `${relatedNodeVariable}_${connectionResolveTree.alias}`) {
                                 res[k] = v;
                             }
                             return res;
                         }, {}),
                     };
 
-                    if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`]) {
+                    if (nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.alias}`]) {
                         if (!nestedConnectionFieldParams) nestedConnectionFieldParams = {};
                         nestedConnectionFieldParams = {
                             ...nestedConnectionFieldParams,
                             ...{
-                                [connectionResolveTree.name]:
-                                    nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.name}`],
+                                [connectionResolveTree.alias]:
+                                    nestedConnection[1][`${relatedNodeVariable}_${connectionResolveTree.alias}`],
                             },
                         };
                     }
@@ -403,7 +405,7 @@ function createConnectionAndParams({
     const params = {
         ...globalParams,
         ...((whereInput || nestedConnectionFieldParams) && {
-            [`${nodeVariable}_${resolveTree.name}`]: {
+            [`${nodeVariable}_${resolveTree.alias}`]: {
                 ...(whereInput && { args: { where: whereInput } }),
                 ...(nestedConnectionFieldParams && { edges: { node: { ...nestedConnectionFieldParams } } }),
             },

--- a/packages/graphql/tests/integration/connections/nested.int.test.ts
+++ b/packages/graphql/tests/integration/connections/nested.int.test.ts
@@ -1,0 +1,198 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("Connections Alias", () => {
+    let driver: Driver;
+
+    const movieTitle = "Forrest Gump";
+    const actorName = "Tom Hanks";
+    const screenTime = 120;
+
+    const typeDefs = gql`
+        type Movie {
+            title: String!
+            actors: [Actor!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+        }
+
+        type Actor {
+            name: String!
+            movies: [Movie!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+        }
+
+        interface ActedIn {
+            screenTime: Int!
+        }
+    `;
+
+    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should allow nested connections", async () => {
+        const session = driver.session();
+
+        const query = `
+            {
+                movies(where: { title: "${movieTitle}" }) {
+                    title
+                    actorsConnection(where: { node: { name: "${actorName}" } }) {
+                        edges {
+                            screenTime
+                            node {
+                                name
+                                moviesConnection {
+                                    edges {
+                                        node {
+                                            title
+                                            actors {
+                                                name
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } 
+        `;
+
+        try {
+            await session.run(
+                `
+                    CREATE (movie:Movie {title: $movieTitle})
+                    CREATE (actor:Actor {name: $actorName})
+                    CREATE (actor)-[:ACTED_IN {screenTime: $screenTime}]->(movie)
+                `,
+                {
+                    movieTitle,
+                    actorName,
+                    screenTime,
+                }
+            );
+
+            const result = await graphql({
+                schema,
+                source: query,
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+            });
+
+            expect(result.errors).toBeUndefined();
+
+            expect((result.data as any).movies[0].actorsConnection.edges[0].node.moviesConnection).toEqual({
+                edges: [
+                    {
+                        node: {
+                            title: movieTitle,
+                            actors: [
+                                {
+                                    name: actorName,
+                                },
+                            ],
+                        },
+                    },
+                ],
+            });
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should allow where clause on nested connections", async () => {
+        const session = driver.session();
+
+        const query = `
+            {
+                movies(where: { title: "${movieTitle}" }) {
+                    title
+                    actorsConnection(where: { node: { name: "${actorName}" } }) {
+                        edges {
+                            screenTime
+                            node {
+                                name
+                                moviesConnection(where: { node: { title: "${movieTitle}" } }) {
+                                    edges {
+                                        node {
+                                            title
+                                            actors {
+                                                name
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } 
+        `;
+
+        try {
+            await session.run(
+                `
+                    CREATE (movie:Movie {title: $movieTitle})
+                    CREATE (actor:Actor {name: $actorName})
+                    CREATE (actor)-[:ACTED_IN {screenTime: $screenTime}]->(movie)
+                `,
+                {
+                    movieTitle,
+                    actorName,
+                    screenTime,
+                }
+            );
+
+            const result = await graphql({
+                schema,
+                source: query,
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+            });
+
+            expect(result.errors).toBeUndefined();
+
+            expect((result.data as any).movies[0].actorsConnection.edges[0].node.moviesConnection).toEqual({
+                edges: [
+                    {
+                        node: {
+                            title: movieTitle,
+                            actors: [
+                                {
+                                    name: actorName,
+                                },
+                            ],
+                        },
+                    },
+                ],
+            });
+        } finally {
+            await session.close();
+        }
+    });
+});


### PR DESCRIPTION
# Description

Similar to #359, this adds the ability to have multiple aliases on connection fields without overwriting parameters by naming parameters after aliases and fields after names.

# Issue

- #392 

# Checklist

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
