### PR TITLE
fix: wrap auth sub clauses in parentheses to preserve precedence

### DIFF
--- a/packages/graphql/src/translate/create-auth-and-params.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.ts
@@ -22,7 +22,7 @@ import { Neo4jGraphQLAuthenticationError, Node } from "../classes";
 import { AuthOperations, BaseField, AuthRule, BaseAuthRule, Context } from "../types";
 import { AUTH_UNAUTHENTICATED_ERROR } from "../constants";
 import mapToDbProperty from "../utils/map-to-db-property";
-import joinPredicates from "../utils/join-predicates";
+import joinPredicates, { isPredicateJoin, PREDICATE_JOINS } from "../utils/join-predicates";
 
 interface Res {
     strs: string[];
@@ -73,7 +73,7 @@ function createAuthPredicate({
 
     const result = Object.entries(rule[kind] as any).reduce(
         (res: Res, [key, value]) => {
-            if (key === "AND" || key === "OR") {
+            if (isPredicateJoin(key)) {
                 const inner: string[] = [];
 
                 (value as any[]).forEach((v, i) => {
@@ -93,7 +93,7 @@ function createAuthPredicate({
                     res.params = { ...res.params, ...authPredicate[1] };
                 });
 
-                res.strs.push(joinPredicates(inner, key as "AND" | "OR"));
+                res.strs.push(joinPredicates(inner, key));
             }
 
             const authableField = node.authableFields.find((field) => field.fieldName === key);
@@ -225,9 +225,7 @@ function createAuthAndParams({
             { strs: [], params: {} }
         );
 
-        const filteredSubPredicates = subPredicates.strs.filter(Boolean);
-
-        return [joinPredicates(filteredSubPredicates, "OR"), subPredicates.params];
+        return [joinPredicates(subPredicates.strs, "OR"), subPredicates.params];
     }
 
     function createSubPredicate({
@@ -269,7 +267,7 @@ function createAuthAndParams({
             }
         }
 
-        ["AND", "OR"].forEach((key) => {
+        PREDICATE_JOINS.forEach((key) => {
             const value = authRule[key] as AuthRule["AND"] | AuthRule["OR"];
 
             if (!value) {
@@ -294,7 +292,7 @@ function createAuthAndParams({
                 predicateParams = { ...predicateParams, ...par };
             });
 
-            thisPredicates.push(joinPredicates(predicates, key as "AND" | "OR"));
+            thisPredicates.push(joinPredicates(predicates, key));
             thisParams = { ...thisParams, ...predicateParams };
         });
 
@@ -328,9 +326,7 @@ function createAuthAndParams({
         { strs: [], params: {} }
     );
 
-    const filteredSubPredicates = subPredicates.strs.filter(Boolean);
-
-    return [joinPredicates(filteredSubPredicates, "OR"), subPredicates.params];
+    return [joinPredicates(subPredicates.strs, "OR"), subPredicates.params];
 }
 
 export default createAuthAndParams;

--- a/packages/graphql/src/utils/join-predicates.test.ts
+++ b/packages/graphql/src/utils/join-predicates.test.ts
@@ -22,6 +22,26 @@ import trimmer from "./trimmer";
 
 describe("join predicates", () => {
     describe("AND", () => {
+        test("it should return empty for an empty predicate list", () => {
+            expect(joinPredicates([], "AND")).toBe("");
+        });
+
+        test("it should filter singular empty predicates", () => {
+            expect(joinPredicates([""], "AND")).toBe("");
+        });
+
+        test("it should filter multiple non-empty predicates", () => {
+            expect(joinPredicates(["", ""], "AND")).toBe("");
+        });
+
+        test("it should return singular non-empty predicates", () => {
+            expect(joinPredicates(["", "true", ""], "AND")).toBe("true");
+        });
+
+        test("it should join non-empty predicates", () => {
+            expect(joinPredicates(["", "true", "", "false"], "AND")).toBe("(true AND false)");
+        });
+
         test("it should return a single predicate as-is", () => {
             expect(joinPredicates(["true"], "AND")).toBe(trimmer("true"));
         });
@@ -36,6 +56,26 @@ describe("join predicates", () => {
     });
 
     describe("OR", () => {
+        test("it should return empty for an empty predicate list", () => {
+            expect(joinPredicates([], "OR")).toBe("");
+        });
+
+        test("it should filter singular empty predicates", () => {
+            expect(joinPredicates([""], "OR")).toBe("");
+        });
+
+        test("it should filter multiple non-empty predicates", () => {
+            expect(joinPredicates(["", ""], "OR")).toBe("");
+        });
+
+        test("it should return singular non-empty predicates", () => {
+            expect(joinPredicates(["", "true", ""], "OR")).toBe("true");
+        });
+
+        test("it should join non-empty predicates", () => {
+            expect(joinPredicates(["", "true", "", "false"], "OR")).toBe("((true) OR (false))");
+        });
+
         test("it should return a single predicate as-is", () => {
             expect(joinPredicates(["true"], "OR")).toBe(trimmer("true"));
         });

--- a/packages/graphql/src/utils/join-predicates.test.ts
+++ b/packages/graphql/src/utils/join-predicates.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import joinPredicates from "./join-predicates";
+import trimmer from "./trimmer";
+
+describe("join predicates", () => {
+    describe("AND", () => {
+        test("it should return a single predicate as-is", () => {
+            expect(joinPredicates(["true"], "AND")).toBe(trimmer("true"));
+        });
+
+        test("it should join predicates and wrap them in parentheses", () => {
+            expect(joinPredicates(["true", "false"], "AND")).toBe(trimmer("(true AND false)"));
+        });
+
+        test("it should work with an arbitrary number of predicates", () => {
+            expect(joinPredicates(["yes", "no", "maybe"], "AND")).toBe(trimmer("(yes AND no AND maybe)"));
+        });
+    });
+
+    describe("OR", () => {
+        test("it should return a single predicate as-is", () => {
+            expect(joinPredicates(["true"], "OR")).toBe(trimmer("true"));
+        });
+
+        test("it should wrap predicates in parentheses, then join, and wrap in outer parentheses", () => {
+            expect(joinPredicates(["true", "false"], "OR")).toBe(trimmer("((true) OR (false))"));
+        });
+
+        test("it should work with an arbitrary number of predicates", () => {
+            expect(joinPredicates(["yes", "no", "maybe"], "OR")).toBe(trimmer("((yes) OR (no) OR (maybe))"));
+        });
+    });
+});

--- a/packages/graphql/src/utils/join-predicates.ts
+++ b/packages/graphql/src/utils/join-predicates.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default function joinPredicates(predicates: string[], joinType: "AND" | "OR"): string {
+    if (predicates.length === 0) {
+        return "";
+    }
+
+    if (predicates.length === 1) {
+        return predicates[0];
+    }
+
+    return `(${
+        joinType === "AND" ? predicates.join(" AND ") : predicates.map((predicate) => `(${predicate})`).join(" OR ")
+    })`;
+}

--- a/packages/graphql/src/utils/join-predicates.ts
+++ b/packages/graphql/src/utils/join-predicates.ts
@@ -17,16 +17,28 @@
  * limitations under the License.
  */
 
-export default function joinPredicates(predicates: string[], joinType: "AND" | "OR"): string {
-    if (predicates.length === 0) {
+
+export const PREDICATE_JOINS = ["AND", "OR"] as const;
+export type PredicateJoin = typeof PREDICATE_JOINS[number];
+
+export function isPredicateJoin(value: string): value is PredicateJoin {
+    return ["AND", "OR"].includes(value);
+}
+
+export default function joinPredicates(predicates: string[], joinType: PredicateJoin): string {
+    const filteredPredicates = predicates.filter(Boolean);
+
+    if (filteredPredicates.length === 0) {
         return "";
     }
 
-    if (predicates.length === 1) {
-        return predicates[0];
+    if (filteredPredicates.length === 1) {
+        return filteredPredicates[0];
     }
 
     return `(${
-        joinType === "AND" ? predicates.join(" AND ") : predicates.map((predicate) => `(${predicate})`).join(" OR ")
+        joinType === "AND" 
+            ? filteredPredicates.join(" AND ") 
+            : filteredPredicates.map((predicate) => `(${predicate})`).join(" OR ")
     })`;
 }

--- a/packages/graphql/tests/integration/issues/505.int.test.ts
+++ b/packages/graphql/tests/integration/issues/505.int.test.ts
@@ -1,0 +1,876 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/550", () => {
+    let driver: Driver;
+    // Update to use _INCLUDES once https://github.com/neo4j/graphql/pull/500 is merged
+    const typeDefs = gql`
+    type Person {
+        id: ID! @id(autogenerate: false)
+
+        authId: String
+        
+        workspaces: [Workspace!] @relationship(type: "MEMBER_OF", direction: OUT)
+
+        adminOf: [Workspace!] @relationship(type: "HAS_ADMIN", direction: IN)
+
+        createdPages: [Page!] @relationship(type: "CREATED_PAGE", direction: OUT)
+    }
+
+    type Workspace @auth(rules: [
+        { 
+            operations: [READ],
+            where: { 
+                OR: [
+                    { members: { authId: """$jwt.sub""" } }
+                    { admins: { authId: """$jwt.sub""" } }
+                ]
+            }
+        }
+    ]) @exclude(operations: [CREATE, UPDATE]) {
+        id: ID! @id(autogenerate: false)
+
+        name: String!
+
+        members: [Person!] @relationship(type: "MEMBER_OF", direction: IN)
+
+        admins: [Person!] @relationship(type: "HAS_ADMIN", direction: OUT)
+
+        pages: [Page!] @relationship(type: "HAS_PAGE", direction: OUT)
+    }
+
+    type Page @auth(rules: [
+        {
+            operations: [READ],
+            where: {
+                OR: [ 
+                    { owner: { authId: """$jwt.sub""" } }, 
+                    { 
+                        AND: [ 
+                            { shared: true },
+                            { 
+                                workspace: {
+                                    OR: [
+                                        { members: { authId: """$jwt.sub""" } },
+                                        { admins: { authId: """$jwt.sub""" } },
+                                    ]
+                                }
+                            }
+                        ] 
+                    } 
+                ] 
+            }
+        }
+    ]) {
+        id: ID! @id(autogenerate: false)
+
+        shared: Boolean!
+
+        owner: Person! @relationship(type: "CREATED_PAGE", direction: IN)
+
+        workspace: Workspace! @relationship(type: "HAS_PAGE", direction: IN)
+    }
+    `;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("single user, single workspace, multiple pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userId = generate({ charset: "alphabetic" });
+        const workspaceId = generate({ charset: "alphabetic" });
+        const pageIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        await session.run(
+            `CREATE (u:Person {id: $userId, authId: $userId}),
+                (w:Workspace {id: $workspaceId}),
+                (p0:Page {id: $p0id}),
+                (p1:Page {id: $p1id}),
+                (u)-[:MEMBER_OF]->(w),
+                (w)-[:HAS_PAGE]->(p0),
+                (w)-[:HAS_PAGE]->(p1),
+                (u)-[:CREATED_PAGE]->(p0),
+                (u)-[:CREATED_PAGE]->(p1)
+            `,
+            { userId, workspaceId, p0id: pageIds[0], p1id: pageIds[1] }
+        );
+
+        const variableValues = {
+            userId,
+            workspaceId
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userId
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(2);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(2);
+
+            expect(mutationResult?.data?.pages).toHaveLength(2);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(2);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("single user, multiple workspaces, multiple pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userId = generate({ charset: "alphabetic" });
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        await session.run(
+            `CREATE (u:Person {id: $userId, authId: $userId}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id}),
+                (p1:Page {id: $p1id}),
+                (p2:Page {id: $p2id}),
+                (p3:Page {id: $p3id}),
+                (u)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (u)-[:CREATED_PAGE]->(p0),
+                (u)-[:CREATED_PAGE]->(p1),
+                (u)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u)-[:CREATED_PAGE]->(p2),
+                (u)-[:CREATED_PAGE]->(p3)
+            `,
+            { userId, w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId,
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userId
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(4);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(2);
+
+            expect(mutationResult?.data?.pages).toHaveLength(2);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(4);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("multiple users, multiple workspaces, multiple shared pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        // current relationship on where checks *all* nodes hold true
+        // so all members/admins of workspace must have matching jwt sub
+        // for now, don't add u0 as member of workspaces so constraint holds
+        await session.run(
+            `CREATE (u0:Person {id: $u0id, authId: $u0id}),
+                (u1:Person {id: $u1id, authId: $u1id}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id, shared: true}),
+                (p1:Page {id: $p1id, shared: true}),
+                (p2:Page {id: $p2id, shared: true}),
+                (p3:Page {id: $p3id, shared: true}),
+                // (u0)-[:MEMBER_OF]->(w1),
+                (u1)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (p1)-[:CREATED_PAGE]->(p0),
+                (u0)-[:CREATED_PAGE]->(p1),
+                // (u0)-[:MEMBER_OF]->(w2),
+                (u1)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u0)-[:CREATED_PAGE]->(p2),
+                (u0)-[:CREATED_PAGE]->(p3)
+            `,
+            { u0id: userIds[0], u1id: userIds[1], w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId: userIds[1],
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userIds[1]
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(0);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(2);
+
+            expect(mutationResult?.data?.pages).toHaveLength(2);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(4);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("multiple users, multiple workspaces, multiple mixed shared pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        // current relationship on where checks *all* nodes hold true
+        // so all members/admins of workspace must have matching jwt sub
+        // for now, don't add u0 as member of workspaces so constraint holds
+        await session.run(
+            `CREATE (u0:Person {id: $u0id, authId: $u0id}),
+                (u1:Person {id: $u1id, authId: $u1id}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id, shared: true}),
+                (p1:Page {id: $p1id, shared: false}),
+                (p2:Page {id: $p2id, shared: true}),
+                (p3:Page {id: $p3id, shared: false}),
+                // (u0)-[:MEMBER_OF]->(w1),
+                (u1)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (p1)-[:CREATED_PAGE]->(p0),
+                (u0)-[:CREATED_PAGE]->(p1),
+                // (u0)-[:MEMBER_OF]->(w2),
+                (u1)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u0)-[:CREATED_PAGE]->(p2),
+                (u0)-[:CREATED_PAGE]->(p3)
+            `,
+            { u0id: userIds[0], u1id: userIds[1], w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId: userIds[1],
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userIds[1]
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(0);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(1);
+
+            expect(mutationResult?.data?.pages).toHaveLength(1);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(2);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("multiple users, multiple workspaces, multiple private pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        // current relationship on where checks *all* nodes hold true
+        // so all members/admins of workspace must have matching jwt sub
+        // for now, don't add u0 as member of workspaces so constraint holds
+        await session.run(
+            `CREATE (u0:Person {id: $u0id, authId: $u0id}),
+                (u1:Person {id: $u1id, authId: $u1id}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id, shared: false}),
+                (p1:Page {id: $p1id, shared: false}),
+                (p2:Page {id: $p2id, shared: false}),
+                (p3:Page {id: $p3id, shared: false}),
+                // (u0)-[:MEMBER_OF]->(w1),
+                (u1)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (p1)-[:CREATED_PAGE]->(p0),
+                (u0)-[:CREATED_PAGE]->(p1),
+                // (u0)-[:MEMBER_OF]->(w2),
+                (u1)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u0)-[:CREATED_PAGE]->(p2),
+                (u0)-[:CREATED_PAGE]->(p3)
+            `,
+            { u0id: userIds[0], u1id: userIds[1], w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId: userIds[1],
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userIds[1]
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(0);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(0);
+
+            expect(mutationResult?.data?.pages).toHaveLength(0);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(0);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("multiple users, multiple workspaces where not member, multiple shared pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        // current relationship on where checks *all* nodes hold true
+        // so all members/admins of workspace must have matching jwt sub
+        // for now, don't add u0 as member of workspaces so constraint holds
+        await session.run(
+            `CREATE (u0:Person {id: $u0id, authId: $u0id}),
+                (u1:Person {id: $u1id, authId: $u1id}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id, shared: true}),
+                (p1:Page {id: $p1id, shared: true}),
+                (p2:Page {id: $p2id, shared: true}),
+                (p3:Page {id: $p3id, shared: true}),
+                (u0)-[:MEMBER_OF]->(w1),
+                // (u1)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (p1)-[:CREATED_PAGE]->(p0),
+                (u0)-[:CREATED_PAGE]->(p1),
+                (u0)-[:MEMBER_OF]->(w2),
+                // (u1)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u0)-[:CREATED_PAGE]->(p2),
+                (u0)-[:CREATED_PAGE]->(p3)
+            `,
+            { u0id: userIds[0], u1id: userIds[1], w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId: userIds[1],
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userIds[1]
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(0);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(0);
+
+            expect(mutationResult?.data?.pages).toHaveLength(0);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(0);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("multiple users, multiple workspaces with partial membership, multiple shared pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        // current relationship on where checks *all* nodes hold true
+        // so all members/admins of workspace must have matching jwt sub
+        // for now, don't add u0 as member of workspaces so constraint holds
+        await session.run(
+            `CREATE (u0:Person {id: $u0id, authId: $u0id}),
+                (u1:Person {id: $u1id, authId: $u1id}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id, shared: true}),
+                (p1:Page {id: $p1id, shared: true}),
+                (p2:Page {id: $p2id, shared: true}),
+                (p3:Page {id: $p3id, shared: true}),
+                // (u0)-[:MEMBER_OF]->(w1),
+                (u1)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (p1)-[:CREATED_PAGE]->(p0),
+                (u0)-[:CREATED_PAGE]->(p1),
+                (u0)-[:MEMBER_OF]->(w2),
+                // (u1)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u0)-[:CREATED_PAGE]->(p2),
+                (u0)-[:CREATED_PAGE]->(p3)
+            `,
+            { u0id: userIds[0], u1id: userIds[1], w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId: userIds[1],
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userIds[1]
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(0);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(2);
+
+            expect(mutationResult?.data?.pages).toHaveLength(2);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(2);
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("multiple users, multiple workspaces with partial membership, multiple mixed shared pages", async () => {
+        const session = driver.session();
+        const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+        const userIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const workspaceIds = Array(2).fill(0).map(() => generate({ charset: "alphabetic" }));
+        const pageIds = Array(4).fill(0).map(() => generate({ charset: "alphabetic" }));
+
+        // current relationship on where checks *all* nodes hold true
+        // so all members/admins of workspace must have matching jwt sub
+        // for now, don't add u0 as member of workspaces so constraint holds
+        await session.run(
+            `CREATE (u0:Person {id: $u0id, authId: $u0id}),
+                (u1:Person {id: $u1id, authId: $u1id}),
+                (w1:Workspace {id: $w0id}),
+                (w2:Workspace {id: $w1id}),
+                (p0:Page {id: $p0id, shared: false}),
+                (p1:Page {id: $p1id, shared: false}),
+                (p2:Page {id: $p2id, shared: true}),
+                (p3:Page {id: $p3id, shared: true}),
+                // (u0)-[:MEMBER_OF]->(w1),
+                (u1)-[:MEMBER_OF]->(w1),
+                (w1)-[:HAS_PAGE]->(p0),
+                (w1)-[:HAS_PAGE]->(p1),
+                (p1)-[:CREATED_PAGE]->(p0),
+                (u0)-[:CREATED_PAGE]->(p1),
+                (u0)-[:MEMBER_OF]->(w2),
+                // (u1)-[:MEMBER_OF]->(w2),
+                (w2)-[:HAS_PAGE]->(p2),
+                (w2)-[:HAS_PAGE]->(p3),
+                (u0)-[:CREATED_PAGE]->(p2),
+                (u0)-[:CREATED_PAGE]->(p3)
+            `,
+            { u0id: userIds[0], u1id: userIds[1], w0id: workspaceIds[0], w1id: workspaceIds[1], p0id: pageIds[0], p1id: pageIds[1], p2id: pageIds[2], p3id: pageIds[3] }
+        );
+
+        const variableValues = {
+            userId: userIds[1],
+            workspaceId: workspaceIds[0],
+        };
+
+        const mutation = `
+            query PeopleWorkspaceAndPages($userId: ID!, $workspaceId: ID!) {
+                people(where: { id: $userId } ) {
+                    createdPages {
+                        id
+                    }
+                }
+                
+                workspaces(where: { id: $workspaceId })
+                {
+                    pages {
+                        id
+                    }
+                }
+
+                pages(where: { workspace: { id: $workspaceId } } ) {
+                    id
+                }
+
+                allPages: pages {
+                    id
+                }
+            }
+        `;
+
+        try {
+            await neoSchema.checkNeo4jCompat();
+
+            const mutationResult = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { 
+                    driver,
+                    driverConfig: {
+                        bookmarks: session.lastBookmark() 
+                    },
+                    jwt: {
+                        sub: userIds[1]
+                    }
+                },
+                variableValues,
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+
+            expect(mutationResult?.data?.people).toHaveLength(1);
+            expect(mutationResult?.data?.people[0]?.createdPages).toHaveLength(0);
+
+            expect(mutationResult?.data?.workspaces).toHaveLength(1);
+            expect(mutationResult?.data?.workspaces[0]?.pages).toHaveLength(0);
+
+            expect(mutationResult?.data?.pages).toHaveLength(0);
+            
+            expect(mutationResult?.data?.allPages).toHaveLength(0);
+        } finally {
+            await session.close();
+        }
+    });
+});


### PR DESCRIPTION
# Description

Complex auth rules, combined with where filters can generate cypher queries with invalid predicate precedence which evaluate incorrectly.

Type definitions

simplified for readability

```
type Person {
    id: ID! @id(autogenerate: false)

    authId: String
    
    workspaces: [Workspace] @relationship(type: "MEMBER_OF", direction: OUT)

    adminOf: [Workspace] @relationship(type: "HAS_ADMIN", direction: IN)
}

type Workspace @auth(rules: [
    { 
        operations: [READ],
        roles: ["""member"""],
        where: { 
            OR: [
                { members_INCLUDES: { authId: """$jwt.sub""" } }
                { admins_INCLUDES: { authId: """$jwt.sub""" } }
            ]
        }
    },
    {
        operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE ]
        roles: ["""admin"""]
    },
]) @exclude(operations: [CREATE, UPDATE]) {
    id: ID! @id(autogenerate: false)

    name: String!

    members: [Person!] @relationship(type: "MEMBER_OF", direction: IN)
    admins: [Person!] @relationship(type: "HAS_ADMIN", direction: OUT)

    pages: [Page!] @relationship(type: "HAS_PAGE", direction: OUT)
}

type Page implements AccountOrPageInterface @auth(rules: [
    { 
        operations: [READ], 
        roles: ["""member"""], 
        where: {
            OR: [ 
                { owner: { authId: """$jwt.sub""" } }, 
                { 
                    AND: [ 
                        { shared: true },
                        { workspace: { members_INCLUDES: { authId: """$jwt.sub""" } } },
                    ] 
                } 
            ] 
        } 
    },
    {
        operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE ]
        roles: ["""admin"""] 
    },
]) {
    id: ID! @id(autogenerate: false)

    name: String!
    shared: Boolean!

    owner: Person! @relationship(type: "CREATED_PAGE", direction: IN)

    workspace: Workspace! @relationship(type: "HAS_PAGE", direction: IN)
}
```

To Reproduce
execute a GraphQL query

```
query Pages($pagesWhere: PageWhere) {
    pages(where: $pagesWhere) {
        id
        name
    }
}
```

with a where filter on the workspace id

```
{
  "pagesWhere": {
    "workspace": {
      "id": "workspace_id"
    }
  }
}
```

The library generates the cypher:

```
MATCH (this:Page)
WHERE EXISTS((this)<-[:HAS_PAGE]-(:Workspace)) AND ANY(this_workspace IN [(this)<-[:HAS_PAGE]-(this_workspace:Workspace) | this_workspace] WHERE this_workspace.id = $this_workspace_id) AND ANY(r IN ["member"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND (EXISTS((this)<-[:CREATED_PAGE]-(:Person)) AND  ALL(owner IN [(this)<-[:CREATED_PAGE]-(owner:Person) | owner] WHERE owner.authId IS NOT NULL AND owner.authId = $this_auth_where0_OR0_owner_authId) OR (this.shared IS NOT NULL AND this.shared = $this_auth_where0_OR1_AND0_shared AND EXISTS((this)<-[:HAS_PAGE]-(:Workspace)) AND  ALL(workspace IN [(this)<-[:HAS_PAGE]-(workspace:Workspace) | workspace] WHERE EXISTS((workspace)<-[:MEMBER_OF]-(:Person)) AND  ANY(members IN [(workspace)<-[:MEMBER_OF]-(members:Person) | members] WHERE members.authId IS NOT NULL AND members.authId = $this_auth_where0_OR1_AND1_workspace_members_INCLUDES_authId)))) OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))
CALL apoc.util.validate(NOT(ANY(r IN ["member"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) OR ANY(r IN ["admin"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), "@neo4j/graphql/FORBIDDEN", [0])
RETURN this { .id, .name } as this
```

Note the lack of parentheses around conjoined AND and OR statements.

In the case of simple rules, where all clauses are AND'ed there is no problem, but when there are rules being OR'ed together, the lack of parentheses causes the predicates to evaluate incorrectly yielding in incorrect results.

Expected behavior
All predicates should be wrapped in parentheses to ensure that precedence is explicit and the cypher evaluates correctly.

Screenshots
If applicable, add screenshots to help explain your problem.

The example here is using the latest @pandaai/graphql-fork package which consists of master combined with #501 , #500, #495, and #490 but the issue exists in master.

See create-auth-and-params.ts#L165, create-auth-and-params.ts#L227, create-auth-and-params.ts#L296, create-auth-and-params.ts#L315, create-auth-and-params.ts#L315

Updating these locations to wrap the joined strings in parentheses maintains precedence and allows the generated cypher to produce semantically correct results.

In order to minimize noise in this change, I have specifically targeted `OR` joins which would be evaluated incorrectly.  Auth clauses generated by create-auth-and-params are wrapped in parentheses when joining, and `OR` joins have the predicates they join wrapped in addition.

# Issue

#505

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
