### PR TITLE
Fix typo in example

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/relationships.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/relationships.adoc
@@ -97,7 +97,7 @@ mutation CreateMovieAndDirector {
                 create: {
                     node: {
                         name: "Robert Zemeckis"
-                        born: 1951s
+                        born: 1951
                     }
                 }
             }


### PR DESCRIPTION
# Description

Fixed a typo in a graphql example, where a year was listed as `1951s` rather than `1951`. Likely just a typo. Saw it while reading through the docs.

# Issue

I didn't create an issue for this because it seems a typo did not require one.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] ~~TCK tests have been updated~~ N/A (I think)
- [x] ~~Integration tests have been updated~~ N/A (I think)
- [x] ~~Example applications have been updated~~ N/A (I think)
- [x] ~~New files have copyright header~~ N/A
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
