### PR TITLE
Fix aliasing of ID, Int, and Float fields

### DIFF
--- a/packages/graphql/src/schema/to-compose.ts
+++ b/packages/graphql/src/schema/to-compose.ts
@@ -23,6 +23,7 @@ import { isInt, Integer } from "neo4j-driver";
 import getFieldTypeMeta from "./get-field-type-meta";
 import parseValueNode from "./parse-value-node";
 import { BaseField } from "../types";
+import { defaultFieldResolver } from "./resolvers";
 
 export function graphqlArgsToCompose(args: InputValueDefinitionNode[]) {
     return args.reduce((res, arg) => {
@@ -68,8 +69,8 @@ export function objectFieldsToComposeFields(
         }
 
         if (["Int", "Float"].includes(field.typeMeta.name)) {
-            newField.resolve = (source) => {
-                const value = source[field.fieldName];
+            newField.resolve = (source, args, context, info) => {
+                const value = defaultFieldResolver(source, args, context, info);
 
                 // @ts-ignore: outputValue is unknown, and to cast to object would be an antipattern
                 if (isInt(value)) {
@@ -81,8 +82,8 @@ export function objectFieldsToComposeFields(
         }
 
         if (field.typeMeta.name === "ID") {
-            newField.resolve = (source) => {
-                const value = source[field.fieldName];
+            newField.resolve = (source, args, context, info) => {
+                const value = defaultFieldResolver(source, args, context, info);
 
                 // @ts-ignore: outputValue is unknown, and to cast to object would be an antipattern
                 if (isInt(value)) {

--- a/packages/graphql/tests/integration/alias.int.test.ts
+++ b/packages/graphql/tests/integration/alias.int.test.ts
@@ -25,7 +25,7 @@ import { Neo4jGraphQL } from "../../src/classes";
 
 const testLabel = generate({ charset: "alphabetic" });
 
-describe("autogenerate", () => {
+describe("Alias", () => {
     let driver: Driver;
 
     const typeDefs = `

--- a/packages/graphql/tests/integration/alias.int.test.ts
+++ b/packages/graphql/tests/integration/alias.int.test.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { generate } from "randomstring";
+import neo4j from "./neo4j";
+import { Neo4jGraphQL } from "../../src/classes";
+
+const testLabel = generate({ charset: "alphabetic" });
+
+describe("autogenerate", () => {
+    let driver: Driver;
+
+    const typeDefs = `
+        type Movie {
+          id: ID!
+          budget: Int!
+          boxOffice: Float!
+        }
+    `;
+
+    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+    const id = generate({ readable: false });
+    const budget = 63;
+    const boxOffice = 465.3;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+        const session = driver.session();
+        try {
+            await session.run(
+                `
+                    CREATE (movie:Movie)
+                    SET movie:${testLabel}
+                    SET movie += $properties
+                `,
+                {
+                    properties: {
+                        id,
+                        boxOffice,
+                        budget,
+                    },
+                }
+            );
+        } finally {
+            await session.close();
+        }
+    });
+
+    afterAll(async () => {
+        const session = driver.session();
+        try {
+            await session.run(
+                `
+                  MATCH(node:${testLabel})
+                  DETACH DELETE node
+              `
+            );
+        } finally {
+            await session.close();
+            await driver.close();
+        }
+    });
+
+    test("should correctly alias an ID field", async () => {
+        const query = `
+            query ($id: ID!) {
+                movies(where: { id: $id }) {
+                    aliased: id
+                    budget
+                    boxOffice
+                }
+            }
+        `;
+
+        const gqlResult = await graphql({
+            schema,
+            source: query,
+            contextValue: { driver },
+            variableValues: { id },
+        });
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data?.movies[0]).toEqual({
+            aliased: id,
+            budget,
+            boxOffice,
+        });
+    });
+
+    test("should correctly alias an Int field", async () => {
+        const query = `
+            query ($id: ID!) {
+                movies(where: { id: $id }) {
+                    id
+                    aliased: budget
+                    boxOffice
+                }
+            }
+        `;
+
+        const gqlResult = await graphql({
+            schema,
+            source: query,
+            contextValue: { driver },
+            variableValues: { id },
+        });
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data?.movies[0]).toEqual({
+            id,
+            aliased: budget,
+            boxOffice,
+        });
+    });
+
+    test("should correctly alias an Float field", async () => {
+        const query = `
+            query ($id: ID!) {
+                movies(where: { id: $id }) {
+                    id
+                    budget
+                    aliased: boxOffice
+                }
+            }
+        `;
+
+        const gqlResult = await graphql({
+            schema,
+            source: query,
+            contextValue: { driver },
+            variableValues: { id },
+        });
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult?.data?.movies[0]).toEqual({
+            id,
+            budget,
+            aliased: boxOffice,
+        });
+    });
+});


### PR DESCRIPTION
# Description
This fixes an issue brought up in https://github.com/neo4j/graphql/issues/388#issuecomment-901340465. When composing object fields the `ID`, `Int`, and `Float` fields are being given a `resolve` that does not use the default resolver needed for aliasing.

This PR first extracts the value given from the `defaultFieldResolver` before checking it.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
