### PR TITLE
FEAT: extend auth rules with field modifiers

### DIFF
--- a/docs/modules/ROOT/pages/auth/auth-directive.adoc
+++ b/docs/modules/ROOT/pages/auth/auth-directive.adoc
@@ -1,7 +1,7 @@
 [[auth-directive]]
 = `@auth` directive
 
-The `@auth` directive definition is dynamically generated on runtime based on user type definitions.
+The `@auth` directive definition is dynamically generated at runtime based on user type definitions.
 
 == `rules`
 
@@ -15,6 +15,49 @@ You can have many rules for many operations. Each rule is fallen through until a
     { operations: [DELETE, UPDATE], ... } ## or
 ])
 ----
+
+An auth rule can contain one of the four different kinds of check explained on the xref::auth/authorization/index.adoc[Authorization] documentation.
+
+Different checks within a single rule can be combined together and all must succeed, or evaluate to true for an action to be allowed.  You can think of types of check within a rule as being combined with an `AND`.
+
+[source, graphql, indent=0]
+----
+@auth(rules: [
+    { 
+        operations: [READ],
+        roles: ["user"], ## and
+        allow: { id: $jwt.sub }
+    }, ## or
+    { 
+        operations: [READ],
+        roles: ["admin"],
+    }
+])
+----
+
+In this example, for a caller to be allowed to see the data, they must have a JWT role of "user", or "admin", and if they have a role of "user", they are only permitted to read nodes with an id field matching their JWT subject.
+
+You can also combine checks within a single rule using `OR`, or `AND` explicity and passing a list of sub-rules for example,
+
+[source, graphql, indent=0]
+----
+@auth(rules: [
+    { 
+        operations: [READ],
+        OR: [
+            {
+                roles: ["user"], ## and
+                allow: { id: $jwt.sub }
+            }, ## or
+            {
+                roles: ["admin"],
+            }
+        ]
+    }
+])
+----
+
+This rule has the same behavior as when the rules are specified separately.
 
 == `operations`
 

--- a/docs/modules/ROOT/pages/auth/authorization/allow.adoc
+++ b/docs/modules/ROOT/pages/auth/authorization/allow.adoc
@@ -127,6 +127,10 @@ extend type Post
     )
 ----
 
+== Field modifiers
+
+You can combine fields in `allow` rules with the provided field modifiers to customize the allow rules checked, see the xref::auth/authorization/modifiers.adoc[Modifiers] documentation.
+
 == Field-level `allow`
 
 `allow` works the same as it does on Types although its context is the Field. So instead of enforcing auth rules when the node is matched and/or modified, it would instead be called when the Field is match and/or modified. Given the following, it is hiding the password to all users but the user themselves:

--- a/docs/modules/ROOT/pages/auth/authorization/modifiers.adoc
+++ b/docs/modules/ROOT/pages/auth/authorization/modifiers.adoc
@@ -1,0 +1,324 @@
+[[auth-authorization-modifiers]]
+= Auth rule modifiers
+
+By default, on primitive fields, auth rules will do an equality comparison.
+
+On relationships, the default match depends on the type of rule.  For `allow`, *any* connected node can match the specified pattern, for `bind`, and `allow`, *all* must match.
+
+There are a number of modifiers which can be applied to field names to customize the behavior of the auth checks performed to suit your needs.  The modifiers are designed to be similar in look and feel to the `where` filters generated in the GraphQL schema queries and mutations.
+
+== Primitive modifiers
+
+On primitive fields, the default behavior is to perform an equality check.
+
+In the following example the allow rule permits callers to perform `UPDATE` operations on `User` nodes where the id of the node matches the provided JWT subject, else a forbidden error will be raised.
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+    deletedDate: DateTime
+    publishedDate: DateTime
+    contentType: String
+}
+
+extend type User @auth(rules: [
+    { operations: [UPDATE], allow: { id: "$jwt.sub" } }
+])
+----
+
+=== Equals `null`
+
+As well as checking for an equality, you can also check that a value is `null`, in this case, that there is no date the `User` was deleted
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+    deletedDate: DateTime
+    publishedDate: DateTime
+    contentType: String
+}
+
+extend type User @auth(rules: [
+    { operations: [UPDATE], allow: { deletedDate: null } }
+])
+----
+
+=== Not equals `null`
+
+Or not null, verifying that the publishedDate field on the `User` is not null
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+    deletedDate: DateTime
+    publishedDate: DateTime
+    contentType: String
+}
+
+extend type User @auth(rules: [
+    { operations: [UPDATE], allow: { publishedDate_NOT: null } }
+])
+----
+
+=== Value in list
+
+You can also check that a value exists within a provided list of values such that only those with a contentType in the list can be updated
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+    deletedDate: DateTime
+    publishedDate: DateTime
+    contentType: String
+}
+
+extend type User @auth(rules: [
+    { operations: [UPDATE], allow: { contentType_IN: ["updateable", "new"] } }
+])
+----
+
+=== Value not in list
+
+Or that the value does not exist within the specified list, preventing update to nodes with one of the specified content types
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+    deletedDate: DateTime
+    publishedDate: DateTime
+    contentType: String
+}
+
+extend type User @auth(rules: [
+    { operations: [UPDATE], allow: { contentType_NOT_IN: ["unmodifyable", "deleted"] } }
+])
+----
+
+== Relationship modifiers
+
+The default behavior for a check on a related node depends on the type of rule.  In `allow` clauses, the default behavior is that *any* connected node can match for an operation to be allowed, but in `bind` and `where` clauses, *all* connected nodes must match.
+
+For example the following `allow` clause allows a caller to update any `Post` where any moderator has an id matching the provided JWT subject
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [UPDATE], allow: { moderators: { id: "$jwt.sub" } } }
+])
+----
+
+Conversely, the following `where` clause requires all moderators to have an id matching the provided JWT subject
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators: { id: "$jwt.sub" } } }
+])
+----
+
+
+=== Not
+
+Using the `_NOT` modifier you can invert the default behavior of the clause
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [UPDATE], allow: { moderators_NOT: { id: "$jwt.sub" } } }
+])
+----
+
+For `allow`, this permits a `Post` to be updated where there is *no* moderator (`NOT ALL`) with an id matching the provided JWT subject.
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators_NOT: { id: "$jwt.sub" } } }
+])
+----
+
+For `where` and `bind`, this permits a `Post` to be read where *no* moderator (`NOT ANY`) exists with an id that matches the provided JWT subject.
+
+=== No connection exists
+
+If the value for a relationship clause is `null`, the query will check that no edge exists
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [UPDATE], allow: { moderators: null } }
+])
+----
+
+=== Connection exists
+
+You can also require the existence of an edge by using the `_NOT` modifier with a value of `null`
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [UPDATE], allow: { moderators_NOT: null } }
+])
+----
+
+=== Any connection matches
+
+You can use the `_INCLUDES` modifier to check that any connected node matches the specified pattern.  Here we allow a caller to read all `Post` nodes where a moderator has an id matching the provided JWT subject.
+
+**Note that this is the default behavior for the `allow` rule**
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators_INCLUDES: { id: "$jwt.sub" } } }
+])
+----
+
+=== No connection matches
+
+You can use the `_NOT_INCLUDES` modifier to check that there are not any connected nodes matching the specified pattern.  Here we allow a caller to read all `Post` nodes where no moderator has an id matching the provided JWT subject.
+
+**Note that this is the default behavior for the `allow` rule**
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators_NOT_INCLUDES: { id: "$jwt.sub" } } }
+])
+----
+
+=== Every connection matches
+
+You can use the `_EVERY` modifier to check that all connected nodes match the specified pattern.  Here we allow a caller to read `Post` nodes where all moderators have an id matching the provided JWT subject.
+
+**Note that this is the default behavior for the `allow` rule**
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators_EVERY_: { id: "$jwt.sub" } } }
+])
+----
+
+=== Not every connection matches
+
+You can use the `_NOT_EVERY` modifier to check that all connected nodes match the specified pattern.  Here we allow a caller to read `Post` nodes where any moderator exists that has an id which doesn't match the provided JWT subject.
+
+**Note that this is the default behavior for the `allow` rule**
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators_NOT_EVERY: { id: "$jwt.sub" } } }
+])
+----

--- a/docs/modules/ROOT/pages/auth/authorization/where.adoc
+++ b/docs/modules/ROOT/pages/auth/authorization/where.adoc
@@ -44,3 +44,30 @@ Where is used on the following operations;
 - `CONNECT`
 - `DISCONNECT`
 - `DELETE`
+
+== `where` on relationships
+
+You can use a `where` clause with a relationship on a type to filter the results that will be returned to a caller.
+
+In the following schema, the `where` clause allows the caller to see the `Post` nodes where all of the moderators have an id matching the provided JWT subject.
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID
+    name: String
+}
+
+type Post {
+    content: String
+    moderators: [User] @relationship(type: "MODERATES_POST", direction: IN)
+}
+
+extend type Post @auth(rules: [
+    { operations: [READ], where: { moderators: { id: "$jwt.sub" } } }
+])
+----
+
+== Field modifiers
+
+You can combine fields in `where` clauses with supported field modifiers to customize the filtering that is performed, see the xref::auth/authorization/modifiers.adoc[Modifiers] documentation.

--- a/examples/neo-push/client/src/components/Blog.tsx
+++ b/examples/neo-push/client/src/components/Blog.tsx
@@ -66,7 +66,7 @@ function CreatePost({ close, blog }: { close: () => void; blog: BlogInterface })
             try {
                 const response = await mutate({
                     mutation: CREATE_POST,
-                    variables: { title, content, user: getId(), blog: blog.id },
+                    variables: { title, isPublic: true, content, user: getId(), blog: blog.id },
                 });
 
                 history.push(constants.POST_PAGE + "/" + response.createPosts.posts[0].id);

--- a/examples/neo-push/client/src/queries.ts
+++ b/examples/neo-push/client/src/queries.ts
@@ -117,11 +117,12 @@ export const DELETE_BLOG = gql`
 `;
 
 export const CREATE_POST = gql`
-    mutation createPost($title: String!, $content: String!, $user: ID, $blog: ID) {
+    mutation createPost($title: String!, $isPublic: Boolean!, $content: String!, $user: ID, $blog: ID) {
         createPosts(
             input: [
                 {
                     title: $title
+                    isPublic: $isPublic
                     content: $content
                     blog: { connect: { where: { node: { id: $blog } } } }
                     author: { connect: { where: { node: { id: $user } } } }

--- a/examples/neo-push/server/src/gql/Blog.ts
+++ b/examples/neo-push/server/src/gql/Blog.ts
@@ -6,6 +6,7 @@ export const typeDefs = gql`
         name: String!
         creator: User @relationship(type: "HAS_BLOG", direction: IN)
         authors: [User] @relationship(type: "CAN_POST", direction: IN)
+        subscribers: [User] @relationship(type: "SUBSCRIBED_TO", direction: IN)
         posts: [Post] @relationship(type: "HAS_POST", direction: OUT)
         isCreator: Boolean
             @cypher(

--- a/examples/neo-push/server/src/gql/User.ts
+++ b/examples/neo-push/server/src/gql/User.ts
@@ -24,8 +24,16 @@ export const typeDefs = gql`
                     allow: {
                         OR: [
                             { id: "$jwt.sub" }
-                            { createdBlogs: { OR: [{ creator: { id: "$jwt.sub" } }, { authors: { id: "$jwt.sub" } }] } }
-                            { authorsBlogs: { OR: [{ creator: { id: "$jwt.sub" } }, { authors: { id: "$jwt.sub" } }] } }
+                            {
+                                createdBlogs: {
+                                    OR: [{ creator: { id: "$jwt.sub" } }, { authors_INCLUDES: { id: "$jwt.sub" } }]
+                                }
+                            }
+                            {
+                                authorsBlogs: {
+                                    OR: [{ creator: { id: "$jwt.sub" } }, { authors_INCLUDES: { id: "$jwt.sub" } }]
+                                }
+                            }
                         ]
                     }
                 }

--- a/examples/neo-push/server/src/seeder.ts
+++ b/examples/neo-push/server/src/seeder.ts
@@ -45,6 +45,7 @@ async function main() {
                 posts: {
                     create: new Array(3).fill(null).map(() => ({
                         title: faker.lorem.word(),
+                        isPublic: true,
                         content: faker.lorem.paragraphs(4),
                         author: {
                             connect: { where: { node: { id: user.id } } },

--- a/examples/neo-push/server/tests/integration/graphql/post-auth.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/post-auth.test.ts
@@ -31,6 +31,7 @@ describe("post-auth", () => {
                     input: [
                         {
                             title: "some post"
+                            isPublic: true
                             content: "content"
                             author: { connect: { where: { node: { id: "invalid" } } } }
                         }

--- a/examples/neo-push/server/tests/integration/graphql/post-custom.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/post-custom.test.ts
@@ -53,7 +53,7 @@ describe("post-custom", () => {
                 await session.run(`
                     CREATE (u:User {id: "${userId}"})
                     -[:HAS_BLOG]->(:Blog {id: "${blogId}"})
-                    -[:HAS_POST]->(:Post {id: "${postId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: true})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -104,7 +104,7 @@ describe("post-custom", () => {
                 await session.run(`
                     CREATE (u:User {id: "${userId}"})
                     -[:CAN_POST]->(:Blog {id: "${blogId}"})
-                    -[:HAS_POST]->(:Post {id: "${postId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: true})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -154,7 +154,7 @@ describe("post-custom", () => {
             try {
                 await session.run(`
                     CREATE (u:User {id: "${userId}"})-[:WROTE]->
-                           (:Post {id: "${postId}"})<-[:HAS_POST]-(:Blog {id: "${blogId}"})
+                           (:Post {id: "${postId}", isPublic: true})<-[:HAS_POST]-(:Blog {id: "${blogId}"})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -209,7 +209,7 @@ describe("post-custom", () => {
                 await session.run(`
                     CREATE (u:User {id: "${otherUser}"})
                     -[:HAS_BLOG]->(:Blog {id: "${blogId}"})
-                    -[:HAS_POST]->(:Post {id: "${postId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: true})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -262,7 +262,7 @@ describe("post-custom", () => {
                 await session.run(`
                     CREATE (u:User {id: "${userId}"})
                     -[:HAS_BLOG]->(:Blog {id: "${blogId}"})
-                    -[:HAS_POST]->(:Post {id: "${postId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: true})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -313,7 +313,7 @@ describe("post-custom", () => {
                 await session.run(`
                     CREATE (u:User {id: "${userId}"})
                     -[:WROTE]->(:Post {id: "${postId}"})
-                    <-[:HAS_POST]-(:Blog {id: "${blogId}"})
+                    <-[:HAS_POST]-(:Blog {id: "${blogId}", isPublic: true})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -368,7 +368,7 @@ describe("post-custom", () => {
                 await session.run(`
                     CREATE (u:User {id: "${otherUser}"})
                     -[:HAS_BLOG]->(:Blog {id: "${blogId}"})
-                    -[:HAS_POST]->(:Post {id: "${postId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: true})
                 `);
 
                 const apolloServer = server(driver, { req });
@@ -380,6 +380,177 @@ describe("post-custom", () => {
                 expect(response.errors).toBeUndefined();
 
                 expect(response.data.posts[0].canDelete).toEqual(false);
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("read-rules-where", () => {
+        test("should not be able to see private posts when not a subscriber to a blog", async () => {
+            const session = driver.session();
+
+            const authorId = generate({
+                charset: "alphabetic",
+            });
+
+            const otherUser = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const blogId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = gql`
+                {
+                    posts(where: {id: "${postId}"}) {
+                        id
+                    }
+                }
+            `;
+
+            const token = await createJWT({ sub: otherUser });
+
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+            req.headers.authorization = `Bearer ${token}`;
+
+            try {
+                await session.run(`
+                    CREATE (u:User {id: "${authorId}"})
+                    -[:HAS_BLOG]->(:Blog {id: "${blogId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: false})
+                `);
+
+                const apolloServer = server(driver, { req });
+
+                const response = await apolloServer.query({
+                    query,
+                });
+
+                expect(response.errors).toBeUndefined();
+
+                expect(response.data.posts).toHaveLength(0);
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should be able to see private posts when a subscriber to a blog", async () => {
+            const session = driver.session();
+
+            const authorId = generate({
+                charset: "alphabetic",
+            });
+
+            const otherUser = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const blogId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = gql`
+                {
+                    posts(where: {id: "${postId}"}) {
+                        id
+                    }
+                }
+            `;
+
+            const token = await createJWT({ sub: otherUser });
+
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+            req.headers.authorization = `Bearer ${token}`;
+
+            try {
+                await session.run(`
+                    CREATE (u:User {id: "${authorId}"})
+                    -[:HAS_BLOG]->(b:Blog {id: "${blogId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: false}),
+                    (otherUser:User {id: "${otherUser}"})-[:SUBSCRIBED_TO]->(b)
+                `);
+
+                const apolloServer = server(driver, { req });
+
+                const response = await apolloServer.query({
+                    query,
+                });
+
+                expect(response.errors).toBeUndefined();
+
+                expect(response.data.posts).toHaveLength(1);
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should be able to see private posts when one of multiple subscribers to a blog", async () => {
+            const session = driver.session();
+
+            const authorId = generate({
+                charset: "alphabetic",
+            });
+
+            const otherUser = generate({
+                charset: "alphabetic",
+            });
+
+            const thirdUser = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const blogId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = gql`
+                {
+                    posts(where: {id: "${postId}"}) {
+                        id
+                    }
+                }
+            `;
+
+            const token = await createJWT({ sub: otherUser });
+
+            const socket = new Socket({ readable: true });
+            const req = new IncomingMessage(socket);
+            req.headers.authorization = `Bearer ${token}`;
+
+            try {
+                await session.run(`
+                    CREATE (u:User {id: "${authorId}"})
+                    -[:HAS_BLOG]->(b:Blog {id: "${blogId}"})
+                    -[:HAS_POST]->(:Post {id: "${postId}", isPublic: false}),
+                    (:User {id: "${otherUser}"})-[:SUBSCRIBED_TO]->(b),
+                    (:User {id: "${thirdUser}"})-[:SUBSCRIBED_TO]->(b)
+                `);
+
+                const apolloServer = server(driver, { req });
+
+                const response = await apolloServer.query({
+                    query,
+                });
+
+                expect(response.errors).toBeUndefined();
+
+                expect(response.data.posts).toHaveLength(1);
             } finally {
                 await session.close();
             }

--- a/examples/neo-push/server/tests/integration/graphql/workflow.test.ts
+++ b/examples/neo-push/server/tests/integration/graphql/workflow.test.ts
@@ -134,6 +134,7 @@ describe("workflow", () => {
                             input: [
                                 {
                                     content: "cool post"
+                                    isPublic: true
                                     title: "${post.initialTitle}"
                                     author: {
                                         connect: {

--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -21,6 +21,7 @@ import { generate } from "randomstring";
 import createAuthAndParams from "./create-auth-and-params";
 import { Neo4jGraphQL, Node } from "../classes";
 import { trimmer } from "../utils";
+import { PrimitiveField, RelationField } from "../types";
 
 describe("createAuthAndParams", () => {
     describe("operations", () => {
@@ -826,6 +827,2152 @@ describe("createAuthAndParams", () => {
                 trimmer('false OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))')
             );
             expect(result[1]).toEqual({});
+        });
+    });
+
+    describe("rule modifiers", () => {
+        describe("allow", () => {
+            describe("primitives", () => {
+                test("default", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ allow: { id: "$jwt.sub" } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND this.id = $this_auth_allow0_id
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_id: sub,
+                    });
+                });
+
+                test("_NOT", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ allow: { id_NOT: "$jwt.sub" } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND this.id <> $this_auth_allow0_id_NOT
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_id_NOT: sub,
+                    });
+                });
+
+                test("_IN", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const subs = Array(3).map(() => generate({ charset: "alphabetic" }));
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ allow: { id_IN: subs } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub: subs[0],
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND this.id IN $this_auth_allow0_id_IN
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_id_IN: subs,
+                    });
+                });
+
+                test("_NOT_IN", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const subs = Array(3).map(() => generate({ charset: "alphabetic" }));
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ allow: { id_NOT_IN: subs } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub: subs[0],
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND NOT this.id IN $this_auth_allow0_id_NOT_IN
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_id_NOT_IN: subs,
+                    });
+                });
+            });
+
+            describe("relation field", () => {
+                test("default", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ allow: { ids: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND ANY(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_allow0_ids_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_ids_id: sub,
+                    });
+                });
+
+                test("null", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ allow: { ids: null } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        NOT EXISTS((this)-[:HAS_ID]->(:MovieID))
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({});
+                });
+
+                test("_NOT null", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ allow: { ids_NOT: null } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID))
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({});
+                });
+
+                test("_INCLUDES", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ allow: { ids_INCLUDES: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND ANY(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_allow0_ids_INCLUDES_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_ids_INCLUDES_id: sub,
+                    });
+                });
+
+                test("_NOT_INCLUDES", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ allow: { ids_NOT_INCLUDES: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        allow: { parentNode: node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND NOT ANY(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_allow0_ids_NOT_INCLUDES_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_allow0_ids_NOT_INCLUDES_id: sub,
+                    });
+                });
+            });
+        });
+
+        describe("where", () => {
+            describe("primitives", () => {
+                test("default", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ where: { id: "$jwt.sub" } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND this.id = $this_auth_where0_id
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_id: sub,
+                    });
+                });
+
+                test("_NOT", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ where: { id_NOT: "$jwt.sub" } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND this.id <> $this_auth_where0_id_NOT
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_id_NOT: sub,
+                    });
+                });
+
+                test("_IN", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const subs = Array(3).map(() => generate({ charset: "alphabetic" }));
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ where: { id_IN: subs } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub: subs[0],
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND this.id IN $this_auth_where0_id_IN
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_id_IN: subs,
+                    });
+                });
+
+                test("_NOT_IN", () => {
+                    const idField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const subs = Array(3).map(() => generate({ charset: "alphabetic" }));
+
+                    // @ts-ignore
+                    const node: Node = {
+                        name: "Movie",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        authableFields: [idField],
+                        auth: {
+                            rules: [{ where: { id_NOT_IN: subs } }],
+                            type: "JWT",
+                        },
+                    };
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [node],
+                    };
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub: subs[0],
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        this.id IS NOT NULL AND NOT this.id IN $this_auth_where0_id_NOT_IN
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_id_NOT_IN: subs,
+                    });
+                });
+            });
+
+            describe("relation field", () => {
+                test("default", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND ALL(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_where0_ids_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_ids_id: sub,
+                    });
+                });
+
+                test("null", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids: null } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        NOT EXISTS((this)-[:HAS_ID]->(:MovieID))
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({});
+                });
+
+                test("_NOT null", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids_NOT: null } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID))
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({});
+                });
+
+                test("_INCLUDES", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids_INCLUDES: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND ANY(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_where0_ids_INCLUDES_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_ids_INCLUDES_id: sub,
+                    });
+                });
+
+                test("_NOT_INCLUDES", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids_NOT_INCLUDES: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND NOT ANY(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_where0_ids_NOT_INCLUDES_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_ids_NOT_INCLUDES_id: sub,
+                    });
+                });
+
+                test("_EVERY", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids_EVERY: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND ALL(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_where0_ids_EVERY_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_ids_EVERY_id: sub,
+                    });
+                });
+
+                test("_NOT_EVERY", () => {
+                    const idField: PrimitiveField = {
+                        fieldName: "id",
+                        typeMeta: {
+                            name: "ID",
+                            array: false,
+                            required: false,
+                            pretty: "String",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const idsField: RelationField = {
+                        fieldName: "ids",
+                        direction: "OUT",
+                        type: "HAS_ID",
+                        typeMeta: {
+                            name: "MovieID",
+                            array: true,
+                            required: false,
+                            pretty: "MovieID",
+                            input: {
+                                where: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                create: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                                update: {
+                                    type: "String",
+                                    pretty: "String",
+                                },
+                            },
+                        },
+                        otherDirectives: [],
+                        arguments: [],
+                    };
+
+                    const movieIdNode: Node = new Node({
+                        name: "MovieID",
+                        relationFields: [],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [idField],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                    });
+
+                    const node: Node = new Node({
+                        name: "Movie",
+                        relationFields: [idsField],
+                        cypherFields: [],
+                        enumFields: [],
+                        scalarFields: [],
+                        primitiveFields: [],
+                        temporalFields: [],
+                        interfaceFields: [],
+                        objectFields: [],
+                        pointFields: [],
+                        unionFields: [],
+                        connectionFields: [],
+                        ignoredFields: [],
+                        interfaces: [],
+                        otherDirectives: [],
+                        auth: {
+                            rules: [{ where: { ids_NOT_EVERY: { id: "$jwt.sub" } } }],
+                            type: "JWT",
+                        },
+                    });
+
+                    // @ts-ignore
+                    const neoSchema: Neo4jGraphQL = {
+                        nodes: [movieIdNode, node],
+                    };
+
+                    const sub = generate({
+                        charset: "alphabetic",
+                    });
+
+                    // @ts-ignore
+                    const context: Context = { neoSchema };
+                    context.jwt = {
+                        sub,
+                    };
+
+                    const result = createAuthAndParams({
+                        context,
+                        entity: node,
+                        where: { node, varName: "this" },
+                    });
+
+                    expect(trimmer(result[0])).toEqual(
+                        trimmer(`
+                        EXISTS((this)-[:HAS_ID]->(:MovieID)) AND NOT ALL(ids IN [(this)-[:HAS_ID]->(ids:MovieID) | ids] WHERE ids.id IS NOT NULL AND ids.id = $this_auth_where0_ids_NOT_EVERY_id)
+                    `)
+                    );
+
+                    expect(result[1]).toMatchObject({
+                        this_auth_where0_ids_NOT_EVERY_id: sub,
+                    });
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
This pull request adds initial extended support for modifiers on auth clauses.  The API is designed to mimic the interface of the generated GraphQL query/mutation.

For primitives:

Support _NOT, _IN, _NOT_IN

_NOT checks for inequality using <>
_IN checks for membership in a list of values
_NOT_IN checks that the value is not a member of a list of values

For relationships:

Support _NOT, _INCLUDES, _NOT_INCLUDES, _EVERY, _NOT_EVERY

Also add support for a `null` value to check EXISTS()/NOT EXISTS.

_NOT negates the default ANY/ALL, depending on the clause
_ INCLUDES specifies `ANY`
_NOT_INCLUDES specifies `NOT ANY`
_ EVERY specifies `ALL`
_NOT_EVERY specifies `NOT ALL`

Using null as a value for the relationship checks that no edge exists, _NOT: `null` checks that an edge must exist.

# Issue

The implemented design is that which was proposed by @darrellwarde on issue #469 , following discussion on #293.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
