### PR TITLE
Fix: call new on GraphQLString

### DIFF
--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -130,7 +130,7 @@ export const nodeDirective = new GraphQLDirective({
         },
         additionalLabels: {
             description: "Map the GraphQL type to match additional Neo4j node labels",
-            type: GraphQLList(new GraphQLNonNull(GraphQLString)),
+            type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
         },
         plural: {
             description: "Defines a custom plural for the Node API",


### PR DESCRIPTION
# Description

I don't know how this worked before, this PR simply called `new` on a class that should be invoked. 
