### PR TITLE
Update custom-resolvers.adoc

### DIFF
--- a/docs/modules/ROOT/pages/ogm/examples/custom-resolvers.adoc
+++ b/docs/modules/ROOT/pages/ogm/examples/custom-resolvers.adoc
@@ -77,7 +77,7 @@ const resolvers = {
             return createJWT({ sub: user.id });
         },
         signIn: async (_source, { username, password }) => {
-            const [user] = await User.find({
+            const user = await User.find({
                 where: {
                     username,
                 },


### PR DESCRIPTION
Extra brackets in const [user] = await User.create({... were leading to the following error message: "(intermediate value) is not iterable"

# Description

Remove the brackets so that the final line is : "const user = await User.create({... "

# Issue

Please provide a link to the GitHub issue in which the proposal for this work was discussed. 

It's important that changes are discussed in advance to make sure we choose the right solution and to avoid duplication of effort.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
