### PR TITLE
Resolve node/relationship variable naming collision

### DIFF
--- a/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
@@ -106,8 +106,8 @@ describe("createConnectionAndParams", () => {
 
         expect(dedent(entry[0])).toEqual(dedent`CALL {
         WITH this
-        MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-        WITH collect({ screenTime: this_acted_in.screenTime }) AS edges
+        MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+        WITH collect({ screenTime: this_acted_in_relationship.screenTime }) AS edges
         RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
         }`);
     });
@@ -201,10 +201,10 @@ describe("createConnectionAndParams", () => {
 
         expect(dedent(entry[0])).toEqual(dedent`CALL {
             WITH this
-            MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-            WITH this_acted_in, this_actor
-            ORDER BY this_acted_in.screenTime DESC, this_actor.name ASC
-            WITH collect({ screenTime: this_acted_in.screenTime }) AS edges
+            MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+            WITH this_acted_in_relationship, this_actor
+            ORDER BY this_acted_in_relationship.screenTime DESC, this_actor.name ASC
+            WITH collect({ screenTime: this_acted_in_relationship.screenTime }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
             }`);
     });
@@ -289,8 +289,8 @@ describe("createConnectionAndParams", () => {
 
         expect(dedent(entry[0])).toEqual(dedent`CALL {
             WITH this
-            MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-            WITH collect({ screenTime: this_acted_in.screenTime }) AS edges
+            MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+            WITH collect({ screenTime: this_acted_in_relationship.screenTime }) AS edges
             WITH size(edges) AS totalCount, edges[11..21] AS limitedSelection
             RETURN { edges: limitedSelection, totalCount: totalCount } AS actorsConnection
             }`);

--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -54,7 +54,7 @@ function createConnectionAndParams({
     const firstInput = resolveTree.args.first;
     const whereInput = resolveTree.args.where as ConnectionWhereArg;
 
-    const relationshipVariable = `${nodeVariable}_${field.relationship.type.toLowerCase()}`;
+    const relationshipVariable = `${nodeVariable}_${field.relationship.type.toLowerCase()}_relationship`;
     const relationship = context.neoSchema.relationships.find(
         (r) => r.name === field.relationshipTypeName
     ) as Relationship;

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/alias.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/alias.md
@@ -42,7 +42,7 @@ interface ActedIn {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WITH collect({ }) AS edges
     RETURN {
         totalCount: size(edges)
@@ -94,10 +94,10 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name = $this_hanks.args.where.node.name
     WITH collect({
-        screenTime: this_acted_in.screenTime,
+        screenTime: this_acted_in_relationship.screenTime,
         node: {
             name: this_actor.name
         }
@@ -106,10 +106,10 @@ CALL {
 }
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name = $this_jenny.args.where.node.name
     WITH collect({
-        screenTime: this_acted_in.screenTime,
+        screenTime: this_acted_in_relationship.screenTime,
         node: {
             name: this_actor.name
         }

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/composite.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/composite.md
@@ -56,9 +56,9 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE ((this_acted_in.screenTime > $this_actorsConnection.args.where.edge.AND[0].screenTime_GT) AND (this_acted_in.screenTime < $this_actorsConnection.args.where.edge.AND[1].screenTime_LT)) AND ((this_actor.firstName = $this_actorsConnection.args.where.node.AND[0].firstName) AND (this_actor.lastName = $this_actorsConnection.args.where.node.AND[1].lastName))
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE ((this_acted_in_relationship.screenTime > $this_actorsConnection.args.where.edge.AND[0].screenTime_GT) AND (this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.AND[1].screenTime_LT)) AND ((this_actor.firstName = $this_actorsConnection.args.where.node.AND[0].firstName) AND (this_actor.lastName = $this_actorsConnection.args.where.node.AND[1].lastName))
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/and.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/and.md
@@ -54,9 +54,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE ((this_actor.firstName = $this_actorsConnection.args.where.node.AND[0].firstName) AND (this_actor.lastName = $this_actorsConnection.args.where.node.AND[1].lastName))
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/arrays.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/arrays.md
@@ -51,9 +51,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name IN $this_actorsConnection.args.where.node.name_IN
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -105,9 +105,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE (NOT this_actor.name IN $this_actorsConnection.args.where.node.name_NOT_IN)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -160,9 +160,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE $this_actorsConnection.args.where.node.favouriteColours_INCLUDES IN this_actor.favouriteColours
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, favouriteColours: this_actor.favouriteColours } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, favouriteColours: this_actor.favouriteColours } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -215,9 +215,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE (NOT $this_actorsConnection.args.where.node.favouriteColours_NOT_INCLUDES IN this_actor.favouriteColours)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, favouriteColours: this_actor.favouriteColours } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, favouriteColours: this_actor.favouriteColours } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/equality.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/equality.md
@@ -48,9 +48,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name = $this_actorsConnection.args.where.node.name
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -100,9 +100,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE (NOT this_actor.name = $this_actorsConnection.args.where.node.name_NOT)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/numerical.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/numerical.md
@@ -50,9 +50,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.age < $this_actorsConnection.args.where.node.age_LT
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -106,9 +106,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.age <= $this_actorsConnection.args.where.node.age_LTE
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -162,9 +162,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.age > $this_actorsConnection.args.where.node.age_GT
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -218,9 +218,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.age >= $this_actorsConnection.args.where.node.age_GTE
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/or.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/or.md
@@ -54,9 +54,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE ((this_actor.firstName = $this_actorsConnection.args.where.node.OR[0].firstName) OR (this_actor.lastName = $this_actorsConnection.args.where.node.OR[1].lastName))
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/points.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/points.md
@@ -62,9 +62,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE distance(this_actor.currentLocation, point($this_actorsConnection.args.where.node.currentLocation_DISTANCE.point)) = $this_actorsConnection.args.where.node.currentLocation_DISTANCE.distance
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, currentLocation: { point: this_actor.currentLocation } } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, currentLocation: { point: this_actor.currentLocation } } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/string.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/string.md
@@ -52,9 +52,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name CONTAINS $this_actorsConnection.args.where.node.name_CONTAINS
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -104,9 +104,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE (NOT this_actor.name CONTAINS $this_actorsConnection.args.where.node.name_NOT_CONTAINS)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -156,9 +156,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name STARTS WITH $this_actorsConnection.args.where.node.name_STARTS_WITH
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -208,9 +208,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE (NOT this_actor.name STARTS WITH $this_actorsConnection.args.where.node.name_NOT_STARTS_WITH)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -260,9 +260,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name ENDS WITH $this_actorsConnection.args.where.node.name_ENDS_WITH
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -312,9 +312,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE (NOT this_actor.name ENDS WITH $this_actorsConnection.args.where.node.name_NOT_ENDS_WITH)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -364,9 +364,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name =~ $this_actorsConnection.args.where.node.name_MATCHES
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/and.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/and.md
@@ -56,9 +56,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE ((this_acted_in.role ENDS WITH $this_actorsConnection.args.where.edge.AND[0].role_ENDS_WITH) AND (this_acted_in.screenTime < $this_actorsConnection.args.where.edge.AND[1].screenTime_LT))
-    WITH collect({ role: this_acted_in.role, screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE ((this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.AND[0].role_ENDS_WITH) AND (this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.AND[1].screenTime_LT))
+    WITH collect({ role: this_acted_in_relationship.role, screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/arrays.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/arrays.md
@@ -49,9 +49,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.screenTime IN $this_actorsConnection.args.where.edge.screenTime_IN
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.screenTime IN $this_actorsConnection.args.where.edge.screenTime_IN
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -110,9 +110,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE (NOT this_acted_in.screenTime IN $this_actorsConnection.args.where.edge.screenTime_NOT_IN)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE (NOT this_acted_in_relationship.screenTime IN $this_actorsConnection.args.where.edge.screenTime_NOT_IN)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -175,9 +175,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE $this_actorsConnection.args.where.edge.quotes_INCLUDES IN this_acted_in.quotes
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE $this_actorsConnection.args.where.edge.quotes_INCLUDES IN this_acted_in_relationship.quotes
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -233,9 +233,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE (NOT $this_actorsConnection.args.where.edge.quotes_NOT_INCLUDES IN this_acted_in.quotes)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE (NOT $this_actorsConnection.args.where.edge.quotes_NOT_INCLUDES IN this_acted_in_relationship.quotes)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/equality.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/equality.md
@@ -48,9 +48,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.screenTime = $this_actorsConnection.args.where.edge.screenTime
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.screenTime = $this_actorsConnection.args.where.edge.screenTime
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -103,9 +103,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE (NOT this_acted_in.screenTime = $this_actorsConnection.args.where.edge.screenTime_NOT)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE (NOT this_acted_in_relationship.screenTime = $this_actorsConnection.args.where.edge.screenTime_NOT)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/numerical.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/numerical.md
@@ -48,9 +48,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.screenTime < $this_actorsConnection.args.where.edge.screenTime_LT
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.screenTime_LT
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -103,9 +103,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.screenTime <= $this_actorsConnection.args.where.edge.screenTime_LTE
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.screenTime <= $this_actorsConnection.args.where.edge.screenTime_LTE
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -158,9 +158,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.screenTime > $this_actorsConnection.args.where.edge.screenTime_GT
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.screenTime > $this_actorsConnection.args.where.edge.screenTime_GT
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -213,9 +213,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.screenTime >= $this_actorsConnection.args.where.edge.screenTime_GTE
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.screenTime >= $this_actorsConnection.args.where.edge.screenTime_GTE
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/or.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/or.md
@@ -56,9 +56,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE ((this_acted_in.role ENDS WITH $this_actorsConnection.args.where.edge.OR[0].role_ENDS_WITH) OR (this_acted_in.screenTime < $this_actorsConnection.args.where.edge.OR[1].screenTime_LT))
-    WITH collect({ role: this_acted_in.role, screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE ((this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.OR[0].role_ENDS_WITH) OR (this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.OR[1].screenTime_LT))
+    WITH collect({ role: this_acted_in_relationship.role, screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/points.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/points.md
@@ -62,9 +62,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE distance(this_acted_in.location, point($this_actorsConnection.args.where.edge.location_DISTANCE.point)) = $this_actorsConnection.args.where.edge.location_DISTANCE.distance
-    WITH collect({ screenTime: this_acted_in.screenTime, location: { point: this_acted_in.location }, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE distance(this_acted_in_relationship.location, point($this_actorsConnection.args.where.edge.location_DISTANCE.point)) = $this_actorsConnection.args.where.edge.location_DISTANCE.distance
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, location: { point: this_acted_in_relationship.location }, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/string.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/string.md
@@ -53,9 +53,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.role CONTAINS $this_actorsConnection.args.where.edge.role_CONTAINS
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.role CONTAINS $this_actorsConnection.args.where.edge.role_CONTAINS
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -105,9 +105,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE (NOT this_acted_in.role CONTAINS $this_actorsConnection.args.where.edge.role_NOT_CONTAINS)
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE (NOT this_acted_in_relationship.role CONTAINS $this_actorsConnection.args.where.edge.role_NOT_CONTAINS)
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -157,9 +157,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.role STARTS WITH $this_actorsConnection.args.where.edge.role_STARTS_WITH
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.role STARTS WITH $this_actorsConnection.args.where.edge.role_STARTS_WITH
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -209,9 +209,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE (NOT this_acted_in.role STARTS WITH $this_actorsConnection.args.where.edge.role_NOT_STARTS_WITH)
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE (NOT this_acted_in_relationship.role STARTS WITH $this_actorsConnection.args.where.edge.role_NOT_STARTS_WITH)
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -261,9 +261,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.role ENDS WITH $this_actorsConnection.args.where.edge.role_ENDS_WITH
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.role_ENDS_WITH
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -313,9 +313,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE (NOT this_acted_in.role ENDS WITH $this_actorsConnection.args.where.edge.role_NOT_ENDS_WITH)
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE (NOT this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.role_NOT_ENDS_WITH)
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -365,9 +365,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.role =~ $this_actorsConnection.args.where.edge.role_MATCHES
-    WITH collect({ role: this_acted_in.role, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.role =~ $this_actorsConnection.args.where.edge.role_MATCHES
+    WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/temporal.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/relationship/temporal.md
@@ -57,9 +57,9 @@ query {
 MATCH (this:Movie)
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WHERE this_acted_in.startDate > $this_actorsConnection.args.where.edge.startDate_GT AND this_acted_in.endDateTime < $this_actorsConnection.args.where.edge.endDateTime_LT
-    WITH collect({ startDate: this_acted_in.startDate, endDateTime: apoc.date.convertFormat(toString(this_acted_in.endDateTime), "iso_zoned_date_time", "iso_offset_date_time"), node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE this_acted_in_relationship.startDate > $this_actorsConnection.args.where.edge.startDate_GT AND this_acted_in_relationship.endDateTime < $this_actorsConnection.args.where.edge.endDateTime_LT
+    WITH collect({ startDate: this_acted_in_relationship.startDate, endDateTime: apoc.date.convertFormat(toString(this_acted_in_relationship.endDateTime), "iso_zoned_date_time", "iso_offset_date_time"), node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/mixed-nesting.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/mixed-nesting.md
@@ -52,10 +52,10 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name = $this_actorsConnection.args.where.node.name
     WITH collect({
-        screenTime: this_acted_in.screenTime,
+        screenTime: this_acted_in_relationship.screenTime,
         node: {
             name: this_actor.name,
             movies: [ (this_actor)-[:ACTED_IN]->(this_actor_movies:Movie) WHERE (NOT this_actor_movies.title = $this_actor_movies_title_NOT) | this_actor_movies { .title } ]
@@ -125,11 +125,11 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name = $this_actorsConnection.args.where.node.name
     CALL {
         WITH this_actor
-        MATCH (this_actor)-[this_actor_acted_in:ACTED_IN]->(this_actor_movie:Movie)
+        MATCH (this_actor)-[this_actor_acted_in_relationship:ACTED_IN]->(this_actor_movie:Movie)
         WHERE (NOT this_actor_movie.title = $this_actorsConnection.edges.node.moviesConnection.args.where.node.title_NOT)
         WITH collect({
             node: {
@@ -139,7 +139,7 @@ CALL {
         }) AS edges
         RETURN { edges: edges, totalCount: size(edges) } AS moviesConnection
     }
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -212,9 +212,9 @@ RETURN this {
         .name,
         moviesConnection: apoc.cypher.runFirstColumn("CALL {
                     WITH this_actors
-                    MATCH (this_actors)-[this_actors_acted_in:ACTED_IN]->(this_actors_movie:Movie)
+                    MATCH (this_actors)-[this_actors_acted_in_relationship:ACTED_IN]->(this_actors_movie:Movie)
                     WHERE (NOT this_actors_movie.title = $this_actors_moviesConnection.args.where.node.title_NOT)
-                    WITH collect({ screenTime: this_actors_acted_in.screenTime, node: { title: this_actors_movie.title } }) AS edges
+                    WITH collect({ screenTime: this_actors_acted_in_relationship.screenTime, node: { title: this_actors_movie.title } }) AS edges
                     RETURN { edges: edges, totalCount: size(edges) } AS moviesConnection
                 } RETURN moviesConnection", { this_actors: this_actors, this_actors_moviesConnection: $this_actors_moviesConnection }, false)
         }

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/create.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/create.md
@@ -54,8 +54,8 @@ CALL {
 }
 CALL {
     WITH this0
-    MATCH (this0)<-[this0_acted_in:ACTED_IN]-(this0_actor:Actor)
-    WITH collect({ screenTime: this0_acted_in.screenTime, node: { name: this0_actor.name } }) AS edges
+    MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
+    WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this0 { .title, actorsConnection } AS this0
@@ -108,14 +108,14 @@ CALL {
 }
 CALL {
     WITH this0
-    MATCH (this0)<-[this0_acted_in:ACTED_IN]-(this0_actor:Actor)
-    WITH collect({ screenTime: this0_acted_in.screenTime, node: { name: this0_actor.name } }) AS edges
+    MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
+    WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 CALL {
     WITH this1
-    MATCH (this1)<-[this1_acted_in:ACTED_IN]-(this1_actor:Actor)
-    WITH collect({ screenTime: this1_acted_in.screenTime, node: { name: this1_actor.name } }) AS edges
+    MATCH (this1)<-[this1_acted_in_relationship:ACTED_IN]-(this1_actor:Actor)
+    WITH collect({ screenTime: this1_acted_in_relationship.screenTime, node: { name: this1_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this0 { .title, actorsConnection } AS this0, this1 { .title, actorsConnection } AS this1
@@ -169,16 +169,16 @@ CALL {
 }
 CALL {
     WITH this0
-    MATCH (this0)<-[this0_acted_in:ACTED_IN]-(this0_actor:Actor)
+    MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
     WHERE this0_actor.name = $this0_actorsConnection.args.where.node.name
-    WITH collect({ screenTime: this0_acted_in.screenTime, node: { name: this0_actor.name } }) AS edges
+    WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 CALL {
     WITH this1
-    MATCH (this1)<-[this1_acted_in:ACTED_IN]-(this1_actor:Actor)
+    MATCH (this1)<-[this1_acted_in_relationship:ACTED_IN]-(this1_actor:Actor)
     WHERE this1_actor.name = $this1_actorsConnection.args.where.node.name
-    WITH collect({ screenTime: this1_acted_in.screenTime, node: { name: this1_actor.name } }) AS edges
+    WITH collect({ screenTime: this1_acted_in_relationship.screenTime, node: { name: this1_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this0 { .title, actorsConnection } AS this0, this1 { .title, actorsConnection } AS this1

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/projections.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/projections.md
@@ -47,7 +47,7 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WITH collect({ }) AS edges
     RETURN { totalCount: size(edges) } AS actorsConnection
 }
@@ -91,7 +91,7 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WITH collect({ }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
@@ -130,7 +130,7 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WITH collect({ }) AS edges
     WITH size(edges) AS totalCount, edges[..5] AS limitedSelection
     RETURN { edges: limitedSelection, totalCount: totalCount } AS actorsConnection
@@ -172,12 +172,12 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Movie:Movie)
+        OPTIONAL MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Movie:Movie)
         WITH { node: { __resolveType: "Movie" } } AS edge
         RETURN edge
         UNION
         WITH this
-        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Series:Series)
+        OPTIONAL MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Series:Series)
         WITH { node: { __resolveType: "Series" } } AS edge
         RETURN edge
     }
@@ -226,12 +226,12 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Movie:Movie)
+        OPTIONAL MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Movie:Movie)
         WITH { node: { __resolveType: "Movie" } } AS edge
         RETURN edge
         UNION
         WITH this
-        OPTIONAL MATCH (this)-[this_acted_in:ACTED_IN]->(this_Series:Series)
+        OPTIONAL MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Series:Series)
         WITH { node: { __resolveType: "Series" } } AS edge
         RETURN edge
     }
@@ -278,7 +278,7 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WITH collect({ node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
@@ -322,7 +322,7 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WITH collect({ node: { name: this_actor.name } }) AS edges
     WITH size(edges) AS totalCount, edges[..5] AS limitedSelection
     RETURN { edges: limitedSelection, totalCount: totalCount } AS actorsConnection

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/update.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/projections/update.md
@@ -52,8 +52,8 @@ WHERE this.title = $this_title
 WITH this
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } AS this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/relationship-properties.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/relationship-properties.md
@@ -49,8 +49,8 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -93,9 +93,9 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     WHERE this_actor.name = $this_actorsConnection.args.where.node.name
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -147,10 +147,10 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WITH this_acted_in, this_actor
-    ORDER BY this_acted_in.screenTime DESC
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WITH this_acted_in_relationship, this_actor
+    ORDER BY this_acted_in_relationship.screenTime DESC
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -201,14 +201,14 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     CALL {
         WITH this_actor
-        MATCH (this_actor)-[this_actor_acted_in:ACTED_IN]->(this_actor_movie:Movie)
-        WITH collect({ screenTime: this_actor_acted_in.screenTime, node: { title: this_actor_movie.title } }) AS edges
+        MATCH (this_actor)-[this_actor_acted_in_relationship:ACTED_IN]->(this_actor_movie:Movie)
+        WITH collect({ screenTime: this_actor_acted_in_relationship.screenTime, node: { title: this_actor_movie.title } }) AS edges
         RETURN { edges: edges, totalCount: size(edges) } AS moviesConnection
     }
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this
@@ -267,20 +267,20 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
     CALL {
         WITH this_actor
-        MATCH (this_actor)-[this_actor_acted_in:ACTED_IN]->(this_actor_movie:Movie)
+        MATCH (this_actor)-[this_actor_acted_in_relationship:ACTED_IN]->(this_actor_movie:Movie)
         CALL {
             WITH this_actor_movie
-            MATCH (this_actor_movie)<-[this_actor_movie_acted_in:ACTED_IN]-(this_actor_movie_actor:Actor)
-            WITH collect({ screenTime: this_actor_movie_acted_in.screenTime, node: { name: this_actor_movie_actor.name } }) AS edges
+            MATCH (this_actor_movie)<-[this_actor_movie_acted_in_relationship:ACTED_IN]-(this_actor_movie_actor:Actor)
+            WITH collect({ screenTime: this_actor_movie_acted_in_relationship.screenTime, node: { name: this_actor_movie_actor.name } }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
         }
-        WITH collect({ screenTime: this_actor_acted_in.screenTime, node: { title: this_actor_movie.title, actorsConnection: actorsConnection } }) AS edges
+        WITH collect({ screenTime: this_actor_acted_in_relationship.screenTime, node: { title: this_actor_movie.title, actorsConnection: actorsConnection } }) AS edges
         RETURN { edges: edges, totalCount: size(edges) } AS moviesConnection
     }
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } as this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/relationship_properties/connect.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/relationship_properties/connect.md
@@ -71,8 +71,8 @@ CALL {
 }
 CALL {
     WITH this0
-    MATCH (this0)<-[this0_acted_in:ACTED_IN]-(this0_actor:Actor)
-    WITH collect({ screenTime: this0_acted_in.screenTime, node: { name: this0_actor.name } }) AS edges
+    MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
+    WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 
@@ -151,8 +151,8 @@ CALL {
 }
 CALL {
     WITH this0
-    MATCH (this0)<-[this0_acted_in:ACTED_IN]-(this0_actor:Actor)
-    WITH collect({ screenTime: this0_acted_in.screenTime, node: { name: this0_actor.name } }) AS edges
+    MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
+    WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 
@@ -218,8 +218,8 @@ CALL {
 WITH this
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } AS this
@@ -288,8 +288,8 @@ CALL {
 WITH this
 CALL {
     WITH this
-    MATCH (this)<-[this_acted_in:ACTED_IN]-(this_actor:Actor)
-    WITH collect({ screenTime: this_acted_in.screenTime, node: { name: this_actor.name } }) AS edges
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 RETURN this { .title, actorsConnection } AS this

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/relationship_properties/create.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/relationship_properties/create.md
@@ -75,8 +75,8 @@ CALL {
 }
 CALL {
     WITH this0
-    MATCH (this0)<-[this0_acted_in:ACTED_IN]-(this0_actor:Actor)
-    WITH collect({ screenTime: this0_acted_in.screenTime, node: { name: this0_actor.name } }) AS edges
+    MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
+    WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
 }
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/unions.md
@@ -63,13 +63,13 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Book:Book)
-        WITH { words: this_wrote.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Book:Book)
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
         RETURN edge
     UNION
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Journal:Journal)
-        WITH { words: this_wrote.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Journal:Journal)
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
         RETURN edge
     }
     WITH collect(edge) as edges, count(edge) as totalCount
@@ -124,15 +124,15 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Book:Book)
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Book:Book)
         WHERE this_Book.title = $this_publicationsConnection.args.where.Book.node.title
-        WITH { words: this_wrote.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
         RETURN edge
     UNION
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Journal:Journal)
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Journal:Journal)
         WHERE this_Journal.subject = $this_publicationsConnection.args.where.Journal.node.subject
-        WITH { words: this_wrote.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
         RETURN edge
     }
     WITH collect(edge) as edges, count(edge) as totalCount
@@ -204,15 +204,15 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Book:Book)
-        WHERE this_wrote.words = $this_publicationsConnection.args.where.Book.edge.words
-        WITH { words: this_wrote.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Book:Book)
+        WHERE this_wrote_relationship.words = $this_publicationsConnection.args.where.Book.edge.words
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
         RETURN edge
     UNION
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Journal:Journal)
-        WHERE this_wrote.words = $this_publicationsConnection.args.where.Journal.edge.words
-        WITH { words: this_wrote.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Journal:Journal)
+        WHERE this_wrote_relationship.words = $this_publicationsConnection.args.where.Journal.edge.words
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
         RETURN edge
     }
     WITH collect(edge) as edges, count(edge) as totalCount
@@ -293,15 +293,15 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Book:Book)
-        WHERE this_Book.title = $this_publicationsConnection.args.where.Book.node.title AND this_wrote.words = $this_publicationsConnection.args.where.Book.edge.words
-        WITH { words: this_wrote.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Book:Book)
+        WHERE this_Book.title = $this_publicationsConnection.args.where.Book.node.title AND this_wrote_relationship.words = $this_publicationsConnection.args.where.Book.edge.words
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Book", title: this_Book.title } } AS edge
         RETURN edge
     UNION
         WITH this
-        OPTIONAL MATCH (this)-[this_wrote:WROTE]->(this_Journal:Journal)
-        WHERE this_Journal.subject = $this_publicationsConnection.args.where.Journal.node.subject AND this_wrote.words = $this_publicationsConnection.args.where.Journal.edge.words
-        WITH { words: this_wrote.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
+        OPTIONAL MATCH (this)-[this_wrote_relationship:WROTE]->(this_Journal:Journal)
+        WHERE this_Journal.subject = $this_publicationsConnection.args.where.Journal.node.subject AND this_wrote_relationship.words = $this_publicationsConnection.args.where.Journal.edge.words
+        WITH { words: this_wrote_relationship.words, node: { __resolveType: "Journal", subject: this_Journal.subject } } AS edge
         RETURN edge
     }
     WITH collect(edge) as edges, count(edge) as totalCount

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/where.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/where.md
@@ -207,7 +207,7 @@ RETURN this {
 MATCH (this:User)
 WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 CALL {
-    WITH this MATCH (this)-[this_has_post:HAS_POST]->(this_post:Post)
+    WITH this MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_post:Post)
     WHERE EXISTS((this_post)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_where0_creator_id)
     WITH collect({ node: { content: this_post.content } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS postsConnection
@@ -260,7 +260,7 @@ RETURN this { .id, postsConnection } as this
 MATCH (this:User)
 WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 CALL {
-    WITH this MATCH (this)-[this_has_post:HAS_POST]->(this_post:Post)
+    WITH this MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_post:Post)
     WHERE this_post.id = $this_postsConnection.args.where.node.id AND EXISTS((this_post)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_where0_creator_id)
     WITH collect({ node: { content: this_post.content } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS postsConnection
@@ -423,7 +423,7 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_has_post:HAS_POST]->(this_Post:Post)
+        OPTIONAL MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_Post:Post)
         WHERE EXISTS((this_Post)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_Post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_where0_creator_id)
         WITH { node: { __resolveType: "Post", id: this_Post.id } } AS edge
         RETURN edge
@@ -484,7 +484,7 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_has_post:HAS_POST]->(this_Post:Post)
+        OPTIONAL MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_Post:Post)
         WHERE this_Post.id = $this_contentConnection.args.where.Post.node.id AND EXISTS((this_Post)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_Post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_where0_creator_id)
         WITH { node: { __resolveType: "Post", id: this_Post.id } } AS edge
         RETURN edge

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/projection-connection-union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/projection-connection-union.md
@@ -60,11 +60,11 @@ CALL {
     WITH this
     CALL {
         WITH this
-        OPTIONAL MATCH (this)-[this_published:PUBLISHED]->(this_Post:Post)
+        OPTIONAL MATCH (this)-[this_published_relationship:PUBLISHED]->(this_Post:Post)
         CALL apoc.util.validate(NOT(EXISTS((this_Post)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_Post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
         CALL {
             WITH this_Post
-            MATCH (this_Post)<-[this_Post_has_post:HAS_POST]-(this_Post_user:User)
+            MATCH (this_Post)<-[this_Post_has_post_relationship:HAS_POST]-(this_Post_user:User)
             CALL apoc.util.validate(NOT(this_Post_user.id IS NOT NULL AND this_Post_user.id = $this_Post_user_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
             WITH collect({ node: { name: this_Post_user.name } }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS creatorConnection

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/projection-connection.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/projection-connection.md
@@ -48,7 +48,7 @@ MATCH (this:User)
 CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 CALL {
     WITH this
-    MATCH (this)-[this_has_post:HAS_POST]->(this_post:Post)
+    MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_post:Post)
     CALL apoc.util.validate(NOT(EXISTS((this_post)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
     WITH collect({ node: { content: this_post.content } }) AS edges
     RETURN { edges: edges, totalCount: size(edges) } AS postsConnection
@@ -108,11 +108,11 @@ MATCH (this:User)
 CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
 CALL {
     WITH this
-    MATCH (this)-[this_has_post:HAS_POST]->(this_post:Post)
+    MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_post:Post)
     CALL apoc.util.validate(NOT(EXISTS((this_post)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_allow0_creator_id)), "@neo4j/graphql/FORBIDDEN", [0])
     CALL {
         WITH this_post
-        MATCH (this_post)<-[this_post_has_post:HAS_POST]-(this_post_user:User)
+        MATCH (this_post)<-[this_post_has_post_relationship:HAS_POST]-(this_post_user:User)
         CALL apoc.util.validate(NOT(this_post_user.id IS NOT NULL AND this_post_user.id = $this_post_user_auth_allow0_id), "@neo4j/graphql/FORBIDDEN", [0])
         WITH collect({ node: { name: this_post_user.name } }) AS edges
         RETURN { edges: edges, totalCount: size(edges) } AS creatorConnection


### PR DESCRIPTION
# Description

Fixes remnant relationship variable not suffixed with "_relationship".

# Issue

#412

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
