### PR TITLE
Introspector fixes

### DIFF
--- a/packages/introspector/src/transforms/neo4j-graphql/graphql.ts
+++ b/packages/introspector/src/transforms/neo4j-graphql/graphql.ts
@@ -26,6 +26,7 @@ import generateRelationshipPropsName from "./utils/generate-relationship-props-n
 import { RelationshipPropertiesDirective } from "./directives/RelationshipProperties";
 import createRelationshipFields from "./utils/create-relationship-fields";
 import { ExcludeDirective } from "./directives/Exclude";
+import generateGraphQLSafeName from "./utils/generate-graphql-safe-name";
 
 type GraphQLNodeMap = {
     [key: string]: GraphQLNode;
@@ -45,7 +46,8 @@ function transformNodes(nodes: NodeMap, readonly: boolean): GraphQLNodeMap {
     Object.keys(nodes).forEach((nodeType) => {
         const neo4jNode = nodes[nodeType];
         const mainLabel = neo4jNode.labels[0];
-        const typeName = mainLabel.replace(/[^_0-9A-Z]+/gi, "_");
+        const typeName = generateGraphQLSafeName(mainLabel);
+
         const uniqueTypeName = uniqueString(typeName, takenTypeNames);
         takenTypeNames.push(uniqueTypeName);
 
@@ -79,7 +81,7 @@ function hydrateWithRelationships(nodes: GraphQLNodeMap, rels: RelationshipMap):
 
         if (rel.properties.length) {
             relInterfaceName = uniqueString(
-                generateRelationshipPropsName(relType),
+                generateGraphQLSafeName(generateRelationshipPropsName(relType)),
                 Object.values(nodes).map((n) => n.typeName)
             );
             const relInterfaceNode = new GraphQLNode("interface", relInterfaceName);

--- a/packages/introspector/src/transforms/neo4j-graphql/utils/create-relationship-fields.ts
+++ b/packages/introspector/src/transforms/neo4j-graphql/utils/create-relationship-fields.ts
@@ -29,14 +29,14 @@ export default function createRelationshipFields(
 ): { fromField: NodeField; toField: NodeField } {
     const fromField = new NodeField(
         generateRelationshipFieldName(relType, fromTypeName, toTypeName, "OUT"),
-        `[${toTypeName}]`
+        `[${toTypeName}!]!`
     );
     const fromDirective = new RelationshipDirective(relType, "OUT", propertiesTypeName);
     fromField.addDirective(fromDirective);
 
     const toField = new NodeField(
         generateRelationshipFieldName(relType, fromTypeName, toTypeName, "IN"),
-        `[${fromTypeName}]`
+        `[${fromTypeName}!]!`
     );
     const toDirective = new RelationshipDirective(relType, "IN", propertiesTypeName);
     toField.addDirective(toDirective);

--- a/packages/introspector/src/transforms/neo4j-graphql/utils/generate-graphql-safe-name.test.ts
+++ b/packages/introspector/src/transforms/neo4j-graphql/utils/generate-graphql-safe-name.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import generateGraphQLSafeName from "./generate-graphql-safe-name";
+
+type Args = [string, string];
+
+describe("generateGraphQLSafeName", () => {
+    const cases: Args[] = [
+        ["", ""],
+        ["Abc", "Abc"],
+        ["A1bc", "A1bc"],
+        ["1234", "_1234"],
+        ["12-34", "_12_34"],
+    ];
+
+    test.each<Args>(cases)("given input %p, returns %p", (inStr, expectedResult) => {
+        const result = generateGraphQLSafeName(inStr);
+        expect(result).toEqual(expectedResult);
+    });
+});

--- a/packages/introspector/src/transforms/neo4j-graphql/utils/generate-graphql-safe-name.ts
+++ b/packages/introspector/src/transforms/neo4j-graphql/utils/generate-graphql-safe-name.ts
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export default function generateGraphQLSafeName(input: string): string {
+    // Replace all non supported characters
+    const name = input.replace(/[^_0-9A-Z]+/gi, "_");
+    // GraphQL types cannot start with a number
+    return name.replace(/^([0-9])/, "_$1");
+}

--- a/packages/introspector/src/tsconfig.json
+++ b/packages/introspector/src/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "../dist"
     },
+    "exclude": ["**/*.test.ts"],
     "references": [
         { "path": "../" } // for package.json import
     ]

--- a/packages/introspector/tests/integration/graphql/graphs.test.ts
+++ b/packages/introspector/tests/integration/graphql/graphs.test.ts
@@ -103,12 +103,12 @@ describe("GraphQL - Infer Schema on graphs", () => {
 
         expect(typeDefs).toMatchInlineSnapshot(`
             "type Actor {
-            	actedInMovies: [Movie] @relationship(type: \\"ACTED_IN\\", direction: OUT)
+            	actedInMovies: [Movie!]! @relationship(type: \\"ACTED_IN\\", direction: OUT)
             	name: String!
             }
 
             type Movie {
-            	actorsActedIn: [Actor] @relationship(type: \\"ACTED_IN\\", direction: IN)
+            	actorsActedIn: [Actor!]! @relationship(type: \\"ACTED_IN\\", direction: IN)
             	title: String!
             }"
         `);
@@ -145,26 +145,26 @@ describe("GraphQL - Infer Schema on graphs", () => {
         const typeDefs = await toGraphQLTypeDefs(sessionFactory(bm));
         expect(typeDefs).toMatchInlineSnapshot(`
             "type Actor {
-            	actedInMovies: [Movie] @relationship(type: \\"ACTED_IN\\", direction: OUT)
-            	actedInPlays: [Play] @relationship(type: \\"ACTED_IN\\", direction: OUT)
-            	directedMovies: [Movie] @relationship(type: \\"DIRECTED\\", direction: OUT)
+            	actedInMovies: [Movie!]! @relationship(type: \\"ACTED_IN\\", direction: OUT)
+            	actedInPlays: [Play!]! @relationship(type: \\"ACTED_IN\\", direction: OUT)
+            	directedMovies: [Movie!]! @relationship(type: \\"DIRECTED\\", direction: OUT)
             	name: String!
             }
 
             type Dog {
-            	actedInMovies: [Movie] @relationship(type: \\"ACTED_IN\\", direction: OUT)
+            	actedInMovies: [Movie!]! @relationship(type: \\"ACTED_IN\\", direction: OUT)
             	name: String!
             }
 
             type Movie {
-            	actorsActedIn: [Actor] @relationship(type: \\"ACTED_IN\\", direction: IN)
-            	actorsDirected: [Actor] @relationship(type: \\"DIRECTED\\", direction: IN)
-            	dogsActedIn: [Dog] @relationship(type: \\"ACTED_IN\\", direction: IN)
+            	actorsActedIn: [Actor!]! @relationship(type: \\"ACTED_IN\\", direction: IN)
+            	actorsDirected: [Actor!]! @relationship(type: \\"DIRECTED\\", direction: IN)
+            	dogsActedIn: [Dog!]! @relationship(type: \\"ACTED_IN\\", direction: IN)
             	title: String!
             }
 
             type Play {
-            	actorsActedIn: [Actor] @relationship(type: \\"ACTED_IN\\", direction: IN)
+            	actorsActedIn: [Actor!]! @relationship(type: \\"ACTED_IN\\", direction: IN)
             	title: String!
             }"
         `);
@@ -215,9 +215,9 @@ describe("GraphQL - Infer Schema on graphs", () => {
             }
 
             type Actor {
-            	actedInMovies: [Movie] @relationship(type: \\"ACTED_IN\\", direction: OUT, properties: \\"ActedInProperties\\")
-            	directedMovies: [Movie] @relationship(type: \\"DIRECTED\\", direction: OUT, properties: \\"DirectedProperties\\")
-            	moviesWonPrizeFor: [Movie] @relationship(type: \\"WON_PRIZE_FOR\\", direction: IN)
+            	actedInMovies: [Movie!]! @relationship(type: \\"ACTED_IN\\", direction: OUT, properties: \\"ActedInProperties\\")
+            	directedMovies: [Movie!]! @relationship(type: \\"DIRECTED\\", direction: OUT, properties: \\"DirectedProperties\\")
+            	moviesWonPrizeFor: [Movie!]! @relationship(type: \\"WON_PRIZE_FOR\\", direction: IN)
             	name: String!
             }
 
@@ -226,10 +226,10 @@ describe("GraphQL - Infer Schema on graphs", () => {
             }
 
             type Movie {
-            	actorsActedIn: [Actor] @relationship(type: \\"ACTED_IN\\", direction: IN, properties: \\"ActedInProperties\\")
-            	actorsDirected: [Actor] @relationship(type: \\"DIRECTED\\", direction: IN, properties: \\"DirectedProperties\\")
+            	actorsActedIn: [Actor!]! @relationship(type: \\"ACTED_IN\\", direction: IN, properties: \\"ActedInProperties\\")
+            	actorsDirected: [Actor!]! @relationship(type: \\"DIRECTED\\", direction: IN, properties: \\"DirectedProperties\\")
             	title: String!
-            	wonPrizeForActors: [Actor] @relationship(type: \\"WON_PRIZE_FOR\\", direction: OUT)
+            	wonPrizeForActors: [Actor!]! @relationship(type: \\"WON_PRIZE_FOR\\", direction: OUT)
             }"
         `);
 
@@ -269,15 +269,15 @@ describe("GraphQL - Infer Schema on graphs", () => {
             }
 
             type Actor_Label @node(label: \\"Actor-Label\\") {
-            	actedInMovieLabels: [Movie_Label] @relationship(type: \\"ACTED-IN\\", direction: OUT, properties: \\"ActedInProperties\\")
-            	movieLabelsWonPrizeFor: [Movie_Label] @relationship(type: \\"WON_PRIZE_FOR\\", direction: IN)
+            	actedInMovieLabels: [Movie_Label!]! @relationship(type: \\"ACTED-IN\\", direction: OUT, properties: \\"ActedInProperties\\")
+            	movieLabelsWonPrizeFor: [Movie_Label!]! @relationship(type: \\"WON_PRIZE_FOR\\", direction: IN)
             	name: String!
             }
 
             type Movie_Label @node(label: \\"Movie-Label\\") {
-            	actorLabelsActedIn: [Actor_Label] @relationship(type: \\"ACTED-IN\\", direction: IN, properties: \\"ActedInProperties\\")
+            	actorLabelsActedIn: [Actor_Label!]! @relationship(type: \\"ACTED-IN\\", direction: IN, properties: \\"ActedInProperties\\")
             	title: String!
-            	wonPrizeForActorLabels: [Actor_Label] @relationship(type: \\"WON_PRIZE_FOR\\", direction: OUT)
+            	wonPrizeForActorLabels: [Actor_Label!]! @relationship(type: \\"WON_PRIZE_FOR\\", direction: OUT)
             }"
         `);
 

--- a/packages/introspector/tests/integration/graphql/nodes.test.ts
+++ b/packages/introspector/tests/integration/graphql/nodes.test.ts
@@ -235,6 +235,34 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
 
         expect(() => new Neo4jGraphQL({ typeDefs, driver })).not.toThrow();
     });
+
+    // Enable when Neo4j GraphQL Library has support for this
+    test.skip("Can introspect and generate label that starts with a number", async () => {
+        // Skip if multi-db not supported
+        if (!MULTIDB_SUPPORT) {
+            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
+            pending();
+            return;
+        }
+
+        const nodeProperties = { first: "testString", second: neo4j.int(42) };
+        const wSession = driver.session({ defaultAccessMode: neo4j.session.WRITE, database: dbName });
+        await wSession.writeTransaction((tx) =>
+            tx.run("CREATE (:`2number` {prop: $props.second})", { props: nodeProperties })
+        );
+        const bm = wSession.lastBookmark();
+        await wSession.close();
+
+        const typeDefs = await toGraphQLTypeDefs(sessionFactory(bm));
+
+        expect(typeDefs).toMatchInlineSnapshot(`
+            "type _2number @node(label: \\"2number\\") {
+            	prop: BigInt!
+            }"
+        `);
+
+        expect(() => new Neo4jGraphQL({ typeDefs, driver })).not.toThrow();
+    });
     test("Should not include properties with ambiguous types", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {

--- a/packages/introspector/tests/integration/graphql/nodes.test.ts
+++ b/packages/introspector/tests/integration/graphql/nodes.test.ts
@@ -308,11 +308,11 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
 
         expect(typeDefs).toMatchInlineSnapshot(`
             "type EmptyNode {
-            	relationshipFullNodes: [FullNode] @relationship(type: \\"RELATIONSHIP\\", direction: OUT)
+            	relationshipFullNodes: [FullNode!]! @relationship(type: \\"RELATIONSHIP\\", direction: OUT)
             }
 
             type FullNode {
-            	emptyNodesRelationship: [EmptyNode] @relationship(type: \\"RELATIONSHIP\\", direction: IN)
+            	emptyNodesRelationship: [EmptyNode!]! @relationship(type: \\"RELATIONSHIP\\", direction: IN)
             	prop: BigInt!
             }"
         `);

--- a/packages/introspector/tests/integration/graphql/nodes.test.ts
+++ b/packages/introspector/tests/integration/graphql/nodes.test.ts
@@ -236,8 +236,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
         expect(() => new Neo4jGraphQL({ typeDefs, driver })).not.toThrow();
     });
 
-    // Enable when Neo4j GraphQL Library has support for this
-    test.skip("Can introspect and generate label that starts with a number", async () => {
+    test("Can introspect and generate label that starts with a number", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
             // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
@@ -245,11 +244,8 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
             return;
         }
 
-        const nodeProperties = { first: "testString", second: neo4j.int(42) };
         const wSession = driver.session({ defaultAccessMode: neo4j.session.WRITE, database: dbName });
-        await wSession.writeTransaction((tx) =>
-            tx.run("CREATE (:`2number` {prop: $props.second})", { props: nodeProperties })
-        );
+        await wSession.writeTransaction((tx) => tx.run("CREATE (:`2number` {prop: 1})"));
         const bm = wSession.lastBookmark();
         await wSession.close();
 
@@ -261,7 +257,8 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
             }"
         `);
 
-        expect(() => new Neo4jGraphQL({ typeDefs, driver })).not.toThrow();
+        // TODO: Uncomment when there's support in Neo4j GraphQL
+        // expect(() => new Neo4jGraphQL({ typeDefs, driver })).not.toThrow();
     });
     test("Should not include properties with ambiguous types", async () => {
         // Skip if multi-db not supported


### PR DESCRIPTION
# Description

Two fixes for the introspector:

- Create correct non-nullable arrays for relationships.
- Don't generate invalid type/interface names with regards to node labels and rel-types that starts with invalid characters (i.e. numbers).

For the last point, the integration test assertion with Neo4j GraphQL is commented out due to lack of support in the library for labels starting with numbers.

fyi: I deliberately named this in a way so it doesn't show up in changelogs.