### PR TITLE
Feature: Add Time Scalar

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/types.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/types.adoc
@@ -71,6 +71,17 @@ type Movie {
 }
 ----
 
+=== `Time`
+
+RFC3339 time string stored as a https://neo4j.com/docs/cypher-manual/current/functions/temporal/#functions-time[Time] temporal type.
+
+[source, graphql, indent=0]
+----
+type Movie {
+    nextShowing: Time
+}
+----
+
 [[type-definitions-types-spatial]]
 == Spatial Types
 

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -62,7 +62,7 @@ function getWhereFields({
                 res[`${f.fieldName}_IN`] = `[${f.typeMeta.input.where.pretty}]`;
                 res[`${f.fieldName}_NOT_IN`] = `[${f.typeMeta.input.where.pretty}]`;
 
-                if (["Float", "Int", "BigInt", "DateTime", "Date"].includes(f.typeMeta.name)) {
+                if (["Float", "Int", "BigInt", "DateTime", "Date", "Time"].includes(f.typeMeta.name)) {
                     ["_LT", "_LTE", "_GT", "_GTE"].forEach((comparator) => {
                         res[`${f.fieldName}${comparator}`] = f.typeMeta.name;
                     });

--- a/packages/graphql/src/schema/scalars/Time.ts
+++ b/packages/graphql/src/schema/scalars/Time.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
+import neo4j from "neo4j-driver";
+
+export const RFC_3339_REGEX = /^(?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d)(\.(?<fraction>\d{1}(?:\d{0,8})))?((?:[Zz])|((?<offsetDirection>[-|+])(?<offsetHour>[01]\d|2[0-3]):(?<offsetMinute>[0-5]\d)))?$/;
+
+export const validateTime = (value: any) => {
+    if (typeof value !== "string") {
+        throw new TypeError(`Value must be of type string: ${value}`);
+    }
+
+    if (!RFC_3339_REGEX.test(value)) {
+        throw new TypeError(`Value must be formatted as Time: ${value}`);
+    }
+
+    return value;
+};
+
+export const parseTime = (value: any) => {
+    const validatedValue = validateTime(value);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { hour, minute, second, fraction, offsetDirection, offsetHour, offsetMinute } = RFC_3339_REGEX.exec(
+        validatedValue
+    )!.groups!;
+
+    // Calculate the number of nanoseconds by padding the fraction of seconds with zeroes to nine digits
+    let nanosecond = 0;
+    if (fraction) {
+        nanosecond = +`${fraction}000000000`.substring(0, 9);
+    }
+
+    // Calculate the timeZoneOffsetSeconds by calculating the offset in seconds with the appropriate sign
+    let timeZoneOffsetSeconds = 0;
+    if (offsetDirection && offsetHour && offsetMinute) {
+        const offsetInMinutes = +offsetMinute + +offsetHour * 60;
+        const offsetInSeconds = offsetInMinutes * 60;
+        timeZoneOffsetSeconds = +`${offsetDirection}${offsetInSeconds}`;
+    }
+
+    return {
+        hour: +hour,
+        minute: +minute,
+        second: +second,
+        nanosecond,
+        timeZoneOffsetSeconds,
+    };
+};
+
+const parse = (value: any) => {
+    const { hour, minute, second, nanosecond, timeZoneOffsetSeconds } = parseTime(value);
+
+    return new neo4j.types.Time(hour, minute, second, nanosecond, timeZoneOffsetSeconds);
+};
+
+export default new GraphQLScalarType({
+    name: "Time",
+    description: "A time, represented as an RFC3339 time string",
+    serialize: (value: typeof neo4j.types.Time) => {
+        return validateTime(value.toString());
+    },
+    parseValue: (value) => {
+        return parse(value);
+    },
+    parseLiteral: (ast) => {
+        if (ast.kind !== Kind.STRING) {
+            throw new GraphQLError(`Only strings can be validated as Time, but received: ${ast.kind}`);
+        }
+        return parse(ast.value);
+    },
+});

--- a/packages/graphql/src/schema/scalars/index.ts
+++ b/packages/graphql/src/schema/scalars/index.ts
@@ -20,3 +20,4 @@
 export { default as BigInt } from "./BigInt";
 export { default as DateTime } from "./DateTime";
 export { default as Date } from "./Date";
+export { default as Time } from "./Time";

--- a/packages/graphql/tests/integration/types/time.int.test.ts
+++ b/packages/graphql/tests/integration/types/time.int.test.ts
@@ -1,0 +1,557 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import faker from "faker";
+import { graphql } from "graphql";
+import neo4jDriver, { Driver } from "neo4j-driver";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { parseTime } from "../../../src/schema/scalars/Time";
+
+describe("Time", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    describe("create", () => {
+        test("should create a movie (with a Time)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                  id: ID!
+                  time: Time!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const time = faker.date.past().toISOString().split("T")[1];
+            const parsedTime = parseTime(time);
+
+            try {
+                const mutation = `
+                    mutation ($id: ID!, $time: Time!) {
+                        createMovies(input: { id: $id, time: $time }) {
+                            movies {
+                                time
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, time },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { time: string } = graphqlResult.data?.createMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(parseTime(graphqlMovie.time)).toStrictEqual(parsedTime);
+
+                const neo4jResult = await session.run(
+                    `
+                      MATCH (movie:Movie {id: $id})
+                      RETURN movie {.id, .time} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jDriver.isTime(neo4jMovie.time)).toBe(true);
+                expect(parseTime(neo4jMovie.time.toString())).toStrictEqual(parsedTime);
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should create a movie (with many Times)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                  id: ID!
+                  times: [Time!]!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const times = [...new Array(faker.random.number({ min: 2, max: 4 }))].map(
+                () => faker.date.past().toISOString().split("T")[1]
+            );
+            const parsedTimes = times.map((time) => parseTime(time));
+
+            try {
+                const mutation = `
+                    mutation ($id: ID!, $times: [Time!]!) {
+                        createMovies(input: { id: $id, times: $times }) {
+                            movies {
+                                times
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, times },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { times: string[] } = graphqlResult.data?.createMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.times).toHaveLength(times.length);
+
+                const parsedGraphQLTimes = graphqlMovie.times.map((time) => parseTime(time));
+
+                parsedTimes.forEach((parsedTime) => {
+                    expect(parsedGraphQLTimes).toContainEqual(parsedTime);
+                });
+
+                const neo4jResult = await session.run(
+                    `
+                      MATCH (movie:Movie {id: $id})
+                      RETURN movie {.id, .times} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; times: any[] } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jMovie.times).toHaveLength(times.length);
+
+                neo4jMovie.times.forEach((time) => {
+                    expect(neo4jDriver.isTime(time)).toBe(true);
+                });
+
+                const parsedNeo4jTimes = neo4jMovie.times.map((time) => parseTime(time.toString()));
+
+                parsedTimes.forEach((parsedTime) => {
+                    expect(parsedNeo4jTimes).toContainEqual(parsedTime);
+                });
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("update", () => {
+        test("should update a movie (with a Time)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                  id: ID!
+                  time: Time
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const time = faker.date.past().toISOString().split("T")[1];
+            const parsedTime = parseTime(time);
+
+            try {
+                await session.run(
+                    `
+                        CREATE (movie:Movie {id: $id})
+                    `,
+                    { id }
+                );
+
+                const mutation = `
+                    mutation ($id: ID!, $time: Time) {
+                        updateMovies(where: { id: $id }, update: { time: $time }) {
+                            movies {
+                                id
+                                time
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, time },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; time: string } = graphqlResult.data?.updateMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toEqual(id);
+                expect(parseTime(graphqlMovie.time)).toStrictEqual(parsedTime);
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .time} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; time: any } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jDriver.isTime(neo4jMovie.time)).toBe(true);
+                expect(parseTime(neo4jMovie.time.toString())).toStrictEqual(parsedTime);
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("filter", () => {
+        test("should filter based on time equality", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    time: Time!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const date = faker.date.future();
+            const time = date.toISOString().split("T")[1];
+            const neo4jTime = neo4jDriver.types.Time.fromStandardDate(date);
+            const parsedTime = parseTime(time);
+
+            try {
+                await session.run(
+                    `
+                        CREATE (movie:Movie {id: $id})
+                        SET movie.time = $neo4jTime
+                    `,
+                    { id, neo4jTime }
+                );
+
+                const query = `
+                    query ($time: Time!) {
+                        movies(where: { time: $time }) {
+                            id
+                            time
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: query,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { time },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; time: string } = graphqlResult.data?.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toEqual(id);
+                expect(parseTime(graphqlMovie.time)).toStrictEqual(parsedTime);
+            } finally {
+                await session.close();
+            }
+        });
+        test("should filter based on time comparison", () =>
+            Promise.all(
+                ["LT", "LTE", "GT", "GTE"].map(async (filter) => {
+                    const session = driver.session();
+
+                    const typeDefs = `
+                        type Movie {
+                            id: ID!
+                            time: Time!
+                        }
+                    `;
+
+                    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+                    const futureId = generate({ readable: false });
+                    const future = "13:00:00";
+                    const parsedFuture = parseTime(future);
+                    const neo4jFuture = new neo4jDriver.types.Time(
+                        parsedFuture.hour,
+                        parsedFuture.minute,
+                        parsedFuture.second,
+                        parsedFuture.nanosecond,
+                        parsedFuture.timeZoneOffsetSeconds
+                    );
+
+                    const presentId = generate({ readable: false });
+                    const present = "12:00:00";
+                    const parsedPresent = parseTime(present);
+                    const neo4jPresent = new neo4jDriver.types.Time(
+                        parsedPresent.hour,
+                        parsedPresent.minute,
+                        parsedPresent.second,
+                        parsedPresent.nanosecond,
+                        parsedPresent.timeZoneOffsetSeconds
+                    );
+
+                    const pastId = generate({ readable: false });
+                    const past = "11:00:00";
+                    const parsedPast = parseTime(past);
+                    const neo4jPast = new neo4jDriver.types.Time(
+                        parsedPast.hour,
+                        parsedPast.minute,
+                        parsedPast.second,
+                        parsedPast.nanosecond,
+                        parsedPast.timeZoneOffsetSeconds
+                    );
+
+                    try {
+                        await session.run(
+                            `
+                                CREATE (future:Movie:FINDTHIS)
+                                SET future = $future
+                                CREATE (present:Movie:FINDTHIS)
+                                SET present = $present
+                                CREATE (past:Movie:FINDTHIS)
+                                SET past = $past
+                            `,
+                            {
+                                future: { id: futureId, time: neo4jFuture },
+                                present: { id: presentId, time: neo4jPresent },
+                                past: { id: pastId, time: neo4jPast },
+                            }
+                        );
+
+                        const query = `
+                            query ($where: MovieWhere!) {
+                                movies(
+                                    where: $where
+                                    options: { sort: [{ time: ASC }]}
+                                ) {
+                                    id
+                                    time
+                                }
+                            }
+                        `;
+
+                        const graphqlResult = await graphql({
+                            schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                            variableValues: {
+                                where: { id_IN: [futureId, presentId, pastId], [`time_${filter}`]: present },
+                            },
+                        });
+
+                        expect(graphqlResult.errors).toBeUndefined();
+
+                        const graphqlMovies: { id: string; time: string }[] = graphqlResult.data?.movies;
+                        expect(graphqlMovies).toBeDefined();
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (filter === "LT") {
+                            expect(graphqlMovies).toHaveLength(1);
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseTime(graphqlMovies[0].time)).toStrictEqual(parsedPast);
+                        }
+
+                        if (filter === "LTE") {
+                            expect(graphqlMovies).toHaveLength(2);
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseTime(graphqlMovies[0].time)).toStrictEqual(parsedPast);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseTime(graphqlMovies[1].time)).toStrictEqual(parsedPresent);
+                        }
+
+                        if (filter === "GT") {
+                            expect(graphqlMovies).toHaveLength(1);
+                            expect(graphqlMovies[0].id).toBe(futureId);
+                            expect(parseTime(graphqlMovies[0].time)).toStrictEqual(parsedFuture);
+                        }
+
+                        if (filter === "GTE") {
+                            expect(graphqlMovies).toHaveLength(2);
+                            expect(graphqlMovies[0].id).toBe(presentId);
+                            expect(parseTime(graphqlMovies[0].time)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[1].id).toBe(futureId);
+                            expect(parseTime(graphqlMovies[1].time)).toStrictEqual(parsedFuture);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
+                    }
+                })
+            ));
+    });
+
+    describe("sorting", () => {
+        test("should sort based on time", () =>
+            Promise.all(
+                ["ASC", "DESC"].map(async (sort) => {
+                    const session = driver.session();
+
+                    const typeDefs = `
+                        type Movie {
+                            id: ID!
+                            time: Time!
+                        }
+                    `;
+
+                    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+                    const futureId = generate({ readable: false });
+                    const future = "13:00:00";
+                    const parsedFuture = parseTime(future);
+                    const neo4jFuture = new neo4jDriver.types.Time(
+                        parsedFuture.hour,
+                        parsedFuture.minute,
+                        parsedFuture.second,
+                        parsedFuture.nanosecond,
+                        parsedFuture.timeZoneOffsetSeconds
+                    );
+
+                    const presentId = generate({ readable: false });
+                    const present = "12:00:00";
+                    const parsedPresent = parseTime(present);
+                    const neo4jPresent = new neo4jDriver.types.Time(
+                        parsedPresent.hour,
+                        parsedPresent.minute,
+                        parsedPresent.second,
+                        parsedPresent.nanosecond,
+                        parsedPresent.timeZoneOffsetSeconds
+                    );
+
+                    const pastId = generate({ readable: false });
+                    const past = "11:00:00";
+                    const parsedPast = parseTime(past);
+                    const neo4jPast = new neo4jDriver.types.Time(
+                        parsedPast.hour,
+                        parsedPast.minute,
+                        parsedPast.second,
+                        parsedPast.nanosecond,
+                        parsedPast.timeZoneOffsetSeconds
+                    );
+
+                    try {
+                        await session.run(
+                            `
+                                CREATE (future:Movie:FINDTHIS)
+                                SET future = $future
+                                CREATE (present:Movie:FINDTHIS)
+                                SET present = $present
+                                CREATE (past:Movie:FINDTHIS)
+                                SET past = $past
+                            `,
+                            {
+                                future: { id: futureId, time: neo4jFuture },
+                                present: { id: presentId, time: neo4jPresent },
+                                past: { id: pastId, time: neo4jPast },
+                            }
+                        );
+
+                        const query = `
+                            query ($futureId: ID!, $presentId: ID!, $pastId: ID!, $sort: SortDirection!) {
+                                movies(
+                                    where: { id_IN: [$futureId, $presentId, $pastId]}
+                                    options: { sort: [{ time: $sort }]}
+                                ) {
+                                    id
+                                    time
+                                }
+                            }
+                        `;
+
+                        const graphqlResult = await graphql({
+                            schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                            variableValues: {
+                                futureId,
+                                presentId,
+                                pastId,
+                                sort,
+                            },
+                        });
+
+                        expect(graphqlResult.errors).toBeUndefined();
+
+                        const graphqlMovies: { id: string; time: string }[] = graphqlResult.data?.movies;
+                        expect(graphqlMovies).toBeDefined();
+                        expect(graphqlMovies).toHaveLength(3);
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (sort === "ASC") {
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseTime(graphqlMovies[0].time)).toStrictEqual(parsedPast);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseTime(graphqlMovies[1].time)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[2].id).toBe(futureId);
+                            expect(parseTime(graphqlMovies[2].time)).toStrictEqual(parsedFuture);
+                        }
+
+                        if (sort === "DESC") {
+                            expect(graphqlMovies[0].id).toBe(futureId);
+                            expect(parseTime(graphqlMovies[0].time)).toStrictEqual(parsedFuture);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseTime(graphqlMovies[1].time)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[2].id).toBe(pastId);
+                            expect(parseTime(graphqlMovies[2].time)).toStrictEqual(parsedPast);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
+                    }
+                })
+            ));
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/types/time.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/types/time.md
@@ -1,0 +1,166 @@
+# Cypher Time
+
+Tests Time operations. ⚠ The string in params is actually an object but the test suite turns it into a string when calling `JSON.stringify`.
+
+Schema:
+
+```graphql
+type Movie {
+    id: ID
+    time: Time
+}
+```
+
+---
+
+## Simple Read
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { time: "12:00:00" }) {
+        time
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.time = $this_time
+RETURN this { .time } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_time": {
+        "hour": 12,
+        "minute": 0,
+        "second": 0,
+        "nanosecond": 0,
+        "timeZoneOffsetSeconds": 0
+    }
+}
+```
+
+---
+
+## GTE Read
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { time_GTE: "13:45:33.250" }) {
+        time
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.time >= $this_time_GTE
+RETURN this { .time } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_time_GTE": {
+        "hour": 13,
+        "minute": 45,
+        "second": 33,
+        "nanosecond": 250000000,
+        "timeZoneOffsetSeconds": 0
+    }
+}
+```
+
+---
+
+## Simple Create
+
+### GraphQL Input
+
+```graphql
+mutation {
+    createMovies(input: [{ time: "22:00:15.555-01:00" }]) {
+        movies {
+            time
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+CALL {
+    CREATE (this0:Movie)
+    SET this0.time = $this0_time
+    RETURN this0
+}
+RETURN this0 { .time } AS this0
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this0_time": {
+        "hour": 22,
+        "minute": 0,
+        "second": 15,
+        "nanosecond": 555000000,
+        "timeZoneOffsetSeconds": -3600
+    }
+}
+```
+
+---
+
+## Simple Update
+
+### GraphQL Input
+
+```graphql
+mutation {
+    updateMovies(update: { time: "09:24:40.845512+06:30" }) {
+        movies {
+            id
+            time
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+SET this.time = $this_update_time
+RETURN this { .id, .time } AS this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_update_time": {
+        "hour": 9,
+        "minute": 24,
+        "second": 40,
+        "nanosecond": 845512000,
+        "timeZoneOffsetSeconds": 23400
+    }
+}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/schema/types/time.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/types/time.md
@@ -1,0 +1,120 @@
+# Schema Time
+
+Tests that the provided typeDefs return the correct schema.
+
+---
+
+## Time
+
+### TypeDefs
+
+```graphql
+type Movie {
+    id: ID
+    time: Time
+}
+```
+
+### Output
+
+```graphql
+"""
+A time, represented as an RFC3339 time string
+"""
+scalar Time
+
+type Movie {
+    id: ID
+    time: Time
+}
+
+type DeleteInfo {
+    nodesDeleted: Int!
+    relationshipsDeleted: Int!
+}
+
+enum SortDirection {
+    """
+    Sort by field values in ascending order.
+    """
+    ASC
+    """
+    Sort by field values in descending order.
+    """
+    DESC
+}
+
+input MovieCreateInput {
+    id: ID
+    time: Time
+}
+
+input MovieOptions {
+    """
+    Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+    """
+    sort: [MovieSort]
+    limit: Int
+    offset: Int
+}
+
+"""
+Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+"""
+input MovieSort {
+    id: SortDirection
+    time: SortDirection
+}
+
+input MovieWhere {
+    id: ID
+    id_IN: [ID]
+    id_NOT: ID
+    id_NOT_IN: [ID]
+    id_CONTAINS: ID
+    id_NOT_CONTAINS: ID
+    id_STARTS_WITH: ID
+    id_NOT_STARTS_WITH: ID
+    id_ENDS_WITH: ID
+    id_NOT_ENDS_WITH: ID
+    time: Time
+    time_GT: Time
+    time_GTE: Time
+    time_IN: [Time]
+    time_NOT: Time
+    time_NOT_IN: [Time]
+    time_LT: Time
+    time_LTE: Time
+    OR: [MovieWhere!]
+    AND: [MovieWhere!]
+}
+
+input MovieUpdateInput {
+    id: ID
+    time: Time
+}
+
+type CreateMoviesMutationResponse {
+    movies: [Movie!]!
+}
+
+type UpdateMoviesMutationResponse {
+    movies: [Movie!]!
+}
+
+type Mutation {
+    createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+    deleteMovies(where: MovieWhere): DeleteInfo!
+    updateMovies(
+        where: MovieWhere
+        update: MovieUpdateInput
+    ): UpdateMoviesMutationResponse!
+}
+
+type Query {
+    movies(where: MovieWhere, options: MovieOptions): [Movie!]!
+    moviesCount(where: MovieWhere): Int!
+}
+```
+
+---


### PR DESCRIPTION
# Description

Adds a `Time` scalar. It is passed in as an RFC 3339 compliant time string and stored in the database as a neo4j `Time` instance.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
