### PR TITLE
Feature: Add LocalDateTime Scalar

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/types.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/types.adoc
@@ -71,6 +71,17 @@ type Movie {
 }
 ----
 
+=== `LocalDateTime`
+
+"YYYY-MM-DDTHH:MM:SS" datetime string stored as a https://neo4j.com/docs/cypher-manual/current/functions/temporal/#functions-localdatetime[LocalDateTime] temporal type.
+
+[source, graphql, indent=0]
+----
+type Movie {
+    nextShowing: LocalDateTime
+}
+----
+
 [[type-definitions-types-spatial]]
 == Spatial Types
 

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -62,7 +62,7 @@ function getWhereFields({
                 res[`${f.fieldName}_IN`] = `[${f.typeMeta.input.where.pretty}]`;
                 res[`${f.fieldName}_NOT_IN`] = `[${f.typeMeta.input.where.pretty}]`;
 
-                if (["Float", "Int", "BigInt", "DateTime", "Date"].includes(f.typeMeta.name)) {
+                if (["Float", "Int", "BigInt", "DateTime", "Date", "LocalDateTime"].includes(f.typeMeta.name)) {
                     ["_LT", "_LTE", "_GT", "_GTE"].forEach((comparator) => {
                         res[`${f.fieldName}${comparator}`] = f.typeMeta.name;
                     });

--- a/packages/graphql/src/schema/scalars/LocalDateTime.ts
+++ b/packages/graphql/src/schema/scalars/LocalDateTime.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
+import neo4j from "neo4j-driver";
+
+// Matching YYYY-MM-DDTHH:MM:SS(.sss+)
+const LOCAL_DATE_TIME_REGEX = /^(?<year>\d{4})-(?<month>[0]\d|1[0-2])-(?<day>[0-2]\d|3[01])T(?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d)(\.(?<fraction>\d+))?$/;
+
+export const parseLocalDateTime = (value: any) => {
+    if (typeof value !== "string") {
+        throw new TypeError(`Value must be of type string: ${value}`);
+    }
+
+    const match = LOCAL_DATE_TIME_REGEX.exec(value);
+
+    if (!match) {
+        throw new TypeError(`Value must be formatted as LocalDateTime: ${value}`);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { year, month, day, hour, minute, second, fraction = 0 } = match.groups!;
+
+    // Take first nine digits if received more
+    let nanosecond = `${fraction}`.substring(0, 9);
+    // Pad with zeros to reach nine digits if received less
+    while (nanosecond.toString().length < 9) {
+        nanosecond = `${nanosecond}0`;
+    }
+
+    return {
+        year: +year,
+        month: +month,
+        day: +day,
+        hour: +hour,
+        minute: +minute,
+        second: +second,
+        nanosecond: +nanosecond,
+    };
+};
+
+const parse = (value: any) => {
+    const { year, month, day, hour, minute, second, nanosecond } = parseLocalDateTime(value);
+
+    return new neo4j.types.LocalDateTime(year, month, day, hour, minute, second, nanosecond);
+};
+
+export default new GraphQLScalarType({
+    name: "LocalDateTime",
+    description: "A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'",
+    serialize: (value: any) => {
+        if (typeof value !== "string" && !(value instanceof neo4j.types.LocalDateTime)) {
+            throw new TypeError(`Value must be of type string: ${value}`);
+        }
+
+        const stringifiedValue = value.toString();
+
+        if (!LOCAL_DATE_TIME_REGEX.test(stringifiedValue)) {
+            throw new TypeError(`Value must be formatted as LocalDateTime: ${stringifiedValue}`);
+        }
+
+        return stringifiedValue;
+    },
+    parseValue: (value) => {
+        return parse(value);
+    },
+    parseLiteral: (ast) => {
+        if (ast.kind !== Kind.STRING) {
+            throw new GraphQLError(`Only strings can be validated as LocalDateTime, but received: ${ast.kind}`);
+        }
+        return parse(ast.value);
+    },
+});

--- a/packages/graphql/src/schema/scalars/index.ts
+++ b/packages/graphql/src/schema/scalars/index.ts
@@ -20,3 +20,4 @@
 export { default as BigInt } from "./BigInt";
 export { default as DateTime } from "./DateTime";
 export { default as Date } from "./Date";
+export { default as LocalDateTime } from "./LocalDateTime";

--- a/packages/graphql/tests/integration/types/localdatetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localdatetime.int.test.ts
@@ -1,0 +1,576 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import faker from "faker";
+import { graphql } from "graphql";
+import neo4jDriver, { Driver } from "neo4j-driver";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { parseLocalDateTime } from "../../../src/schema/scalars/LocalDateTime";
+
+describe("LocalDateTime", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    describe("create", () => {
+        test("should create a movie (with a LocalDateTime)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    localDT: LocalDateTime!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const localDT = faker.date.past().toISOString().split("Z")[0];
+            const parsedLocalDateTime = parseLocalDateTime(localDT);
+
+            try {
+                const mutation = `
+                    mutation ($id: ID!, $localDT: LocalDateTime!) {
+                        createMovies(input: { id: $id, localDT: $localDT }) {
+                            movies {
+                                id
+                                localDT
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, localDT },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; localDT: string } = graphqlResult.data?.createMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toBe(id);
+                expect(parseLocalDateTime(graphqlMovie.localDT)).toStrictEqual(parsedLocalDateTime);
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .localDT} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; localDT: any } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jDriver.isLocalDateTime(neo4jMovie.localDT)).toBe(true);
+                expect(parseLocalDateTime(neo4jMovie.localDT.toString())).toStrictEqual(parsedLocalDateTime);
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should create a movie (with many Times)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    localDTs: [LocalDateTime!]!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const localDTs = [...new Array(faker.random.number({ min: 2, max: 4 }))].map(
+                () => faker.date.past().toISOString().split("Z")[0]
+            );
+            const parsedLocalDateTimes = localDTs.map((localDT) => parseLocalDateTime(localDT));
+
+            try {
+                const mutation = `
+                    mutation ($id: ID!, $localDTs: [LocalDateTime!]!) {
+                        createMovies(input: { id: $id, localDTs: $localDTs }) {
+                            movies {
+                                id
+                                localDTs
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, localDTs },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; localDTs: string[] } = graphqlResult.data?.createMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toBe(id);
+                expect(graphqlMovie.localDTs).toHaveLength(localDTs.length);
+
+                const parsedGraphQLLocalDateTimes = graphqlMovie.localDTs.map((localDT) => parseLocalDateTime(localDT));
+
+                parsedLocalDateTimes.forEach((parsedLocalDateTime) => {
+                    expect(parsedGraphQLLocalDateTimes).toContainEqual(parsedLocalDateTime);
+                });
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .localDTs} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; localDTs: any[] } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jMovie.localDTs).toHaveLength(localDTs.length);
+
+                neo4jMovie.localDTs.forEach((localDT) => {
+                    expect(neo4jDriver.isLocalDateTime(localDT)).toBe(true);
+                });
+
+                const parsedNeo4jLocalDateTimes = neo4jMovie.localDTs.map((localDT) =>
+                    parseLocalDateTime(localDT.toString())
+                );
+
+                parsedLocalDateTimes.forEach((parsedLocalDateTime) => {
+                    expect(parsedNeo4jLocalDateTimes).toContainEqual(parsedLocalDateTime);
+                });
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("update", () => {
+        test("should update a movie (with a LocalDateTime)", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    localDT: LocalDateTime
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const localDT = faker.date.past().toISOString().split("Z")[0];
+            const parsedLocalDateTime = parseLocalDateTime(localDT);
+
+            try {
+                await session.run(
+                    `
+                        CREATE (movie:Movie)
+                        SET movie = $movie
+                    `,
+                    { movie: { id } }
+                );
+
+                const mutation = `
+                    mutation ($id: ID!, $localDT: LocalDateTime) {
+                        updateMovies(where: { id: $id }, update: { localDT: $localDT }) {
+                            movies {
+                                id
+                                localDT
+                            }
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: mutation,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { id, localDT },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; localDT: string } = graphqlResult.data?.updateMovies.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toEqual(id);
+                expect(parseLocalDateTime(graphqlMovie.localDT)).toStrictEqual(parsedLocalDateTime);
+
+                const neo4jResult = await session.run(
+                    `
+                        MATCH (movie:Movie {id: $id})
+                        RETURN movie {.id, .localDT} as movie
+                    `,
+                    { id }
+                );
+
+                const neo4jMovie: { id: string; localDT: any } = neo4jResult.records[0].toObject().movie;
+                expect(neo4jMovie).toBeDefined();
+                expect(neo4jMovie.id).toEqual(id);
+                expect(neo4jDriver.isLocalDateTime(neo4jMovie.localDT)).toBe(true);
+                expect(parseLocalDateTime(neo4jMovie.localDT.toString())).toStrictEqual(parsedLocalDateTime);
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("filter", () => {
+        test("should filter based on localDT equality", async () => {
+            const session = driver.session();
+
+            const typeDefs = `
+                type Movie {
+                    id: ID!
+                    localDT: LocalDateTime!
+                }
+            `;
+
+            const { schema } = new Neo4jGraphQL({
+                typeDefs,
+            });
+
+            const id = generate({ readable: false });
+            const date = faker.date.future();
+            const localDT = date.toISOString().split("Z")[0];
+            const neo4jLocalDateTime = neo4jDriver.types.LocalDateTime.fromStandardDate(date);
+            const parsedLocalDateTime = parseLocalDateTime(localDT);
+
+            try {
+                await session.run(
+                    `
+                        CREATE (movie:Movie)
+                        SET movie = $movie
+                    `,
+                    { movie: { id, localDT: neo4jLocalDateTime } }
+                );
+
+                const query = `
+                    query ($localDT: LocalDateTime!) {
+                        movies(where: { localDT: $localDT }) {
+                            id
+                            localDT
+                        }
+                    }
+                `;
+
+                const graphqlResult = await graphql({
+                    schema,
+                    source: query,
+                    contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                    variableValues: { localDT },
+                });
+
+                expect(graphqlResult.errors).toBeFalsy();
+
+                const graphqlMovie: { id: string; localDT: string } = graphqlResult.data?.movies[0];
+                expect(graphqlMovie).toBeDefined();
+                expect(graphqlMovie.id).toEqual(id);
+                expect(parseLocalDateTime(graphqlMovie.localDT)).toStrictEqual(parsedLocalDateTime);
+            } finally {
+                await session.close();
+            }
+        });
+        test("should filter based on localDT comparison", () =>
+            Promise.all(
+                ["LT", "LTE", "GT", "GTE"].map(async (filter) => {
+                    const session = driver.session();
+
+                    const typeDefs = `
+                        type Movie {
+                            id: ID!
+                            localDT: LocalDateTime!
+                        }
+                    `;
+
+                    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+                    const futureId = generate({ readable: false });
+                    const future = faker.date.future(100).toISOString().split("Z")[0];
+                    const parsedFuture = parseLocalDateTime(future);
+                    const neo4jFuture = new neo4jDriver.types.LocalDateTime(
+                        parsedFuture.year,
+                        parsedFuture.month,
+                        parsedFuture.day,
+                        parsedFuture.hour,
+                        parsedFuture.minute,
+                        parsedFuture.second,
+                        parsedFuture.nanosecond
+                    );
+
+                    const presentId = generate({ readable: false });
+                    const present = new Date().toISOString().split("Z")[0];
+                    const parsedPresent = parseLocalDateTime(present);
+                    const neo4jPresent = new neo4jDriver.types.LocalDateTime(
+                        parsedPresent.year,
+                        parsedPresent.month,
+                        parsedPresent.day,
+                        parsedPresent.hour,
+                        parsedPresent.minute,
+                        parsedPresent.second,
+                        parsedPresent.nanosecond
+                    );
+
+                    const pastId = generate({ readable: false });
+                    const past = faker.date.past(100).toISOString().split("Z")[0];
+                    const parsedPast = parseLocalDateTime(past);
+                    const neo4jPast = new neo4jDriver.types.LocalDateTime(
+                        parsedPast.year,
+                        parsedPast.month,
+                        parsedPast.day,
+                        parsedPast.hour,
+                        parsedPast.minute,
+                        parsedPast.second,
+                        parsedPast.nanosecond
+                    );
+
+                    try {
+                        await session.run(
+                            `
+                                CREATE (future:Movie)
+                                SET future = $future
+                                CREATE (present:Movie)
+                                SET present = $present
+                                CREATE (past:Movie)
+                                SET past = $past
+                            `,
+                            {
+                                future: { id: futureId, localDT: neo4jFuture },
+                                present: { id: presentId, localDT: neo4jPresent },
+                                past: { id: pastId, localDT: neo4jPast },
+                            }
+                        );
+
+                        const query = `
+                            query ($where: MovieWhere!) {
+                                movies(
+                                    where: $where
+                                    options: { sort: [{ localDT: ASC }]}
+                                ) {
+                                    id
+                                    localDT
+                                }
+                            }
+                        `;
+
+                        const graphqlResult = await graphql({
+                            schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                            variableValues: {
+                                where: { id_IN: [futureId, presentId, pastId], [`localDT_${filter}`]: present },
+                            },
+                        });
+
+                        expect(graphqlResult.errors).toBeUndefined();
+
+                        const graphqlMovies: { id: string; localDT: string }[] = graphqlResult.data?.movies;
+                        expect(graphqlMovies).toBeDefined();
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (filter === "LT") {
+                            expect(graphqlMovies).toHaveLength(1);
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseLocalDateTime(graphqlMovies[0].localDT)).toStrictEqual(parsedPast);
+                        }
+
+                        if (filter === "LTE") {
+                            expect(graphqlMovies).toHaveLength(2);
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseLocalDateTime(graphqlMovies[0].localDT)).toStrictEqual(parsedPast);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseLocalDateTime(graphqlMovies[1].localDT)).toStrictEqual(parsedPresent);
+                        }
+
+                        if (filter === "GT") {
+                            expect(graphqlMovies).toHaveLength(1);
+                            expect(graphqlMovies[0].id).toBe(futureId);
+                            expect(parseLocalDateTime(graphqlMovies[0].localDT)).toStrictEqual(parsedFuture);
+                        }
+
+                        if (filter === "GTE") {
+                            expect(graphqlMovies).toHaveLength(2);
+                            expect(graphqlMovies[0].id).toBe(presentId);
+                            expect(parseLocalDateTime(graphqlMovies[0].localDT)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[1].id).toBe(futureId);
+                            expect(parseLocalDateTime(graphqlMovies[1].localDT)).toStrictEqual(parsedFuture);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
+                    }
+                })
+            ));
+    });
+
+    describe("sorting", () => {
+        test("should sort based on localDT", () =>
+            Promise.all(
+                ["ASC", "DESC"].map(async (sort) => {
+                    const session = driver.session();
+
+                    const typeDefs = `
+                        type Movie {
+                            id: ID!
+                            localDT: LocalDateTime!
+                        }
+                    `;
+
+                    const { schema } = new Neo4jGraphQL({ typeDefs });
+
+                    const futureId = generate({ readable: false });
+                    const future = faker.date.future(100).toISOString().split("Z")[0];
+                    const parsedFuture = parseLocalDateTime(future);
+                    const neo4jFuture = new neo4jDriver.types.LocalDateTime(
+                        parsedFuture.year,
+                        parsedFuture.month,
+                        parsedFuture.day,
+                        parsedFuture.hour,
+                        parsedFuture.minute,
+                        parsedFuture.second,
+                        parsedFuture.nanosecond
+                    );
+
+                    const presentId = generate({ readable: false });
+                    const present = new Date().toISOString().split("Z")[0];
+                    const parsedPresent = parseLocalDateTime(present);
+                    const neo4jPresent = new neo4jDriver.types.LocalDateTime(
+                        parsedPresent.year,
+                        parsedPresent.month,
+                        parsedPresent.day,
+                        parsedPresent.hour,
+                        parsedPresent.minute,
+                        parsedPresent.second,
+                        parsedPresent.nanosecond
+                    );
+
+                    const pastId = generate({ readable: false });
+                    const past = faker.date.past(100).toISOString().split("Z")[0];
+                    const parsedPast = parseLocalDateTime(past);
+                    const neo4jPast = new neo4jDriver.types.LocalDateTime(
+                        parsedPast.year,
+                        parsedPast.month,
+                        parsedPast.day,
+                        parsedPast.hour,
+                        parsedPast.minute,
+                        parsedPast.second,
+                        parsedPast.nanosecond
+                    );
+
+                    try {
+                        await session.run(
+                            `
+                                CREATE (future:Movie)
+                                SET future = $future
+                                CREATE (present:Movie)
+                                SET present = $present
+                                CREATE (past:Movie)
+                                SET past = $past
+                            `,
+                            {
+                                future: { id: futureId, localDT: neo4jFuture },
+                                present: { id: presentId, localDT: neo4jPresent },
+                                past: { id: pastId, localDT: neo4jPast },
+                            }
+                        );
+
+                        const query = `
+                            query ($futureId: ID!, $presentId: ID!, $pastId: ID!, $sort: SortDirection!) {
+                                movies(
+                                    where: { id_IN: [$futureId, $presentId, $pastId] }
+                                    options: { sort: [{ localDT: $sort }] }
+                                ) {
+                                    id
+                                    localDT
+                                }
+                            }
+                        `;
+
+                        const graphqlResult = await graphql({
+                            schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: [session.lastBookmark()] } },
+                            variableValues: {
+                                futureId,
+                                presentId,
+                                pastId,
+                                sort,
+                            },
+                        });
+
+                        expect(graphqlResult.errors).toBeUndefined();
+
+                        const graphqlMovies: { id: string; localDT: string }[] = graphqlResult.data?.movies;
+                        expect(graphqlMovies).toBeDefined();
+                        expect(graphqlMovies).toHaveLength(3);
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (sort === "ASC") {
+                            expect(graphqlMovies[0].id).toBe(pastId);
+                            expect(parseLocalDateTime(graphqlMovies[0].localDT)).toStrictEqual(parsedPast);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseLocalDateTime(graphqlMovies[1].localDT)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[2].id).toBe(futureId);
+                            expect(parseLocalDateTime(graphqlMovies[2].localDT)).toStrictEqual(parsedFuture);
+                        }
+
+                        if (sort === "DESC") {
+                            expect(graphqlMovies[0].id).toBe(futureId);
+                            expect(parseLocalDateTime(graphqlMovies[0].localDT)).toStrictEqual(parsedFuture);
+
+                            expect(graphqlMovies[1].id).toBe(presentId);
+                            expect(parseLocalDateTime(graphqlMovies[1].localDT)).toStrictEqual(parsedPresent);
+
+                            expect(graphqlMovies[2].id).toBe(pastId);
+                            expect(parseLocalDateTime(graphqlMovies[2].localDT)).toStrictEqual(parsedPast);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
+                    }
+                })
+            ));
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/cypher/types/localdatetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/types/localdatetime.md
@@ -1,0 +1,174 @@
+# Cypher LocalDateTime
+
+Tests LocalDateTime operations. ⚠ The string in params is actually an object but the test suite turns it into a string when calling `JSON.stringify`.
+
+Schema:
+
+```graphql
+type Movie {
+    id: ID
+    localDT: LocalDateTime
+}
+```
+
+---
+
+## Simple Read
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { localDT: "2003-09-14T12:00:00" }) {
+        localDT
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.localDT = $this_localDT
+RETURN this { .localDT } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_localDT": {
+        "year": 2003,
+        "month": 9,
+        "day": 14,
+        "hour": 12,
+        "minute": 0,
+        "second": 0,
+        "nanosecond": 0
+    }
+}
+```
+
+---
+
+## GTE Read
+
+### GraphQL Input
+
+```graphql
+query {
+    movies(where: { localDT_GTE: "2010-08-23T13:45:33.250" }) {
+        localDT
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.localDT >= $this_localDT_GTE
+RETURN this { .localDT } as this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_localDT_GTE": {
+        "year": 2010,
+        "month": 8,
+        "day": 23,
+        "hour": 13,
+        "minute": 45,
+        "second": 33,
+        "nanosecond": 250000000
+    }
+}
+```
+
+---
+
+## Simple Create
+
+### GraphQL Input
+
+```graphql
+mutation {
+    createMovies(input: [{ localDT: "1974-05-01T22:00:15.555" }]) {
+        movies {
+            localDT
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+CALL {
+    CREATE (this0:Movie)
+    SET this0.localDT = $this0_localDT
+    RETURN this0
+}
+RETURN this0 { .localDT } AS this0
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this0_localDT": {
+        "year": 1974,
+        "month": 5,
+        "day": 1,
+        "hour": 22,
+        "minute": 0,
+        "second": 15,
+        "nanosecond": 555000000
+    }
+}
+```
+
+---
+
+## Simple Update
+
+### GraphQL Input
+
+```graphql
+mutation {
+    updateMovies(update: { localDT: "1881-07-13T09:24:40.845512" }) {
+        movies {
+            id
+            localDT
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+SET this.localDT = $this_update_localDT
+RETURN this { .id, .localDT } AS this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_update_localDT": {
+        "year": 1881,
+        "month": 7,
+        "day": 13,
+        "hour": 9,
+        "minute": 24,
+        "second": 40,
+        "nanosecond": 845512000
+    }
+}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/schema/types/localdatetime.md
+++ b/packages/graphql/tests/tck/tck-test-files/schema/types/localdatetime.md
@@ -1,0 +1,120 @@
+# Schema LocalDateTime
+
+Tests that the provided typeDefs return the correct schema.
+
+---
+
+## LocalDateTime
+
+### TypeDefs
+
+```graphql
+type Movie {
+    id: ID
+    localDT: LocalDateTime
+}
+```
+
+### Output
+
+```graphql
+"""
+A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'
+"""
+scalar LocalDateTime
+
+type Movie {
+    id: ID
+    localDT: LocalDateTime
+}
+
+type DeleteInfo {
+    nodesDeleted: Int!
+    relationshipsDeleted: Int!
+}
+
+enum SortDirection {
+    """
+    Sort by field values in ascending order.
+    """
+    ASC
+    """
+    Sort by field values in descending order.
+    """
+    DESC
+}
+
+input MovieCreateInput {
+    id: ID
+    localDT: LocalDateTime
+}
+
+input MovieOptions {
+    """
+    Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+    """
+    sort: [MovieSort]
+    limit: Int
+    offset: Int
+}
+
+"""
+Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+"""
+input MovieSort {
+    id: SortDirection
+    localDT: SortDirection
+}
+
+input MovieWhere {
+    id: ID
+    id_IN: [ID]
+    id_NOT: ID
+    id_NOT_IN: [ID]
+    id_CONTAINS: ID
+    id_NOT_CONTAINS: ID
+    id_STARTS_WITH: ID
+    id_NOT_STARTS_WITH: ID
+    id_ENDS_WITH: ID
+    id_NOT_ENDS_WITH: ID
+    localDT: LocalDateTime
+    localDT_GT: LocalDateTime
+    localDT_GTE: LocalDateTime
+    localDT_IN: [LocalDateTime]
+    localDT_NOT: LocalDateTime
+    localDT_NOT_IN: [LocalDateTime]
+    localDT_LT: LocalDateTime
+    localDT_LTE: LocalDateTime
+    OR: [MovieWhere!]
+    AND: [MovieWhere!]
+}
+
+input MovieUpdateInput {
+    id: ID
+    localDT: LocalDateTime
+}
+
+type CreateMoviesMutationResponse {
+    movies: [Movie!]!
+}
+
+type UpdateMoviesMutationResponse {
+    movies: [Movie!]!
+}
+
+type Mutation {
+    createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+    deleteMovies(where: MovieWhere): DeleteInfo!
+    updateMovies(
+        where: MovieWhere
+        update: MovieUpdateInput
+    ): UpdateMoviesMutationResponse!
+}
+
+type Query {
+    movies(where: MovieWhere, options: MovieOptions): [Movie!]!
+    moviesCount(where: MovieWhere): Int!
+}
+```
+
+---


### PR DESCRIPTION
# Description

Adds a `LocalDateTime` scalar. It is passed in as an ISO 8601 datetime string without timezone information and stored in the database as a neo4j `localdatetime` value.

This allows for ISO 8601 datetime strings in the extended format: `YYYY-MM-DDTHH:MM:SS`

# Issue

- #274 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
