### PR TITLE
Refactor of execute.ts ahead of adding bookmark return

### DIFF
--- a/packages/graphql/src/schema/resolvers/count.test.ts
+++ b/packages/graphql/src/schema/resolvers/count.test.ts
@@ -20,7 +20,6 @@
 const executeMock = jest.fn();
 
 /* eslint-disable import/first */
-import { int } from "neo4j-driver";
 import { Node } from "../../classes";
 import countResolver from "./count";
 /* eslint-enable import/first */
@@ -61,11 +60,13 @@ describe("Count resolver", () => {
         const result = countResolver({ node });
 
         executeMock.mockReturnValue({
-            records: [
-                {
-                    _fields: [42],
-                },
-            ],
+            result: {
+                records: [
+                    {
+                        get: () => 42,
+                    },
+                ],
+            },
         });
 
         const foo = await result.resolve(null, null, "mockContext");
@@ -82,11 +83,13 @@ describe("Count resolver", () => {
         const result = countResolver({ node });
 
         executeMock.mockReturnValue({
-            records: [
-                {
-                    _fields: [int(43)],
-                },
-            ],
+            result: {
+                records: [
+                    {
+                        get: () => 43,
+                    },
+                ],
+            },
         });
 
         const foo = await result.resolve(null, null, "mockContext");

--- a/packages/graphql/src/schema/resolvers/count.ts
+++ b/packages/graphql/src/schema/resolvers/count.ts
@@ -27,15 +27,14 @@ export default function countResolver({ node }: { node: Node }) {
         const context = _context as Context;
         const [cypher, params] = translateCount({ context, node });
 
-        const result = await execute({
+        const executeResult = await execute({
             cypher,
             params,
             defaultAccessMode: "READ",
             context,
-            raw: true,
         });
 
-        const count = result.records[0]._fields[0];
+        const count = executeResult.result.records[0].get(0);
 
         // @ts-ignore: count is unknown, and to cast to object would be an antipattern
         if (isInt(count)) {

--- a/packages/graphql/src/schema/resolvers/create.ts
+++ b/packages/graphql/src/schema/resolvers/create.ts
@@ -30,7 +30,7 @@ export default function createResolver({ node }: { node: Node }) {
         const context = _context as Context;
         const [cypher, params] = translateCreate({ context, node });
 
-        const result = await execute({
+        const executeResult = await execute({
             cypher,
             params,
             defaultAccessMode: "WRITE",
@@ -44,7 +44,7 @@ export default function createResolver({ node }: { node: Node }) {
         const responseKey = responseField.alias ? responseField.alias.value : responseField.name.value;
 
         return {
-            [responseKey]: Object.values(result[0] || {}),
+            [responseKey]: Object.values(executeResult.records[0] || {}),
         };
     }
 

--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -135,17 +135,15 @@ export default function cypherResolver({
             cypherStrs.push(`RETURN this ${projectionStr} AS this`);
         }
 
-        const result = await execute({
+        const executeResult = await execute({
             cypher: cypherStrs.join("\n"),
             params,
             defaultAccessMode: "WRITE",
-            raw: true,
             context,
         });
 
-        const values = result.records.map((record) => {
-            // eslint-disable-next-line no-underscore-dangle
-            const value = record._fields[0];
+        const values = executeResult.result.records.map((record) => {
+            const value = record.get(0);
 
             if (["number", "string", "boolean"].includes(typeof value)) {
                 return value;

--- a/packages/graphql/src/schema/resolvers/delete.ts
+++ b/packages/graphql/src/schema/resolvers/delete.ts
@@ -25,15 +25,14 @@ export default function deleteResolver({ node }: { node: Node }) {
     async function resolve(_root: any, _args: any, _context: unknown) {
         const context = _context as Context;
         const [cypher, params] = translateDelete({ context, node });
-        const result = await execute({
+        const executeResult = await execute({
             cypher,
             params,
             defaultAccessMode: "WRITE",
-            statistics: true,
             context,
         });
 
-        return result;
+        return executeResult.statistics;
     }
 
     return {

--- a/packages/graphql/src/schema/resolvers/read.ts
+++ b/packages/graphql/src/schema/resolvers/read.ts
@@ -26,14 +26,14 @@ export default function findResolver({ node }: { node: Node }) {
         const context = _context as Context;
         const [cypher, params] = translateRead({ context, node });
 
-        const result = await execute({
+        const executeResult = await execute({
             cypher,
             params,
             defaultAccessMode: "READ",
             context,
         });
 
-        return result.map((x) => x.this);
+        return executeResult.records.map((x) => x.this);
     }
 
     return {

--- a/packages/graphql/src/schema/resolvers/update.ts
+++ b/packages/graphql/src/schema/resolvers/update.ts
@@ -29,7 +29,7 @@ export default function updateResolver({ node }: { node: Node }) {
     async function resolve(_root: any, _args: any, _context: unknown, info: GraphQLResolveInfo) {
         const context = _context as Context;
         const [cypher, params] = translateUpdate({ context, node });
-        const result = await execute({
+        const executeResult = await execute({
             cypher,
             params,
             defaultAccessMode: "WRITE",
@@ -43,7 +43,7 @@ export default function updateResolver({ node }: { node: Node }) {
         const responseKey = responseField.alias ? responseField.alias.value : responseField.name.value;
 
         return {
-            [responseKey]: result.map((x) => x.this),
+            [responseKey]: executeResult.records.map((x) => x.this),
         };
     }
 

--- a/packages/graphql/src/utils/execute.test.ts
+++ b/packages/graphql/src/utils/execute.test.ts
@@ -62,7 +62,7 @@ describe("execute", () => {
                                 expect(paramCypher).toEqual(cypher);
                                 expect(paramParams).toEqual(params);
 
-                                return { records };
+                                return { records, summary: { counters: { updates: () => ({ test: 1 }) } } };
                             },
                         };
 
@@ -75,6 +75,7 @@ describe("execute", () => {
                                 // @ts-ignore
                                 return fn(tx);
                             },
+                            lastBookmark: () => "bookmark",
                             close: () => true,
                         };
                     },
@@ -88,14 +89,14 @@ describe("execute", () => {
                     options: {},
                 };
 
-                const result = await execute({
+                const executeResult = await execute({
                     cypher,
                     params,
                     defaultAccessMode,
                     context: { driverConfig: { database, bookmarks }, neoSchema, driver } as Context,
                 });
 
-                expect(result).toEqual([{ title }]);
+                expect(executeResult.records).toEqual([{ title }]);
                 // @ts-ignore
                 expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
                 // @ts-ignore
@@ -132,7 +133,7 @@ describe("execute", () => {
                             expect(trimmer(paramCypher)).toEqual(cypher);
                             expect(paramParams).toEqual(params);
 
-                            return { records };
+                            return { records, summary: { counters: { updates: () => ({ test: 1 }) } } };
                         },
                     };
 
@@ -145,6 +146,7 @@ describe("execute", () => {
                             // @ts-ignore
                             return fn(tx);
                         },
+                        lastBookmark: () => "bookmark",
                         close: () => true,
                     };
                 },
@@ -158,7 +160,7 @@ describe("execute", () => {
                 options: {},
             };
 
-            const result = await execute({
+            const executeResult = await execute({
                 cypher,
                 params,
                 defaultAccessMode,
@@ -170,7 +172,7 @@ describe("execute", () => {
                 } as Context,
             });
 
-            expect(result).toEqual([{ title }]);
+            expect(executeResult.records).toEqual([{ title }]);
             // @ts-ignore
             expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
             // @ts-ignore
@@ -210,7 +212,7 @@ describe("execute", () => {
                             expect(trimmer(paramCypher)).toEqual(expectedCypher);
                             expect(paramParams).toEqual(params);
 
-                            return { records };
+                            return { records, summary: { counters: { updates: () => ({ test: 1 }) } } };
                         },
                     };
 
@@ -223,6 +225,7 @@ describe("execute", () => {
                             // @ts-ignore
                             return fn(tx);
                         },
+                        lastBookmark: () => "bookmark",
                         close: () => true,
                     };
                 },
@@ -236,7 +239,7 @@ describe("execute", () => {
                 options: {},
             };
 
-            const result = await execute({
+            const executeResult = await execute({
                 cypher: inputCypher,
                 params,
                 defaultAccessMode,
@@ -257,7 +260,7 @@ describe("execute", () => {
                 } as Context,
             });
 
-            expect(result).toEqual([{ title }]);
+            expect(executeResult.records).toEqual([{ title }]);
             // @ts-ignore
             expect(driver._userAgent).toEqual(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
             // @ts-ignore

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { SessionMode, Transaction, Result } from "neo4j-driver";
+import { SessionMode, Transaction, QueryResult } from "neo4j-driver";
 import Debug from "debug";
 import { Neo4jGraphQLForbiddenError, Neo4jGraphQLAuthenticationError } from "../classes";
 import { AUTH_FORBIDDEN_ERROR, AUTH_UNAUTHENTICATED_ERROR, DEBUG_EXECUTE } from "../constants";
@@ -27,14 +27,19 @@ import environment from "../environment";
 
 const debug = Debug(DEBUG_EXECUTE);
 
+interface ExecuteResult {
+    bookmark: string | null;
+    result: QueryResult;
+    statistics: Record<string, number>;
+    records: Record<PropertyKey, any>[];
+}
+
 async function execute(input: {
     cypher: string;
     params: any;
     defaultAccessMode: SessionMode;
-    statistics?: boolean;
-    raw?: boolean;
     context: Context;
-}): Promise<any> {
+}): Promise<ExecuteResult> {
     const sessionParams: {
         defaultAccessMode?: SessionMode;
         bookmarks?: string | string[];
@@ -84,23 +89,20 @@ async function execute(input: {
     try {
         debug("%s", `About to execute Cypher:\nCypher:\n${cypher}\nParams:\n${JSON.stringify(input.params, null, 2)}`);
 
-        const result: Result = await session[`${input.defaultAccessMode.toLowerCase()}Transaction`]((tx: Transaction) =>
-            tx.run(cypher, input.params)
-        );
+        const result: QueryResult = await session[
+            `${input.defaultAccessMode.toLowerCase()}Transaction`
+        ]((tx: Transaction) => tx.run(cypher, input.params));
 
-        if (input.statistics) {
-            return (await result).summary.counters.updates();
-        }
-
-        if (input.raw) {
-            return result;
-        }
-
-        const records = (await result).records.map((r) => r.toObject());
+        const records = result.records.map((r) => r.toObject());
 
         debug(`Execute successful, received ${records.length} records`);
 
-        return records;
+        return {
+            bookmark: session.lastBookmark(),
+            result,
+            statistics: result.summary.counters.updates(),
+            records: result.records.map((r) => r.toObject()),
+        };
     } catch (error) {
         if (error.message.includes(`Caused by: java.lang.RuntimeException: ${AUTH_FORBIDDEN_ERROR}`)) {
             throw new Neo4jGraphQLForbiddenError("Forbidden");


### PR DESCRIPTION
# Description

So far, just a refactor of `execute.ts`, and figured sensible to review that before introducing the tonne of TCK test changes associated with adding the bookmark return to the schema.

This has replaced a load of usages of private fields in the driver with the actual fields which should be used for these purposes.

# Issue

Bookmark needed to allow users to read their own rights, especially important when dealing with causal clusters.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
