### PR TITLE
Fix incorrect replacement of projection parameters in translateCreate

### DIFF
--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -127,6 +127,9 @@ function translateCreate({ context, node }: { context: Context; node: Node }): [
         .map(
             (_, i) =>
                 `\nthis${i} ${projection[0]
+                    // First look to see if projection param is being reassigned
+                    // e.g. in an apoc.cypher.runFirstColumn function call used in createProjection->connectionField
+                    .replace(/REPLACE_ME(?=\w+: \$REPLACE_ME)/, "projection")
                     .replace(/\$REPLACE_ME/g, "$projection")
                     .replace(/REPLACE_ME/g, `this${i}`)} AS this${i}`
         )

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -129,7 +129,7 @@ function translateCreate({ context, node }: { context: Context; node: Node }): [
                 `\nthis${i} ${projection[0]
                     // First look to see if projection param is being reassigned
                     // e.g. in an apoc.cypher.runFirstColumn function call used in createProjection->connectionField
-                    .replace(/REPLACE_ME(?=\w+: \$REPLACE_ME)/, "projection")
+                    .replace(/REPLACE_ME(?=\w+: \$REPLACE_ME)/g, "projection")
                     .replace(/\$REPLACE_ME/g, "$projection")
                     .replace(/REPLACE_ME/g, `this${i}`)} AS this${i}`
         )

--- a/packages/graphql/tests/integration/create.int.test.ts
+++ b/packages/graphql/tests/integration/create.int.test.ts
@@ -89,7 +89,7 @@ describe("create", () => {
         }
     });
 
-    test("should create movie and resolve connection with where clause on relationship field", async () => {
+    test("should create actor and resolve actorsConnection with where clause on movie field", async () => {
         const session = driver.session();
 
         const typeDefs = `
@@ -141,7 +141,6 @@ describe("create", () => {
                 `,
                 {
                     movieTitle,
-                    actorName,
                 }
             );
 
@@ -151,6 +150,7 @@ describe("create", () => {
                 contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
                 variableValues: { movieTitle, actorName },
             });
+
             expect(result.errors).toBeFalsy();
             expect(result.data?.createActors).toEqual({
                 actors: [


### PR DESCRIPTION
# Description

Proposed fix for #427 wherein `projection` parameters are incorrectly replaced when translating the `create` mutation. The proposed change is to replace parameter reassignments prior to replacing parameters and node names.

# Issue

- #427 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
