### PR TITLE
Test the right thing in multi-database integration tests

### DIFF
--- a/packages/graphql/tests/integration/multi-database.int.test.ts
+++ b/packages/graphql/tests/integration/multi-database.int.test.ts
@@ -54,7 +54,11 @@ describe("multi-database", () => {
                 if (e.message.includes("Unsupported administration command")) {
                     // No multi-db support, so we skip tests
                     MULTIDB_SUPPORT = false;
+                } else {
+                    throw e;
                 }
+            } else {
+                throw e;
             }
         }
     });


### PR DESCRIPTION
# Description

Currently the tests are passing but for the wrong reason.

We need to specify _something_ (an object) as `contextValue` when using `graphql` from `graphql` directly, otherwise the context in the resolvers are undefined.

I've added both negative and positive tests now as well to make sure we don't introduce any regressions in this area.