### PR TITLE
Added OpenID Json Web Key Sets for verification via the @auth directive

### DIFF
--- a/docs/markdown/DEVELOPING.md
+++ b/docs/markdown/DEVELOPING.md
@@ -31,7 +31,7 @@ git@github.com:USERNAME/graphql.git
 You will then need to add our repository as an upstream:
 
 ```bash
-git add remote upstream git@github.com/neo4j/graphql.git
+git remote add upstream git@github.com:neo4j/graphql.git
 ```
 
 You can then fetch and merge from the upstream to keep in sync.

--- a/docs/modules/ROOT/pages/auth/setup.adoc
+++ b/docs/modules/ROOT/pages/auth/setup.adoc
@@ -3,13 +3,31 @@
 
 == Configuration
 
-If you want the Neo4j GraphQL Library to perform JWT decoding and verification for you, you must pass the configuration option `jwt` into the `Neo4jGraphQL` or `OGM` constructor, which has the following arguments:
+If you want the Neo4j GraphQL Library to perform JWT decoding and verification for you, you must pass the configuration option `jwt` into the `Neo4jGraphQL` or `OGM` constructor, which has EITHER of the following arguments:
 
-- `secret` - The secret to be used to decode and verify JWTs
+- `jwksEndpoint` (recomended) - The OpenID Public Key Endpoint that verifies the JWT. The https://auth0.com/docs/security/tokens/json-web-tokens/json-web-key-sets[JSON Web Key Sets] used under the OpenID Configuration is typically stored at an endpoint similar to \https://YOUR_DOMAIN/.well-known/jwks.json
+- `secret` - The secret to be used to decode and verify JWTs. Either the secret or the PEM encoded public key used to verify the JWT.
+
+Optional arguments:
+
 - `noVerify` (optional) - Disable verification of JWTs, defaults to _false_
 - `rolesPath` (optional) - A string key to specify where to find roles in the JWT, defaults to "roles"
 
-The simplest construction of a `Neo4jGraphQL` instance would be:
+The recommended construction of a `Neo4jGraphQL` instance would be:
+
+[source, javascript, indent=0]
+----
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    config: {
+        jwt: {
+            jwksEndpoint: "https://YOUR_DOMAIN/.well-known/jwks.json"
+        }
+    }
+});
+----
+
+Another valid construction could be:
 
 [source, javascript, indent=0]
 ----
@@ -22,6 +40,7 @@ const neoSchema = new Neo4jGraphQL({
     }
 });
 ----
+
 
 It is also possible to pass in JWTs which have already been decoded, in which case the `jwt` option is _not necessary_. This is covered in the section xref::auth/setup.adoc#auth-setup-passing-in[Passing in JWTs] below.
 
@@ -46,8 +65,8 @@ const neoSchema = new Neo4jGraphQL({
     typeDefs,
     config: {
         jwt: {
-            secret,
-            rolesPath: "https://auth0.mysite.com/claims\\.https://auth0.mysite.com/claims/roles"
+            jwksEndpoint: "https://YOUR_DOMAIN/.well-known/jwks.json",
+            rolesPath: "https://YOUR_DOMAIN/claims\\.https://YOUR_DOMAIN/claims/roles"
         }
     }
 });

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -72,6 +72,7 @@
         "graphql-parse-resolve-info": "^4.12.0",
         "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",
+        "jwks-rsa": "^2.0.5",
         "pluralize": "^8.0.0",
         "semver": "^7.3.5"
     },

--- a/packages/graphql/src/auth/get-jwt.ts
+++ b/packages/graphql/src/auth/get-jwt.ts
@@ -76,7 +76,7 @@ function getJWT(context: Context): any {
             // Create a JWK Client with a rate limit that
             // limits the number of calls to our JWK endpoint
             client = new JwksClient({
-                jwksUri: jwtConfig.jwkEndpoint || "",
+                jwksUri: jwtConfig.jwkEndpoint,
                 rateLimit: true,
                 jwksRequestsPerMinute: 10, // Default Value
                 cache: true, // Default Value

--- a/packages/graphql/src/auth/get-jwt.ts
+++ b/packages/graphql/src/auth/get-jwt.ts
@@ -19,6 +19,7 @@
 
 import { IncomingMessage } from "http";
 import jsonwebtoken from "jsonwebtoken";
+import { JwksClient } from "jwks-rsa";
 import Debug from "debug";
 import { Context } from "../types";
 import { DEBUG_AUTH } from "../constants";
@@ -28,6 +29,7 @@ const debug = Debug(DEBUG_AUTH);
 function getJWT(context: Context): any {
     const jwtConfig = context.neoSchema.config?.jwt;
     let result;
+    let client;
 
     if (!jwtConfig) {
         debug("JWT not configured");
@@ -68,8 +70,33 @@ function getJWT(context: Context): any {
             debug("Skipping verifying JWT as noVerify is not set");
 
             result = jsonwebtoken.decode(token);
-        } else {
-            debug("Verifying JWT");
+        } else if (jwtConfig.jwkEndpoint) {
+            debug("Verifying JWT using OpenID Public Key Endpoint");
+
+            // Create a JWK Client with a rate limit that
+            // limits the number of calls to our JWK endpoint
+            client = new JwksClient({
+                jwksUri: jwtConfig.jwkEndpoint || "",
+                rateLimit: true,
+                jwksRequestsPerMinute: 10, // Default Value
+                cache: true, // Default Value
+                cacheMaxEntries: 5, // Default value
+                cacheMaxAge: 600000, // Defaults to 10m
+            });
+
+            /* eslint-disable-next-line no-inner-declarations */
+            function getKey(header, callback) {
+                client.getSigningKey(header.kid, function (err, key) {
+                    const signingKey = key.getPublicKey();
+                    callback(null, signingKey);
+                });
+            }
+
+            result = jsonwebtoken.verify(token, getKey, {
+                algorithms: ["HS256", "RS256"],
+            });
+        } else if (jwtConfig.secret) {
+            debug("Verifying JWT using secret");
 
             result = jsonwebtoken.verify(token, jwtConfig.secret, {
                 algorithms: ["HS256", "RS256"],

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -38,7 +38,8 @@ import assertIndexesAndConstraints, {
 const debug = Debug(DEBUG_GRAPHQL);
 
 export interface Neo4jGraphQLJWT {
-    secret: string;
+    jwkEndpoint?: string;
+    secret?: string;
     noVerify?: boolean;
     rolesPath?: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1071,6 +1071,7 @@ __metadata:
     is-uuid: 1.0.2
     jest: 26.2.2
     jsonwebtoken: ^8.5.1
+    jwks-rsa: ^2.0.5
     libnpmsearch: 3.1.0
     npm-run-all: 4.1.5
     pluralize: ^8.0.0
@@ -1137,6 +1138,13 @@ __metadata:
     mkdirp: ^1.0.4
     rimraf: ^3.0.2
   checksum: d178d86a0a96e5aa12e6d70c00d50eb3bb9a58c0cf1c36e1d7f240acb4ae3f14642c6314659c438ea409a509f08c2a62e29c9346a033e554c3f6921cdb293219
+  languageName: node
+  linkType: hard
+
+"@panva/asn1.js@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@panva/asn1.js@npm:1.0.0"
+  checksum: 0563c1372d99051d8e2268541a6ef9ec5d0495e9b943b0b1b738eb40ffd21e8bf7690f313d5ce86cccb32e646f9bb75f1af3cd45bce5d04b85ad9c04f0b596aa
   languageName: node
   linkType: hard
 
@@ -1511,6 +1519,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/express-jwt@npm:0.0.42":
+  version: 0.0.42
+  resolution: "@types/express-jwt@npm:0.0.42"
+  dependencies:
+    "@types/express": "*"
+    "@types/express-unless": "*"
+  checksum: 82477e875e2ef225c69488262bbf86d77c3ce604792b3d8d9fcf4033296fc66baa290f37aed05e237cee8e2bbd6f801f0f75d5b661f649c94a668f20b66899f8
+  languageName: node
+  linkType: hard
+
 "@types/express-serve-static-core@npm:*, @types/express-serve-static-core@npm:4.17.19, @types/express-serve-static-core@npm:^4.17.18":
   version: 4.17.19
   resolution: "@types/express-serve-static-core@npm:4.17.19"
@@ -1541,6 +1559,15 @@ __metadata:
     "@types/qs": "*"
     "@types/range-parser": "*"
   checksum: 30fc9b62a7cc52fa320fbdf11510b20d91c1aa55d99d90ecb51708b9178aa670f2aaa94eed01f68a96a1a80b3575f1143c0cb23b0e69d60070d6d6d42e40b62a
+  languageName: node
+  linkType: hard
+
+"@types/express-unless@npm:*":
+  version: 0.5.2
+  resolution: "@types/express-unless@npm:0.5.2"
+  dependencies:
+    "@types/express": "*"
+  checksum: 113ca55a96f4aa21e0ddc4e8b95efe27e55213a7dfe0d3cce87330e32742edbbe3c3249e61e7b93a2cf584ba3227f14c7bea7b64d6eef17f4fdab6b268cd0cb4
   languageName: node
   linkType: hard
 
@@ -8813,6 +8840,15 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jose@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "jose@npm:2.0.5"
+  dependencies:
+    "@panva/asn1.js": ^1.0.0
+  checksum: 7c6eecb0bf26109c1be5a18084276492a957be4876acae2529904c4e54cee50c736a8fe65702bcdd7537313a3a9ff94e44f9987423a59989920018ff144eb936
+  languageName: node
+  linkType: hard
+
 "js-tokens@npm:^3.0.0 || ^4.0.0, js-tokens@npm:^4.0.0":
   version: 4.0.0
   resolution: "js-tokens@npm:4.0.0"
@@ -9023,6 +9059,19 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"jwks-rsa@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "jwks-rsa@npm:2.0.5"
+  dependencies:
+    "@types/express-jwt": 0.0.42
+    debug: ^4.3.2
+    jose: ^2.0.5
+    limiter: ^1.1.5
+    lru-memoizer: ^2.1.4
+  checksum: 9bb9f9be0c507e448af95a57ae6caf0e63defd3b935c2bb98b5b2fd9f43e23ff84b45e643a30f04118b7b9e88fefd8b7ec449b6e4af2f2bf3d0e906a23096012
+  languageName: node
+  linkType: hard
+
 "jws@npm:^3.2.2":
   version: 3.2.2
   resolution: "jws@npm:3.2.2"
@@ -9146,6 +9195,13 @@ fsevents@^1.2.7:
   dependencies:
     npm-registry-fetch: ^9.0.0
   checksum: 840e983dbc6fb1ca2e2b9d15b416482e774df9b88a1224c44ab16491ea3f6fb04cfc4cba97146da6d00c06a82be44fed471b0e5e30986e7cb0c86b6e8614f718
+  languageName: node
+  linkType: hard
+
+"limiter@npm:^1.1.5":
+  version: 1.1.5
+  resolution: "limiter@npm:1.1.5"
+  checksum: 83f7aa20fefdcfc72a76f034ce804ad8d0063cd94c3ebd9c9b08157051b3f76b099cb953ccd09a0117ed06b876773c6b3876afd88be8d11ced252a8a85603786
   languageName: node
   linkType: hard
 
@@ -9304,6 +9360,13 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
+"lodash.clonedeep@npm:^4.5.0":
+  version: 4.5.0
+  resolution: "lodash.clonedeep@npm:4.5.0"
+  checksum: 41e2fe4c57c56a66a4775a6ddeebe9272f0ce4d257d97b3cb8724a9b01eeec9b09ce7e8603d6926baf5f48c287d988f0de4bf5aa244ea86b1f22c1e6f203cc27
+  languageName: node
+  linkType: hard
+
 "lodash.includes@npm:^4.3.0":
   version: 4.3.0
   resolution: "lodash.includes@npm:4.3.0"
@@ -9450,6 +9513,26 @@ fsevents@^1.2.7:
   dependencies:
     yallist: ^4.0.0
   checksum: b8b78353d2391c0f135cdc245c4744ad41c2efb1a6d98f31bc57a2cf48ebf02de96e4876657c3026673576bf1f1f61fc3fdd77ab00ad1ead737537bf17d8019d
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:~4.0.0":
+  version: 4.0.2
+  resolution: "lru-cache@npm:4.0.2"
+  dependencies:
+    pseudomap: ^1.0.1
+    yallist: ^2.0.0
+  checksum: 503a21816bef4909ebb3a6b6916f8aafb73c850cf4dd27905d2971311954d630ec004c72ac8521165cf196782f8a45b13cc34935209cec6339e4951e155e659b
+  languageName: node
+  linkType: hard
+
+"lru-memoizer@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "lru-memoizer@npm:2.1.4"
+  dependencies:
+    lodash.clonedeep: ^4.5.0
+    lru-cache: ~4.0.0
+  checksum: 31f52aaec58f3185f256d78fb803398c11727adf5fb318fedc11cf77a4297815f409d36e509dad788cd2e19254756599f36ef40d0ec91db83320bc5ebcc91da3
   languageName: node
   linkType: hard
 
@@ -11307,6 +11390,13 @@ fsevents@^1.2.7:
   version: 1.0.1
   resolution: "prr@npm:1.0.1"
   checksum: ac5c0986b46390140b920b8e7f6b56e769a00620af02b6bbdfc6658e8a36b876569c8f174a7c209843f5b9af3d13cbf847c2a9dded4d965b01afbfa5ea8d0761
+  languageName: node
+  linkType: hard
+
+"pseudomap@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "pseudomap@npm:1.0.2"
+  checksum: 1ad1802645e830d99f9c1db97efc6902d2316b660454633229f636dd59e751d00498dd325d3b18d49f2be990a2c9d28f8bfe6f9b544a8220a5faa2bfb4694bb7
   languageName: node
   linkType: hard
 
@@ -14702,6 +14792,13 @@ typescript@4.1.3:
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 56275bfa72a8a585c4d2905b086862fb881dfe7871adcefe4ecf4c1a6a78c6389b459b427c0a8672ccdb09731a78143acc71f0bcc8dc8d8427869fafe7f18b95
+  languageName: node
+  linkType: hard
+
+"yallist@npm:^2.0.0":
+  version: 2.1.2
+  resolution: "yallist@npm:2.1.2"
+  checksum: f83e3d18eeba68a0276be2ab09260be3f2a300307e84b1565c620ef71f03f106c3df9bec4c3a91e5fa621a038f8826c19b3786804d3795dd4f999e5b6be66ea3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

According to OpenID configuration, verification of JWTs should be validated against the authentication server's JWKS to ensure that the server signed it. Instead of interpreting the JWT via a secret or PEM file (which if maliciously stolen, could rewrite JWTs), we verify via the signature represented by the token's kid at the endpoint `https://YOUR_DOMAIN/.well-known/jwks.json`. 

These changes are currently non-breaking changes.

# Issue

#252 

Passing a decoded token only partially solves this verification issue. We'd rather perform verification via the GraphQL @auth directive so checks occur at each request and are done **without secrets**.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
