### PR TITLE
Fix missing subscription payload

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,6 +22,7 @@ const baseRules = {
     "no-param-reassign": "warn", // Dangerous to have this off (out-of-scope side effects are bad), but there are some valid reasons for violations (Array.reduce(), setting GraphQL context, etc.), so use comments to disable ESLint for these
     "max-classes-per-file": "off", // Stylistic decision - we can judge whether there are too many classes in one file during code review
     "eslint-comments/no-unused-disable": "error", // Turn on optional rule to report eslint-disable comments having no effect
+    "class-methods-use-this": "off"    
 };
 
 const typeScriptParser = {

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ e2e/fixtures/cache/
 
 test-api.ts
 packages/package-tests/**/package-lock.json
+scratchpad/
 
 .yarn/*
 !.yarn/patches

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -114,7 +114,7 @@ class Neo4jGraphQL {
         schema: GraphQLSchema;
         config: Neo4jGraphQLConfig;
     }): GraphQLSchema {
-        return addSchemaLevelResolver(schema, (_obj, _args, context: any, resolveInfo: GraphQLResolveInfo) => {
+        return addSchemaLevelResolver(schema, (obj, _args, context: any, resolveInfo: GraphQLResolveInfo) => {
             const { driverConfig } = config;
 
             if (debug.enabled) {
@@ -161,6 +161,7 @@ class Neo4jGraphQL {
             context.auth = createAuthParam({ context });
 
             context.queryOptions = config.queryOptions;
+            return obj;
         });
     }
 


### PR DESCRIPTION
# Description
Adds a return of the obj parameter, this seems to be the expected way of using addSchemaLevelResolver. Its omission was causing the missing results in subscription payload when using neo4j/graphql library

# Issue

#212 


It's important that changes are discussed in advance to make sure we choose the right solution and to avoid duplication of effort.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [X] CLA (https://neo4j.com/developer/cla/) has been signed
