### PR TITLE
Feature: Add LocalTime Scalar

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/types.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/types.adoc
@@ -71,6 +71,17 @@ type Movie {
 }
 ----
 
+=== `LocalTime`
+
+"HH:MM:SS[.sss+]" time string stored as a https://neo4j.com/docs/cypher-manual/current/functions/temporal/#functions-localtime[LocalTime] temporal type.
+
+[source, graphql, indent=0]
+----
+type Movie {
+    nextShowing: LocalTime
+}
+----
+
 [[type-definitions-types-spatial]]
 == Spatial Types
 

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -62,7 +62,7 @@ function getWhereFields({
                 res[`${f.fieldName}_IN`] = `[${f.typeMeta.input.where.pretty}]`;
                 res[`${f.fieldName}_NOT_IN`] = `[${f.typeMeta.input.where.pretty}]`;
 
-                if (["Float", "Int", "BigInt", "DateTime", "Date"].includes(f.typeMeta.name)) {
+                if (["Float", "Int", "BigInt", "DateTime", "Date", "LocalTime"].includes(f.typeMeta.name)) {
                     ["_LT", "_LTE", "_GT", "_GTE"].forEach((comparator) => {
                         res[`${f.fieldName}${comparator}`] = f.typeMeta.name;
                     });

--- a/packages/graphql/src/schema/scalars/LocalTime.ts
+++ b/packages/graphql/src/schema/scalars/LocalTime.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
+import neo4j from "neo4j-driver";
+
+export const LOCAL_TIME_REGEX = /^(?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d)(\.(?<fraction>\d{1}(?:\d{0,8})))?$/;
+
+export const validateLocalTime = (value: any) => {
+    if (typeof value !== "string") {
+        throw new TypeError(`Value must be of type string: ${value}`);
+    }
+
+    if (!LOCAL_TIME_REGEX.test(value)) {
+        throw new TypeError(`Value must be formatted as LocalTime: ${value}`);
+    }
+
+    return value;
+};
+
+export const parseLocalTime = (value: any) => {
+    const validatedValue = validateLocalTime(value);
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { hour, minute, second, fraction } = LOCAL_TIME_REGEX.exec(validatedValue)!.groups!;
+
+    // Calculate the number of nanoseconds by padding the fraction of seconds with zeroes to nine digits
+    let nanosecond = 0;
+    if (fraction) {
+        nanosecond = +`${fraction}000000000`.substring(0, 9);
+    }
+
+    return {
+        hour: +hour,
+        minute: +minute,
+        second: +second,
+        nanosecond,
+    };
+};
+
+const parse = (value: any) => {
+    const { hour, minute, second, nanosecond } = parseLocalTime(value);
+
+    return new neo4j.types.LocalTime(hour, minute, second, nanosecond);
+};
+
+export default new GraphQLScalarType({
+    name: "LocalTime",
+    description: "A local time, represented as a time string without timezone information",
+    serialize: (value: typeof neo4j.types.LocalTime) => {
+        return validateLocalTime(value.toString());
+    },
+    parseValue: (value) => {
+        return parse(value);
+    },
+    parseLiteral: (ast) => {
+        if (ast.kind !== Kind.STRING) {
+            throw new GraphQLError(`Only strings can be validated as LocalTime, but received: ${ast.kind}`);
+        }
+        return parse(ast.value);
+    },
+});

--- a/packages/graphql/src/schema/scalars/index.ts
+++ b/packages/graphql/src/schema/scalars/index.ts
@@ -20,3 +20,4 @@
 export { default as BigInt } from "./BigInt";
 export { default as DateTime } from "./DateTime";
 export { default as Date } from "./Date";
+export { default as LocalTime } from "./LocalTime";

--- a/packages/graphql/tests/integration/types/localtime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localtime.int.test.ts
@@ -1,0 +1,556 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import faker from "faker";
+import { graphql } from "graphql";
+import neo4jDriver, { Driver } from "neo4j-driver";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { parseLocalTime } from "../../../src/schema/scalars/LocalTime";
+
+describe("LocalTime", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    describe("create", () => {
+        test("should create a movie (with a LocalTime)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    time: LocalTime!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const time = faker.date.past().toISOString().split("T")[1].split("Z")[0];
+            const parsedTime = parseLocalTime(time);
+
+            try {
+                const mutation = `
+                    mutation ($id: ID!, $time: LocalTime!) {
+                        createMovies(input: { id: $id, time: $time }) {
+                            movies {
+                                id
+                                time
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, time },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; time: string } = graphqlResult.data?.createMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toBe(id);
+                expect(parseLocalTime(graphqlMovie.time)).toStrictEqual(parsedTime);
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .time} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; time: any } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jDriver.isLocalTime(neo4jMovie.time)).toBe(true);
+                expect(parseLocalTime(neo4jMovie.time.toString())).toStrictEqual(parsedTime);
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should create a movie (with many Times)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    times: [LocalTime!]!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const times = [...new Array(faker.random.number({ min: 2, max: 4 }))].map(
+                () => faker.date.past().toISOString().split("T")[1].split("Z")[0]
+            );
+            const parsedTimes = times.map((time) => parseLocalTime(time));
+
+            try {
+                const mutation = `
+                    mutation ($id: ID!, $times: [LocalTime!]!) {
+                        createMovies(input: { id: $id, times: $times }) {
+                            movies {
+                                id
+                                times
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, times },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; times: string[] } = graphqlResult.data?.createMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toBe(id);
+                expect(graphqlMovie.times).toHaveLength(times.length);
+
+                const parsedGraphQLTimes = graphqlMovie.times.map((time) => parseLocalTime(time));
+
+                parsedTimes.forEach((parsedTime) => {
+                    expect(parsedGraphQLTimes).toContainEqual(parsedTime);
+                });
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .times} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; times: any[] } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jMovie.times).toHaveLength(times.length);
+
+                neo4jMovie.times.forEach((time) => {
+                    expect(neo4jDriver.isLocalTime(time)).toBe(true);
+                });
+
+                const parsedNeo4jTimes = neo4jMovie.times.map((time) => parseLocalTime(time.toString()));
+
+                parsedTimes.forEach((parsedTime) => {
+                    expect(parsedNeo4jTimes).toContainEqual(parsedTime);
+                });
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("update", () => {
+        test("should update a movie (with a LocalTime)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    time: LocalTime
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const time = faker.date.past().toISOString().split("T")[1].split("Z")[0];
+            const parsedTime = parseLocalTime(time);
+
+            try {
+                await session.run(
+                    `
+                        CREATE (movie:Movie)
+                        SET movie = $movie
+                    `,
+                    { movie: { id } }
+                );
+
+                const mutation = `
+                    mutation ($id: ID!, $time: LocalTime) {
+                        updateMovies(where: { id: $id }, update: { time: $time }) {
+                            movies {
+                                id
+                                time
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, time },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; time: string } = graphqlResult.data?.updateMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toEqual(id);
+                expect(parseLocalTime(graphqlMovie.time)).toStrictEqual(parsedTime);
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .time} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; time: any } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jDriver.isLocalTime(neo4jMovie.time)).toBe(true);
+                expect(parseLocalTime(neo4jMovie.time.toString())).toStrictEqual(parsedTime);
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("filter", () => {
+        test("should filter based on time equality", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    time: LocalTime!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const date = faker.date.future();
+            const time = date.toISOString().split("T")[1].split("Z")[0];
+            const neo4jTime = neo4jDriver.types.LocalTime.fromStandardDate(date);
+            const parsedTime = parseLocalTime(time);
+
+            try {
+                await session.run(
+                    `
+                        CREATE (movie:Movie)
+                        SET movie = $movie
+                    `,
+                    { movie: { id, time: neo4jTime } }
+                );
+
+                const query = `
+                    query ($time: LocalTime!) {
+                        movies(where: { time: $time }) {
+                            id
+                            time
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: query,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { time },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; time: string } = graphqlResult.data?.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toEqual(id);
+                expect(parseLocalTime(graphqlMovie.time)).toStrictEqual(parsedTime);
+            } finally {
+                await session.close();
+            }
+        });
+        test("should filter based on time comparison", () =>
+            Promise.all(
+                ["LT", "LTE", "GT", "GTE"].map(async (filter) => {
+                    const session = driver.session();
+
+                    const typeDefs = `
+                        type Movie {
+                            id: ID!
+                            time: LocalTime!
+                        }
+                    `;
+
+                    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+                    const futureId = generate({ readable: false });
+                    const future = "13:00:00";
+                    const parsedFuture = parseLocalTime(future);
+                    const neo4jFuture = new neo4jDriver.types.LocalTime(
+                        parsedFuture.hour,
+                        parsedFuture.minute,
+                        parsedFuture.second,
+                        parsedFuture.nanosecond
+                    );
+
+                    const presentId = generate({ readable: false });
+                    const present = "12:00:00";
+                    const parsedPresent = parseLocalTime(present);
+                    const neo4jPresent = new neo4jDriver.types.LocalTime(
+                        parsedPresent.hour,
+                        parsedPresent.minute,
+                        parsedPresent.second,
+                        parsedPresent.nanosecond
+                    );
+
+                    const pastId = generate({ readable: false });
+                    const past = "11:00:00";
+                    const parsedPast = parseLocalTime(past);
+                    const neo4jPast = new neo4jDriver.types.LocalTime(
+                        parsedPast.hour,
+                        parsedPast.minute,
+                        parsedPast.second,
+                        parsedPast.nanosecond
+                    );
+
+                    try {
+                        await session.run(
+                            `
+                                CREATE (future:Movie)
+                                SET future = $future
+                                CREATE (present:Movie)
+                                SET present = $present
+                                CREATE (past:Movie)
+                                SET past = $past
+                            `,
+                            {
+                                future: { id: futureId, time: neo4jFuture },
+                                present: { id: presentId, time: neo4jPresent },
+                                past: { id: pastId, time: neo4jPast },
+                            }
+                        );
+
+                        const query = `
+                            query ($where: MovieWhere!) {
+                                movies(
+                                    where: $where
+                                    options: { sort: [{ time: ASC }]}
+                                ) {
+                                    id
+                                    time
+                                }
+                            }
+                        `;
+
+                        const graphqlResult = await graphql({
+                            schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                            variableValues: {
+                                where: { id_IN: [futureId, presentId, pastId], [`time_${filter}`]: present },
+                            },
+                        });
+
+                        expect(graphqlResult.errors).toBeUndefined();
+
+                        const graphqlMovies: { id: string; time: string }[] = graphqlResult.data?.movies;
+                        expect(graphqlMovies).toBeDefined();
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (filter === "LT") {
+                            expect(graphqlMovies).toHaveLength(1);
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseLocalTime(graphqlMovies[0].time)).toStrictEqual(parsedPast);
+                        }
+
+                        if (filter === "LTE") {
+                            expect(graphqlMovies).toHaveLength(2);
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseLocalTime(graphqlMovies[0].time)).toStrictEqual(parsedPast);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseLocalTime(graphqlMovies[1].time)).toStrictEqual(parsedPresent);
+                        }
+
+                        if (filter === "GT") {
+                            expect(graphqlMovies).toHaveLength(1);
+                            expect(graphqlMovies[0].id).toBe(futureId);
+                            expect(parseLocalTime(graphqlMovies[0].time)).toStrictEqual(parsedFuture);
+                        }
+
+                        if (filter === "GTE") {
+                            expect(graphqlMovies).toHaveLength(2);
+                            expect(graphqlMovies[0].id).toBe(presentId);
+                            expect(parseLocalTime(graphqlMovies[0].time)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[1].id).toBe(futureId);
+                            expect(parseLocalTime(graphqlMovies[1].time)).toStrictEqual(parsedFuture);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
+                    }
+                })
+            ));
+    });
+
+    describe("sorting", () => {
+        test("should sort based on time", () =>
+            Promise.all(
+                ["ASC", "DESC"].map(async (sort) => {
+                    const session = driver.session();
+
+                    const typeDefs = `
+                        type Movie {
+                            id: ID!
+                            time: LocalTime!
+                        }
+                    `;
+
+                    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+                    const futureId = generate({ readable: false });
+                    const future = "13:00:00";
+                    const parsedFuture = parseLocalTime(future);
+                    const neo4jFuture = new neo4jDriver.types.LocalTime(
+                        parsedFuture.hour,
+                        parsedFuture.minute,
+                        parsedFuture.second,
+                        parsedFuture.nanosecond
+                    );
+
+                    const presentId = generate({ readable: false });
+                    const present = "12:00:00";
+                    const parsedPresent = parseLocalTime(present);
+                    const neo4jPresent = new neo4jDriver.types.LocalTime(
+                        parsedPresent.hour,
+                        parsedPresent.minute,
+                        parsedPresent.second,
+                        parsedPresent.nanosecond
+                    );
+
+                    const pastId = generate({ readable: false });
+                    const past = "11:00:00";
+                    const parsedPast = parseLocalTime(past);
+                    const neo4jPast = new neo4jDriver.types.LocalTime(
+                        parsedPast.hour,
+                        parsedPast.minute,
+                        parsedPast.second,
+                        parsedPast.nanosecond
+                    );
+
+                    try {
+                        await session.run(
+                            `
+                                CREATE (future:Movie)
+                                SET future = $future
+                                CREATE (present:Movie)
+                                SET present = $present
+                                CREATE (past:Movie)
+                                SET past = $past
+                            `,
+                            {
+                                future: { id: futureId, time: neo4jFuture },
+                                present: { id: presentId, time: neo4jPresent },
+                                past: { id: pastId, time: neo4jPast },
+                            }
+                        );
+
+                        const query = `
+                            query ($futureId: ID!, $presentId: ID!, $pastId: ID!, $sort: SortDirection!) {
+                                movies(
+                                    where: { id_IN: [$futureId, $presentId, $pastId] }
+                                    options: { sort: [{ time: $sort }] }
+                                ) {
+                                    id
+                                    time
+                                }
+                            }
+                        `;
+
+                        const graphqlResult = await graphql({
+                            schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                            variableValues: {
+                                futureId,
+                                presentId,
+                                pastId,
+                                sort,
+                            },
+                        });
+
+                        expect(graphqlResult.errors).toBeUndefined();
+
+                        const graphqlMovies: { id: string; time: string }[] = graphqlResult.data?.movies;
+                        expect(graphqlMovies).toBeDefined();
+                        expect(graphqlMovies).toHaveLength(3);
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (sort === "ASC") {
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseLocalTime(graphqlMovies[0].time)).toStrictEqual(parsedPast);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseLocalTime(graphqlMovies[1].time)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[2].id).toBe(futureId);
+                            expect(parseLocalTime(graphqlMovies[2].time)).toStrictEqual(parsedFuture);
+                        }
+
+                        if (sort === "DESC") {
+                            expect(graphqlMovies[0].id).toBe(futureId);
+                            expect(parseLocalTime(graphqlMovies[0].time)).toStrictEqual(parsedFuture);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseLocalTime(graphqlMovies[1].time)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[2].id).toBe(pastId);
+                            expect(parseLocalTime(graphqlMovies[2].time)).toStrictEqual(parsedPast);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
+                    }
+                })
+            ));
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/types/localtime.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/types/localtime.md
@@ -1,0 +1,162 @@
+# Cypher LocalTime
+
+Tests LocalTime operations. ⚠ The string in params is actually an object but the test suite turns it into a string when calling `JSON.stringify`.
+
+Schema:
+
+```graphql
+type Movie {
+    id: ID
+    time: LocalTime
+}
+```
+
+---
+
+## Simple Read
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { time: "12:00:00" }) {
+        time
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.time = $this_time
+RETURN this { .time } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_time": {
+        "hour": 12,
+        "minute": 0,
+        "second": 0,
+        "nanosecond": 0
+    }
+}
+```
+
+---
+
+## GTE Read
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { time_GTE: "13:45:33.250" }) {
+        time
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.time >= $this_time_GTE
+RETURN this { .time } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_time_GTE": {
+        "hour": 13,
+        "minute": 45,
+        "second": 33,
+        "nanosecond": 250000000
+    }
+}
+```
+
+---
+
+## Simple Create
+
+### GraphQL Input
+
+```graphql
+mutation {
+    createMovies(input: [{ time: "22:00:15.555" }]) {
+        movies {
+            time
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+CALL {
+    CREATE (this0:Movie)
+    SET this0.time = $this0_time
+    RETURN this0
+}
+RETURN this0 { .time } AS this0
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this0_time": {
+        "hour": 22,
+        "minute": 0,
+        "second": 15,
+        "nanosecond": 555000000
+    }
+}
+```
+
+---
+
+## Simple Update
+
+### GraphQL Input
+
+```graphql
+mutation {
+    updateMovies(update: { time: "09:24:40.845512" }) {
+        movies {
+            id
+            time
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+SET this.time = $this_update_time
+RETURN this { .id, .time } AS this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_update_time": {
+        "hour": 9,
+        "minute": 24,
+        "second": 40,
+        "nanosecond": 845512000
+    }
+}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/schema/types/localtime.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/types/localtime.md
@@ -1,0 +1,120 @@
+# Schema LocalTime
+
+Tests that the provided typeDefs return the correct schema.
+
+---
+
+## LocalTime
+
+### TypeDefs
+
+```graphql
+type Movie {
+    id: ID
+    time: LocalTime
+}
+```
+
+### Output
+
+```graphql
+"""
+A local time, represented as a time string without timezone information
+"""
+scalar LocalTime
+
+type Movie {
+    id: ID
+    time: LocalTime
+}
+
+type DeleteInfo {
+    nodesDeleted: Int!
+    relationshipsDeleted: Int!
+}
+
+enum SortDirection {
+    """
+    Sort by field values in ascending order.
+    """
+    ASC
+    """
+    Sort by field values in descending order.
+    """
+    DESC
+}
+
+input MovieCreateInput {
+    id: ID
+    time: LocalTime
+}
+
+input MovieOptions {
+    """
+    Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+    """
+    sort: [MovieSort]
+    limit: Int
+    offset: Int
+}
+
+"""
+Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+"""
+input MovieSort {
+    id: SortDirection
+    time: SortDirection
+}
+
+input MovieWhere {
+    id: ID
+    id_IN: [ID]
+    id_NOT: ID
+    id_NOT_IN: [ID]
+    id_CONTAINS: ID
+    id_NOT_CONTAINS: ID
+    id_STARTS_WITH: ID
+    id_NOT_STARTS_WITH: ID
+    id_ENDS_WITH: ID
+    id_NOT_ENDS_WITH: ID
+    time: LocalTime
+    time_GT: LocalTime
+    time_GTE: LocalTime
+    time_IN: [LocalTime]
+    time_NOT: LocalTime
+    time_NOT_IN: [LocalTime]
+    time_LT: LocalTime
+    time_LTE: LocalTime
+    OR: [MovieWhere!]
+    AND: [MovieWhere!]
+}
+
+input MovieUpdateInput {
+    id: ID
+    time: LocalTime
+}
+
+type CreateMoviesMutationResponse {
+    movies: [Movie!]!
+}
+
+type UpdateMoviesMutationResponse {
+    movies: [Movie!]!
+}
+
+type Mutation {
+    createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+    deleteMovies(where: MovieWhere): DeleteInfo!
+    updateMovies(
+        where: MovieWhere
+        update: MovieUpdateInput
+    ): UpdateMoviesMutationResponse!
+}
+
+type Query {
+    movies(where: MovieWhere, options: MovieOptions): [Movie!]!
+    moviesCount(where: MovieWhere): Int!
+}
+```
+
+---


### PR DESCRIPTION
# Description

Adds a `LocalTime` scalar. It is passed in as a time string without timezone information and stored in the database as a neo4j `LocalTime` instance.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
