### PR TITLE
Fix variable assignment for filtering on relationship node in connections

### DIFF
--- a/packages/graphql/src/translate/where/create-node-where-and-params.ts
+++ b/packages/graphql/src/translate/where/create-node-where-and-params.ts
@@ -123,9 +123,9 @@ function createNodeWhereAndParams({
                     `EXISTS((${nodeVariable})${inStr}${relTypeStr}${outStr}(:${relationField.typeMeta.name}))`,
                     `AND ${
                         not ? "NONE" : "ANY"
-                    }(${param} IN [(${nodeVariable})${inStr}${relTypeStr}${outStr}(${relatedNodeVariable}:${
+                    }(${relatedNodeVariable} IN [(${nodeVariable})${inStr}${relTypeStr}${outStr}(${relatedNodeVariable}:${
                         relationField.typeMeta.name
-                    }) | ${param}] INNER_WHERE `,
+                    }) | ${relatedNodeVariable}] INNER_WHERE `,
                 ].join(" ");
 
                 const recurse = createNodeWhereAndParams({

--- a/packages/graphql/tests/integration/connections/filtering.int.test.ts
+++ b/packages/graphql/tests/integration/connections/filtering.int.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { generate } from "randomstring";
+import { gql } from "apollo-server";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("Connections Filtering", () => {
+    let driver: Driver;
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+    test("should allow where clause on relationship property of node", async () => {
+        const movieTitle = generate({ charset: "alphabetic" });
+        const actorOneName = generate({ charset: "alphabetic" });
+        const actorTwoName = generate({ charset: "alphabetic" });
+
+        const typeDefs = gql`
+            type Movie {
+                title: String!
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Actor {
+                name: String!
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+            }
+        `;
+        const { schema } = new Neo4jGraphQL({ typeDefs, driver });
+
+        const query = `
+			query ($movieTitle: String!) {
+				movies(where: { title: $movieTitle }) {
+					actorsConnection(where: {node: {movies: { title: $movieTitle } } }) {
+						edges {
+							node {
+								name
+							}
+						}
+					}
+				}
+			}
+		`;
+
+        const session = driver.session();
+        try {
+            await session.run(
+                `
+					CREATE (movie:Movie {title: $movieTitle})
+					CREATE (actorOne:Actor {name: $actorOneName})
+					CREATE (actorTwo:Actor {name: $actorTwoName})
+					CREATE (actorOne)-[:ACTED_IN]->(movie)<-[:ACTED_IN]-(actorTwo)
+                `,
+                {
+                    movieTitle,
+                    actorOneName,
+                    actorTwoName,
+                }
+            );
+            const result = await graphql({
+                schema,
+                source: query,
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                variableValues: {
+                    movieTitle,
+                },
+            });
+            expect(result.errors).toBeFalsy();
+            expect(result?.data?.movies[0].actorsConnection.edges).toContainEqual({ node: { name: actorOneName } });
+            expect(result?.data?.movies[0].actorsConnection.edges).toContainEqual({ node: { name: actorTwoName } });
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/relationship.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/connections/filtering/node/relationship.md
@@ -1,0 +1,72 @@
+# Cypher -> Connections -> Filtering -> Node -> Relationship
+
+Schema:
+
+```graphql
+type Movie {
+    title: String!
+    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+}
+
+type Actor {
+    name: String!
+    movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+}
+```
+
+---
+
+## Equality
+
+### GraphQL Input
+
+```graphql
+query {
+    movies {
+        title
+        actorsConnection(
+            where: { node: { movies: { title: "Forrest Gump" } } }
+        ) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+CALL {
+    WITH this
+    MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
+    WHERE EXISTS((this_actor)-[:ACTED_IN]->(:Movie)) AND ANY(this_actor_movies IN [(this_actor)-[:ACTED_IN]->(this_actor_movies:Movie) | this_actor_movies] WHERE this_actor_movies.title = $this_actorsConnection.args.where.node.movies.title)
+    WITH collect({ node: { name: this_actor.name } }) AS edges
+    RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_actorsConnection": {
+        "args": {
+            "where": {
+                "node": {
+                    "movies": {
+                        "title": "Forrest Gump"
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+---


### PR DESCRIPTION
# Description

Propose fix for #437 wherein the variable in the pattern comprehension is set to `relatedNodeVariable` as opposed to `param`.

# Issue

- #437 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
