### PR TITLE
Check for new error that's cropping up in AuraDB

### DIFF
--- a/packages/graphql/tests/integration/assert-indexes-and-constraints.int.test.ts
+++ b/packages/graphql/tests/integration/assert-indexes-and-constraints.int.test.ts
@@ -42,7 +42,12 @@ describe("assertIndexesAndConstraints", () => {
             await session.run(cypher);
         } catch (e) {
             if (e instanceof Error) {
-                if (e.message.includes(`Neo4jError: Unsupported administration command: ${cypher}`)) {
+                if (
+                    e.message.includes(
+                        "Neo4jError: This is an administration command and it should be executed against the system database: CREATE DATABASE"
+                    ) ||
+                    e.message.includes(`Neo4jError: Unsupported administration command: ${cypher}`)
+                ) {
                     // No multi-db support, so we skip tests
                     MULTIDB_SUPPORT = false;
                 } else {

--- a/packages/graphql/tests/integration/multi-database.int.test.ts
+++ b/packages/graphql/tests/integration/multi-database.int.test.ts
@@ -51,7 +51,12 @@ describe("multi-database", () => {
             await waitSession.close();
         } catch (e) {
             if (e instanceof Error) {
-                if (e.message.includes("Unsupported administration command")) {
+                if (
+                    e.message.includes(
+                        "Neo4jError: This is an administration command and it should be executed against the system database: CREATE DATABASE"
+                    ) ||
+                    e.message.includes("Unsupported administration command")
+                ) {
                     // No multi-db support, so we skip tests
                     MULTIDB_SUPPORT = false;
                 } else {


### PR DESCRIPTION
# Description

We seem to be encountering a different error in AuraDB when trying to create a database for test purposes:

```Neo4jError: This is an administration command and it should be executed against the system database: CREATE DATABASE```

This checks also for this when setting the `MULTIDB_SUPPORT` flag.
