### PR TITLE
Fix/433 - Exclude empty where from cypher generation

### DIFF
--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -204,7 +204,9 @@ function createConnectionAndParams({
                     });
                     const [whereClause] = where;
                     if (whereClause) {
-                        whereStrs.push(whereClause);
+                        if (whereClause) {
+                            whereStrs.push(whereClause);
+                        }
                     }
                 }
 
@@ -274,7 +276,9 @@ function createConnectionAndParams({
                 }.args.where`,
             });
             const [whereClause] = where;
-            whereStrs.push(`${whereClause}`);
+            if (whereClause) {
+                whereStrs.push(`${whereClause}`);
+            }
         }
 
         const whereAuth = createAuthAndParams({

--- a/packages/graphql/tests/integration/issues/433.int.test.ts
+++ b/packages/graphql/tests/integration/issues/433.int.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("433", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should recreate issue and return correct data", async () => {
+        const session = driver.session();
+
+        const typeDefs = gql`
+            # Cannot use 'type Node'
+            type Movie {
+                title: String
+                actors: [Person] @relationship(type: "ACTED_IN", direction: IN)
+            }
+
+            type Person {
+                name: String
+            }
+        `;
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const personName = generate({
+            charset: "alphabetic",
+        });
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const query = `
+            query {
+                movies(where: {title: "${movieTitle}"}) {
+                    title
+                    actorsConnection(where: {}) {
+                      edges {
+                        node {
+                          name
+                        }
+                      }
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run(
+                `
+                    CREATE (:Movie {title: $movieTitle})<-[:ACTED_IN]-(:Person {name: $personName})
+                `,
+                { movieTitle, personName }
+            );
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: query,
+                contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+            });
+
+            expect(result.errors).toBeFalsy();
+
+            expect(result.data as any).toEqual({
+                movies: [
+                    {
+                        title: movieTitle,
+                        actorsConnection: {
+                            edges: [{ node: { name: personName } }],
+                        },
+                    },
+                ],
+            });
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/issues/433.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/issues/433.md
@@ -1,0 +1,68 @@
+# #413
+
+<https://github.com/neo4j/graphql/issues/433>
+
+Schema:
+
+```graphql
+# Cannot use 'type Node'
+type Movie {
+    title: String
+    actors: [Person] @relationship(type: "ACTED_IN", direction: OUT)
+}
+
+type Person {
+    name: String
+}
+```
+
+---
+
+## Should not add where keyword if empty where
+
+### GraphQL Input
+
+```graphql
+query {
+    movies {
+        title
+        actorsConnection(where: {}) {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+CALL {
+    WITH this
+    MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_person:Person)
+    WITH collect({ node: { name: this_person.name } }) AS edges
+    RETURN {
+        edges: edges,
+        totalCount: size(edges)
+    } AS actorsConnection
+}
+RETURN this { .title, actorsConnection } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_actorsConnection": {
+        "args": {
+            "where": {}
+        }
+    }
+}
+```
+
+---


### PR DESCRIPTION
# Description

Check if where is truthy before adding to `whereStrs`. 

# Issue

Fixes: #433 


# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
