### PR TITLE
Disable fail-fast for integration tests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -74,6 +74,7 @@ jobs:
       - cache-dependencies
 
     strategy:
+      fail-fast: false
       matrix:
         package:
           - graphql


### PR DESCRIPTION
Disable fail-fast for integration tests - useful for us to be able to see which versions tests fail on
