### PR TITLE
Remove Node casting in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ e2e/fixtures/cache/
 
 test-api.ts
 packages/package-tests/**/package-lock.json
+scratchpad/
 
 .yarn/*
 !.yarn/patches

--- a/packages/graphql/src/schema/resolvers/count.test.ts
+++ b/packages/graphql/src/schema/resolvers/count.test.ts
@@ -20,8 +20,8 @@
 const executeMock = jest.fn();
 
 /* eslint-disable import/first */
-import { Node } from "../../classes";
 import countResolver from "./count";
+import { NodeBuilder } from "../../utils/test";
 /* eslint-enable import/first */
 
 jest.mock("../../translate", () => {
@@ -38,10 +38,9 @@ jest.mock("../../utils", () => {
 
 describe("Count resolver", () => {
     test("should return the correct; type, args and resolve", () => {
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
-        };
+        }).instance();
 
         const result = countResolver({ node });
         expect(result.type).toEqual("Int!");
@@ -52,10 +51,9 @@ describe("Count resolver", () => {
     });
 
     test("should resolve correctly for a plain number", async () => {
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
-        };
+        }).instance();
 
         const result = countResolver({ node });
 
@@ -75,10 +73,9 @@ describe("Count resolver", () => {
     });
 
     test("should resolve correctly for a Neo4j Integer", async () => {
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
-        };
+        }).instance();
 
         const result = countResolver({ node });
 

--- a/packages/graphql/src/schema/resolvers/delete.test.ts
+++ b/packages/graphql/src/schema/resolvers/delete.test.ts
@@ -17,17 +17,15 @@
  * limitations under the License.
  */
 
-import { Node } from "../../classes";
 import deleteResolver from "./delete";
+import { NodeBuilder } from "../../utils/test";
 
 describe("Delete resolver", () => {
     test("should return the correct; type, args and resolve", () => {
-        // @ts-ignore
-        const node: Node = {
-            // @ts-ignore
+        const node = new NodeBuilder({
             name: "Movie",
             relationFields: [],
-        };
+        }).instance();
 
         const result = deleteResolver({ node });
         expect(result.type).toEqual(`DeleteInfo!`);

--- a/packages/graphql/src/schema/resolvers/read.test.ts
+++ b/packages/graphql/src/schema/resolvers/read.test.ts
@@ -17,16 +17,14 @@
  * limitations under the License.
  */
 
-import { Node } from "../../classes";
+import { NodeBuilder } from "../../utils/test";
 import findResolver from "./read";
 
 describe("Read resolver", () => {
     test("should return the correct; type, args and resolve", () => {
-        // @ts-ignore
-        const node: Node = {
-            // @ts-ignore
+        const node = new NodeBuilder({
             name: "Movie",
-        };
+        }).instance();
 
         const result = findResolver({ node });
         expect(result.type).toEqual(`[Movie!]!`);

--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -19,8 +19,9 @@
 
 import { generate } from "randomstring";
 import createAuthAndParams from "./create-auth-and-params";
-import { Neo4jGraphQL, Node } from "../classes";
+import { Neo4jGraphQL } from "../classes";
 import { trimmer } from "../utils";
+import { NodeBuilder } from "../utils/test";
 
 describe("createAuthAndParams", () => {
     describe("operations", () => {
@@ -51,19 +52,9 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [
                         { allow: { id: "$jwt.sub" } },
@@ -72,7 +63,7 @@ describe("createAuthAndParams", () => {
                     ],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -133,24 +124,14 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [{ allow: { id: "$jwt.sub" } }, { roles: ["admin"] }],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -211,24 +192,14 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [{ allow: { id: "$jwt.sub" }, roles: ["admin"] }],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -292,24 +263,14 @@ describe("createAuthAndParams", () => {
                     arguments: [],
                 };
 
-                // @ts-ignore
-                const node: Node = {
+                const node = new NodeBuilder({
                     name: "Movie",
-                    relationFields: [],
-                    cypherFields: [],
-                    enumFields: [],
-                    scalarFields: [],
                     primitiveFields: [idField],
-                    temporalFields: [],
-                    interfaceFields: [],
-                    objectFields: [],
-                    pointFields: [],
-                    authableFields: [idField],
                     auth: {
                         rules: [{ [key]: [{ allow: { id: "$jwt.sub" } }, { roles: ["admin"] }] }],
                         type: "JWT",
                     },
-                };
+                }).instance();
 
                 // @ts-ignore
                 const neoSchema: Neo4jGraphQL = {
@@ -371,19 +332,9 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [
                         {
@@ -395,7 +346,7 @@ describe("createAuthAndParams", () => {
                     ],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -467,13 +418,8 @@ describe("createAuthAndParams", () => {
                     arguments: [],
                 };
 
-                // @ts-ignore
-                const node: Node = {
+                const node = new NodeBuilder({
                     name: "Movie",
-                    relationFields: [],
-                    cypherFields: [],
-                    enumFields: [],
-                    scalarFields: [],
                     primitiveFields: [
                         idField,
                         {
@@ -502,16 +448,11 @@ describe("createAuthAndParams", () => {
                             arguments: [],
                         },
                     ],
-                    temporalFields: [],
-                    interfaceFields: [],
-                    objectFields: [],
-                    pointFields: [],
-                    authableFields: [idField],
                     auth: {
                         rules: [{ allow: { [key]: [{ id: "$jwt.sub" }, { id: "$jwt.sub" }, { id: "$jwt.sub" }] } }],
                         type: "JWT",
                     },
-                };
+                }).instance();
 
                 // @ts-ignore
                 const neoSchema: Neo4jGraphQL = {
@@ -577,19 +518,9 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [
                         { allow: { id: "$jwt.sub" } },
@@ -598,7 +529,7 @@ describe("createAuthAndParams", () => {
                     ],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -645,19 +576,9 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [
                         { allow: { id: "$context.nop" } },
@@ -666,7 +587,7 @@ describe("createAuthAndParams", () => {
                     ],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -713,19 +634,9 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [
                         { allow: { id: "$jwt.sub" }, allowUnauthenticated: true },
@@ -734,7 +645,7 @@ describe("createAuthAndParams", () => {
                     ],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {
@@ -784,19 +695,9 @@ describe("createAuthAndParams", () => {
                 arguments: [],
             };
 
-            // @ts-ignore
-            const node: Node = {
+            const node = new NodeBuilder({
                 name: "Movie",
-                relationFields: [],
-                cypherFields: [],
-                enumFields: [],
-                scalarFields: [],
                 primitiveFields: [idField],
-                temporalFields: [],
-                interfaceFields: [],
-                objectFields: [],
-                pointFields: [],
-                authableFields: [idField],
                 auth: {
                     rules: [
                         { allow: { id: "$context.nop" }, allowUnauthenticated: true },
@@ -805,7 +706,7 @@ describe("createAuthAndParams", () => {
                     ],
                     type: "JWT",
                 },
-            };
+            }).instance();
 
             // @ts-ignore
             const neoSchema: Neo4jGraphQL = {

--- a/packages/graphql/src/translate/create-projection-and-params.test.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.test.ts
@@ -18,8 +18,9 @@
  */
 
 import createProjectionAndParams from "./create-projection-and-params";
-import { Neo4jGraphQL, Node } from "../classes";
+import { Neo4jGraphQL } from "../classes";
 import { Context } from "../types";
+import { NodeBuilder } from "../utils/test";
 
 describe("createProjectionAndParams", () => {
     test("should be a function", () => {
@@ -38,15 +39,9 @@ describe("createProjectionAndParams", () => {
             },
         };
 
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
-            relationFields: [],
-            connectionFields: [],
-            cypherFields: [],
-            enumFields: [],
-            unionFields: [],
-            scalarFields: [],
+
             primitiveFields: [
                 {
                     fieldName: "title",
@@ -68,13 +63,7 @@ describe("createProjectionAndParams", () => {
                     arguments: [],
                 },
             ],
-            temporalFields: [],
-            pointFields: [],
-            interfaceFields: [],
-            objectFields: [],
-            authableFields: [],
-            mutableFields: [],
-        };
+        }).instance();
 
         // @ts-ignore
         const neoSchema: Neo4jGraphQL = {

--- a/packages/graphql/src/translate/create-update-and-params.test.ts
+++ b/packages/graphql/src/translate/create-update-and-params.test.ts
@@ -18,9 +18,10 @@
  */
 
 import createUpdateAndParams from "./create-update-and-params";
-import { Neo4jGraphQL, Node } from "../classes";
+import { Neo4jGraphQL } from "../classes";
 import { Context } from "../types";
 import { trimmer } from "../utils";
+import { NodeBuilder } from "../utils/test";
 
 describe("createUpdateAndParams", () => {
     test("should return the correct update and params", () => {
@@ -50,22 +51,10 @@ describe("createUpdateAndParams", () => {
             arguments: [],
         };
 
-        // @ts-ignore
-        const node: Node = {
+        const node = new NodeBuilder({
             name: "Movie",
-            relationFields: [],
-            cypherFields: [],
-            enumFields: [],
-            unionFields: [],
-            scalarFields: [],
             primitiveFields: [idField],
-            temporalFields: [],
-            interfaceFields: [],
-            objectFields: [],
-            pointFields: [],
-            mutableFields: [idField],
-            authableFields: [],
-        };
+        }).instance();
 
         // @ts-ignore
         const neoSchema: Neo4jGraphQL = {

--- a/packages/graphql/src/translate/create-where-and-params.test.ts
+++ b/packages/graphql/src/translate/create-where-and-params.test.ts
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-import { Node } from "../classes";
 import createWhereAndParams from "./create-where-and-params";
 import { Context } from "../types";
+import { NodeBuilder } from "../utils/test";
 
 describe("createWhereAndParams", () => {
     test("should be a function", () => {
@@ -33,21 +33,7 @@ describe("createWhereAndParams", () => {
 
         const varName = "this";
 
-        // @ts-ignore
-        const node: Node = {
-            relationFields: [],
-            cypherFields: [],
-            enumFields: [],
-            scalarFields: [],
-            primitiveFields: [],
-            temporalFields: [],
-            interfaceFields: [],
-            unionFields: [],
-            objectFields: [],
-            pointFields: [],
-            otherDirectives: [],
-            interfaces: [],
-        };
+        const node = new NodeBuilder().instance();
 
         // @ts-ignore
         const context: Context = { neoSchema: { nodes: [] } };

--- a/packages/graphql/src/utils/test/node-builder.ts
+++ b/packages/graphql/src/utils/test/node-builder.ts
@@ -22,7 +22,7 @@ import { NodeConstructor, Node } from "../../classes";
 export default class NodeBuilder {
     private options: NodeConstructor;
 
-    constructor(newOptions: Partial<NodeConstructor>) {
+    constructor(newOptions: Partial<NodeConstructor> = {}) {
         this.options = {
             name: "",
             relationFields: [],


### PR DESCRIPTION
# Description
Using NodeBuilder in tests we can avoid typecasting and remove several mock properties
