### PR TITLE
Feature: Support `Order By` for Primitive `@cypher` Fields

### DIFF
--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -566,6 +566,21 @@ function makeAugmentedSchema(
             ...node.scalarFields,
             ...node.temporalFields,
             ...node.pointFields,
+            ...node.cypherFields.filter((field) =>
+                [
+                    "Boolean",
+                    "ID",
+                    "Int",
+                    "BigInt",
+                    "Float",
+                    "String",
+                    "DateTime",
+                    "LocalDateTime",
+                    "Time",
+                    "LocalTime",
+                    "Date",
+                ].includes(field.typeMeta.name)
+            ),
         ].reduce((res, f) => {
             return f.typeMeta.array
                 ? {

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -151,10 +151,10 @@ function translateRead({ node, context }: { context: Context; node: Node }): [st
         matchStr,
         whereStr,
         authStr,
-        ...(sortStr ? [`WITH ${varName}`, sortStr] : []),
         ...(projAuth ? [`WITH ${varName}`, projAuth] : []),
         ...connectionStrs,
         `RETURN ${varName} ${projStr} as ${varName}`,
+        ...(sortStr ? [sortStr] : []),
         offsetStr,
         limitStr,
     ];

--- a/packages/graphql/tests/integration/sort.int.test.ts
+++ b/packages/graphql/tests/integration/sort.int.test.ts
@@ -17,9 +17,10 @@
  * limitations under the License.
  */
 
-import { Driver } from "neo4j-driver";
+import { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
+import { gql } from "apollo-server";
 import neo4j from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
@@ -34,217 +35,233 @@ describe("sort", () => {
         await driver.close();
     });
 
-    test("should sort a list of nodes", async () => {
-        await Promise.all(
-            ["ASC", "DESC"].map(async (type) => {
-                const session = driver.session();
+    describe("primitive fields", () => {
+        test("should sort a list of nodes", async () => {
+            await Promise.all(
+                ["ASC", "DESC"].map(async (type) => {
+                    const session = driver.session();
 
-                const typeDefs = `
-                    type Movie {
-                        id: ID
-                        number: Int
-                    }
-                `;
-
-                const neoSchema = new Neo4jGraphQL({ typeDefs });
-
-                const movieIds = [
-                    generate({
-                        charset: "alphabetic",
-                    }),
-                    generate({
-                        charset: "alphabetic",
-                    }),
-                    generate({
-                        charset: "alphabetic",
-                    }),
-                ].map((x) => `"${x}"`);
-
-                const query = `
-                    query {
-                        movies(
-                            where: { id_IN: [${movieIds.join(",")}] },
-                            options: { sort: [{ number: ${type} }] }
-                        ) {
-                           number
+                    const typeDefs = `
+                        type Movie {
+                            id: ID
+                            number: Int
                         }
-                    }
-                `;
+                    `;
 
-                try {
-                    await session.run(`
-                        CREATE (:Movie {id: ${movieIds[0]}, number: 1})
-                        CREATE (:Movie {id: ${movieIds[1]}, number: 2})
-                        CREATE (:Movie {id: ${movieIds[2]}, number: 3})
-                    `);
+                    const neoSchema = new Neo4jGraphQL({ typeDefs });
 
-                    const gqlResult = await graphql({
-                        schema: neoSchema.schema,
-                        source: query,
-                        contextValue: { driver, driverConfig: { bookmarks: session.lastBookmark() } },
-                    });
+                    const movieIds = [
+                        generate({
+                            charset: "alphabetic",
+                        }),
+                        generate({
+                            charset: "alphabetic",
+                        }),
+                        generate({
+                            charset: "alphabetic",
+                        }),
+                    ].map((x) => `"${x}"`);
 
-                    expect(gqlResult.errors).toBeUndefined();
-
-                    const { movies } = gqlResult.data as any;
-
-                    /* eslint-disable jest/no-conditional-expect */
-                    if (type === "ASC") {
-                        expect(movies[0].number).toEqual(1);
-                        expect(movies[1].number).toEqual(2);
-                        expect(movies[2].number).toEqual(3);
-                    }
-
-                    if (type === "DESC") {
-                        expect(movies[0].number).toEqual(3);
-                        expect(movies[1].number).toEqual(2);
-                        expect(movies[2].number).toEqual(1);
-                    }
-                    /* eslint-enable jest/no-conditional-expect */
-                } finally {
-                    await session.close();
-                }
-            })
-        );
-    });
-
-    test("should sort nested relationships", async () => {
-        await Promise.all(
-            ["ASC", "DESC"].map(async (type) => {
-                const session = driver.session();
-
-                const typeDefs = `
-                    type Movie {
-                        id: ID
-                        genres: [Genre] @relationship(type: "HAS_GENRE", direction: OUT)
-                    }
-
-                    type Genre {
-                        id: ID
-                    }
-                `;
-
-                const neoSchema = new Neo4jGraphQL({ typeDefs });
-
-                const movieId = generate({
-                    charset: "alphabetic",
-                });
-
-                const query = `
-                    query {
-                        movies(where: { id: "${movieId}" }) {
-                            genres(options: { sort: [{ id: ${type} }] }) {
-                                id
+                    const query = `
+                        query {
+                            movies(
+                                where: { id_IN: [${movieIds.join(",")}] },
+                                options: { sort: [{ number: ${type} }] }
+                            ) {
+                               number
                             }
                         }
+                    `;
+
+                    try {
+                        await session.run(`
+                            CREATE (:Movie {id: ${movieIds[0]}, number: 1})
+                            CREATE (:Movie {id: ${movieIds[1]}, number: 2})
+                            CREATE (:Movie {id: ${movieIds[2]}, number: 3})
+                        `);
+
+                        const gqlResult = await graphql({
+                            schema: neoSchema.schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: session.lastBookmark() } },
+                        });
+
+                        expect(gqlResult.errors).toBeUndefined();
+
+                        const { movies } = gqlResult.data as any;
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (type === "ASC") {
+                            expect(movies[0].number).toEqual(1);
+                            expect(movies[1].number).toEqual(2);
+                            expect(movies[2].number).toEqual(3);
+                        }
+
+                        if (type === "DESC") {
+                            expect(movies[0].number).toEqual(3);
+                            expect(movies[1].number).toEqual(2);
+                            expect(movies[2].number).toEqual(1);
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
                     }
-                `;
+                })
+            );
+        });
 
-                try {
-                    await session.run(`
-                        CREATE (m:Movie {id: "${movieId}"})
-                        CREATE (g1:Genre {id: "1"})
-                        CREATE (g2:Genre {id: "2"})
-                        MERGE (m)-[:HAS_GENRE]->(g1)
-                        MERGE (m)-[:HAS_GENRE]->(g2)
-                    `);
+        test("should sort nested relationships", async () => {
+            await Promise.all(
+                ["ASC", "DESC"].map(async (type) => {
+                    const session = driver.session();
 
-                    const gqlResult = await graphql({
-                        schema: neoSchema.schema,
-                        source: query,
-                        contextValue: { driver, driverConfig: { bookmarks: session.lastBookmark() } },
+                    const typeDefs = `
+                        type Movie {
+                            id: ID
+                            genres: [Genre] @relationship(type: "HAS_GENRE", direction: OUT)
+                        }
+    
+                        type Genre {
+                            id: ID
+                        }
+                    `;
+
+                    const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+                    const movieId = generate({
+                        charset: "alphabetic",
                     });
 
-                    expect(gqlResult.errors).toBeUndefined();
+                    const query = `
+                        query {
+                            movies(where: { id: "${movieId}" }) {
+                                genres(options: { sort: [{ id: ${type} }] }) {
+                                    id
+                                }
+                            }
+                        }
+                    `;
 
-                    const { genres } = (gqlResult.data as any).movies[0];
+                    try {
+                        await session.run(`
+                            CREATE (m:Movie {id: "${movieId}"})
+                            CREATE (g1:Genre {id: "1"})
+                            CREATE (g2:Genre {id: "2"})
+                            MERGE (m)-[:HAS_GENRE]->(g1)
+                            MERGE (m)-[:HAS_GENRE]->(g2)
+                        `);
 
-                    /* eslint-disable jest/no-conditional-expect */
-                    if (type === "ASC") {
-                        expect(genres[0].id).toEqual("1");
-                        expect(genres[1].id).toEqual("2");
+                        const gqlResult = await graphql({
+                            schema: neoSchema.schema,
+                            source: query,
+                            contextValue: { driver, driverConfig: { bookmarks: session.lastBookmark() } },
+                        });
+
+                        expect(gqlResult.errors).toBeUndefined();
+
+                        const { genres } = (gqlResult.data as any).movies[0];
+
+                        /* eslint-disable jest/no-conditional-expect */
+                        if (type === "ASC") {
+                            expect(genres[0].id).toEqual("1");
+                            expect(genres[1].id).toEqual("2");
+                        }
+
+                        if (type === "DESC") {
+                            expect(genres[0].id).toEqual("2");
+                            expect(genres[1].id).toEqual("1");
+                        }
+                        /* eslint-enable jest/no-conditional-expect */
+                    } finally {
+                        await session.close();
                     }
-
-                    if (type === "DESC") {
-                        expect(genres[0].id).toEqual("2");
-                        expect(genres[1].id).toEqual("1");
-                    }
-                    /* eslint-enable jest/no-conditional-expect */
-                } finally {
-                    await session.close();
-                }
-            })
-        );
+                })
+            );
+        });
     });
 
-    test("should sort on primitive cypher field", async () => {
-        await Promise.all(
-            ["ASC", "DESC"].map(async (type) => {
-                const session = driver.session();
+    describe("cypher fields", () => {
+        let session: Session;
 
-                const typeDefs = `
-                    type Movie {
-                        title: String!
-                        actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
-                    }
-                    type Actor {
-                        name: String!
-                        movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
-                        totalScreenTime: Int! @cypher(statement: """
-                            MATCH (this)-[r:ACTED_IN]->(:Movie)
-                            RETURN sum(r.screenTime)
-                        """)
-                    }
-                    interface ActedIn {
-                        screenTime: Int!
-                    }
-                `;
+        const typeDefs = gql`
+            type Movie {
+                title: String!
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+            type Actor {
+                name: String!
+                movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                totalScreenTime: Int!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[r:ACTED_IN]->(:Movie)
+                        RETURN sum(r.screenTime)
+                        """
+                    )
+            }
+            interface ActedIn {
+                screenTime: Int!
+            }
+        `;
 
-                const { schema } = new Neo4jGraphQL({ typeDefs });
+        const { schema } = new Neo4jGraphQL({ typeDefs });
 
-                const title1 = generate({
-                    charset: "alphabetic",
-                });
-                const title2 = generate({
-                    charset: "alphabetic",
-                });
-                const name1 = generate({
-                    charset: "alphabetic",
-                });
-                const name2 = generate({
-                    charset: "alphabetic",
-                });
+        const title1 = generate({
+            charset: "alphabetic",
+        });
+        const title2 = generate({
+            charset: "alphabetic",
+        });
+        const name1 = generate({
+            charset: "alphabetic",
+        });
+        const name2 = generate({
+            charset: "alphabetic",
+        });
 
-                const query = `
-                    query ($actorNames: [String!]!, $direction: SortDirection!) {
-                        actors(where: {name_IN: $actorNames}, options: { sort: [{ totalScreenTime: $direction}]}) {
-                            name
-                            totalScreenTime
+        beforeAll(async () => {
+            session = driver.session();
+            await session.run(
+                `
+                        CREATE (m1:Movie {title: $title1})
+                        CREATE (m2:Movie {title: $title2})
+                        CREATE (a1:Actor {name: $name1})
+                        CREATE (a2:Actor {name: $name2})
+                        MERGE (a1)-[:ACTED_IN {screenTime: 1}]->(m1)<-[:ACTED_IN {screenTime: 1}]-(a2)
+                        MERGE (a1)-[:ACTED_IN {screenTime: 1}]->(m2)
+                    `,
+                {
+                    title1,
+                    title2,
+                    name1,
+                    name2,
+                }
+            );
+        });
+
+        afterAll(async () => {
+            await session.close();
+        });
+
+        test("should sort on top level", async () => {
+            await Promise.all(
+                ["ASC", "DESC"].map(async (type) => {
+                    const query = gql`
+                        query($actorNames: [String!]!, $direction: SortDirection!) {
+                            actors(
+                                where: { name_IN: $actorNames }
+                                options: { sort: [{ totalScreenTime: $direction }] }
+                            ) {
+                                name
+                                totalScreenTime
+                            }
                         }
-                    }
-                `;
-
-                try {
-                    await session.run(
-                        `
-                            CREATE (m1:Movie {title: $title1})
-                            CREATE (m2:Movie {title: $title2})
-                            CREATE (a1:Actor {name: $name1})
-                            CREATE (a2:Actor {name: $name2})
-                            MERGE (a1)-[:ACTED_IN {screenTime: 1}]->(m1)<-[:ACTED_IN {screenTime: 1}]-(a2)
-                            MERGE (a1)-[:ACTED_IN {screenTime: 1}]->(m2)
-                        `,
-                        {
-                            title1,
-                            title2,
-                            name1,
-                            name2,
-                        }
-                    );
+                    `;
 
                     const graphqlResult = await graphql({
                         schema,
-                        source: query,
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        source: query.loc!.source,
                         contextValue: { driver, driverConfig: { bookmarks: session.lastBookmark() } },
                         variableValues: { actorNames: [name1, name2], direction: type },
                     });
@@ -270,10 +287,64 @@ describe("sort", () => {
                         expect(graphqlActors[1].totalScreenTime).toEqual(1);
                     }
                     /* eslint-enable jest/no-conditional-expect */
-                } finally {
-                    await session.close();
-                }
-            })
-        );
+                })
+            );
+        });
+
+        test("should sort on nested level", async () => {
+            await Promise.all(
+                ["ASC", "DESC"].map(async (type) => {
+                    const query = gql`
+                        query($title: String!, $actorNames: [String!]!, $direction: SortDirection!) {
+                            movies(where: { title: $title }) {
+                                title
+                                actors(
+                                    where: { name_IN: $actorNames }
+                                    options: { sort: [{ totalScreenTime: $direction }] }
+                                ) {
+                                    name
+                                    totalScreenTime
+                                }
+                            }
+                        }
+                    `;
+
+                    const graphqlResult = await graphql({
+                        schema,
+                        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                        source: query.loc!.source,
+                        contextValue: { driver, driverConfig: { bookmarks: session.lastBookmark() } },
+                        variableValues: { title: title1, actorNames: [name1, name2], direction: type },
+                    });
+
+                    expect(graphqlResult.errors).toBeUndefined();
+
+                    const graphqlMovies = graphqlResult.data?.movies;
+
+                    expect(graphqlMovies).toHaveLength(1);
+                    expect(graphqlMovies[0].title).toBe(title1);
+
+                    const graphqlActors = graphqlResult.data?.movies[0].actors;
+
+                    expect(graphqlActors).toHaveLength(2);
+
+                    /* eslint-disable jest/no-conditional-expect */
+                    if (type === "ASC") {
+                        expect(graphqlActors[0].name).toEqual(name2);
+                        expect(graphqlActors[0].totalScreenTime).toEqual(1);
+                        expect(graphqlActors[1].name).toEqual(name1);
+                        expect(graphqlActors[1].totalScreenTime).toEqual(2);
+                    }
+
+                    if (type === "DESC") {
+                        expect(graphqlActors[0].name).toEqual(name1);
+                        expect(graphqlActors[0].totalScreenTime).toEqual(2);
+                        expect(graphqlActors[1].name).toEqual(name2);
+                        expect(graphqlActors[1].totalScreenTime).toEqual(1);
+                    }
+                    /* eslint-enable jest/no-conditional-expect */
+                })
+            );
+        });
     });
 });

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -216,4 +216,207 @@ describe("Cypher", () => {
             "
         `);
     });
+
+    test("Sort On Primitive Field", () => {
+        const typeDefs = gql`
+            type Actor {
+                name: String
+                totalScreenTime: Int!
+                    @cypher(
+                        statement: """
+                        MATCH (this)-[r:ACTED_IN]->(:Movie)
+                        RETURN sum(r.screenTime)
+                        """
+                    )
+            }
+
+            type Movie {
+                id: ID
+                actors(title: String): [Actor]
+                    @cypher(
+                        statement: """
+                        MATCH (a:Actor {title: $title})
+                        RETURN a
+                        LIMIT 1
+                        """
+                    )
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(neoSchema.schema));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+          "schema {
+            query: Query
+            mutation: Mutation
+          }
+
+          type Actor {
+            name: String
+            totalScreenTime: Int!
+          }
+
+          type ActorAggregateSelection {
+            count: Int!
+            name: StringAggregateSelection!
+          }
+
+          input ActorCreateInput {
+            name: String
+          }
+
+          input ActorOptions {
+            limit: Int
+            offset: Int
+            \\"\\"\\"Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.\\"\\"\\"
+            sort: [ActorSort]
+          }
+
+          \\"\\"\\"Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.\\"\\"\\"
+          input ActorSort {
+            name: SortDirection
+            totalScreenTime: SortDirection
+          }
+
+          input ActorUpdateInput {
+            name: String
+          }
+
+          input ActorWhere {
+            AND: [ActorWhere!]
+            OR: [ActorWhere!]
+            name: String
+            name_CONTAINS: String
+            name_ENDS_WITH: String
+            name_IN: [String]
+            name_NOT: String
+            name_NOT_CONTAINS: String
+            name_NOT_ENDS_WITH: String
+            name_NOT_IN: [String]
+            name_NOT_STARTS_WITH: String
+            name_STARTS_WITH: String
+          }
+
+          type CreateActorsMutationResponse {
+            actors: [Actor!]!
+            info: CreateInfo!
+          }
+
+          type CreateInfo {
+            bookmark: String
+            nodesCreated: Int!
+            relationshipsCreated: Int!
+          }
+
+          type CreateMoviesMutationResponse {
+            info: CreateInfo!
+            movies: [Movie!]!
+          }
+
+          type DeleteInfo {
+            bookmark: String
+            nodesDeleted: Int!
+            relationshipsDeleted: Int!
+          }
+
+          type IDAggregateSelection {
+            longest: ID!
+            shortest: ID!
+          }
+
+          type Movie {
+            actors(title: String): [Actor]
+            id: ID
+          }
+
+          type MovieAggregateSelection {
+            count: Int!
+            id: IDAggregateSelection!
+          }
+
+          input MovieCreateInput {
+            id: ID
+          }
+
+          input MovieOptions {
+            limit: Int
+            offset: Int
+            \\"\\"\\"Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.\\"\\"\\"
+            sort: [MovieSort]
+          }
+
+          \\"\\"\\"Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.\\"\\"\\"
+          input MovieSort {
+            id: SortDirection
+          }
+
+          input MovieUpdateInput {
+            id: ID
+          }
+
+          input MovieWhere {
+            AND: [MovieWhere!]
+            OR: [MovieWhere!]
+            id: ID
+            id_CONTAINS: ID
+            id_ENDS_WITH: ID
+            id_IN: [ID]
+            id_NOT: ID
+            id_NOT_CONTAINS: ID
+            id_NOT_ENDS_WITH: ID
+            id_NOT_IN: [ID]
+            id_NOT_STARTS_WITH: ID
+            id_STARTS_WITH: ID
+          }
+
+          type Mutation {
+            createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+            createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+            deleteActors(where: ActorWhere): DeleteInfo!
+            deleteMovies(where: MovieWhere): DeleteInfo!
+            updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+            updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+          }
+
+          type Query {
+            actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+            actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+            actorsCount(where: ActorWhere): Int!
+            movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+            moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+            moviesCount(where: MovieWhere): Int!
+          }
+
+          enum SortDirection {
+            \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+            ASC
+            \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+            DESC
+          }
+
+          type StringAggregateSelection {
+            longest: String!
+            shortest: String!
+          }
+
+          type UpdateActorsMutationResponse {
+            actors: [Actor!]!
+            info: UpdateInfo!
+          }
+
+          type UpdateInfo {
+            bookmark: String
+            nodesCreated: Int!
+            nodesDeleted: Int!
+            relationshipsCreated: Int!
+            relationshipsDeleted: Int!
+          }
+
+          type UpdateMoviesMutationResponse {
+            info: UpdateInfo!
+            movies: [Movie!]!
+          }
+          "
+      `);
+    });
 });

--- a/packages/graphql/tests/tck/tck-test-files/cypher/sort.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/sort.md
@@ -9,6 +9,13 @@ type Movie {
     id: ID
     title: String
     genres: [Genre] @relationship(type: "HAS_GENRE", direction: OUT)
+    totalGenres: Int!
+        @cypher(
+            statement: """
+            MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+            RETURN count(DISTINCT genre)
+            """
+        )
 }
 
 type Genre {
@@ -43,6 +50,40 @@ ORDER BY this.id DESC
 
 ```json
 {}
+```
+
+---
+
+## Simple Sort On Cypher Field
+
+### GraphQL Input
+
+```graphql
+{
+    movies(options: { sort: [{ totalGenres: DESC }] }) {
+        totalGenres
+    }
+}
+```
+
+### Expected Cypher Output
+
+```cypher
+MATCH (this:Movie)
+RETURN this { totalGenres: apoc.cypher.runFirstColumn("MATCH (this)-[:HAS_GENRE]->(genre:Genre) RETURN count(DISTINCT genre)", {this: this, auth: $auth}, false) } as this
+ORDER BY this.totalGenres DESC
+```
+
+### Expected Cypher Params
+
+```json
+{
+    "auth": {
+        "isAuthenticated": true,
+        "jwt": {},
+        "roles": []
+    }
+}
 ```
 
 ---

--- a/packages/graphql/tests/tck/tck-test-files/cypher/sort.md
+++ b/packages/graphql/tests/tck/tck-test-files/cypher/sort.md
@@ -35,9 +35,8 @@ type Genre {
 
 ```cypher
 MATCH (this:Movie)
-WITH this
-ORDER BY this.id DESC
 RETURN this { .title } as this
+ORDER BY this.id DESC
 ```
 
 ### Expected Cypher Params
@@ -64,9 +63,8 @@ RETURN this { .title } as this
 
 ```cypher
 MATCH (this:Movie)
-WITH this
-ORDER BY this.id DESC, this.title ASC
 RETURN this { .title } as this
+ORDER BY this.id DESC, this.title ASC
 ```
 
 ### Expected Cypher Params
@@ -111,9 +109,8 @@ query($title: String, $offset: Int, $limit: Int) {
 ```cypher
 MATCH (this:Movie)
 WHERE this.title = $this_title
-WITH this
-ORDER BY this.id DESC, this.title ASC
 RETURN this { .title } as this
+ORDER BY this.id DESC, this.title ASC
 SKIP $this_offset
 LIMIT $this_limit
 ```


### PR DESCRIPTION
# Description

Implementation of a proposal by @rcbevans to support sorting of `@cypher` fields that return a primitive field.

# Issue

- #474 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
