### PR TITLE
Fix: Creation of Empty `{Create,Update}Input` for Relationship Properties

### DIFF
--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -60,7 +60,7 @@ function createConnectAndParams({
         const relationshipName = `${baseName}_relationship`;
         const inStr = relationField.direction === "IN" ? "<-" : "-";
         const outStr = relationField.direction === "OUT" ? "->" : "-";
-        const relTypeStr = `[${connect.edge ? relationshipName : ""}:${relationField.type}]`;
+        const relTypeStr = `[${relationField.properties ? relationshipName : ""}:${relationField.type}]`;
 
         const labels = refNode.labelString;
         const label = labelOverride ? `:${labelOverride}` : labels;
@@ -161,13 +161,13 @@ function createConnectAndParams({
         res.connects.push(`FOREACH(_ IN CASE ${nodeName} WHEN NULL THEN [] ELSE [1] END | `);
         res.connects.push(`MERGE (${parentVar})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
-        if (connect.edge) {
+        if (relationField.properties) {
             const relationship = (context.neoSchema.relationships.find(
                 (x) => x.properties === relationField.properties
             ) as unknown) as Relationship;
 
             const setA = createSetRelationshipPropertiesAndParams({
-                properties: connect.edge,
+                properties: connect.edge ?? {},
                 varName: relationshipName,
                 relationship,
                 operation: "CREATE",

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -99,16 +99,16 @@ function createCreateAndParams({
 
                         const inStr = relationField.direction === "IN" ? "<-" : "-";
                         const outStr = relationField.direction === "OUT" ? "->" : "-";
-                        const relTypeStr = `[${create.edge ? propertiesName : ""}:${relationField.type}]`;
+                        const relTypeStr = `[${relationField.properties ? propertiesName : ""}:${relationField.type}]`;
                         res.creates.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
-                        if (create.edge) {
+                        if (relationField.properties) {
                             const relationship = (context.neoSchema.relationships.find(
                                 (x) => x.properties === relationField.properties
                             ) as unknown) as Relationship;
 
                             const setA = createSetRelationshipPropertiesAndParams({
-                                properties: create.edge,
+                                properties: create.edge ?? {},
                                 varName: propertiesName,
                                 relationship,
                                 operation: "CREATE",

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -209,7 +209,7 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
                     }${index}`;
                     const nodeName = `${baseName}_node`;
                     const propertiesName = `${baseName}_relationship`;
-                    const relTypeStr = `[${create.edge ? propertiesName : ""}:${relationField.type}]`;
+                    const relTypeStr = `[${relationField.properties ? propertiesName : ""}:${relationField.type}]`;
 
                     const createAndParams = createCreateAndParams({
                         context,
@@ -222,13 +222,13 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
                     cypherParams = { ...cypherParams, ...createAndParams[1] };
                     createStrs.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
-                    if (create.edge) {
+                    if (relationField.properties) {
                         const relationship = (context.neoSchema.relationships.find(
                             (x) => x.properties === relationField.properties
                         ) as unknown) as Relationship;
 
                         const setA = createSetRelationshipPropertiesAndParams({
-                            properties: create.edge,
+                            properties: create.edge ?? {},
                             varName: propertiesName,
                             relationship,
                             operation: "CREATE",

--- a/packages/graphql/tests/schema/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/relationship-properties.test.ts
@@ -45,40 +45,482 @@ describe("Relationship-properties", () => {
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(neoSchema.schema));
 
         expect(printedSchema).toMatchInlineSnapshot(`
+      "schema {
+        query: Query
+        mutation: Mutation
+      }
+
+      interface ActedIn {
+        leadRole: Boolean!
+        screenTime: Int!
+        startDate: Date!
+      }
+
+      input ActedInCreateInput {
+        leadRole: Boolean!
+        screenTime: Int!
+        startDate: Date!
+      }
+
+      input ActedInSort {
+        leadRole: SortDirection
+        screenTime: SortDirection
+        startDate: SortDirection
+      }
+
+      input ActedInUpdateInput {
+        leadRole: Boolean
+        screenTime: Int
+        startDate: Date
+      }
+
+      input ActedInWhere {
+        AND: [ActedInWhere!]
+        OR: [ActedInWhere!]
+        leadRole: Boolean
+        leadRole_NOT: Boolean
+        screenTime: Int
+        screenTime_GT: Int
+        screenTime_GTE: Int
+        screenTime_IN: [Int]
+        screenTime_LT: Int
+        screenTime_LTE: Int
+        screenTime_NOT: Int
+        screenTime_NOT_IN: [Int]
+        startDate: Date
+        startDate_GT: Date
+        startDate_GTE: Date
+        startDate_IN: [Date]
+        startDate_LT: Date
+        startDate_LTE: Date
+        startDate_NOT: Date
+        startDate_NOT_IN: [Date]
+      }
+
+      type Actor {
+        movies(options: MovieOptions, where: MovieWhere): [Movie]
+        moviesConnection(after: String, first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+        name: String!
+      }
+
+      type ActorAggregateSelection {
+        count: Int!
+        name: StringAggregateSelection!
+      }
+
+      input ActorConnectInput {
+        movies: [ActorMoviesConnectFieldInput!]
+      }
+
+      input ActorConnectWhere {
+        node: ActorWhere!
+      }
+
+      input ActorCreateInput {
+        movies: ActorMoviesFieldInput
+        name: String!
+      }
+
+      input ActorDeleteInput {
+        movies: [ActorMoviesDeleteFieldInput!]
+      }
+
+      input ActorDisconnectInput {
+        movies: [ActorMoviesDisconnectFieldInput!]
+      }
+
+      input ActorMoviesConnectFieldInput {
+        connect: [MovieConnectInput!]
+        edge: ActedInCreateInput!
+        where: MovieConnectWhere
+      }
+
+      type ActorMoviesConnection {
+        edges: [ActorMoviesRelationship!]!
+        pageInfo: PageInfo!
+        totalCount: Int!
+      }
+
+      input ActorMoviesConnectionSort {
+        edge: ActedInSort
+        node: MovieSort
+      }
+
+      input ActorMoviesConnectionWhere {
+        AND: [ActorMoviesConnectionWhere!]
+        OR: [ActorMoviesConnectionWhere!]
+        edge: ActedInWhere
+        edge_NOT: ActedInWhere
+        node: MovieWhere
+        node_NOT: MovieWhere
+      }
+
+      input ActorMoviesCreateFieldInput {
+        edge: ActedInCreateInput!
+        node: MovieCreateInput!
+      }
+
+      input ActorMoviesDeleteFieldInput {
+        delete: MovieDeleteInput
+        where: ActorMoviesConnectionWhere
+      }
+
+      input ActorMoviesDisconnectFieldInput {
+        disconnect: MovieDisconnectInput
+        where: ActorMoviesConnectionWhere
+      }
+
+      input ActorMoviesFieldInput {
+        connect: [ActorMoviesConnectFieldInput!]
+        create: [ActorMoviesCreateFieldInput!]
+      }
+
+      type ActorMoviesRelationship implements ActedIn {
+        cursor: String!
+        leadRole: Boolean!
+        node: Movie!
+        screenTime: Int!
+        startDate: Date!
+      }
+
+      input ActorMoviesUpdateConnectionInput {
+        edge: ActedInUpdateInput
+        node: MovieUpdateInput
+      }
+
+      input ActorMoviesUpdateFieldInput {
+        connect: [ActorMoviesConnectFieldInput!]
+        create: [ActorMoviesCreateFieldInput!]
+        delete: [ActorMoviesDeleteFieldInput!]
+        disconnect: [ActorMoviesDisconnectFieldInput!]
+        update: ActorMoviesUpdateConnectionInput
+        where: ActorMoviesConnectionWhere
+      }
+
+      input ActorOptions {
+        limit: Int
+        offset: Int
+        \\"\\"\\"Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.\\"\\"\\"
+        sort: [ActorSort]
+      }
+
+      input ActorRelationInput {
+        movies: [ActorMoviesCreateFieldInput!]
+      }
+
+      \\"\\"\\"Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.\\"\\"\\"
+      input ActorSort {
+        name: SortDirection
+      }
+
+      input ActorUpdateInput {
+        movies: [ActorMoviesUpdateFieldInput!]
+        name: String
+      }
+
+      input ActorWhere {
+        AND: [ActorWhere!]
+        OR: [ActorWhere!]
+        movies: MovieWhere
+        moviesConnection: ActorMoviesConnectionWhere
+        moviesConnection_NOT: ActorMoviesConnectionWhere
+        movies_NOT: MovieWhere
+        name: String
+        name_CONTAINS: String
+        name_ENDS_WITH: String
+        name_IN: [String]
+        name_NOT: String
+        name_NOT_CONTAINS: String
+        name_NOT_ENDS_WITH: String
+        name_NOT_IN: [String]
+        name_NOT_STARTS_WITH: String
+        name_STARTS_WITH: String
+      }
+
+      type CreateActorsMutationResponse {
+        actors: [Actor!]!
+        info: CreateInfo!
+      }
+
+      type CreateInfo {
+        bookmark: String
+        nodesCreated: Int!
+        relationshipsCreated: Int!
+      }
+
+      type CreateMoviesMutationResponse {
+        info: CreateInfo!
+        movies: [Movie!]!
+      }
+
+      \\"\\"\\"A date, represented as a 'yyyy-mm-dd' string\\"\\"\\"
+      scalar Date
+
+      type DeleteInfo {
+        bookmark: String
+        nodesDeleted: Int!
+        relationshipsDeleted: Int!
+      }
+
+      type Movie {
+        actors(options: ActorOptions, where: ActorWhere): [Actor]!
+        actorsConnection(after: String, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+        title: String!
+      }
+
+      input MovieActorsConnectFieldInput {
+        connect: [ActorConnectInput!]
+        edge: ActedInCreateInput!
+        where: ActorConnectWhere
+      }
+
+      type MovieActorsConnection {
+        edges: [MovieActorsRelationship!]!
+        pageInfo: PageInfo!
+        totalCount: Int!
+      }
+
+      input MovieActorsConnectionSort {
+        edge: ActedInSort
+        node: ActorSort
+      }
+
+      input MovieActorsConnectionWhere {
+        AND: [MovieActorsConnectionWhere!]
+        OR: [MovieActorsConnectionWhere!]
+        edge: ActedInWhere
+        edge_NOT: ActedInWhere
+        node: ActorWhere
+        node_NOT: ActorWhere
+      }
+
+      input MovieActorsCreateFieldInput {
+        edge: ActedInCreateInput!
+        node: ActorCreateInput!
+      }
+
+      input MovieActorsDeleteFieldInput {
+        delete: ActorDeleteInput
+        where: MovieActorsConnectionWhere
+      }
+
+      input MovieActorsDisconnectFieldInput {
+        disconnect: ActorDisconnectInput
+        where: MovieActorsConnectionWhere
+      }
+
+      input MovieActorsFieldInput {
+        connect: [MovieActorsConnectFieldInput!]
+        create: [MovieActorsCreateFieldInput!]
+      }
+
+      type MovieActorsRelationship implements ActedIn {
+        cursor: String!
+        leadRole: Boolean!
+        node: Actor!
+        screenTime: Int!
+        startDate: Date!
+      }
+
+      input MovieActorsUpdateConnectionInput {
+        edge: ActedInUpdateInput
+        node: ActorUpdateInput
+      }
+
+      input MovieActorsUpdateFieldInput {
+        connect: [MovieActorsConnectFieldInput!]
+        create: [MovieActorsCreateFieldInput!]
+        delete: [MovieActorsDeleteFieldInput!]
+        disconnect: [MovieActorsDisconnectFieldInput!]
+        update: MovieActorsUpdateConnectionInput
+        where: MovieActorsConnectionWhere
+      }
+
+      type MovieAggregateSelection {
+        count: Int!
+        title: StringAggregateSelection!
+      }
+
+      input MovieConnectInput {
+        actors: [MovieActorsConnectFieldInput!]
+      }
+
+      input MovieConnectWhere {
+        node: MovieWhere!
+      }
+
+      input MovieCreateInput {
+        actors: MovieActorsFieldInput
+        title: String!
+      }
+
+      input MovieDeleteInput {
+        actors: [MovieActorsDeleteFieldInput!]
+      }
+
+      input MovieDisconnectInput {
+        actors: [MovieActorsDisconnectFieldInput!]
+      }
+
+      input MovieOptions {
+        limit: Int
+        offset: Int
+        \\"\\"\\"Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.\\"\\"\\"
+        sort: [MovieSort]
+      }
+
+      input MovieRelationInput {
+        actors: [MovieActorsCreateFieldInput!]
+      }
+
+      \\"\\"\\"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.\\"\\"\\"
+      input MovieSort {
+        title: SortDirection
+      }
+
+      input MovieUpdateInput {
+        actors: [MovieActorsUpdateFieldInput!]
+        title: String
+      }
+
+      input MovieWhere {
+        AND: [MovieWhere!]
+        OR: [MovieWhere!]
+        actors: ActorWhere
+        actorsConnection: MovieActorsConnectionWhere
+        actorsConnection_NOT: MovieActorsConnectionWhere
+        actors_NOT: ActorWhere
+        title: String
+        title_CONTAINS: String
+        title_ENDS_WITH: String
+        title_IN: [String]
+        title_NOT: String
+        title_NOT_CONTAINS: String
+        title_NOT_ENDS_WITH: String
+        title_NOT_IN: [String]
+        title_NOT_STARTS_WITH: String
+        title_STARTS_WITH: String
+      }
+
+      type Mutation {
+        createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+        createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+        deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+        deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+        updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+        updateMovies(connect: MovieConnectInput, create: MovieRelationInput, delete: MovieDeleteInput, disconnect: MovieDisconnectInput, update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+      }
+
+      \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+      type PageInfo {
+        endCursor: String
+        hasNextPage: Boolean!
+        hasPreviousPage: Boolean!
+        startCursor: String
+      }
+
+      type Query {
+        actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+        actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+        actorsCount(where: ActorWhere): Int!
+        movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+        moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+        moviesCount(where: MovieWhere): Int!
+      }
+
+      enum SortDirection {
+        \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+        ASC
+        \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+        DESC
+      }
+
+      type StringAggregateSelection {
+        longest: String!
+        shortest: String!
+      }
+
+      type UpdateActorsMutationResponse {
+        actors: [Actor!]!
+        info: UpdateInfo!
+      }
+
+      type UpdateInfo {
+        bookmark: String
+        nodesCreated: Int!
+        nodesDeleted: Int!
+        relationshipsCreated: Int!
+        relationshipsDeleted: Int!
+      }
+
+      type UpdateMoviesMutationResponse {
+        info: UpdateInfo!
+        movies: [Movie!]!
+      }
+      "
+  `);
+    });
+
+    test("should filter out generated fields", () => {
+        const typeDefs = gql`
+            type Actor {
+                name: String!
+                movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type Movie {
+                title: String!
+                actors: [Actor]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            interface ActedIn @relationshipProperties {
+                id: ID! @id
+                timestamp: DateTime! @timestamp
+                screenTime: Int!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(neoSchema.schema));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
             "schema {
               query: Query
               mutation: Mutation
             }
 
             interface ActedIn {
-              leadRole: Boolean!
+              id: ID!
               screenTime: Int!
-              startDate: Date!
+              timestamp: DateTime!
             }
 
             input ActedInCreateInput {
-              leadRole: Boolean!
               screenTime: Int!
-              startDate: Date!
             }
 
             input ActedInSort {
-              leadRole: SortDirection
+              id: SortDirection
               screenTime: SortDirection
-              startDate: SortDirection
+              timestamp: SortDirection
             }
 
             input ActedInUpdateInput {
-              leadRole: Boolean
               screenTime: Int
-              startDate: Date
             }
 
             input ActedInWhere {
               AND: [ActedInWhere!]
               OR: [ActedInWhere!]
-              leadRole: Boolean
-              leadRole_NOT: Boolean
+              id: ID
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_IN: [ID]
+              id_NOT: ID
+              id_NOT_CONTAINS: ID
+              id_NOT_ENDS_WITH: ID
+              id_NOT_IN: [ID]
+              id_NOT_STARTS_WITH: ID
+              id_STARTS_WITH: ID
               screenTime: Int
               screenTime_GT: Int
               screenTime_GTE: Int
@@ -87,14 +529,14 @@ describe("Relationship-properties", () => {
               screenTime_LTE: Int
               screenTime_NOT: Int
               screenTime_NOT_IN: [Int]
-              startDate: Date
-              startDate_GT: Date
-              startDate_GTE: Date
-              startDate_IN: [Date]
-              startDate_LT: Date
-              startDate_LTE: Date
-              startDate_NOT: Date
-              startDate_NOT_IN: [Date]
+              timestamp: DateTime
+              timestamp_GT: DateTime
+              timestamp_GTE: DateTime
+              timestamp_IN: [DateTime]
+              timestamp_LT: DateTime
+              timestamp_LTE: DateTime
+              timestamp_NOT: DateTime
+              timestamp_NOT_IN: [DateTime]
             }
 
             type Actor {
@@ -177,10 +619,10 @@ describe("Relationship-properties", () => {
 
             type ActorMoviesRelationship implements ActedIn {
               cursor: String!
-              leadRole: Boolean!
+              id: ID!
               node: Movie!
               screenTime: Int!
-              startDate: Date!
+              timestamp: DateTime!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -253,8 +695,8 @@ describe("Relationship-properties", () => {
               movies: [Movie!]!
             }
 
-            \\"\\"\\"A date, represented as a 'yyyy-mm-dd' string\\"\\"\\"
-            scalar Date
+            \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
+            scalar DateTime
 
             type DeleteInfo {
               bookmark: String
@@ -316,14 +758,429 @@ describe("Relationship-properties", () => {
 
             type MovieActorsRelationship implements ActedIn {
               cursor: String!
-              leadRole: Boolean!
+              id: ID!
               node: Actor!
               screenTime: Int!
-              startDate: Date!
+              timestamp: DateTime!
             }
 
             input MovieActorsUpdateConnectionInput {
               edge: ActedInUpdateInput
+              node: ActorUpdateInput
+            }
+
+            input MovieActorsUpdateFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+              delete: [MovieActorsDeleteFieldInput!]
+              disconnect: [MovieActorsDisconnectFieldInput!]
+              update: MovieActorsUpdateConnectionInput
+              where: MovieActorsConnectionWhere
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              title: StringAggregateSelection!
+            }
+
+            input MovieConnectInput {
+              actors: [MovieActorsConnectFieldInput!]
+            }
+
+            input MovieConnectWhere {
+              node: MovieWhere!
+            }
+
+            input MovieCreateInput {
+              actors: MovieActorsFieldInput
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actors: [MovieActorsDeleteFieldInput!]
+            }
+
+            input MovieDisconnectInput {
+              actors: [MovieActorsDisconnectFieldInput!]
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.\\"\\"\\"
+              sort: [MovieSort]
+            }
+
+            input MovieRelationInput {
+              actors: [MovieActorsCreateFieldInput!]
+            }
+
+            \\"\\"\\"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.\\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actors: [MovieActorsUpdateFieldInput!]
+              title: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              OR: [MovieWhere!]
+              actors: ActorWhere
+              actorsConnection: MovieActorsConnectionWhere
+              actorsConnection_NOT: MovieActorsConnectionWhere
+              actors_NOT: ActorWhere
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String]
+              title_NOT: String
+              title_NOT_CONTAINS: String
+              title_NOT_ENDS_WITH: String
+              title_NOT_IN: [String]
+              title_NOT_STARTS_WITH: String
+              title_STARTS_WITH: String
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateMovies(connect: MovieConnectInput, create: MovieRelationInput, delete: MovieDeleteInput, disconnect: MovieDisconnectInput, update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsCount(where: ActorWhere): Int!
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesCount(where: MovieWhere): Int!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelection {
+              longest: String!
+              shortest: String!
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+            "
+        `);
+    });
+
+    test("should not create or use <RelationshipProperties>{Create,Update}Input if only generated fields", () => {
+        const typeDefs = gql`
+            type Actor {
+                name: String!
+                movies: [Movie] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type Movie {
+                title: String!
+                actors: [Actor]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            interface ActedIn @relationshipProperties {
+                id: ID! @id
+                timestamp: DateTime! @timestamp
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(neoSchema.schema));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            interface ActedIn {
+              id: ID!
+              timestamp: DateTime!
+            }
+
+            input ActedInSort {
+              id: SortDirection
+              timestamp: SortDirection
+            }
+
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              OR: [ActedInWhere!]
+              id: ID
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_IN: [ID]
+              id_NOT: ID
+              id_NOT_CONTAINS: ID
+              id_NOT_ENDS_WITH: ID
+              id_NOT_IN: [ID]
+              id_NOT_STARTS_WITH: ID
+              id_STARTS_WITH: ID
+              timestamp: DateTime
+              timestamp_GT: DateTime
+              timestamp_GTE: DateTime
+              timestamp_IN: [DateTime]
+              timestamp_LT: DateTime
+              timestamp_LTE: DateTime
+              timestamp_NOT: DateTime
+              timestamp_NOT_IN: [DateTime]
+            }
+
+            type Actor {
+              movies(options: MovieOptions, where: MovieWhere): [Movie]
+              moviesConnection(after: String, first: Int, sort: [ActorMoviesConnectionSort!], where: ActorMoviesConnectionWhere): ActorMoviesConnection!
+              name: String!
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              name: StringAggregateSelection!
+            }
+
+            input ActorConnectInput {
+              movies: [ActorMoviesConnectFieldInput!]
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              movies: ActorMoviesFieldInput
+              name: String!
+            }
+
+            input ActorDeleteInput {
+              movies: [ActorMoviesDeleteFieldInput!]
+            }
+
+            input ActorDisconnectInput {
+              movies: [ActorMoviesDisconnectFieldInput!]
+            }
+
+            input ActorMoviesConnectFieldInput {
+              connect: [MovieConnectInput!]
+              where: MovieConnectWhere
+            }
+
+            type ActorMoviesConnection {
+              edges: [ActorMoviesRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorMoviesConnectionSort {
+              edge: ActedInSort
+              node: MovieSort
+            }
+
+            input ActorMoviesConnectionWhere {
+              AND: [ActorMoviesConnectionWhere!]
+              OR: [ActorMoviesConnectionWhere!]
+              edge: ActedInWhere
+              edge_NOT: ActedInWhere
+              node: MovieWhere
+              node_NOT: MovieWhere
+            }
+
+            input ActorMoviesCreateFieldInput {
+              node: MovieCreateInput!
+            }
+
+            input ActorMoviesDeleteFieldInput {
+              delete: MovieDeleteInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesDisconnectFieldInput {
+              disconnect: MovieDisconnectInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorMoviesFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+            }
+
+            type ActorMoviesRelationship implements ActedIn {
+              cursor: String!
+              id: ID!
+              node: Movie!
+              timestamp: DateTime!
+            }
+
+            input ActorMoviesUpdateConnectionInput {
+              node: MovieUpdateInput
+            }
+
+            input ActorMoviesUpdateFieldInput {
+              connect: [ActorMoviesConnectFieldInput!]
+              create: [ActorMoviesCreateFieldInput!]
+              delete: [ActorMoviesDeleteFieldInput!]
+              disconnect: [ActorMoviesDisconnectFieldInput!]
+              update: ActorMoviesUpdateConnectionInput
+              where: ActorMoviesConnectionWhere
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.\\"\\"\\"
+              sort: [ActorSort]
+            }
+
+            input ActorRelationInput {
+              movies: [ActorMoviesCreateFieldInput!]
+            }
+
+            \\"\\"\\"Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.\\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              movies: [ActorMoviesUpdateFieldInput!]
+              name: String
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              OR: [ActorWhere!]
+              movies: MovieWhere
+              moviesConnection: ActorMoviesConnectionWhere
+              moviesConnection_NOT: ActorMoviesConnectionWhere
+              movies_NOT: MovieWhere
+              name: String
+              name_CONTAINS: String
+              name_ENDS_WITH: String
+              name_IN: [String]
+              name_NOT: String
+              name_NOT_CONTAINS: String
+              name_NOT_ENDS_WITH: String
+              name_NOT_IN: [String]
+              name_NOT_STARTS_WITH: String
+              name_STARTS_WITH: String
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
+            scalar DateTime
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              actors(options: ActorOptions, where: ActorWhere): [Actor]!
+              actorsConnection(after: String, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+              title: String!
+            }
+
+            input MovieActorsConnectFieldInput {
+              connect: [ActorConnectInput!]
+              where: ActorConnectWhere
+            }
+
+            type MovieActorsConnection {
+              edges: [MovieActorsRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorsConnectionSort {
+              edge: ActedInSort
+              node: ActorSort
+            }
+
+            input MovieActorsConnectionWhere {
+              AND: [MovieActorsConnectionWhere!]
+              OR: [MovieActorsConnectionWhere!]
+              edge: ActedInWhere
+              edge_NOT: ActedInWhere
+              node: ActorWhere
+              node_NOT: ActorWhere
+            }
+
+            input MovieActorsCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieActorsDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+            }
+
+            type MovieActorsRelationship implements ActedIn {
+              cursor: String!
+              id: ID!
+              node: Actor!
+              timestamp: DateTime!
+            }
+
+            input MovieActorsUpdateConnectionInput {
               node: ActorUpdateInput
             }
 

--- a/packages/graphql/tests/tck/tck-test-files/cypher/operations/update.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/operations/update.md
@@ -7,15 +7,13 @@ Schema:
 ```graphql
 type Actor {
     name: String
-    movies: [Movie]
-        @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+    movies: [Movie] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
 }
 
 type Movie {
     id: ID
     title: String
-    actors: [Actor]!
-        @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+    actors: [Actor]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
 }
 
 interface ActedIn {
@@ -68,14 +66,7 @@ RETURN this { .id } AS this
 mutation {
     updateMovies(
         where: { id: "1" }
-        update: {
-            actors: [
-                {
-                    where: { node: { name: "old name" } }
-                    update: { node: { name: "new name" } }
-                }
-            ]
-        }
+        update: { actors: [{ where: { node: { name: "old name" } }, update: { node: { name: "new name" } } }] }
     ) {
         movies {
             id
@@ -157,9 +148,7 @@ mutation {
                             movies: [
                                 {
                                     where: { node: { id: "old movie title" } }
-                                    update: {
-                                        node: { title: "new movie title" }
-                                    }
+                                    update: { node: { title: "new movie title" } }
                                 }
                             ]
                         }
@@ -261,10 +250,7 @@ RETURN this { .id } AS this
 
 ```graphql
 mutation {
-    updateMovies(
-        where: { id: "1" }
-        connect: { actors: [{ where: { node: { name: "Daniel" } } }] }
-    ) {
+    updateMovies(where: { id: "1" }, connect: { actors: [{ where: { node: { name: "Daniel" } } }] }) {
         movies {
             id
         }
@@ -283,7 +269,7 @@ CALL {
     OPTIONAL MATCH (this_connect_actors0_node:Actor)
     WHERE this_connect_actors0_node.name = $this_connect_actors0_node_name
     FOREACH(_ IN CASE this_connect_actors0_node WHEN NULL THEN [] ELSE [1] END |
-    MERGE (this)<-[:ACTED_IN]-(this_connect_actors0_node)
+    MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
     )
     RETURN count(*)
 }
@@ -309,12 +295,7 @@ RETURN this { .id } AS this
 mutation {
     updateMovies(
         where: { id: "1" }
-        connect: {
-            actors: [
-                { where: { node: { name: "Daniel" } } }
-                { where: { node: { name: "Darrell" } } }
-            ]
-        }
+        connect: { actors: [{ where: { node: { name: "Daniel" } } }, { where: { node: { name: "Darrell" } } }] }
     ) {
         movies {
             id
@@ -334,7 +315,7 @@ CALL {
     OPTIONAL MATCH (this_connect_actors0_node:Actor)
     WHERE this_connect_actors0_node.name = $this_connect_actors0_node_name
     FOREACH(_ IN CASE this_connect_actors0_node WHEN NULL THEN [] ELSE [1] END |
-    MERGE (this)<-[:ACTED_IN]-(this_connect_actors0_node)
+    MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
     )
     RETURN count(*)
 }
@@ -344,7 +325,7 @@ CALL {
     OPTIONAL MATCH (this_connect_actors1_node:Actor)
     WHERE this_connect_actors1_node.name = $this_connect_actors1_node_name
     FOREACH(_ IN CASE this_connect_actors1_node WHEN NULL THEN [] ELSE [1] END |
-    MERGE (this)<-[:ACTED_IN]-(this_connect_actors1_node)
+    MERGE (this)<-[this_connect_actors1_relationship:ACTED_IN]-(this_connect_actors1_node)
     )
     RETURN count(*)
 }
@@ -369,10 +350,7 @@ RETURN this { .id } AS this
 
 ```graphql
 mutation {
-    updateMovies(
-        where: { id: "1" }
-        disconnect: { actors: [{ where: { node: { name: "Daniel" } } }] }
-    ) {
+    updateMovies(where: { id: "1" }, disconnect: { actors: [{ where: { node: { name: "Daniel" } } }] }) {
         movies {
             id
         }
@@ -433,12 +411,7 @@ RETURN this { .id } AS this
 mutation {
     updateMovies(
         where: { id: "1" }
-        disconnect: {
-            actors: [
-                { where: { node: { name: "Daniel" } } }
-                { where: { node: { name: "Darrell" } } }
-            ]
-        }
+        disconnect: { actors: [{ where: { node: { name: "Daniel" } } }, { where: { node: { name: "Darrell" } } }] }
     ) {
         movies {
             id
@@ -518,13 +491,7 @@ RETURN this { .id } AS this
 mutation {
     updateActors(
         where: { name: "Dan" }
-        update: {
-            movies: {
-                create: [
-                    { node: { id: "dan_movie_id", title: "The Story of Beer" } }
-                ]
-            }
-        }
+        update: { movies: { create: [{ node: { id: "dan_movie_id", title: "The Story of Beer" } }] } }
     ) {
         actors {
             name
@@ -572,11 +539,7 @@ RETURN this { .name, movies: [ (this)-[:ACTED_IN]->(this_movies:Movie)  | this_m
 mutation {
     updateActors(
         where: { name: "Dan" }
-        create: {
-            movies: [
-                { node: { id: "dan_movie_id", title: "The Story of Beer" } }
-            ]
-        }
+        create: { movies: [{ node: { id: "dan_movie_id", title: "The Story of Beer" } }] }
     ) {
         actors {
             name
@@ -598,7 +561,7 @@ WHERE this.name = $this_name
 CREATE (this_create_movies0_node:Movie)
 SET this_create_movies0_node.id = $this_create_movies0_node_id
 SET this_create_movies0_node.title = $this_create_movies0_node_title
-MERGE (this)-[:ACTED_IN]->(this_create_movies0_node)
+MERGE (this)-[this_create_movies0_relationship:ACTED_IN]->(this_create_movies0_node)
 
 RETURN this { .name, movies: [ (this)-[:ACTED_IN]->(this_movies:Movie) | this_movies { .id, .title } ] } AS this
 ```
@@ -650,12 +613,12 @@ WHERE this.name = $this_name
 CREATE (this_create_movies0_node:Movie)
 SET this_create_movies0_node.id = $this_create_movies0_node_id
 SET this_create_movies0_node.title = $this_create_movies0_node_title
-MERGE (this)-[:ACTED_IN]->(this_create_movies0_node)
+MERGE (this)-[this_create_movies0_relationship:ACTED_IN]->(this_create_movies0_node)
 
 CREATE (this_create_movies1_node:Movie)
 SET this_create_movies1_node.id = $this_create_movies1_node_id
 SET this_create_movies1_node.title = $this_create_movies1_node_title
-MERGE (this)-[:ACTED_IN]->(this_create_movies1_node)
+MERGE (this)-[this_create_movies1_relationship:ACTED_IN]->(this_create_movies1_node)
 
 RETURN this { .name, movies: [ (this)-[:ACTED_IN]->(this_movies:Movie) | this_movies { .id, .title } ] } AS this
 ```
@@ -682,14 +645,7 @@ RETURN this { .name, movies: [ (this)-[:ACTED_IN]->(this_movies:Movie) | this_mo
 mutation {
     updateMovies(
         where: { id: "1" }
-        delete: {
-            actors: {
-                where: {
-                    node: { name: "Actor to delete" }
-                    edge: { screenTime: 60 }
-                }
-            }
-        }
+        delete: { actors: { where: { node: { name: "Actor to delete" }, edge: { screenTime: 60 } } } }
     ) {
         movies {
             id
@@ -751,12 +707,7 @@ RETURN this { .id } AS this
 mutation {
     updateMovies(
         where: { id: "1" }
-        update: {
-            actors: {
-                where: { node: { name: "Actor to update" } }
-                update: { node: { name: "Updated name" } }
-            }
-        }
+        update: { actors: { where: { node: { name: "Actor to update" } }, update: { node: { name: "Updated name" } } } }
         delete: { actors: { where: { node: { name: "Actor to delete" } } } }
     ) {
         movies {
@@ -842,12 +793,7 @@ RETURN this { .id } AS this
 
 ```graphql
 mutation {
-    updateMovies(
-        where: { id: "1" }
-        update: {
-            actors: { delete: { where: { node: { name: "Actor to delete" } } } }
-        }
-    ) {
+    updateMovies(where: { id: "1" }, update: { actors: { delete: { where: { node: { name: "Actor to delete" } } } } }) {
         movies {
             id
         }


### PR DESCRIPTION
# Description

Proposed fix for #496. Current behavior is to create an `edge` and thereby a `CreateInput` and `UpdateInput` for relationship properties if they exist. This PR will strip out generated fields (`@id`, `@timestamp`) before adding these edges to the schema.

# Issue

- #496 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
