### PR TITLE
Querying DateTime in the edge of a connection throws an error

### DIFF
--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -541,7 +541,7 @@ function createProjectionAndParams({
                 : `{ ${chainStr}: ${chainStr} }`;
 
             res.projection.push(
-                `${field.name}: apoc.cypher.runFirstColumn("${connection[0].replace(/"/g, '\\"')} RETURN ${
+                `${field.name}: apoc.cypher.runFirstColumn("${connection[0].replace(/("|')/g, "\\$1")} RETURN ${
                     field.name
                 }", ${runFirstColumnParams}, false)`
             );

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -541,7 +541,9 @@ function createProjectionAndParams({
                 : `{ ${chainStr}: ${chainStr} }`;
 
             res.projection.push(
-                `${field.name}: apoc.cypher.runFirstColumn("${connection[0]} RETURN ${field.name}", ${runFirstColumnParams}, false)`
+                `${field.name}: apoc.cypher.runFirstColumn("${connection[0].replace(/"/g, '\\"')} RETURN ${
+                    field.name
+                }", ${runFirstColumnParams}, false)`
             );
             res.params = { ...res.params, ...connection[1] };
             return res;

--- a/packages/graphql/tests/integration/issues/date-in-edge.test.ts
+++ b/packages/graphql/tests/integration/issues/date-in-edge.test.ts
@@ -24,7 +24,7 @@ import { generate } from "randomstring";
 import neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
-describe("issue", () => {
+describe("587: Dates in edges can cause wrongly generated cypher", () => {
     let driver: Driver;
 
     beforeAll(async () => {
@@ -100,10 +100,6 @@ describe("issue", () => {
                 source: query,
                 contextValue: { driver },
             });
-
-            if (result.errors) {
-                console.log(JSON.stringify(result.errors, null, 2));
-            }
 
             expect(result.errors).toBeFalsy();
         } finally {

--- a/packages/graphql/tests/integration/issues/date-in-edge.test.ts
+++ b/packages/graphql/tests/integration/issues/date-in-edge.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+
+describe("issue", () => {
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should not throw when returning a date in an edge", async () => {
+        const session = driver.session();
+
+        const typeDefs = gql`
+            type Genre {
+                id: ID!
+                movies: [Movie!]! @relationship(type: "MOVIE", direction: OUT)
+            }
+
+            type Movie {
+                title: String!
+                actors: [Actor]! @relationship(type: "ACTOR", direction: OUT)
+            }
+
+            type Actor {
+                name: String!
+                birthday: DateTime!
+                movie: Movie @relationship(type: "ACTOR", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const genreId = generate({
+            charset: "alphabetic",
+        });
+
+        const title = generate({
+            charset: "alphabetic",
+        });
+
+        const name = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+        query {
+            genres(where: { id: "${genreId}" }) {
+                movies {
+                    actorsConnection {
+                        edges {
+                            node {
+                                birthday
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        `;
+
+        try {
+            await session.run(`
+                CREATE (genre:Genre { id: "${genreId}" })
+                CREATE (movie:Movie { title: "${title}" })
+                CREATE (actor:Actor { name: "${name}", birthday: datetime("2021-11-16T10:53:20.200000000Z")})
+                CREATE (genre)-[:MOVIE]->(movie)-[:ACTOR { role: "Name" }]->(actor)
+                RETURN actor
+            `);
+
+            const result = await graphql({
+                schema: neoSchema.schema,
+                source: query,
+                contextValue: { driver },
+            });
+
+            if (result.errors) {
+                console.log(JSON.stringify(result.errors, null, 2));
+            }
+
+            expect(result.errors).toBeFalsy();
+        } finally {
+            await session.close();
+        }
+    });
+});


### PR DESCRIPTION
The error that gets thrown:

```
Neo4jError: Invalid input 'iso_zoned_date_time': expected
  "!="
  "%"
  ")"
  "*"
  "+"
  ","
  "-"
  "."
  "/"
  ":"
  "<"
  "<="
  "<>"
  "="
  "=~"
  ">"
  ">="
  "AND"
  "CONTAINS"
  "ENDS"
  "IN"
  "IS"
  "OR"
  "STARTS"
  "XOR"
  "["
  "^" (line 6, column 97 (offset: 375))
"WITH collect({ node: { birthday: apoc.date.convertFormat(toString(this_movies_actor.birthday), "iso_zoned_date_time", "iso_offset_date_time") } }) AS edges"
```

Generated Cypher:

```
MATCH (this:Genre)
WHERE this.id = $this_id
RETURN this { movies: [ (this)-[:MOVIE]->(this_movies:Movie)   | this_movies { actorsConnection: apoc.cypher.runFirstColumn("CALL {
WITH this_movies
MATCH (this_movies)-[this_movies_actor_relationship:ACTOR]->(this_movies_actor:Actor)
WITH collect({ node: { birthday: apoc.date.convertFormat(toString(this_movies_actor.birthday), "iso_zoned_date_time", "iso_offset_date_time") } }) AS edges
RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
} RETURN actorsConnection", { this_movies: this_movies }, false) } ] } as this
```

# Description

Because runFirstColumn gets called with a string there are numerous places in the current code where the library will generate invalid cypher, because of unescaped quotation marks. I wrote a quick test to demonstrate one of those places, but I'm fairly certain there are more. The fix I also implemented would fix at least this case, however, I feel like it might not be the best solution. I am unsure however, what a better solution would look like. There might have to be some sort of way to track if the cypher that is generated is in quotation marks or not (and maybe even how many levels deep if that is an issue?).

I'm open for suggestions as I would love to get this bug fixed.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
