### PR TITLE
Fix for missing auth parameter

### DIFF
--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -536,14 +536,17 @@ function createProjectionAndParams({
             });
 
             const connectionParamName = Object.keys(connection[1])[0];
-            const runFirstColumnParams = connectionParamName
-                ? `{ ${chainStr}: ${chainStr}, ${connectionParamName}: $${connectionParamName} }`
-                : `{ ${chainStr}: ${chainStr} }`;
+            const runFirstColumnParams = [
+                ...[`${chainStr}: ${chainStr}`],
+                ...(connectionParamName ? [`${connectionParamName}: $${connectionParamName}`] : []),
+                ...(context.auth ? ["auth: $auth"] : []),
+                ...(context.cypherParams ? ["cypherParams: $cypherParams"] : []),
+            ];
 
             res.projection.push(
                 `${field.name}: apoc.cypher.runFirstColumn("${connection[0].replace(/("|')/g, "\\$1")} RETURN ${
                     field.name
-                }", ${runFirstColumnParams}, false)`
+                }", { ${runFirstColumnParams.join(", ")} }, false)`
             );
             res.params = { ...res.params, ...connection[1] };
             return res;

--- a/packages/graphql/tests/tck/tck-test-files/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/mixed-nesting.test.ts
@@ -222,7 +222,7 @@ describe("Mixed nesting", () => {
             WHERE (NOT this_actors_movie.title = $this_actors_moviesConnection.args.where.node.title_NOT)
             WITH collect({ screenTime: this_actors_acted_in_relationship.screenTime, node: { title: this_actors_movie.title } }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS moviesConnection
-            } RETURN moviesConnection\\", { this_actors: this_actors, this_actors_moviesConnection: $this_actors_moviesConnection }, false) } ] } as this"
+            } RETURN moviesConnection\\", { this_actors: this_actors, this_actors_moviesConnection: $this_actors_moviesConnection, auth: $auth }, false) } ] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -237,7 +237,14 @@ describe("Mixed nesting", () => {
                         }
                     }
                 },
-                \\"this_actors_name\\": \\"Tom Hanks\\"
+                \\"this_actors_name\\": \\"Tom Hanks\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [],
+                    \\"jwt\\": {
+                        \\"roles\\": []
+                    }
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/tck-test-files/issues/601.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/601.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../../src/utils/test/utils";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("#601", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface UploadedDocument @relationshipProperties {
+                fileId: ID!
+                uploadedAt: DateTime!
+            }
+
+            type Document @exclude(operations: [CREATE, UPDATE, DELETE]) {
+                id: ID! @id
+                stakeholder: Stakeholder! @relationship(type: "REQUIRES", direction: OUT)
+
+                customerContact: CustomerContact
+                    @relationship(type: "UPLOADED", properties: "UploadedDocument", direction: IN)
+            }
+
+            extend type Document @auth(rules: [{ roles: ["view"] }])
+
+            type CustomerContact @exclude(operations: [CREATE, UPDATE, DELETE]) {
+                email: String!
+                firstname: String!
+                lastname: String!
+                documents: [Document!]! @relationship(type: "UPLOADED", properties: "UploadedDocument", direction: OUT)
+            }
+
+            extend type CustomerContact @auth(rules: [{ roles: ["view"] }])
+
+            type Stakeholder @exclude(operations: [CREATE, UPDATE, DELETE]) {
+                id: ID!
+                fields: String!
+                documents: [Document!]! @relationship(type: "REQUIRES", direction: OUT)
+            }
+
+            extend type Stakeholder @auth(rules: [{ roles: ["view"] }])
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            config: { enableRegex: true, jwt: { secret } },
+        });
+    });
+
+    test("Example 1", async () => {
+        const query = gql`
+            query Document {
+                stakeholders {
+                    documents {
+                        customerContactConnection {
+                            edges {
+                                fileId
+                                uploadedAt
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", {});
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Stakeholder)
+            CALL apoc.util.validate(NOT(ANY(r IN [\\"view\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { documents: [ (this)-[:REQUIRES]->(this_documents:Document)  WHERE apoc.util.validatePredicate(NOT(ANY(r IN [\\"view\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_documents { customerContactConnection: apoc.cypher.runFirstColumn(\\"CALL {
+            WITH this_documents
+            MATCH (this_documents)<-[this_documents_uploaded_relationship:UPLOADED]-(this_documents_customercontact:CustomerContact)
+            CALL apoc.util.validate(NOT(ANY(r IN [\\\\\\"view\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
+            WITH collect({ fileId: this_documents_uploaded_relationship.fileId, uploadedAt: apoc.date.convertFormat(toString(this_documents_uploaded_relationship.uploadedAt), \\\\\\"iso_zoned_date_time\\\\\\", \\\\\\"iso_offset_date_time\\\\\\") }) AS edges
+            RETURN { edges: edges, totalCount: size(edges) } AS customerContactConnection
+            } RETURN customerContactConnection\\", { this_documents: this_documents, auth: $auth }, false) } ] } as this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [],
+                    \\"jwt\\": {
+                        \\"roles\\": []
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
@@ -347,7 +347,7 @@ describe("Cypher Create", () => {
             WHERE this0_movies_actor.name = $projection_movies_actorsConnection.args.where.node.name
             WITH collect({ node: { name: this0_movies_actor.name } }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
-            } RETURN actorsConnection\\", { this0_movies: this0_movies, projection_movies_actorsConnection: $projection_movies_actorsConnection }, false) } ] } AS this0"
+            } RETURN actorsConnection\\", { this0_movies: this0_movies, projection_movies_actorsConnection: $projection_movies_actorsConnection, auth: $auth }, false) } ] } AS this0"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -361,6 +361,13 @@ describe("Cypher Create", () => {
                                 \\"name\\": \\"Dan\\"
                             }
                         }
+                    }
+                },
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [],
+                    \\"jwt\\": {
+                        \\"roles\\": []
                     }
                 }
             }"


### PR DESCRIPTION
# Description

See https://github.com/neo4j/graphql/pull/603/files#diff-59603a7b1cd33f04edc84f5a9aa4efdfb4a5aace657c247ea4b3a1e0850e26d5R102 in the new TCK test file where the `$auth` parameter has been added as needed.

# Issue

#601 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
