### PR TITLE
Allow MutationResponse and SortDirection through validation

### DIFF
--- a/packages/graphql/src/schema/validation/enums.ts
+++ b/packages/graphql/src/schema/validation/enums.ts
@@ -37,6 +37,14 @@ export const RelationshipDirectionEnum = new GraphQLEnumType({
     },
 });
 
+export const SortDirection = new GraphQLEnumType({
+    name: "SortDirection",
+    values: {
+        ASC: {},
+        DESC: {},
+    },
+});
+
 export const TimestampOperationEnum = new GraphQLEnumType({
     name: "TimestampOperation",
     values: {

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -308,6 +308,40 @@ describe("validateDocument", () => {
         });
     });
 
+    describe("https://github.com/neo4j/graphql/issues/442", () => {
+        test("should not throw error on validation of schema if MutationResponse used", () => {
+            const doc = parse(`
+                type Post {
+                    id: Int!
+                    text: String!
+                }
+
+                type Mutation {
+                    create_Post(text: String!): CreatePostsMutationResponse!
+                }
+            `);
+
+            const res = validateDocument(doc);
+            expect(res).toBeUndefined();
+        });
+
+        test("should not throw error on validation of schema if SortDirection used", () => {
+            const doc = parse(`
+                type Post {
+                    id: Int!
+                    text: String!
+                }
+
+                type Mutation {
+                    create_Post(direction: SortDirection!): CreatePostsMutationResponse!
+                }
+            `);
+
+            const res = validateDocument(doc);
+            expect(res).toBeUndefined();
+        });
+    });
+
     describe("Issue https://codesandbox.io/s/github/johnymontana/training-v3/tree/master/modules/graphql-apis/supplemental/code/03-graphql-apis-custom-logic/end?file=/schema.graphql:64-86", () => {
         test("should not throw error on validation of schema", () => {
             const doc = parse(`


### PR DESCRIPTION
# Description

Filters out any fields returning a `*MutationResponse` object, and adds `SortDirection` to validation schema.

# Issue

#442 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
