### PR TITLE
Generate scalar typedefs before extra definitions

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -67,7 +67,7 @@
         "debug": "^4.3.2",
         "deep-equal": "^2.0.5",
         "dot-prop": "^6.0.1",
-        "graphql-compose": "^9.0.2",
+        "graphql-compose": "^9.0.4",
         "graphql-parse-resolve-info": "^4.12.0",
         "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -278,11 +278,11 @@ function makeAugmentedSchema(
         ] as ObjectTypeDefinitionNode[]),
     ].filter(Boolean) as DefinitionNode[];
 
+    Object.keys(Scalars).forEach((scalar) => composer.addTypeDefs(`scalar ${scalar}`));
+
     if (extraDefinitions.length) {
         composer.addTypeDefs(print({ kind: "Document", definitions: extraDefinitions }));
     }
-
-    Object.keys(Scalars).forEach((scalar) => composer.addTypeDefs(`scalar ${scalar}`));
 
     const nodes = objectNodes.map((definition) => {
         const otherDirectives = (definition.directives || []).filter(

--- a/packages/graphql/tests/integration/issues/586.int.test.ts
+++ b/packages/graphql/tests/integration/issues/586.int.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { gql } from "apollo-server";
+import { generate } from "randomstring";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { generateUniqueType } from "../../../src/utils/test/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/586", () => {
+    test("should not throw when using values in BigInt", async () => {
+        const typeDefs = gql`
+            input TestInput {
+                id: BigInt = "0"
+            }
+        `;
+        expect(() => {
+            new Neo4jGraphQL({ typeDefs });
+        }).not.toThrow();
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1817,7 +1817,7 @@ __metadata:
     deep-equal: ^2.0.5
     dot-prop: ^6.0.1
     faker: 5.2.0
-    graphql-compose: ^9.0.2
+    graphql-compose: ^9.0.4
     graphql-parse-resolve-info: ^4.12.0
     graphql-relay: ^0.8.0
     graphql-tag: 2.11.0
@@ -2679,7 +2679,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/object-path@npm:^0.11.0":
+"@types/object-path@npm:0.11.1":
   version: 0.11.1
   resolution: "@types/object-path@npm:0.11.1"
   checksum: d0bdb453cb99e741fc99918889b0262e6ba0848b04c5c686f895de2cc22fde99414971adec6f33467a1c6150fcd624f6cc99eccdd47bffee3909f3883ad557d7
@@ -7897,16 +7897,16 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-compose@npm:^9.0.2":
-  version: 9.0.2
-  resolution: "graphql-compose@npm:9.0.2"
+"graphql-compose@npm:^9.0.4":
+  version: 9.0.4
+  resolution: "graphql-compose@npm:9.0.4"
   dependencies:
-    "@types/object-path": ^0.11.0
+    "@types/object-path": 0.11.1
     graphql-type-json: 0.3.2
-    object-path: 0.11.5
+    object-path: 0.11.8
   peerDependencies:
     graphql: ^14.2.0 || ^15.0.0 || ^16.0.0
-  checksum: 0c5c7967c1e8e6ea4fd7f65fb08212d65ddda980a9321a089599dd7e000b9d53a71be317abe6d16fb4079e6687b95470b383f6670a288322e7d1d16fdfcd2132
+  checksum: 0b738704e915b0605b4a70177c51faa92a71da22ce3e7af3aa93a2782ec8425c2ad6f9a3f8b275d87bebe44b935541764340b1cb93bc149845d717fc47f1531d
   languageName: node
   linkType: hard
 
@@ -11558,7 +11558,14 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"object-path@npm:0.11.5, object-path@npm:^0.11.4":
+"object-path@npm:0.11.8":
+  version: 0.11.8
+  resolution: "object-path@npm:0.11.8"
+  checksum: daf845abe3054b38a2ecd40ada58ffca30b4704d102f0426aa87afa6a02313226d87c9db6a0e9297aeb387047b567dbc790fb0599ab1a53e630298f7f79687db
+  languageName: node
+  linkType: hard
+
+"object-path@npm:^0.11.4":
   version: 0.11.5
   resolution: "object-path@npm:0.11.5"
   checksum: a2be57f65eb247161763280e857ddbafcfbb41ad7cfcfb0a78aca2e8adb990a7b5afe6b182c20baf0e218e541ec75c1807fd04d50e3049920c2ec65e6eb9c900


### PR DESCRIPTION
# Description

Updating graphql-compose from 9.0.3 to 9.0.4 causes `make-augmented-schema` to break when using the following typedefs:
```
    input TestInput {
        id: BigInt = "0"
    }
```
This is due to type BigInt not being defined before `extraDefinitions` are added

A test was added to ensure this behavior does not happen again, but keep in mind that this is not reproducible with graphql-compose < 9.04

# Issue

#586
