### PR TITLE
Add @relationshipProperties directive

### DIFF
--- a/docs/modules/ROOT/pages/directives.adoc
+++ b/docs/modules/ROOT/pages/directives.adoc
@@ -61,6 +61,18 @@ The `@relationship` directive is used to configure relationships between object 
 
 Reference: xref::type-definitions/relationships.adoc[Relationships]
 
+== `@relationshipProperties`
+
+Optional syntactic sugar to help you distinguish between interfaces which are used for relationship properties, and otherwise.
+
+Can only be used on interfaces, as per its definition:
+
+[source, graphql, indent=0]
+----
+"""Syntactic sugar to help differentiate between interfaces for relationship properties, and otherwise."""
+directive @relationshipProperties on INTERFACE
+----
+
 == `@timestamp`
 
 The `@timestamp` directive flags fields to be used to store timestamps on create/update events.

--- a/docs/modules/ROOT/pages/guides/migration-guide/type-definitions.adoc
+++ b/docs/modules/ROOT/pages/guides/migration-guide/type-definitions.adoc
@@ -51,7 +51,7 @@ type Movie {
     actors: [Actor!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
 }
 
-interface ActedIn {
+interface ActedIn @relationshipProperties {
     roles: [String!]
 }
 ----

--- a/docs/modules/ROOT/pages/type-definitions/basics.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/basics.adoc
@@ -53,7 +53,7 @@ type Actor {
     movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
 }
 
-interface ActedIn {
+interface ActedIn @relationshipProperties {
     roles: [String]
 }
 ----

--- a/docs/modules/ROOT/pages/type-definitions/relationships.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/relationships.adoc
@@ -77,7 +77,7 @@ type Movie {
     director: Person! @relationship(type: "DIRECTED", direction: IN)
 }
 
-interface ActedIn {
+interface ActedIn @relationshipProperties {
     roles: [String!]
 }
 ----

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -135,6 +135,12 @@ export const relationshipDirective = new GraphQLDirective({
     },
 });
 
+export const relationshipPropertiesDirective = new GraphQLDirective({
+    name: "relationshipProperties",
+    description: "Syntactic sugar to help differentiate between interfaces for relationship properties, and otherwise.",
+    locations: [DirectiveLocation.INTERFACE],
+});
+
 export const timestampDirective = new GraphQLDirective({
     name: "timestamp",
     description:

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -1,8 +1,3 @@
-/* eslint-disable eslint-comments/disable-enable-pair */
-/* eslint-disable jest/no-conditional-expect */
-/* eslint-disable jest/no-try-expect */
-/* ^ so we can use toContain on the errors */
-
 /*
  * Copyright (c) "Neo4j"
  * Neo4j Sweden AB [http://neo4j.com]
@@ -32,12 +27,7 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain('Directive "@coalesce" may not be used on OBJECT.');
-        }
+        expect(() => validateDocument(doc)).toThrow('Directive "@coalesce" may not be used on OBJECT.');
     });
 
     test("should throw an error if a directive is missing an argument", () => {
@@ -47,14 +37,9 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain(
-                'Directive "@coalesce" argument "value" of type "Scalar!" is required, but it was not provided.'
-            );
-        }
+        expect(() => validateDocument(doc)).toThrow(
+            'Directive "@coalesce" argument "value" of type "Scalar!" is required, but it was not provided.'
+        );
     });
 
     test("should throw a missing scalar error", () => {
@@ -64,12 +49,7 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain('Unknown type "Unknown".');
-        }
+        expect(() => validateDocument(doc)).toThrow('Unknown type "Unknown".');
     });
 
     test("should throw an error if a user tries to pass in their own Point definition", () => {
@@ -84,14 +64,9 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain(
-                'Type "Point" already exists in the schema. It cannot also be defined in this type definition.'
-            );
-        }
+        expect(() => validateDocument(doc)).toThrow(
+            'Type "Point" already exists in the schema. It cannot also be defined in this type definition.'
+        );
     });
 
     test("should throw an error if a user tries to pass in their own DateTime definition", () => {
@@ -103,14 +78,9 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain(
-                'Type "DateTime" already exists in the schema. It cannot also be defined in this type definition.'
-            );
-        }
+        expect(() => validateDocument(doc)).toThrow(
+            'Type "DateTime" already exists in the schema. It cannot also be defined in this type definition.'
+        );
     });
 
     test("should throw an error if a user tries to pass in their own PointInput definition", () => {
@@ -125,14 +95,9 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain(
-                'Type "PointInput" already exists in the schema. It cannot also be defined in this type definition.'
-            );
-        }
+        expect(() => validateDocument(doc)).toThrow(
+            'Type "PointInput" already exists in the schema. It cannot also be defined in this type definition.'
+        );
     });
 
     test("should throw an error if an interface is incorrectly implemented", () => {
@@ -146,12 +111,9 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain("Interface field UserInterface.age expected but User does not provide it.");
-        }
+        expect(() => validateDocument(doc)).toThrow(
+            "Interface field UserInterface.age expected but User does not provide it."
+        );
     });
 
     test("should throw an error a user tries to redefine one of our directives", () => {
@@ -163,14 +125,9 @@ describe("validateDocument", () => {
             }
         `);
 
-        try {
-            validateDocument(doc);
-            throw new Error();
-        } catch (error) {
-            expect(error.message).toContain(
-                'Directive "@relationship" already exists in the schema. It cannot be redefined.'
-            );
-        }
+        expect(() => validateDocument(doc)).toThrow(
+            'Directive "@relationship" already exists in the schema. It cannot be redefined.'
+        );
     });
 
     test("should remove auth directive and pass validation", () => {
@@ -210,6 +167,53 @@ describe("validateDocument", () => {
 
         const res = validateDocument(doc);
         expect(res).toBeUndefined();
+    });
+
+    describe("relationshipProperties directive", () => {
+        test("should not throw when used correctly on an interface", () => {
+            const doc = parse(`
+                interface ActedIn @relationshipProperties {
+                    screenTime: Int!
+                }
+
+                type Actor {
+                    name: String!
+                    movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                }
+
+                type Movie {
+                    title: String!
+                    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                }
+            `);
+
+            const res = validateDocument(doc);
+            expect(res).toBeUndefined();
+        });
+
+        test("should throw if used on an object type", () => {
+            const doc = parse(`
+                type ActedIn @relationshipProperties {
+                    screenTime: Int!
+                }
+            `);
+
+            expect(() => validateDocument(doc)).toThrow(
+                'Directive "@relationshipProperties" may not be used on OBJECT.'
+            );
+        });
+
+        test("should throw if used on a field", () => {
+            const doc = parse(`
+                type ActedIn {
+                    screenTime: Int! @relationshipProperties
+                }
+            `);
+
+            expect(() => validateDocument(doc)).toThrow(
+                'Directive "@relationshipProperties" may not be used on FIELD_DEFINITION.'
+            );
+        });
     });
 
     test("should not throw error on use of internal input types within input types", () => {

--- a/packages/graphql/tests/tck/tck-test-files/schema/relationship-properties.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/relationship-properties.md
@@ -21,7 +21,7 @@ type Movie {
         @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
 }
 
-interface ActedIn {
+interface ActedIn @relationshipProperties {
     screenTime: Int!
     startDate: Date!
     leadRole: Boolean!


### PR DESCRIPTION
# Description

Optional syntactic sugar directive to help users distinguish between interfaces used for relationship properties, and otherwise.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
