### PR TITLE
Fix: Filter Null Values In Union Relationship

### DIFF
--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -268,7 +268,7 @@ function createProjectionAndParams({
                 );
 
                 const unionStrs: string[] = [
-                    `${key}: ${!isArray ? "head(" : ""} [(${
+                    `${key}: ${!isArray ? "head(" : ""} [${param} IN [(${
                         chainStr || varName
                     })${inStr}${relTypeStr}${outStr}(${param})`,
                     `WHERE ${referenceNodes
@@ -323,7 +323,7 @@ function createProjectionAndParams({
                     return innerHeadStr.join(" ");
                 });
                 unionStrs.push(headStrs.join(" + "));
-                unionStrs.push(") ]");
+                unionStrs.push(`) ] WHERE ${param} IS NOT NULL]`);
 
                 if (optionsInput) {
                     const offsetLimit = createOffsetLimitStr({

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/where.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/auth/arguments/where.md
@@ -369,7 +369,7 @@ MATCH (this:User)
 WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
 RETURN this {
     .id,
-    content: [(this)-[:HAS_POST]->(this_content) WHERE ("Post" IN labels(this_content)) | head( [ this_content IN [this_content] WHERE ("Post" IN labels(this_content)) AND EXISTS((this_content)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_content)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_content_Post_auth_where0_creator_id) | this_content { __resolveType: "Post", .id } ] ) ]
+    content: [this_content IN [(this)-[:HAS_POST]->(this_content) WHERE ("Post" IN labels(this_content)) | head( [ this_content IN [this_content] WHERE ("Post" IN labels(this_content)) AND EXISTS((this_content)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_content)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_content_Post_auth_where0_creator_id) | this_content { __resolveType: "Post", .id } ] ) ] WHERE this_content IS NOT NULL]
 } as this
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-label-union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/directives/node/node-label-union.md
@@ -7,8 +7,7 @@ Schema:
 ```graphql
 union Search = Movie | Genre
 
-type Genre
-    @node(label: "Category", additionalLabels: ["ExtraLabel1", "ExtraLabel2"]) {
+type Genre @node(label: "Category", additionalLabels: ["ExtraLabel1", "ExtraLabel2"]) {
     name: String
 }
 
@@ -49,7 +48,7 @@ MATCH (this:Film)
 WHERE this.title = $this_title
 
 RETURN this {
-    search: [(this)-[:SEARCH]->(this_search)
+    search: [this_search IN [(this)-[:SEARCH]->(this_search)
         WHERE
             ("Category" IN labels(this_search) AND
                 "ExtraLabel1" IN labels(this_search) AND
@@ -75,7 +74,7 @@ RETURN this {
                     .title
                 } ]
         )
-    ] [1..11]
+    ] WHERE this_search IS NOT NULL] [1..11]
 } as this
 ```
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher/nested-unions.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/nested-unions.md
@@ -44,11 +44,7 @@ mutation {
             actors: {
                 LeadActor: {
                     where: { node: { name: "Actor" } }
-                    connect: {
-                        actedIn: {
-                            Series: { where: { node: { name: "Series" } } }
-                        }
-                    }
+                    connect: { actedIn: { Series: { where: { node: { name: "Series" } } } } }
                 }
             }
         }
@@ -91,7 +87,7 @@ CALL {
     }
     RETURN count(*)
 }
-RETURN this { .title, actors: [(this)<-[:ACTED_IN]-(this_actors) WHERE ("LeadActor" IN labels(this_actors)) OR ("Extra" IN labels(this_actors)) | head( [ this_actors IN [this_actors] WHERE ("LeadActor" IN labels(this_actors)) | this_actors { __resolveType: "LeadActor", .name, actedIn: [(this_actors)-[:ACTED_IN]->(this_actors_actedIn) WHERE ("Movie" IN labels(this_actors_actedIn)) OR ("Series" IN labels(this_actors_actedIn)) | head( [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Movie" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Movie" } ] + [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Series" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Series", .name } ] ) ] } ] + [ this_actors IN [this_actors] WHERE ("Extra" IN labels(this_actors)) | this_actors { __resolveType: "Extra" } ] ) ] } AS this
+RETURN this { .title, actors: [this_actors IN [(this)<-[:ACTED_IN]-(this_actors) WHERE ("LeadActor" IN labels(this_actors)) OR ("Extra" IN labels(this_actors)) | head( [ this_actors IN [this_actors] WHERE ("LeadActor" IN labels(this_actors)) | this_actors { __resolveType: "LeadActor", .name, actedIn: [this_actors_actedIn IN [(this_actors)-[:ACTED_IN]->(this_actors_actedIn) WHERE ("Movie" IN labels(this_actors_actedIn)) OR ("Series" IN labels(this_actors_actedIn)) | head( [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Movie" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Movie" } ] + [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Series" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Series", .name } ] ) ] WHERE this_actors_actedIn IS NOT NULL] } ] + [ this_actors IN [this_actors] WHERE ("Extra" IN labels(this_actors)) | this_actors { __resolveType: "Extra" } ] ) ] WHERE this_actors IS NOT NULL] } AS this
 ```
 
 ### Expected Cypher Params
@@ -118,11 +114,7 @@ mutation {
             actors: {
                 LeadActor: {
                     where: { node: { name: "Actor" } }
-                    disconnect: {
-                        actedIn: {
-                            Series: { where: { node: { name: "Series" } } }
-                        }
-                    }
+                    disconnect: { actedIn: { Series: { where: { node: { name: "Series" } } } } }
                 }
             }
         }
@@ -170,7 +162,7 @@ CALL {
     RETURN count(*)
 }
 
-RETURN this { .title, actors: [(this)<-[:ACTED_IN]-(this_actors) WHERE ("LeadActor" IN labels(this_actors)) OR ("Extra" IN labels(this_actors)) | head( [ this_actors IN [this_actors] WHERE ("LeadActor" IN labels(this_actors)) | this_actors { __resolveType: "LeadActor", .name, actedIn: [(this_actors)-[:ACTED_IN]->(this_actors_actedIn) WHERE ("Movie" IN labels(this_actors_actedIn)) OR ("Series" IN labels(this_actors_actedIn)) | head( [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Movie" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Movie" } ] + [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Series" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Series", .name } ] ) ] } ] + [ this_actors IN [this_actors] WHERE ("Extra" IN labels(this_actors)) | this_actors { __resolveType: "Extra" } ] ) ] } AS this
+RETURN this { .title, actors: [this_actors IN [(this)<-[:ACTED_IN]-(this_actors) WHERE ("LeadActor" IN labels(this_actors)) OR ("Extra" IN labels(this_actors)) | head( [ this_actors IN [this_actors] WHERE ("LeadActor" IN labels(this_actors)) | this_actors { __resolveType: "LeadActor", .name, actedIn: [this_actors_actedIn IN [(this_actors)-[:ACTED_IN]->(this_actors_actedIn) WHERE ("Movie" IN labels(this_actors_actedIn)) OR ("Series" IN labels(this_actors_actedIn)) | head( [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Movie" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Movie" } ] + [ this_actors_actedIn IN [this_actors_actedIn] WHERE ("Series" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: "Series", .name } ] ) ] WHERE this_actors_actedIn IS NOT NULL] } ] + [ this_actors IN [this_actors] WHERE ("Extra" IN labels(this_actors)) | this_actors { __resolveType: "Extra" } ] ) ] WHERE this_actors IS NOT NULL] } AS this
 ```
 
 ### Expected Cypher Params

--- a/packages/graphql/tests/tck/tck-test-files/cypher/union.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/union.md
@@ -56,7 +56,7 @@ MATCH (this:Movie)
 WHERE this.title = $this_title
 
 RETURN this {
-    search: [(this)-[:SEARCH]->(this_search)
+    search: [this_search IN [(this)-[:SEARCH]->(this_search)
         WHERE ("Genre" IN labels(this_search)) OR ("Movie" IN labels(this_search)) |
         head(
             [ this_search IN [this_search]
@@ -75,7 +75,7 @@ RETURN this {
                     .title
                 } ]
         )
-    ] [1..11]
+    ] WHERE this_search IS NOT NULL] [1..11]
 } as this
 ```
 


### PR DESCRIPTION
# Description

Proposed fix for #493. Current behavior returns null values. This PR filters out null values.

# Issue

- #493 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
