### PR TITLE
Custom pluralization

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ const baseTypeScriptRules = {
     /* end of @typescript-eslint/recommended-requiring-type-checking rules */
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/quotes": "off",
+    "@typescript-eslint/lines-between-class-members": "off",
 };
 
 module.exports = {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,6 +62,7 @@ const baseTypeScriptRules = {
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/quotes": "off",
     "@typescript-eslint/lines-between-class-members": ["error", "always", { exceptAfterSingleLine: true }],
+    "@typescript-eslint/no-unnecessary-type-assertion": ["off"],
 };
 
 module.exports = {
@@ -95,7 +96,6 @@ module.exports = {
             extends: ["airbnb-typescript"],
             rules: {
                 "import/prefer-default-export": "off",
-                "@typescript-eslint/no-unnecessary-type-assertion": ["off"],
                 "@typescript-eslint/indent": "off",
                 "@typescript-eslint/quotes": "off",
                 "react/jsx-indent": "off",
@@ -111,7 +111,6 @@ module.exports = {
                 "@typescript-eslint/no-floating-promises": ["off"],
                 "import/prefer-default-export": "off",
                 "import/no-extraneous-dependencies": "off",
-                "@typescript-eslint/no-unnecessary-type-assertion": ["off"],
                 "@typescript-eslint/no-use-before-define": ["off"],
             },
         },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,7 +61,7 @@ const baseTypeScriptRules = {
     /* end of @typescript-eslint/recommended-requiring-type-checking rules */
     "@typescript-eslint/indent": "off",
     "@typescript-eslint/quotes": "off",
-    "@typescript-eslint/lines-between-class-members": "off",
+    "@typescript-eslint/lines-between-class-members": ["error", "always", { exceptAfterSingleLine: true }],
 };
 
 module.exports = {

--- a/docs/markdown/DEVELOPING.md
+++ b/docs/markdown/DEVELOPING.md
@@ -48,21 +48,42 @@ yarn install
 
 [Visual Studio Code](https://code.visualstudio.com/) comes highly recommended for working in this repository, and we additionally recommend the following extensions:
 
--   [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
--   [Jest](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest)
--   [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
+- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [Jest](https://marketplace.visualstudio.com/items?itemName=Orta.vscode-jest)
+- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
 
 The Jest extension should automatically detect the tests for this repository and watch them in the Status Bar.
 
 ## Testing
 
-Tests are run using Jest, which has been configured to allow for execution of test suites at any level in the project. To run all of the tests in the repository, simply run the following command from the root of the project:
+In order to run all of the tests, you will need to have a local instance of Neo4j running! We highly recommend [Neo4j Desktop](https://neo4j.com/download/) to easily get up and running with a local Neo4j instance.
+
+1. Create and start a new DBMS with a database named neo4j (default).
+2. Install APOC plugin for that DB.
+3. Create appropriate user by running the following command in the DB:
+
+   ```cypher
+   CREATE USER admin
+   SET PASSWORD "password"
+   SET PASSWORD CHANGE NOT REQUIRED
+   SET STATUS ACTIVE
+   ```
+
+4. Grant roles to admin user:
+
+   ```cypher
+   GRANT ROLE admin to admin
+   ```
+
+5. Run tests with `yarn test`.
+
+Tests are run using Jest, which has been configured to allow for execution of test suites at any level in the project.
+
+You can execute tests with a different database, user and password with the following command:
 
 ```bash
 NEO_URL=neo4j://localhost:7687 NEO_USER=admin NEO_PASSWORD=password yarn test
 ```
-
-> In order to run all of the tests, you will need to have a local instance of Neo4j running! We highly recommend [Neo4j Desktop](https://neo4j.com/download/) to easily get up and running with a local Neo4j instance.
 
 The above command can additionally be run from `packages/graphql`, `packages/ogm`, or any directory where there is a `jest.config.js` file!
 

--- a/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
@@ -62,7 +62,7 @@ directive @node(
 ----
 
 === Usage
-`@node` can be used with the optional parameters `label` and `additionalLabels`.
+`@node` can be used with the following optional parameters.
 
 ==== `label`
 The parameter `label` defines the label to be used in Neo4j instead of the GraphQL type name:
@@ -123,7 +123,7 @@ MATCH (this:Actor:Person:User)
 RETURN this { .name } as this
 ----
 
-Note that both parameters can be used at the same time:
+Note that `additionalLabels` can be used along with `label`:
 
 [source, graphql, indent=0]
 ----
@@ -138,3 +138,27 @@ In this case, the resulting Cypher query will use the labels `ActorDB` and `Pers
 MATCH (this:ActorDB:Person)
 RETURN this { .name } as this
 ----
+
+==== `plural`
+The parameter `plural` redefines how to compose the plural of the type for the generated operations. This is particularly
+useful for types that are not correctly pluralized or are non-english words.
+
+[source, graphql, indent=0]
+----
+type Tech @node(plural: "Techs") {
+  name: String
+}
+----
+
+This way, instead of the wrongly generated `teches`, the type is properly written as `techs`:
+
+[source, graphql, indent=0]
+----
+{
+  techs {
+    title
+  }
+}
+----
+
+The same is applied to other operations such as `createTechs`. Note that database labels will not change.

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -61,41 +61,23 @@ export interface NodeConstructor {
 
 class Node {
     public name: string;
-
     public relationFields: RelationField[];
-
     public connectionFields: ConnectionField[];
-
     public cypherFields: CypherField[];
-
     public primitiveFields: PrimitiveField[];
-
     public scalarFields: CustomScalarField[];
-
     public enumFields: CustomEnumField[];
-
     public otherDirectives: DirectiveNode[];
-
     public unionFields: UnionField[];
-
     public interfaceFields: InterfaceField[];
-
     public interfaces: NamedTypeNode[];
-
     public objectFields: ObjectField[];
-
     public temporalFields: TemporalField[];
-
     public pointFields: PointField[];
-
     public ignoredFields: BaseField[];
-
     public exclude?: Exclude;
-
     public nodeDirective?: NodeDirective;
-
     public auth?: Auth;
-
     public description?: string;
 
     /*

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -161,8 +161,12 @@ class Node {
         return this.nodeDirective?.getLabels(this.name) || [this.name];
     }
 
-    getPlural(camelcase = false): string {
-        return this.nodeDirective?.plural || pluralize(camelcase ? camelCase(this.name) : this.name);
+    getPlural(camelcase: boolean): string {
+        if (this.nodeDirective?.plural) {
+            return this.nodeDirective.plural;
+        }
+        // camelCase is optional in this case to maintain backward compatibility
+        return pluralize(camelcase ? camelCase(this.name) : this.name);
     }
 }
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -18,6 +18,7 @@
  */
 
 import { DirectiveNode, NamedTypeNode } from "graphql";
+import camelCase from "camelcase";
 import pluralize from "pluralize";
 import type {
     RelationField,
@@ -160,8 +161,8 @@ class Node {
         return this.nodeDirective?.getLabels(this.name) || [this.name];
     }
 
-    get plural(): string {
-        return this.nodeDirective?.plural || pluralize(this.name);
+    getPlural(camelcase = false): string {
+        return this.nodeDirective?.plural || pluralize(camelcase ? camelCase(this.name) : this.name);
     }
 }
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -162,10 +162,10 @@ class Node {
     }
 
     getPlural(camelcase: boolean): string {
-        if (this.nodeDirective?.plural) {
-            return this.nodeDirective.plural;
-        }
         // camelCase is optional in this case to maintain backward compatibility
+        if (this.nodeDirective?.plural) {
+            return camelcase ? camelCase(this.nodeDirective.plural) : this.nodeDirective.plural;
+        }
         return pluralize(camelcase ? camelCase(this.name) : this.name);
     }
 }

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -18,6 +18,7 @@
  */
 
 import { DirectiveNode, NamedTypeNode } from "graphql";
+import pluralize from "pluralize";
 import type {
     RelationField,
     ConnectionField,
@@ -175,6 +176,10 @@ class Node {
 
     get labels(): string[] {
         return this.nodeDirective?.getLabels(this.name) || [this.name];
+    }
+
+    get plural(): string {
+        return this.nodeDirective?.plural || pluralize(this.name);
     }
 }
 

--- a/packages/graphql/src/classes/NodeDirective.ts
+++ b/packages/graphql/src/classes/NodeDirective.ts
@@ -22,16 +22,18 @@ import { Neo4jGraphQLError } from "./Error";
 export interface NodeDirectiveConstructor {
     label?: string;
     additionalLabels?: string[];
+    plural?: string;
 }
 
 class NodeDirective {
     public readonly label: string | undefined;
-
     public readonly additionalLabels: string[];
+    public readonly plural: string | undefined;
 
     constructor(input: NodeDirectiveConstructor) {
         this.label = input.label;
         this.additionalLabels = input.additionalLabels || [];
+        this.plural = input.plural;
     }
 
     public getLabelsString(typeName: string): string {

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -1310,7 +1310,7 @@ function makeAugmentedSchema(
 
         if (!node.exclude?.operations.includes("update")) {
             composer.Mutation.addFields({
-                [`update${pluralize(node.name)}`]: updateResolver({ node }),
+                [`update${node.getPlural(false)}`]: updateResolver({ node }),
             });
         }
     });

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -1289,11 +1289,11 @@ function makeAugmentedSchema(
             });
 
             composer.Query.addFields({
-                [`${pluralize(camelCase(node.name))}Count`]: countResolver({ node }),
+                [`${node.getPlural(true)}Count`]: countResolver({ node }),
             });
 
             composer.Query.addFields({
-                [`${pluralize(camelCase(node.name))}Aggregate`]: aggregateResolver({ node }),
+                [`${node.getPlural(true)}Aggregate`]: aggregateResolver({ node }),
             });
         }
 

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -1304,7 +1304,7 @@ function makeAugmentedSchema(
 
         if (!node.exclude?.operations.includes("delete")) {
             composer.Mutation.addFields({
-                [`delete${pluralize(node.name)}`]: deleteResolver({ node }),
+                [`delete${node.getPlural(false)}`]: deleteResolver({ node }),
             });
         }
 

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -193,12 +193,14 @@ function makeAugmentedSchema(
 
     const aggregationSelectionTypeNames = aggregationSelectionTypeMatrix.map(([name]) => name);
 
-    const aggregationSelectionTypes = aggregationSelectionTypeMatrix.reduce<Record<string, ObjectTypeComposer<unknown, unknown>>>((res, [name, fields]) => {
+    const aggregationSelectionTypes = aggregationSelectionTypeMatrix.reduce<
+        Record<string, ObjectTypeComposer<unknown, unknown>>
+    >((res, [name, fields]) => {
         return {
             ...res,
             [name]: composer.createObjectTC({
                 name: `${name}AggregateSelection`,
-                fields: fields ? fields : { min: `${name}!`, max: `${name}!` },
+                fields: fields || { min: `${name}!`, max: `${name}!` },
             }),
         };
     }, {});
@@ -1283,7 +1285,7 @@ function makeAugmentedSchema(
 
         if (!node.exclude?.operations.includes("read")) {
             composer.Query.addFields({
-                [pluralize(camelCase(node.name))]: findResolver({ node }),
+                [node.getPlural(true)]: findResolver({ node }),
             });
 
             composer.Query.addFields({

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -20,7 +20,6 @@
 import { mergeTypeDefs } from "@graphql-tools/merge";
 import { IExecutableSchemaDefinition, makeExecutableSchema } from "@graphql-tools/schema";
 import { forEachField } from "@graphql-tools/utils";
-import camelCase from "camelcase";
 import {
     DefinitionNode,
     DirectiveDefinitionNode,
@@ -704,10 +703,10 @@ function makeAugmentedSchema(
 
         ["Create", "Update"].map((operation) =>
             composer.createObjectTC({
-                name: `${operation}${pluralize(node.name)}MutationResponse`,
+                name: `${operation}${node.getPlural(false)}MutationResponse`,
                 fields: {
                     info: `${operation}Info!`,
-                    [pluralize(camelCase(node.name))]: `[${node.name}!]!`,
+                    [node.getPlural(true)]: `[${node.name}!]!`,
                 },
             })
         );
@@ -1299,7 +1298,7 @@ function makeAugmentedSchema(
 
         if (!node.exclude?.operations.includes("create")) {
             composer.Mutation.addFields({
-                [`create${pluralize(node.name)}`]: createResolver({ node }),
+                [`create${node.getPlural(false)}`]: createResolver({ node }),
             });
         }
 

--- a/packages/graphql/src/schema/parse-node-directive.test.ts
+++ b/packages/graphql/src/schema/parse-node-directive.test.ts
@@ -31,7 +31,6 @@ describe("parseNodeDirective", () => {
 
         // @ts-ignore
         const directive = parse(typeDefs).definitions[0].directives[0];
-
         expect(() => parseNodeDirective(directive)).toThrow(
             "Undefined or incorrect directive passed into parseNodeDirective function"
         );
@@ -46,7 +45,6 @@ describe("parseNodeDirective", () => {
 
         // @ts-ignore
         const directive = parse(typeDefs).definitions[0].directives[0];
-
         const expected = new NodeDirective({ label: "MyLabel" });
 
         expect(parseNodeDirective(directive)).toMatchObject(expected);
@@ -61,13 +59,12 @@ describe("parseNodeDirective", () => {
 
         // @ts-ignore
         const directive = parse(typeDefs).definitions[0].directives[0];
-
         const expected = new NodeDirective({ additionalLabels: ["Label", "AnotherLabel"] });
 
         expect(parseNodeDirective(directive)).toMatchObject(expected);
     });
 
-    test("should return a node directive witha label and additional labels", () => {
+    test("should return a node directive with a label and additional labels", () => {
         const typeDefs = `
             type TestType @node(label:"MyLabel", additionalLabels:["Label", "AnotherLabel"]) {
                 name: String
@@ -76,8 +73,21 @@ describe("parseNodeDirective", () => {
 
         // @ts-ignore
         const directive = parse(typeDefs).definitions[0].directives[0];
-
         const expected = new NodeDirective({ label: "MyLabel", additionalLabels: ["Label", "AnotherLabel"] });
+
+        expect(parseNodeDirective(directive)).toMatchObject(expected);
+    });
+
+    test("should return a node directive with custom plural", () => {
+        const typeDefs = `
+            type TestType @node(plural: "testTypes") {
+                name: String
+            }
+        `;
+
+        // @ts-ignore
+        const directive = parse(typeDefs).definitions[0].directives[0];
+        const expected = new NodeDirective({ plural: "testTypes" });
 
         expect(parseNodeDirective(directive)).toMatchObject(expected);
     });

--- a/packages/graphql/src/schema/parse-node-directive.ts
+++ b/packages/graphql/src/schema/parse-node-directive.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { DirectiveNode, valueFromASTUntyped, ArgumentNode } from "graphql";
+import { DirectiveNode, valueFromASTUntyped } from "graphql";
 import NodeDirective from "../classes/NodeDirective";
 
 function parseNodeDirective(nodeDirective: DirectiveNode) {
@@ -25,17 +25,16 @@ function parseNodeDirective(nodeDirective: DirectiveNode) {
         throw new Error("Undefined or incorrect directive passed into parseNodeDirective function");
     }
 
-    const label = nodeDirective.arguments?.find((a) => a.name.value === "label") as ArgumentNode | undefined;
-    const additionalLabels = nodeDirective.arguments?.find((a) => a.name.value === "additionalLabels") as
-        | ArgumentNode
-        | undefined;
+    return new NodeDirective({
+        label: getArgumentValue<string>(nodeDirective, "label"),
+        additionalLabels: getArgumentValue<string[]>(nodeDirective, "additionalLabels"),
+        plural: getArgumentValue<string>(nodeDirective, "plural"),
+    });
+}
 
-    const labelValue: string | undefined = label ? valueFromASTUntyped(label.value) : undefined;
-    const additionalLabelsValue: string[] | undefined = additionalLabels
-        ? valueFromASTUntyped(additionalLabels.value)
-        : undefined;
-
-    return new NodeDirective({ label: labelValue, additionalLabels: additionalLabelsValue });
+function getArgumentValue<T>(directive: DirectiveNode, name: string): T | undefined {
+    const argument = directive.arguments?.find((a) => a.name.value === name);
+    return argument ? valueFromASTUntyped(argument.value) : undefined;
 }
 
 export default parseNodeDirective;

--- a/packages/graphql/src/schema/resolvers/create.test.ts
+++ b/packages/graphql/src/schema/resolvers/create.test.ts
@@ -17,15 +17,14 @@
  * limitations under the License.
  */
 
-import { Node } from "../../classes";
 import createResolver from "./create";
+import { NodeBuilder } from "../../utils/test";
 
 describe("Create resolver", () => {
     test("should return the correct; type, args and resolve", () => {
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
-        };
+        }).instance();
 
         const result = createResolver({ node });
         expect(result.type).toEqual("CreateMoviesMutationResponse!");

--- a/packages/graphql/src/schema/resolvers/create.ts
+++ b/packages/graphql/src/schema/resolvers/create.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import camelCase from "camelcase";
-import pluralize from "pluralize";
 import { FieldNode, GraphQLResolveInfo } from "graphql";
 import { execute } from "../../utils";
 import { translateCreate } from "../../translate";
@@ -38,7 +36,7 @@ export default function createResolver({ node }: { node: Node }) {
         });
 
         const responseField = info.fieldNodes[0].selectionSet?.selections.find(
-            (selection) => selection.kind === "Field" && selection.name.value === pluralize(camelCase(node.name))
+            (selection) => selection.kind === "Field" && selection.name.value === node.getPlural(true)
         ) as FieldNode; // Field exist by construction and must be selected as it is the only field.
 
         const responseKey = responseField.alias ? responseField.alias.value : responseField.name.value;
@@ -53,7 +51,7 @@ export default function createResolver({ node }: { node: Node }) {
     }
 
     return {
-        type: `Create${pluralize(node.name)}MutationResponse!`,
+        type: `Create${node.getPlural(false)}MutationResponse!`,
         resolve,
         args: { input: `[${node.name}CreateInput!]!` },
     };

--- a/packages/graphql/src/schema/resolvers/update.test.ts
+++ b/packages/graphql/src/schema/resolvers/update.test.ts
@@ -17,17 +17,16 @@
  * limitations under the License.
  */
 
-import { Node } from "../../classes";
 import updateResolver from "./update";
+import { NodeBuilder } from "../../utils/test";
 
 describe("Update resolver", () => {
     test("should return the correct; type, args and resolve", () => {
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
             // @ts-ignore
             relationFields: [{}, {}],
-        };
+        }).instance();
 
         const result = updateResolver({ node });
         expect(result.type).toEqual("UpdateMoviesMutationResponse!");

--- a/packages/graphql/src/schema/resolvers/update.ts
+++ b/packages/graphql/src/schema/resolvers/update.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import camelCase from "camelcase";
-import pluralize from "pluralize";
 import { FieldNode, GraphQLResolveInfo } from "graphql";
 import { execute } from "../../utils";
 import { translateUpdate } from "../../translate";
@@ -37,7 +35,7 @@ export default function updateResolver({ node }: { node: Node }) {
         });
 
         const responseField = info.fieldNodes[0].selectionSet?.selections.find(
-            (selection) => selection.kind === "Field" && selection.name.value === pluralize(camelCase(node.name))
+            (selection) => selection.kind === "Field" && selection.name.value === node.getPlural(true)
         ) as FieldNode; // Field exist by construction and must be selected as it is the only field.
 
         const responseKey = responseField.alias ? responseField.alias.value : responseField.name.value;

--- a/packages/graphql/src/schema/resolvers/update.ts
+++ b/packages/graphql/src/schema/resolvers/update.ts
@@ -52,7 +52,7 @@ export default function updateResolver({ node }: { node: Node }) {
     }
 
     return {
-        type: `Update${pluralize(node.name)}MutationResponse!`,
+        type: `Update${node.getPlural(false)}MutationResponse!`,
         resolve,
         args: {
             where: `${node.name}Where`,

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -187,5 +187,9 @@ export const nodeDirective = new GraphQLDirective({
             description: "Map the GraphQL type to match additional Neo4j node labels",
             type: GraphQLList(new GraphQLNonNull(GraphQLString)),
         },
+        plural: {
+            description: "Defines a custom plural for the Node API",
+            type: GraphQLString,
+        },
     },
 });

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import camelCase from "camelcase";
-import pluralize from "pluralize";
 import { Node } from "../classes";
 import createProjectionAndParams from "./create-projection-and-params";
 import createCreateAndParams from "./create-create-and-params";
@@ -36,8 +34,8 @@ function translateCreate({ context, node }: { context: Context; node: Node }): [
     // and find field where field.name ~ node.name which exists by construction
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { fieldsByTypeName } = Object.values(
-        resolveTree.fieldsByTypeName[`Create${pluralize(node.name)}MutationResponse`]
-    ).find((field) => field.name === pluralize(camelCase(node.name)))!;
+        resolveTree.fieldsByTypeName[`Create${node.getPlural(false)}MutationResponse`]
+    ).find((field) => field.name === node.getPlural(true))!;
 
     const { createStrs, params } = (resolveTree.args.input as any[]).reduce(
         (res, input, index) => {

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import camelCase from "camelcase";
-import pluralize from "pluralize";
 import { Node, Relationship } from "../classes";
 import { Context, GraphQLWhereArg, RelationField, ConnectionField } from "../types";
 import createWhereAndParams from "./create-where-and-params";
@@ -61,8 +59,8 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
     // and find field where field.name ~ node.name which exists by construction
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const { fieldsByTypeName } = Object.values(
-        resolveTree.fieldsByTypeName[`Update${pluralize(node.name)}MutationResponse`]
-    ).find((field) => field.name === pluralize(camelCase(node.name)))!;
+        resolveTree.fieldsByTypeName[`Update${node.getPlural(false)}MutationResponse`]
+    ).find((field) => field.name === node.getPlural(true))!;
 
     if (whereInput) {
         const where = createWhereAndParams({

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -1,0 +1,40 @@
+# Node Directive
+
+Custom plural using @node.
+
+Schema:
+
+```graphql
+type Movie @node(plural: "films") {
+    title: String
+}
+```
+
+---
+
+## Select Movie with plural films
+
+### GraphQL Input
+
+```graphql
+{
+    films {
+        title
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+RETURN this { .title } as this
+```
+
+### Expected Cypher Params
+
+```json
+{}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -38,3 +38,55 @@ RETURN this { .title } as this
 ```
 
 ---
+
+## Count Movie with plural films
+
+### GraphQL Input
+
+```graphql
+{
+    filmsCount
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+RETURN count(this)
+```
+
+### Expected Cypher Params
+
+```json
+{}
+```
+
+---
+
+## Count Movie with plural films using aggregation
+
+### GraphQL Input
+
+```graphql
+{
+    filmsAggregate {
+        count
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+RETURN { count: count(this) }
+```
+
+### Expected Cypher Params
+
+```json
+{}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -5,7 +5,7 @@ Custom plural using @node.
 Schema:
 
 ```graphql
-type Movie @node(plural: "films") {
+type Movie @node(plural: "Films") {
     title: String
 }
 ```
@@ -97,7 +97,7 @@ RETURN { count: count(this) }
 
 ```graphql
 mutation {
-    createfilms(input: [{ title: "Highlander" }]) {
+    createFilms(input: [{ title: "Highlander" }]) {
         films {
             title
         }
@@ -132,7 +132,7 @@ RETURN this0 { .title } AS this0
 
 ```graphql
 mutation {
-    updatefilms(update: { title: "Matrix" }) {
+    updateFilms(update: { title: "Matrix" }) {
         films {
             title
         }
@@ -164,7 +164,7 @@ RETURN this { .title } AS this
 
 ```graphql
 mutation {
-    deletefilms(where: { title: "Matrix" }) {
+    deleteFilms(where: { title: "Matrix" }) {
         nodesDeleted
     }
 }

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -90,3 +90,38 @@ RETURN { count: count(this) }
 ```
 
 ---
+
+## Create Movie with plural films using aggregation
+
+### GraphQL Input
+
+```graphql
+mutation {
+    createfilms(input: [{ title: "Highlander" }]) {
+        films {
+            title
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+CALL {
+    CREATE (this0:Movie)
+    SET this0.title = $this0_title
+    RETURN this0
+}
+RETURN this0 { .title } AS this0
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this0_title": "Highlander"
+}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -157,3 +157,33 @@ RETURN this { .title } AS this
 ```
 
 ---
+
+## Delete Movie with plural films using aggregation
+
+### GraphQL Input
+
+```graphql
+mutation {
+    deletefilms(where: { title: "Matrix" }) {
+        nodesDeleted
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+WHERE this.title = $this_title
+DETACH DELETE this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_title": "Matrix"
+}
+```
+
+---

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -5,21 +5,21 @@ Custom plural using @node.
 Schema:
 
 ```graphql
-type Movie @node(plural: "Films") {
-    title: String
+type Tech @node(plural: "Techs") {
+    name: String
 }
 ```
 
 ---
 
-## Select Movie with plural films
+## Select Tech with plural techs
 
 ### GraphQL Input
 
 ```graphql
 {
-    films {
-        title
+    techs {
+        name
     }
 }
 ```
@@ -27,8 +27,8 @@ type Movie @node(plural: "Films") {
 ### Expected Cypher Output
 
 ```cypher
-MATCH (this:Movie)
-RETURN this { .title } as this
+MATCH (this:Tech)
+RETURN this { .name } as this
 ```
 
 ### Expected Cypher Params
@@ -39,20 +39,20 @@ RETURN this { .title } as this
 
 ---
 
-## Count Movie with plural films
+## Count Tech with plural techs
 
 ### GraphQL Input
 
 ```graphql
 {
-    filmsCount
+    techsCount
 }
 ```
 
 ### Expected Cypher Output
 
 ```cypher
-MATCH (this:Movie)
+MATCH (this:Tech)
 RETURN count(this)
 ```
 
@@ -64,13 +64,13 @@ RETURN count(this)
 
 ---
 
-## Count Movie with plural films using aggregation
+## Count Tech with plural techs using aggregation
 
 ### GraphQL Input
 
 ```graphql
 {
-    filmsAggregate {
+    techsAggregate {
         count
     }
 }
@@ -79,7 +79,7 @@ RETURN count(this)
 ### Expected Cypher Output
 
 ```cypher
-MATCH (this:Movie)
+MATCH (this:Tech)
 RETURN { count: count(this) }
 ```
 
@@ -91,15 +91,15 @@ RETURN { count: count(this) }
 
 ---
 
-## Create Movie with plural films using aggregation
+## Create Tech with plural techs using aggregation
 
 ### GraphQL Input
 
 ```graphql
 mutation {
-    createFilms(input: [{ title: "Highlander" }]) {
-        films {
-            title
+    createTechs(input: [{ name: "Highlander" }]) {
+        techs {
+            name
         }
     }
 }
@@ -109,32 +109,32 @@ mutation {
 
 ```cypher
 CALL {
-    CREATE (this0:Movie)
-    SET this0.title = $this0_title
+    CREATE (this0:Tech)
+    SET this0.name = $this0_name
     RETURN this0
 }
-RETURN this0 { .title } AS this0
+RETURN this0 { .name } AS this0
 ```
 
 ### Expected Cypher Params
 
 ```json
 {
-    "this0_title": "Highlander"
+    "this0_name": "Highlander"
 }
 ```
 
 ---
 
-## Update Movie with plural films using aggregation
+## Update Tech with plural techs using aggregation
 
 ### GraphQL Input
 
 ```graphql
 mutation {
-    updateFilms(update: { title: "Matrix" }) {
-        films {
-            title
+    updateTechs(update: { name: "Matrix" }) {
+        techs {
+            name
         }
     }
 }
@@ -143,28 +143,28 @@ mutation {
 ### Expected Cypher Output
 
 ```cypher
-MATCH (this:Movie)
-SET this.title = $this_update_title
-RETURN this { .title } AS this
+MATCH (this:Tech)
+SET this.name = $this_update_name
+RETURN this { .name } AS this
 ```
 
 ### Expected Cypher Params
 
 ```json
 {
-    "this_update_title": "Matrix"
+    "this_update_name": "Matrix"
 }
 ```
 
 ---
 
-## Delete Movie with plural films using aggregation
+## Delete Tech with plural techs using aggregation
 
 ### GraphQL Input
 
 ```graphql
 mutation {
-    deleteFilms(where: { title: "Matrix" }) {
+    deleteTechs(where: { name: "Matrix" }) {
         nodesDeleted
     }
 }
@@ -173,8 +173,8 @@ mutation {
 ### Expected Cypher Output
 
 ```cypher
-MATCH (this:Movie)
-WHERE this.title = $this_title
+MATCH (this:Tech)
+WHERE this.name = $this_name
 DETACH DELETE this
 ```
 
@@ -182,7 +182,7 @@ DETACH DELETE this
 
 ```json
 {
-    "this_title": "Matrix"
+    "this_name": "Matrix"
 }
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-plural.md
@@ -125,3 +125,35 @@ RETURN this0 { .title } AS this0
 ```
 
 ---
+
+## Update Movie with plural films using aggregation
+
+### GraphQL Input
+
+```graphql
+mutation {
+    updatefilms(update: { title: "Matrix" }) {
+        films {
+            title
+        }
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+SET this.title = $this_update_title
+RETURN this { .title } AS this
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "this_update_title": "Matrix"
+}
+```
+
+---

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -28,6 +28,7 @@ import {
     GraphQLResolveInfo,
 } from "graphql";
 import { makeExecutableSchema } from "@graphql-tools/schema";
+import { SchemaDirectiveVisitor } from "@graphql-tools/utils";
 import path from "path";
 import pluralize from "pluralize";
 import jsonwebtoken from "jsonwebtoken";
@@ -41,7 +42,6 @@ import {
     translateRead,
     translateUpdate,
 } from "../../src/translate";
-import { SchemaDirectiveVisitor } from "@graphql-tools/utils";
 import { Context } from "../../src/types";
 import { Neo4jGraphQL } from "../../src";
 import {
@@ -137,9 +137,10 @@ describe("TCK Generated tests", () => {
                         return res;
                     }
 
+                    const node = neoSchema.nodes.find((x) => x.name === def.name.value) as Node;
                     return {
                         ...res,
-                        [pluralize(camelCase(def.name.value))]: (
+                        [node.getPlural(true)]: (
                             _root: any,
                             _params: any,
                             context: Context,
@@ -154,7 +155,7 @@ describe("TCK Generated tests", () => {
 
                             const [cQuery, cQueryParams] = translateRead({
                                 context: mergedContext,
-                                node: neoSchema.nodes.find((x) => x.name === def.name.value) as Node,
+                                node,
                             });
 
                             compare(
@@ -204,7 +205,6 @@ describe("TCK Generated tests", () => {
 
                             const mergedContext = { ...context, ...defaultContext };
 
-                            const node = neoSchema.nodes.find((x) => x.name === def.name.value) as Node;
                             const [cQuery, cQueryParams] = translateAggregate({
                                 context: mergedContext,
                                 node,

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -166,7 +166,7 @@ describe("TCK Generated tests", () => {
 
                             return [];
                         },
-                        [`${pluralize(camelCase(def.name.value))}Count`]: (
+                        [`${node.getPlural(true)}Count`]: (
                             _root: any,
                             _params: any,
                             context: Context,
@@ -192,7 +192,7 @@ describe("TCK Generated tests", () => {
 
                             return 1;
                         },
-                        [`${pluralize(camelCase(def.name.value))}Aggregate`]: (
+                        [`${node.getPlural(true)}Aggregate`]: (
                             _root: any,
                             _params: any,
                             context: Context,

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import camelCase from "camelcase";
 import {
     graphql,
     printSchema,
@@ -344,7 +343,7 @@ describe("TCK Generated tests", () => {
                                 [node.getPlural(true)]: [],
                             };
                         },
-                        [`update${pluralize(def.name.value)}`]: (
+                        [`update${node.getPlural(false)}`]: (
                             _root: any,
                             _params: any,
                             context: any,
@@ -369,7 +368,7 @@ describe("TCK Generated tests", () => {
                             );
 
                             return {
-                                [pluralize(camelCase(def.name.value))]: [],
+                                [node.getPlural(true)]: [],
                             };
                         },
                         [`delete${pluralize(def.name.value)}`]: (_root: any, _params: any, context: any, info) => {

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -313,10 +313,10 @@ describe("TCK Generated tests", () => {
                     if (def.kind !== "ObjectTypeDefinition") {
                         return res;
                     }
-
+                    const node = neoSchema.nodes.find((x) => x.name === def.name.value) as Node;
                     return {
                         ...res,
-                        [`create${pluralize(def.name.value)}`]: (
+                        [`create${node.getPlural(false)}`]: (
                             _root: any,
                             _params: any,
                             context: any,
@@ -331,7 +331,7 @@ describe("TCK Generated tests", () => {
 
                             const [cQuery, cQueryParams] = translateCreate({
                                 context: mergedContext,
-                                node: neoSchema.nodes.find((x) => x.name === def.name.value) as Node,
+                                node,
                             });
 
                             compare(
@@ -341,7 +341,7 @@ describe("TCK Generated tests", () => {
                             );
 
                             return {
-                                [pluralize(camelCase(def.name.value))]: [],
+                                [node.getPlural(true)]: [],
                             };
                         },
                         [`update${pluralize(def.name.value)}`]: (
@@ -359,7 +359,7 @@ describe("TCK Generated tests", () => {
 
                             const [cQuery, cQueryParams] = translateUpdate({
                                 context: mergedContext,
-                                node: neoSchema.nodes.find((x) => x.name === def.name.value) as Node,
+                                node,
                             });
 
                             compare(
@@ -382,7 +382,7 @@ describe("TCK Generated tests", () => {
 
                             const [cQuery, cQueryParams] = translateDelete({
                                 context: mergedContext,
-                                node: neoSchema.nodes.find((x) => x.name === def.name.value) as Node,
+                                node,
                             });
 
                             compare(

--- a/packages/graphql/tests/tck/tck.test.ts
+++ b/packages/graphql/tests/tck/tck.test.ts
@@ -29,7 +29,6 @@ import {
 import { makeExecutableSchema } from "@graphql-tools/schema";
 import { SchemaDirectiveVisitor } from "@graphql-tools/utils";
 import path from "path";
-import pluralize from "pluralize";
 import jsonwebtoken from "jsonwebtoken";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
@@ -371,7 +370,7 @@ describe("TCK Generated tests", () => {
                                 [node.getPlural(true)]: [],
                             };
                         },
-                        [`delete${pluralize(def.name.value)}`]: (_root: any, _params: any, context: any, info) => {
+                        [`delete${node.getPlural(false)}`]: (_root: any, _params: any, context: any, info) => {
                             const resolveTree = getNeo4jResolveTree(info);
 
                             context.neoSchema = neoSchema;


### PR DESCRIPTION
# Description

Exposes the parameter `plural` to the `@node` directive to define a custom plural for the generated operations.

```graphql
type Tech @node(plural: "Techs") {
    name: String
}
```

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [X] Documentation has been updated
- [X] TCK tests have been updated
- [X] Integration tests have been updated
- [X] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
