### PR TITLE
Fix/non null relationships

### DIFF
--- a/packages/graphql/src/classes/Error.ts
+++ b/packages/graphql/src/classes/Error.ts
@@ -59,3 +59,13 @@ export class Neo4jGraphQLConstraintValidationError extends Neo4jGraphQLError {
         Object.defineProperty(this, "name", { value: "Neo4jGraphQLConstraintValidationError" });
     }
 }
+
+export class Neo4jGraphQLRelationshipValidationError extends Neo4jGraphQLError {
+    readonly name;
+
+    constructor(message: string) {
+        super(message);
+
+        Object.defineProperty(this, "name", { value: "Neo4jGraphQLRelationshipValidationError" });
+    }
+}

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -21,6 +21,7 @@ const DEBUG_PREFIX = "@neo4j/graphql";
 
 export const AUTH_FORBIDDEN_ERROR = "@neo4j/graphql/FORBIDDEN";
 export const AUTH_UNAUTHENTICATED_ERROR = "@neo4j/graphql/UNAUTHENTICATED";
+export const RELATIONSHIP_REQUIREMENT_PREFIX = "@neo4j/graphql/RELATIONSHIP-REQUIRED";
 export const MIN_VERSIONS = [
     { majorMinor: "4.1", neo4j: "4.1.5" },
     { majorMinor: "4.2", neo4j: "4.2.9" },

--- a/packages/graphql/src/schema/get-field-type-meta.ts
+++ b/packages/graphql/src/schema/get-field-type-meta.ts
@@ -70,6 +70,7 @@ function getFieldTypeMeta(field: FieldDefinitionNode | InputValueDefinitionNode)
         required,
         pretty,
         arrayTypePretty,
+        arrayTypeRequired,
     };
 
     const isPoint = ["Point", "CartesianPoint"].includes(name);

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -21,9 +21,10 @@ import { Node, Relationship } from "../classes";
 import { Context } from "../types";
 import createConnectAndParams from "./create-connect-and-params";
 import createAuthAndParams from "./create-auth-and-params";
-import { AUTH_FORBIDDEN_ERROR } from "../constants";
+import { AUTH_FORBIDDEN_ERROR, RELATIONSHIP_REQUIREMENT_PREFIX } from "../constants";
 import createSetRelationshipPropertiesAndParams from "./create-set-relationship-properties-and-params";
 import mapToDbProperty from "../utils/map-to-db-property";
+import createRelationshipValidationStr from "./create-relationship-validation-str";
 
 interface Res {
     creates: string[];
@@ -243,6 +244,12 @@ function createCreateAndParams({
     if (meta?.authStrs.length) {
         creates.push(`WITH ${withVars.join(", ")}`);
         creates.push(`CALL apoc.util.validate(NOT(${meta.authStrs.join(" AND ")}), ${forbiddenString}, [0])`);
+    }
+
+    let relationshipValidationStr = createRelationshipValidationStr({ node, context, varName });
+    if (relationshipValidationStr) {
+        creates.push(`WITH ${withVars.join(", ")}`);
+        creates.push(relationshipValidationStr);
     }
 
     return [creates.join("\n"), params];

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -246,7 +246,7 @@ function createCreateAndParams({
         creates.push(`CALL apoc.util.validate(NOT(${meta.authStrs.join(" AND ")}), ${forbiddenString}, [0])`);
     }
 
-    let relationshipValidationStr = createRelationshipValidationStr({ node, context, varName });
+    const relationshipValidationStr = createRelationshipValidationStr({ node, context, varName });
     if (relationshipValidationStr) {
         creates.push(`WITH ${withVars.join(", ")}`);
         creates.push(relationshipValidationStr);

--- a/packages/graphql/src/translate/create-relationship-validation-str.ts
+++ b/packages/graphql/src/translate/create-relationship-validation-str.ts
@@ -1,0 +1,48 @@
+import { Node } from "../classes";
+import { RELATIONSHIP_REQUIREMENT_PREFIX } from "../constants";
+import { Context } from "../types";
+
+function createRelationshipValidationStr({
+    node,
+    context,
+    varName,
+}: {
+    node: Node;
+    context: Context;
+    varName: string;
+}): string {
+    let relationshipValidationStr = "";
+
+    const nonNullRelationFields = node.relationFields.filter((field) => {
+        const isRequired = field.typeMeta.required;
+        const isArrayTypeRequired = field.typeMeta.arrayTypeRequired;
+        const isArray = field.typeMeta.array;
+        const isNotUnionOrInterface = Boolean(field.union) || Boolean(field.interface);
+
+        if (isArray) {
+            return isArrayTypeRequired && !isNotUnionOrInterface;
+        }
+
+        return isRequired && !isNotUnionOrInterface;
+    });
+
+    if (nonNullRelationFields.length) {
+        const nonNullPredicates = nonNullRelationFields.map((field) => {
+            const inStr = field.direction === "IN" ? "<-" : "-";
+            const outStr = field.direction === "OUT" ? "->" : "-";
+            const relTypeStr = `[:${field.type}]`;
+            const toNode = context.neoSchema.nodes.find((n) => n.name === field.typeMeta.name) as Node;
+            const exitsStr = `EXISTS((${varName})${inStr}${relTypeStr}${outStr}(${toNode.getLabelString(context)}))`;
+
+            return `apoc.util.validatePredicate(NOT(${exitsStr}), '${RELATIONSHIP_REQUIREMENT_PREFIX}${node.name}.${field.fieldName} required', [0])`;
+        });
+
+        relationshipValidationStr = `CALL apoc.util.validate(NOT(${nonNullPredicates.join(
+            " AND "
+        )}), '${RELATIONSHIP_REQUIREMENT_PREFIX}', [0])`;
+    }
+
+    return relationshipValidationStr;
+}
+
+export default createRelationshipValidationStr;

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -29,6 +29,7 @@ import createAuthAndParams from "./create-auth-and-params";
 import createSetRelationshipProperties from "./create-set-relationship-properties";
 import createConnectionWhereAndParams from "./where/create-connection-where-and-params";
 import mapToDbProperty from "../utils/map-to-db-property";
+import createRelationshipValidationStr from "./create-relationship-validation-str";
 
 interface Res {
     strs: string[];
@@ -51,6 +52,7 @@ function createUpdateAndParams({
     withVars,
     context,
     parameterPrefix,
+    fromTopLevel,
 }: {
     parentVar: string;
     updateInput: any;
@@ -61,6 +63,7 @@ function createUpdateAndParams({
     insideDoWhen?: boolean;
     context: Context;
     parameterPrefix: string;
+    fromTopLevel?: boolean;
 }): [string, any] {
     let hasAppliedTimeStamps = false;
 
@@ -510,6 +513,7 @@ function createUpdateAndParams({
 
     let preAuthStr = "";
     let postAuthStr = "";
+    const relationshipValidationStr = !fromTopLevel ? createRelationshipValidationStr({ node, context, varName }) : "";
 
     const forbiddenString = insideDoWhen ? `\\"${AUTH_FORBIDDEN_ERROR}\\"` : `"${AUTH_FORBIDDEN_ERROR}"`;
 
@@ -523,9 +527,15 @@ function createUpdateAndParams({
         postAuthStr = `${withStr}\n${apocStr}`;
     }
 
-    const str = `${preAuthStr}\n${strs.join("\n")}\n${postAuthStr}`;
-
-    return [str, params];
+    return [
+        [
+            preAuthStr,
+            ...strs,
+            postAuthStr,
+            ...(relationshipValidationStr ? [withStr, relationshipValidationStr] : []),
+        ].join("\n"),
+        params,
+    ];
 }
 
 export default createUpdateAndParams;

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -26,11 +26,12 @@ import createAuthAndParams from "./create-auth-and-params";
 import createUpdateAndParams from "./create-update-and-params";
 import createConnectAndParams from "./create-connect-and-params";
 import createDisconnectAndParams from "./create-disconnect-and-params";
-import { AUTH_FORBIDDEN_ERROR } from "../constants";
+import { AUTH_FORBIDDEN_ERROR, RELATIONSHIP_REQUIREMENT_PREFIX } from "../constants";
 import createDeleteAndParams from "./create-delete-and-params";
 import createConnectionAndParams from "./connection/create-connection-and-params";
 import createSetRelationshipPropertiesAndParams from "./create-set-relationship-properties-and-params";
 import createInterfaceProjectionAndParams from "./create-interface-projection-and-params";
+import createRelationshipValidationStr from "./create-relationship-validation-str";
 
 function translateUpdate({ node, context }: { node: Node; context: Context }): [string, any] {
     const { resolveTree } = context;
@@ -102,6 +103,7 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
             parentVar: varName,
             withVars: [varName],
             parameterPrefix: `${resolveTree.name}.args.update`,
+            fromTopLevel: true,
         });
         [updateStr] = updateAndParams;
         cypherParams = {
@@ -376,6 +378,8 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
         }
     }
 
+    const relationshipValidationStr = createRelationshipValidationStr({ node, context, varName });
+
     const returnStatement = nodeProjection
         ? `RETURN ${varName} ${projStr} AS ${varName}`
         : `RETURN 'Query cannot conclude with CALL'`;
@@ -390,6 +394,7 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
         deleteStr,
         ...(connectionStrs.length || projAuth ? [`WITH ${varName}`] : []), // When FOREACH is the last line of update 'Neo4jError: WITH is required between FOREACH and CALL'
         ...(projAuth ? [projAuth] : []),
+        ...(relationshipValidationStr ? [`WITH ${varName}`, relationshipValidationStr] : []),
         ...connectionStrs,
         ...interfaceStrs,
         returnStatement,

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -88,6 +88,7 @@ export interface TypeMeta {
             pretty: string;
         };
     };
+    arrayTypeRequired?: boolean;
 }
 
 export interface Unique {

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -23,8 +23,14 @@ import {
     Neo4jGraphQLForbiddenError,
     Neo4jGraphQLAuthenticationError,
     Neo4jGraphQLConstraintValidationError,
+    Neo4jGraphQLRelationshipValidationError,
 } from "../classes";
-import { AUTH_FORBIDDEN_ERROR, AUTH_UNAUTHENTICATED_ERROR, DEBUG_EXECUTE } from "../constants";
+import {
+    AUTH_FORBIDDEN_ERROR,
+    AUTH_UNAUTHENTICATED_ERROR,
+    DEBUG_EXECUTE,
+    RELATIONSHIP_REQUIREMENT_PREFIX,
+} from "../constants";
 import createAuthParam from "../translate/create-auth-param";
 import { Context, DriverConfig } from "../types";
 import environment from "../environment";
@@ -118,6 +124,11 @@ async function execute(input: {
 
             if (error.message.includes(`Caused by: java.lang.RuntimeException: ${AUTH_UNAUTHENTICATED_ERROR}`)) {
                 throw new Neo4jGraphQLAuthenticationError("Unauthenticated");
+            }
+
+            if (error.message.includes(`Caused by: java.lang.RuntimeException: ${RELATIONSHIP_REQUIREMENT_PREFIX}`)) {
+                const [, message] = error.message.split(RELATIONSHIP_REQUIREMENT_PREFIX);
+                throw new Neo4jGraphQLRelationshipValidationError(message);
             }
 
             if (error.code === "Neo.ClientError.Schema.ConstraintValidationFailed") {

--- a/packages/graphql/tests/integration/interface-relationships/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/create/create.int.test.ts
@@ -35,24 +35,24 @@ describe("interface relationships", () => {
         const typeDefs = gql`
             type Episode {
                 runtime: Int!
-                series: Series! @relationship(type: "HAS_EPISODE", direction: IN)
+                series: Series @relationship(type: "HAS_EPISODE", direction: IN)
             }
 
             interface Production {
                 title: String!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type Movie implements Production {
                 title: String!
                 runtime: Int!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type Series implements Production {
                 title: String!
-                episodes: [Episode!]! @relationship(type: "HAS_EPISODE", direction: OUT)
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                episodes: [Episode] @relationship(type: "HAS_EPISODE", direction: OUT)
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             interface ActedIn @relationshipProperties {
@@ -61,7 +61,7 @@ describe("interface relationships", () => {
 
             type Actor {
                 name: String!
-                actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                actedIn: [Production] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
             }
         `;
 

--- a/packages/graphql/tests/integration/interface-relationships/update/create.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/create.int.test.ts
@@ -34,34 +34,34 @@ describe("interface relationships", () => {
 
         const typeDefs = gql`
             type Episode {
-                runtime: Int!
-                series: Series! @relationship(type: "HAS_EPISODE", direction: IN)
+                runtime: Int
+                series: Series @relationship(type: "HAS_EPISODE", direction: IN)
             }
 
             interface Production {
-                title: String!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                title: String
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type Movie implements Production {
-                title: String!
-                runtime: Int!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                title: String
+                runtime: Int
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type Series implements Production {
-                title: String!
-                episodes: [Episode!]! @relationship(type: "HAS_EPISODE", direction: OUT)
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                title: String
+                episodes: [Episode] @relationship(type: "HAS_EPISODE", direction: OUT)
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             interface ActedIn @relationshipProperties {
-                screenTime: Int!
+                screenTime: Int
             }
 
             type Actor {
-                name: String!
-                actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                name: String
+                actedIn: [Production] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
             }
         `;
 

--- a/packages/graphql/tests/integration/interface-relationships/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/update.int.test.ts
@@ -35,24 +35,24 @@ describe("interface relationships", () => {
         const typeDefs = gql`
             type Episode {
                 runtime: Int!
-                series: Series! @relationship(type: "HAS_EPISODE", direction: IN)
+                series: Series @relationship(type: "HAS_EPISODE", direction: IN)
             }
 
             interface Production {
                 title: String!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type Movie implements Production {
                 title: String!
                 runtime: Int!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type Series implements Production {
                 title: String!
-                episodes: [Episode!]! @relationship(type: "HAS_EPISODE", direction: OUT)
-                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+                episodes: [Episode] @relationship(type: "HAS_EPISODE", direction: OUT)
+                actors: [Actor] @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             interface ActedIn @relationshipProperties {
@@ -61,7 +61,7 @@ describe("interface relationships", () => {
 
             type Actor {
                 name: String!
-                actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+                actedIn: [Production] @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
             }
         `;
 

--- a/packages/graphql/tests/integration/issues/247.int.test.ts
+++ b/packages/graphql/tests/integration/issues/247.int.test.ts
@@ -39,12 +39,12 @@ describe("https://github.com/neo4j/graphql/issues/247", () => {
         const typeDefs = gql`
             type Movie {
                 title: String!
-                owners: [User!]! @relationship(type: "OWNS", direction: IN)
+                owners: [User] @relationship(type: "OWNS", direction: IN)
             }
 
             type User {
                 name: String!
-                movies: [Movie!]! @relationship(type: "OWNS", direction: OUT)
+                movies: [Movie] @relationship(type: "OWNS", direction: OUT)
             }
         `;
 

--- a/packages/graphql/tests/integration/issues/315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/315.int.test.ts
@@ -36,8 +36,8 @@ describe("https://github.com/neo4j/graphql/issues/315", () => {
 
         type User {
             id: ID!
-            friends: [User!]! @relationship(type: "HAS_FRIEND", direction: OUT)
-            posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            friends: [User] @relationship(type: "HAS_FRIEND", direction: OUT)
+            posts: [Post] @relationship(type: "HAS_POST", direction: OUT)
         }
 
         type Query {

--- a/packages/graphql/tests/integration/issues/388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/388.int.test.ts
@@ -36,8 +36,8 @@ describe("https://github.com/neo4j/graphql/issues/388", () => {
 
         type User {
             id: ID!
-            friends: [User!]! @relationship(type: "HAS_FRIEND", direction: OUT)
-            posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            friends: [User] @relationship(type: "HAS_FRIEND", direction: OUT)
+            posts: [Post] @relationship(type: "HAS_POST", direction: OUT)
         }
 
         type Query {

--- a/packages/graphql/tests/integration/issues/440.int.test.ts
+++ b/packages/graphql/tests/integration/issues/440.int.test.ts
@@ -29,12 +29,12 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
     const typeDefs = gql`
         type Video {
             id: ID! @id(autogenerate: false)
-            categories: [Category!]! @relationship(type: "IS_CATEGORIZED_AS", direction: OUT)
+            categories: [Category] @relationship(type: "IS_CATEGORIZED_AS", direction: OUT)
         }
 
         type Category {
             id: ID! @id(autogenerate: false)
-            videos: [Video!]! @relationship(type: "IS_CATEGORIZED_AS", direction: IN)
+            videos: [Video] @relationship(type: "IS_CATEGORIZED_AS", direction: IN)
         }
     `;
 

--- a/packages/graphql/tests/integration/issues/549.int.test.ts
+++ b/packages/graphql/tests/integration/issues/549.int.test.ts
@@ -1,0 +1,353 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("https://github.com/neo4j/graphql/issues/549", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should throw error when creating a node without a (single) relationship", async () => {
+        const typeDefs = gql`
+            type Director {
+                id: ID!
+            }
+
+            type Movie {
+                id: ID!
+                director: Director! @relationship(type: "DIRECTED", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const mutation = `
+            mutation {
+                createMovies(input: [{id: "${movieId}"}]) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema: neoSchema.schema,
+            source: mutation,
+            contextValue: { driver },
+        });
+
+        expect(result.errors).toBeTruthy();
+        expect((result.errors as any[])[0].message).toEqual("Movie.director required");
+    });
+
+    test("should throw error when creating a node without a (array) relationship", async () => {
+        const typeDefs = gql`
+            type Director {
+                id: ID!
+            }
+
+            type Movie {
+                id: ID!
+                directors: [Director!] @relationship(type: "DIRECTED", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const mutation = `
+            mutation {
+                createMovies(input: [{id: "${movieId}"}]) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema: neoSchema.schema,
+            source: mutation,
+            contextValue: { driver },
+        });
+
+        expect(result.errors).toBeTruthy();
+        expect((result.errors as any[])[0].message).toEqual("Movie.directors required");
+    });
+
+    test("should throw error when updating a node (top level) without a (single) relationship", async () => {
+        const session = driver.session();
+
+        const typeDefs = gql`
+            type Director {
+                id: ID!
+            }
+
+            type Movie {
+                id: ID!
+                director: Director! @relationship(type: "DIRECTED", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const mutation = `
+            mutation {
+                updateMovies(where: {id: "${movieId}"}, update: { id: "${movieId}" }) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run(`
+                CREATE (:Movie {id: "${movieId}"})
+            `);
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { driver },
+            });
+
+            expect(result.errors).toBeTruthy();
+            expect((result.errors as any[])[0].message).toEqual("Movie.director required");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw error when updating a node (top level) without a (array) relationship", async () => {
+        const session = driver.session();
+
+        const typeDefs = gql`
+            type Director {
+                id: ID!
+            }
+
+            type Movie {
+                id: ID!
+                directors: [Director!] @relationship(type: "DIRECTED", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const mutation = `
+            mutation {
+                updateMovies(where: {id: "${movieId}"}, update: { id: "${movieId}" }) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run(`
+                CREATE (:Movie {id: "${movieId}"})
+            `);
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { driver },
+            });
+
+            expect(result.errors).toBeTruthy();
+            expect((result.errors as any[])[0].message).toEqual("Movie.directors required");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw error when updating a node (field level) without a (single) relationship", async () => {
+        const session = driver.session();
+
+        const typeDefs = gql`
+            type Director {
+                id: ID!
+                directed: [Movie!] @relationship(type: "DIRECTED", direction: OUT)
+            }
+
+            type Movie {
+                id: ID!
+                director: Director! @relationship(type: "DIRECTED", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const directorId = generate({
+            charset: "alphabetic",
+        });
+
+        const mutation = `
+            mutation {
+                updateDirectors(
+                    where: { id: "${directorId}" }, 
+                    update: { 
+                        directed: {
+                            update: { ## <---------------------------------------- 👀 The test is making sure the validation gets called here
+                                node: {
+                                    director: {
+                                        disconnect: {
+                                            where: {
+                                                node: {
+                                                    id: "${directorId}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run(`
+                CREATE (:Director {id: "${directorId}"})-[:DIRECTED]->(:Movie {id: "${movieId}"})
+            `);
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { driver },
+            });
+
+            expect(result.errors).toBeTruthy();
+            expect((result.errors as any[])[0].message).toEqual("Movie.director required");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw error when updating a node (field level) without a (array) relationship", async () => {
+        const session = driver.session();
+
+        const typeDefs = gql`
+            type Director {
+                id: ID!
+                directed: [Movie!] @relationship(type: "DIRECTED", direction: OUT)
+            }
+
+            type Movie {
+                id: ID!
+                directors: [Director!]! @relationship(type: "DIRECTED", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const directorId = generate({
+            charset: "alphabetic",
+        });
+
+        const mutation = `
+            mutation {
+                updateDirectors(
+                    where: { id: "${directorId}" }, 
+                    update: { 
+                        directed: {
+                            update: { ## <---------------------------------------- 👀 The test is making sure the validation gets called here
+                                node: {
+                                    directors: {
+                                        disconnect: {
+                                            where: {
+                                                node: {
+                                                    id: "${directorId}"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        try {
+            await session.run(`
+                CREATE (:Director {id: "${directorId}"})-[:DIRECTED]->(:Movie {id: "${movieId}"})
+            `);
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: mutation,
+                contextValue: { driver },
+            });
+
+            expect(result.errors).toBeTruthy();
+            expect((result.errors as any[])[0].message).toEqual("Movie.directors required");
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
@@ -39,12 +39,12 @@ describe("Relationship properties - create", () => {
         const typeDefs = gql`
             type Movie {
                 title: String!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+                actors: [Actor] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
             }
 
             type Actor {
                 name: String!
-                movies: [Movie!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+                movies: [Movie] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
             }
 
             interface ActedIn {

--- a/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
@@ -39,12 +39,12 @@ describe("Relationship properties - delete", () => {
         const typeDefs = gql`
             type Movie {
                 title: String!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+                actors: [Actor] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
             }
 
             type Actor {
                 name: String!
-                movies: [Movie!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+                movies: [Movie] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
             }
 
             interface ActedIn {

--- a/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
@@ -39,12 +39,12 @@ describe("Relationship properties - disconnect", () => {
         const typeDefs = gql`
             type Movie {
                 title: String!
-                actors: [Actor!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+                actors: [Actor] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
             }
 
             type Actor {
                 name: String!
-                movies: [Movie!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+                movies: [Movie] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
             }
 
             interface ActedIn {

--- a/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
@@ -30,12 +30,12 @@ describe("Relationship properties - update", () => {
     const typeDefs = gql`
         type Movie {
             title: String!
-            actors: [Actor!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+            actors: [Actor] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
         }
 
         type Actor {
             name: String!
-            movies: [Movie!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+            movies: [Movie] @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
         }
 
         interface ActedIn {

--- a/packages/graphql/tests/tck/tck-test-files/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/projections/create.test.ts
@@ -79,6 +79,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             "CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
+            WITH this0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this0
             }
             CALL {
@@ -126,11 +128,15 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             "CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
+            WITH this0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this0
             }
             CALL {
             CREATE (this1:Movie)
             SET this1.title = $this1_title
+            WITH this1
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this1)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this1
             }
             CALL {
@@ -186,11 +192,15 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             "CALL {
             CREATE (this0:Movie)
             SET this0.title = $this0_title
+            WITH this0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this0
             }
             CALL {
             CREATE (this1:Movie)
             SET this1.title = $this1_title
+            WITH this1
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this1)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this1
             }
             CALL {

--- a/packages/graphql/tests/tck/tck-test-files/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/projections/update.test.ts
@@ -79,6 +79,8 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
             "MATCH (this:Movie)
             WHERE this.title = $this_title
             WITH this
+            WITH this
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             CALL {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/connect.test.ts
@@ -91,6 +91,8 @@ describe("Relationship Properties Connect Cypher", () => {
             	)
             	RETURN count(*)
             }
+            WITH this0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this0
             }
             CALL {
@@ -162,6 +164,8 @@ describe("Relationship Properties Connect Cypher", () => {
             	)
             	RETURN count(*)
             }
+            WITH this0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this0
             }
             CALL {
@@ -226,6 +230,8 @@ describe("Relationship Properties Connect Cypher", () => {
             	RETURN count(*)
             }
             WITH this
+            WITH this
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             CALL {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
@@ -290,6 +296,8 @@ describe("Relationship Properties Connect Cypher", () => {
             	RETURN count(*)
             }
             WITH this
+            WITH this
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             CALL {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/create.test.ts
@@ -89,8 +89,12 @@ describe("Relationship Properties Create Cypher", () => {
             WITH this0
             CREATE (this0_actors0_node:Actor)
             SET this0_actors0_node.name = $this0_actors0_node_name
+            WITH this0, this0_actors0_node
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0_actors0_node)-[:ACTED_IN]->(:Movie))), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.movies required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
             SET this0_actors0_relationship.screenTime = $this0_actors0_relationship_screenTime
+            WITH this0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this0
             }
             CALL {

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/update.test.ts
@@ -83,6 +83,8 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             RETURN count(*)
             \\", \\"\\", {this_acted_in0_relationship:this_acted_in0_relationship, updateMovies: $updateMovies})
             YIELD value as this_acted_in0_relationship_actors0_edge
+            WITH this
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this { .title } AS this"
         `);
 
@@ -150,6 +152,8 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
             SET this_actors0.name = $this_update_actors0_name
+            WITH this, this_actors0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actors0)-[:ACTED_IN]->(:Movie))), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.movies required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
             YIELD value as _
@@ -158,6 +162,8 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             RETURN count(*)
             \\", \\"\\", {this_acted_in0_relationship:this_acted_in0_relationship, updateMovies: $updateMovies})
             YIELD value as this_acted_in0_relationship_actors0_edge
+            WITH this
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN this { .title } AS this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/update.test.ts
@@ -92,6 +92,8 @@ describe("Interface Relationships - Update update", () => {
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
             SET this_actedIn0.title = $this_update_actedIn0_title
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_title:$this_update_actedIn0_title})
             YIELD value as _
@@ -102,6 +104,8 @@ describe("Interface Relationships - Update update", () => {
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
             SET this_actedIn0.title = $this_update_actedIn0_title
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDSeries.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_title:$this_update_actedIn0_title})
             YIELD value as _
@@ -182,6 +186,8 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*)
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value as _
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value as _
@@ -198,6 +204,8 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*)
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value as _
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDSeries.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value as _
@@ -282,12 +290,16 @@ describe("Interface Relationships - Update update", () => {
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
             WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
+            WITH this, this_actedIn0
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_on_Movie_actors0_name
             RETURN count(*)
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value as _
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value as _
@@ -297,6 +309,8 @@ describe("Interface Relationships - Update update", () => {
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDSeries.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth})
             YIELD value as _
@@ -388,12 +402,16 @@ describe("Interface Relationships - Update update", () => {
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
             WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
+            WITH this, this_actedIn0
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_on_Movie_actors0_name
             RETURN count(*)
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value as _
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value as _
@@ -410,6 +428,8 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*)
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value as _
+            WITH this, this_actedIn0
+            CALL apoc.util.validate(NOT(apoc.util.validatePredicate(NOT(EXISTS((this_actedIn0)<-[:ACTED_IN]-(:Actor))), '@neo4j/graphql/RELATIONSHIP-REQUIREDSeries.actors required', [0])), '@neo4j/graphql/RELATIONSHIP-REQUIRED', [0])
             RETURN count(*)
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value as _


### PR DESCRIPTION
# Description

Enforces that Nodes have relationships, on update and create, if the field is annotated with an `!`. This PR uses `apoc.util.validate` to throw an error inside a transaction. 

# Issue

#549

