### PR TITLE
Fix access-control.adoc operations field for @exclude directive

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/access-control.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/access-control.adoc
@@ -69,7 +69,7 @@ type User @exclude {
 
 [source, graphql, indent=0]
 ----
-type User @exclude(operation: [CREATE, READ, UPDATE, DELETE]) {
+type User @exclude(operations: [CREATE, READ, UPDATE, DELETE]) {
     name: String
 }
 ----


### PR DESCRIPTION
# Description

Fixes the documentation for the `operations` argument in `@exclude` directive.

# Issue

#522 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
