### PR TITLE
Set all aggregation fields as nullable

### DIFF
--- a/packages/graphql/src/schema/aggregations/aggregation-types-mapper.ts
+++ b/packages/graphql/src/schema/aggregations/aggregation-types-mapper.ts
@@ -145,7 +145,8 @@ export class AggregationTypesMapper {
         fields?: Record<string, any>;
     }): ObjectTypeComposer<any, any> {
         const typeName = this.makeNullable(name, nullable);
-        const nullableStr = nullable ? "Nullable" : "NonNullable";
+        const nullableStr = "";
+        // const nullableStr = nullable ? "Nullable" : "NonNullable"; // TODO: #605 Breaking change, uncomment for 3.0
 
         return composer.getOrCreateOTC(`${name}AggregateSelection${nullableStr}`, (tc) => {
             tc.addFields(fields ?? { min: typeName, max: typeName });
@@ -153,6 +154,7 @@ export class AggregationTypesMapper {
     }
 
     private makeNullable(typeStr: string, isNullable: boolean) {
-        return `${typeStr}${isNullable ? "" : "!"}`;
+        return `${typeStr}${isNullable ? "" : ""}`;
+        // return `${typeStr}${isNullable ? "" : "!"}`; // TODO: #605 Breaking change, uncomment for 3.0
     }
 }

--- a/packages/graphql/src/schema/aggregations/aggregations-types-mapper.test.ts
+++ b/packages/graphql/src/schema/aggregations/aggregations-types-mapper.test.ts
@@ -35,19 +35,22 @@ describe("AggregationTypesMapper", () => {
             nullable: false,
         });
 
-        expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelectionNonNullable");
+        expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelection");
+        // expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelectionNonNullable"); // TODO: #605 Breaking change, uncomment for 3.0
         expect(composer.get(aggregationType?.getTypeName())).toBeTruthy();
     });
 
     test("do not duplicate types", () => {
-        const beforeType = composer.get("StringAggregateSelectionNonNullable");
+        const beforeType = composer.get("StringAggregateSelection");
+        // const beforeType = composer.get("StringAggregateSelectionNonNullable"); // TODO: #605 Breaking change, uncomment for 3.0
         const typesMapper2 = new AggregationTypesMapper(composer);
         const aggregationType = typesMapper2.getAggregationType({
             fieldName: "String",
             nullable: false,
         });
 
-        expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelectionNonNullable");
+        expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelection");
+        // expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelectionNonNullable"); // TODO: #605 Breaking change, uncomment for 3.0
         expect(composer.get(aggregationType?.getTypeName())).toBeTruthy();
         expect(beforeType).toEqual(aggregationType);
     });
@@ -58,7 +61,8 @@ describe("AggregationTypesMapper", () => {
             nullable: true,
         });
 
-        expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelectionNullable");
+        expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelection");
+        // expect(aggregationType?.getTypeName()).toEqual("StringAggregateSelectionNullable"); // TODO: #605 Breaking change, uncomment for 3.0
         expect(composer.get(aggregationType?.getTypeName())).toBeTruthy();
     });
 

--- a/packages/graphql/src/translate/field-aggregations/utils.ts
+++ b/packages/graphql/src/translate/field-aggregations/utils.ts
@@ -34,10 +34,11 @@ export enum AggregationType {
 
 export function getFieldType(field: ResolveTree): AggregationType | undefined {
     for (const candidateField of Object.values(AggregationType)) {
-        if (
-            field.fieldsByTypeName[`${candidateField}NonNullable`] ||
-            field.fieldsByTypeName[`${candidateField}Nullable`]
-        )
+        if (field.fieldsByTypeName[`${candidateField}`])
+            // if (
+            //     field.fieldsByTypeName[`${candidateField}NonNullable`] ||
+            //     field.fieldsByTypeName[`${candidateField}Nullable`]
+            // ) // TODO: #605 Breaking change, uncomment for 3.0
             return candidateField;
     }
     return undefined;

--- a/packages/graphql/src/translate/translate-aggregate.ts
+++ b/packages/graphql/src/translate/translate-aggregate.ts
@@ -92,9 +92,10 @@ function translateAggregate({ node, context }: { node: Node; context: Context })
 
         if (field) {
             const thisProjections: string[] = [];
-            const aggregateFields =
-                selection[1].fieldsByTypeName[`${field.typeMeta.name}AggregateSelectionNullable`] ||
-                selection[1].fieldsByTypeName[`${field.typeMeta.name}AggregateSelectionNonNullable`];
+            const aggregateFields = selection[1].fieldsByTypeName[`${field.typeMeta.name}AggregateSelection`];
+            // const aggregateFields =
+            //     selection[1].fieldsByTypeName[`${field.typeMeta.name}AggregateSelectionNullable`] ||
+            //     selection[1].fieldsByTypeName[`${field.typeMeta.name}AggregateSelectionNonNullable`]; // TODO: #605 Breaking change, uncomment for 3.0
 
             Object.entries(aggregateFields).forEach((entry) => {
                 // "min" | "max" | "average" | "sum" | "shortest" | "longest"

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -51,7 +51,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A BigInt value up to 64 bits in size, which can be a number or a string if used inline, or a string only if used as a variable. Always returned as a string.\\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -72,7 +72,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -86,24 +86,24 @@ describe("Aggregations", () => {
             \\"\\"\\"A duration, represented as an ISO 8601 duration string\\"\\"\\"
             scalar Duration
 
-            type DurationAggregateSelectionNullable {
+            type DurationAggregateSelection {
               max: Duration
               min: Duration
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -113,7 +113,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'\\"\\"\\"
             scalar LocalDateTime
 
-            type LocalDateTimeAggregateSelectionNullable {
+            type LocalDateTimeAggregateSelection {
               max: LocalDateTime
               min: LocalDateTime
             }
@@ -121,7 +121,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A local time, represented as a time string without timezone information\\"\\"\\"
             scalar LocalTime
 
-            type LocalTimeAggregateSelectionNullable {
+            type LocalTimeAggregateSelection {
               max: LocalTime
               min: LocalTime
             }
@@ -142,17 +142,17 @@ describe("Aggregations", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
-              imdbRating: FloatAggregateSelectionNullable!
-              isbn: StringAggregateSelectionNonNullable!
-              screenTime: DurationAggregateSelectionNullable!
-              someBigInt: BigIntAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              imdbRating: FloatAggregateSelection!
+              isbn: StringAggregateSelection!
+              screenTime: DurationAggregateSelection!
+              someBigInt: BigIntAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someTime: TimeAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -323,12 +323,7 @@ describe("Aggregations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -336,7 +331,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A time, represented as an RFC3339 time string\\"\\"\\"
             scalar Time
 
-            type TimeAggregateSelectionNullable {
+            type TimeAggregateSelection {
               max: Time
               min: Time
             }
@@ -402,7 +397,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A BigInt value up to 64 bits in size, which can be a number or a string if used inline, or a string only if used as a variable. Always returned as a string.\\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -428,7 +423,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -442,24 +437,24 @@ describe("Aggregations", () => {
             \\"\\"\\"A duration, represented as an ISO 8601 duration string\\"\\"\\"
             scalar Duration
 
-            type DurationAggregateSelectionNullable {
+            type DurationAggregateSelection {
               max: Duration
               min: Duration
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -610,7 +605,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'\\"\\"\\"
             scalar LocalDateTime
 
-            type LocalDateTimeAggregateSelectionNullable {
+            type LocalDateTimeAggregateSelection {
               max: LocalDateTime
               min: LocalDateTime
             }
@@ -618,7 +613,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A local time, represented as a time string without timezone information\\"\\"\\"
             scalar LocalTime
 
-            type LocalTimeAggregateSelectionNullable {
+            type LocalTimeAggregateSelection {
               max: LocalTime
               min: LocalTime
             }
@@ -649,7 +644,7 @@ describe("Aggregations", () => {
 
             type PostAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input PostConnectInput {
@@ -1143,29 +1138,29 @@ describe("Aggregations", () => {
             }
 
             type PostUserLikesEdgeAggregateSelection {
-              someBigInt: BigIntAggregateSelectionNullable!
-              someDateTime: DateTimeAggregateSelectionNullable!
-              someDuration: DurationAggregateSelectionNullable!
-              someFloat: FloatAggregateSelectionNullable!
-              someId: IDAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someString: StringAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someId: IDAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             type PostUserLikesNodeAggregateSelection {
-              someBigInt: BigIntAggregateSelectionNullable!
-              someDateTime: DateTimeAggregateSelectionNullable!
-              someDuration: DurationAggregateSelectionNullable!
-              someFloat: FloatAggregateSelectionNullable!
-              someId: IDAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someString: StringAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someId: IDAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             input PostWhere {
@@ -1204,7 +1199,7 @@ describe("Aggregations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1212,7 +1207,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A time, represented as an RFC3339 time string\\"\\"\\"
             scalar Time
 
-            type TimeAggregateSelectionNullable {
+            type TimeAggregateSelection {
               max: Time
               min: Time
             }
@@ -1250,16 +1245,16 @@ describe("Aggregations", () => {
 
             type UserAggregateSelection {
               count: Int!
-              someBigInt: BigIntAggregateSelectionNullable!
-              someDateTime: DateTimeAggregateSelectionNullable!
-              someDuration: DurationAggregateSelectionNullable!
-              someFloat: FloatAggregateSelectionNullable!
-              someId: IDAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someString: StringAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someId: IDAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             input UserConnectWhere {

--- a/packages/graphql/tests/schema/arrays.test.ts
+++ b/packages/graphql/tests/schema/arrays.test.ts
@@ -57,16 +57,16 @@ describe("Arrays", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+            type FloatAggregateSelection {
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -76,9 +76,9 @@ describe("Arrays", () => {
             }
 
             type MovieAggregateSelection {
-              averageRating: FloatAggregateSelectionNonNullable!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -85,7 +85,7 @@ describe("Comments", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -99,12 +99,12 @@ describe("Comments", () => {
               ROMANCE
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -129,10 +129,10 @@ describe("Comments", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -53,7 +53,7 @@ describe("connect or create with id", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -83,8 +83,8 @@ describe("connect or create with id", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -254,9 +254,9 @@ describe("connect or create with id", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -266,8 +266,8 @@ describe("connect or create with id", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -361,9 +361,9 @@ describe("connect or create with id", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -429,9 +429,9 @@ describe("connect or create with id", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             type DeleteInfo {
@@ -440,9 +440,9 @@ describe("connect or create with id", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -472,10 +472,10 @@ describe("connect or create with id", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PostConnectInput {
@@ -651,8 +651,8 @@ describe("connect or create with id", () => {
             }
 
             type PostUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -709,9 +709,9 @@ describe("connect or create with id", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -742,8 +742,8 @@ describe("connect or create with id", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -788,9 +788,9 @@ describe("connect or create with id", () => {
             }
 
             type UserPostPostsNodeAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input UserPostsAggregateInput {

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -282,7 +282,7 @@ describe("Connect Or Create", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -378,8 +378,8 @@ describe("Connect Or Create", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -493,8 +493,8 @@ describe("Connect Or Create", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectOrCreateWhere {
@@ -564,9 +564,9 @@ describe("Connect Or Create", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -53,7 +53,7 @@ describe("Connect Or Create", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -83,8 +83,8 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -280,8 +280,8 @@ describe("Connect Or Create", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -377,9 +377,9 @@ describe("Connect Or Create", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -481,7 +481,7 @@ describe("Connect Or Create", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -512,13 +512,13 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              characterName: StringAggregateSelectionNullable!
-              screentime: IntAggregateSelectionNonNullable!
+              characterName: StringAggregateSelection!
+              screentime: IntAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -767,11 +767,11 @@ describe("Connect Or Create", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -781,8 +781,8 @@ describe("Connect Or Create", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -878,12 +878,7 @@ describe("Connect Or Create", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -87,7 +87,7 @@ describe("Enums", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -117,7 +117,7 @@ describe("Enums", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -298,7 +298,7 @@ describe("Enums", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -405,7 +405,7 @@ describe("Enums", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -508,9 +508,9 @@ describe("Enums", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -83,7 +83,7 @@ describe("Sort", () => {
 
             type Node1AggregateSelection {
               count: Int!
-              property: StringAggregateSelectionNonNullable!
+              property: StringAggregateSelection!
             }
 
             input Node1ConnectInput {
@@ -253,7 +253,7 @@ describe("Sort", () => {
             }
 
             type Node2Node1RelatedToNodeAggregateSelection {
-              property: StringAggregateSelectionNonNullable!
+              property: StringAggregateSelection!
             }
 
             input Node2Options {
@@ -398,9 +398,9 @@ describe("Sort", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -63,7 +63,7 @@ describe("Unions", () => {
 
             type AuthorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input AuthorConnectInput {
@@ -301,7 +301,7 @@ describe("Unions", () => {
 
             type BookAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input BookAuthorAggregateInput {
@@ -323,11 +323,11 @@ describe("Unions", () => {
             }
 
             type BookAuthorAuthorEdgeAggregateSelection {
-              words: IntAggregateSelectionNonNullable!
+              words: IntAggregateSelection!
             }
 
             type BookAuthorAuthorNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input BookAuthorConnectFieldInput {
@@ -540,11 +540,11 @@ describe("Unions", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Journal {
@@ -556,7 +556,7 @@ describe("Unions", () => {
 
             type JournalAggregateSelection {
               count: Int!
-              subject: StringAggregateSelectionNonNullable!
+              subject: StringAggregateSelection!
             }
 
             input JournalAuthorAggregateInput {
@@ -578,11 +578,11 @@ describe("Unions", () => {
             }
 
             type JournalAuthorAuthorEdgeAggregateSelection {
-              words: IntAggregateSelectionNonNullable!
+              words: IntAggregateSelection!
             }
 
             type JournalAuthorAuthorNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input JournalAuthorConnectFieldInput {
@@ -819,9 +819,9 @@ describe("Unions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateAuthorsMutationResponse {

--- a/packages/graphql/tests/schema/custom-mutations.test.ts
+++ b/packages/graphql/tests/schema/custom-mutations.test.ts
@@ -78,7 +78,7 @@ describe("Custom-mutations", () => {
               id: ID
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -89,7 +89,7 @@ describe("Custom-mutations", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -62,7 +62,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -73,7 +73,7 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -278,9 +278,9 @@ describe("Alias", () => {
             }
 
             type ActorAggregateSelection {
-              city: StringAggregateSelectionNullable!
+              city: StringAggregateSelection!
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -308,13 +308,13 @@ describe("Alias", () => {
             }
 
             type ActorMovieActedInEdgeAggregateSelection {
-              character: StringAggregateSelectionNonNullable!
-              screenTime: IntAggregateSelectionNullable!
+              character: StringAggregateSelection!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieActedInNodeAggregateSelection {
-              rating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              rating: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorOptions {
@@ -392,14 +392,14 @@ describe("Alias", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -413,8 +413,8 @@ describe("Alias", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              rating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              rating: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectWhere {
@@ -500,12 +500,7 @@ describe("Alias", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/schema/directives/autogenerate.test.ts
@@ -56,9 +56,9 @@ describe("Autogenerate", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -68,8 +68,8 @@ describe("Autogenerate", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -137,9 +137,9 @@ describe("Autogenerate", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -56,7 +56,7 @@ describe("Cypher", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorCreateInput {
@@ -116,7 +116,7 @@ describe("Cypher", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -128,7 +128,7 @@ describe("Cypher", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -191,7 +191,7 @@ describe("Cypher", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -258,7 +258,7 @@ describe("Cypher", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorCreateInput {
@@ -319,7 +319,7 @@ describe("Cypher", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -331,7 +331,7 @@ describe("Cypher", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -394,7 +394,7 @@ describe("Cypher", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -64,9 +64,9 @@ describe("@default directive", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             type DeleteInfo {
@@ -75,23 +75,23 @@ describe("@default directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+            type FloatAggregateSelection {
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Mutation {
@@ -113,9 +113,9 @@ describe("@default directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -144,13 +144,13 @@ describe("@default directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              fromInterface: StringAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
-              numberOfFriends: IntAggregateSelectionNonNullable!
-              rating: FloatAggregateSelectionNonNullable!
-              toBeOverridden: StringAggregateSelectionNonNullable!
-              verifiedDate: DateTimeAggregateSelectionNonNullable!
+              fromInterface: StringAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              numberOfFriends: IntAggregateSelection!
+              rating: FloatAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
+              verifiedDate: DateTimeAggregateSelection!
             }
 
             input UserCreateInput {

--- a/packages/graphql/tests/schema/directives/exclude.test.ts
+++ b/packages/graphql/tests/schema/directives/exclude.test.ts
@@ -97,7 +97,7 @@ describe("@exclude directive", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -157,7 +157,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -204,7 +204,7 @@ describe("@exclude directive", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorOptions {
@@ -262,7 +262,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -325,7 +325,7 @@ describe("@exclude directive", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -382,7 +382,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -453,7 +453,7 @@ describe("@exclude directive", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -511,7 +511,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -625,7 +625,7 @@ describe("@exclude directive", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -722,7 +722,7 @@ describe("@exclude directive", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -810,7 +810,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -852,7 +852,7 @@ describe("@exclude directive", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorCreateInput {
@@ -926,7 +926,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -993,7 +993,7 @@ describe("@exclude directive", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieOptions {
@@ -1053,7 +1053,7 @@ describe("@exclude directive", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input SeriesCreateInput {
@@ -1094,7 +1094,7 @@ describe("@exclude directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/ignore.test.ts
+++ b/packages/graphql/tests/schema/directives/ignore.test.ts
@@ -63,9 +63,9 @@ describe("@ignore directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -87,9 +87,9 @@ describe("@ignore directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -115,9 +115,9 @@ describe("@ignore directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {

--- a/packages/graphql/tests/schema/directives/node-plural.test.ts
+++ b/packages/graphql/tests/schema/directives/node-plural.test.ts
@@ -60,7 +60,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -72,8 +72,8 @@ describe("Node Directive", () => {
 
                 type TechAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
-                  value: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
+                  value: StringAggregateSelection!
                 }
 
                 input TechCreateInput {
@@ -195,7 +195,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -207,8 +207,8 @@ describe("Node Directive", () => {
 
                 type TechAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
-                  value: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
+                  value: StringAggregateSelection!
                 }
 
                 input TechCreateInput {
@@ -330,7 +330,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -342,8 +342,8 @@ describe("Node Directive", () => {
 
                 type TechAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
-                  value: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
+                  value: StringAggregateSelection!
                 }
 
                 input TechCreateInput {
@@ -465,7 +465,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -476,7 +476,7 @@ describe("Node Directive", () => {
 
                 type TechsAggregateSelection {
                   count: Int!
-                  value: StringAggregateSelectionNullable!
+                  value: StringAggregateSelection!
                 }
 
                 input TechsCreateInput {
@@ -585,7 +585,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -609,7 +609,7 @@ describe("Node Directive", () => {
 
                 type UserAggregateSelection {
                   count: Int!
-                  value: StringAggregateSelectionNullable!
+                  value: StringAggregateSelection!
                 }
 
                 input UserCreateInput {
@@ -705,7 +705,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -729,7 +729,7 @@ describe("Node Directive", () => {
 
                 type UserAggregateSelection {
                   count: Int!
-                  value: StringAggregateSelectionNullable!
+                  value: StringAggregateSelection!
                 }
 
                 input UserCreateInput {
@@ -825,7 +825,7 @@ describe("Node Directive", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -849,7 +849,7 @@ describe("Node Directive", () => {
 
                 type UsersAggregateSelection {
                   count: Int!
-                  value: StringAggregateSelectionNullable!
+                  value: StringAggregateSelection!
                 }
 
                 input UsersCreateInput {

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -61,7 +61,7 @@ describe("@private directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -104,7 +104,7 @@ describe("@private directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input UserCreateInput {

--- a/packages/graphql/tests/schema/directives/readonly.test.ts
+++ b/packages/graphql/tests/schema/directives/readonly.test.ts
@@ -56,9 +56,9 @@ describe("@readonly directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -80,9 +80,9 @@ describe("@readonly directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -105,8 +105,8 @@ describe("@readonly directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -197,9 +197,9 @@ describe("@readonly directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -221,9 +221,9 @@ describe("@readonly directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -246,8 +246,8 @@ describe("@readonly directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {

--- a/packages/graphql/tests/schema/directives/timestamps.test.ts
+++ b/packages/graphql/tests/schema/directives/timestamps.test.ts
@@ -54,9 +54,9 @@ describe("Timestamps", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             type DeleteInfo {
@@ -65,7 +65,7 @@ describe("Timestamps", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -78,9 +78,9 @@ describe("Timestamps", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNullable!
-              updatedAt: DateTimeAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/directives/writeonly.test.ts
+++ b/packages/graphql/tests/schema/directives/writeonly.test.ts
@@ -75,9 +75,9 @@ describe("@writeonly directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -99,8 +99,8 @@ describe("@writeonly directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -211,9 +211,9 @@ describe("@writeonly directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {
@@ -235,8 +235,8 @@ describe("@writeonly directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {

--- a/packages/graphql/tests/schema/extend.test.ts
+++ b/packages/graphql/tests/schema/extend.test.ts
@@ -59,7 +59,7 @@ describe("Extend", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -71,8 +71,8 @@ describe("Extend", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -142,7 +142,7 @@ describe("Extend", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/fulltext.test.ts
+++ b/packages/graphql/tests/schema/fulltext.test.ts
@@ -70,8 +70,8 @@ describe("@fulltext schema", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -156,7 +156,7 @@ describe("@fulltext schema", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/inputs.test.ts
+++ b/packages/graphql/tests/schema/inputs.test.ts
@@ -63,7 +63,7 @@ describe("Inputs", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -74,7 +74,7 @@ describe("Inputs", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -156,7 +156,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -241,11 +241,11 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -255,8 +255,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -391,8 +391,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesCreateInput {
@@ -448,9 +448,9 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -624,7 +624,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -727,7 +727,7 @@ describe("Interface Relationships", () => {
 
             type EpisodeAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input EpisodeConnectInput {
@@ -875,8 +875,8 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesSeriesNodeAggregateSelection {
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input EpisodeSeriesUpdateConnectionInput {
@@ -920,11 +920,11 @@ describe("Interface Relationships", () => {
               series_NOT: SeriesWhere
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -942,11 +942,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1018,8 +1018,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1365,11 +1365,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -1441,8 +1441,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1477,7 +1477,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodeEpisodesNodeAggregateSelection {
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input SeriesEpisodesAggregateInput {
@@ -1645,9 +1645,9 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -1990,9 +1990,9 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type Type1 {
@@ -2003,7 +2003,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -2031,7 +2031,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -2179,7 +2179,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -2263,7 +2263,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -2356,7 +2356,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -2485,9 +2485,9 @@ describe("Interface Relationships", () => {
             }
 
             type CommentAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input CommentConnectInput {
@@ -2644,8 +2644,8 @@ describe("Interface Relationships", () => {
             }
 
             type CommentPostPostNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             type CommentPostRelationship {
@@ -2690,8 +2690,8 @@ describe("Interface Relationships", () => {
             }
 
             type CommentUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input CommentWhere {
@@ -2944,7 +2944,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -2981,9 +2981,9 @@ describe("Interface Relationships", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             type PostCommentCommentsAggregationSelection {
@@ -2992,8 +2992,8 @@ describe("Interface Relationships", () => {
             }
 
             type PostCommentCommentsNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PostCommentsAggregateInput {
@@ -3186,8 +3186,8 @@ describe("Interface Relationships", () => {
             }
 
             type PostUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -3249,7 +3249,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -3286,8 +3286,8 @@ describe("Interface Relationships", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -76,7 +76,7 @@ describe("Interfaces", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -92,7 +92,7 @@ describe("Interfaces", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -122,7 +122,7 @@ describe("Interfaces", () => {
             }
 
             type MovieMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieMoviesAggregateInput {

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -75,12 +75,12 @@ describe("162", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -132,7 +132,7 @@ describe("162", () => {
 
             type TigerAggregateSelection {
               count: Int!
-              x: IntAggregateSelectionNullable!
+              x: IntAggregateSelection!
             }
 
             input TigerConnectWhere {
@@ -152,7 +152,7 @@ describe("162", () => {
 
             type TigerJawLevel2AggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input TigerJawLevel2ConnectInput {
@@ -199,7 +199,7 @@ describe("162", () => {
 
             type TigerJawLevel2Part1AggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input TigerJawLevel2Part1ConnectFieldInput {
@@ -381,7 +381,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1TigerTigerNodeAggregateSelection {
-              x: IntAggregateSelectionNullable!
+              x: IntAggregateSelection!
             }
 
             input TigerJawLevel2Part1TigerUpdateConnectionInput {
@@ -450,7 +450,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2TigerJawLevel2Part1Part1NodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input TigerJawLevel2UpdateInput {

--- a/packages/graphql/tests/schema/issues/200.test.ts
+++ b/packages/graphql/tests/schema/issues/200.test.ts
@@ -49,10 +49,10 @@ describe("200", () => {
             }
 
             type CategoryAggregateSelection {
-              categoryId: IDAggregateSelectionNonNullable!
+              categoryId: IDAggregateSelection!
               count: Int!
-              description: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input CategoryCreateInput {
@@ -137,9 +137,9 @@ describe("200", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -161,9 +161,9 @@ describe("200", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateCategoriesMutationResponse {

--- a/packages/graphql/tests/schema/null.test.ts
+++ b/packages/graphql/tests/schema/null.test.ts
@@ -64,9 +64,9 @@ describe("Null", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             type DeleteInfo {
@@ -75,23 +75,23 @@ describe("Null", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+            type FloatAggregateSelection {
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -111,12 +111,12 @@ describe("Null", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNonNullable!
-              averageRating: FloatAggregateSelectionNonNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -291,9 +291,9 @@ describe("Null", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateInfo {

--- a/packages/graphql/tests/schema/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/relationship-properties.test.ts
@@ -106,7 +106,7 @@ describe("Relationship-properties", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -137,11 +137,11 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -345,11 +345,11 @@ describe("Relationship-properties", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -366,11 +366,11 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -510,7 +510,7 @@ describe("Relationship-properties", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -608,9 +608,9 @@ describe("Relationship-properties", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -721,7 +721,7 @@ describe("Relationship-properties", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -752,13 +752,13 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              screenTime: IntAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              screenTime: IntAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -972,9 +972,9 @@ describe("Relationship-properties", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             type DeleteInfo {
@@ -983,16 +983,16 @@ describe("Relationship-properties", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+            type IntAggregateSelection {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -1009,13 +1009,13 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              screenTime: IntAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              screenTime: IntAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1171,7 +1171,7 @@ describe("Relationship-properties", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1269,9 +1269,9 @@ describe("Relationship-properties", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -1363,7 +1363,7 @@ describe("Relationship-properties", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -1394,12 +1394,12 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -1584,9 +1584,9 @@ describe("Relationship-properties", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             type DeleteInfo {
@@ -1595,9 +1595,9 @@ describe("Relationship-properties", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -1614,12 +1614,12 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1746,7 +1746,7 @@ describe("Relationship-properties", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1844,9 +1844,9 @@ describe("Relationship-properties", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/relationship.test.ts
+++ b/packages/graphql/tests/schema/relationship.test.ts
@@ -49,7 +49,7 @@ describe("Relationship", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -113,7 +113,7 @@ describe("Relationship", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -131,7 +131,7 @@ describe("Relationship", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -228,7 +228,7 @@ describe("Relationship", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -322,7 +322,7 @@ describe("Relationship", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -378,7 +378,7 @@ describe("Relationship", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -408,7 +408,7 @@ describe("Relationship", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -550,7 +550,7 @@ describe("Relationship", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -568,7 +568,7 @@ describe("Relationship", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -668,7 +668,7 @@ describe("Relationship", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -766,7 +766,7 @@ describe("Relationship", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/scalar.test.ts
+++ b/packages/graphql/tests/schema/scalar.test.ts
@@ -60,7 +60,7 @@ describe("Scalar", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -72,7 +72,7 @@ describe("Scalar", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/simple.test.ts
+++ b/packages/graphql/tests/schema/simple.test.ts
@@ -58,19 +58,19 @@ describe("Simple", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -85,10 +85,10 @@ describe("Simple", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/bigint.test.ts
+++ b/packages/graphql/tests/schema/types/bigint.test.ts
@@ -42,11 +42,11 @@ describe("Bigint", () => {
             \\"\\"\\"A BigInt value up to 64 bits in size, which can be a number or a string if used inline, or a string only if used as a variable. Always returned as a string.\\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNonNullable {
-              average: BigInt!
-              max: BigInt!
-              min: BigInt!
-              sum: BigInt!
+            type BigIntAggregateSelection {
+              average: BigInt
+              max: BigInt
+              min: BigInt
+              sum: BigInt
             }
 
             type CreateFilesMutationResponse {
@@ -73,8 +73,8 @@ describe("Bigint", () => {
 
             type FileAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
-              size: BigIntAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
+              size: BigIntAggregateSelection!
             }
 
             input FileCreateInput {
@@ -142,9 +142,9 @@ describe("Bigint", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+            type StringAggregateSelection {
+              longest: String
+              shortest: String
             }
 
             type UpdateFilesMutationResponse {

--- a/packages/graphql/tests/schema/types/date.test.ts
+++ b/packages/graphql/tests/schema/types/date.test.ts
@@ -59,7 +59,7 @@ describe("Date", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -71,7 +71,7 @@ describe("Date", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/datetime.test.ts
+++ b/packages/graphql/tests/schema/types/datetime.test.ts
@@ -53,7 +53,7 @@ describe("Datetime", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -64,7 +64,7 @@ describe("Datetime", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -76,8 +76,8 @@ describe("Datetime", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              datetime: DateTimeAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              datetime: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/duration.test.ts
+++ b/packages/graphql/tests/schema/types/duration.test.ts
@@ -59,12 +59,12 @@ describe("Duration", () => {
             \\"\\"\\"A duration, represented as an ISO 8601 duration string\\"\\"\\"
             scalar Duration
 
-            type DurationAggregateSelectionNullable {
+            type DurationAggregateSelection {
               max: Duration
               min: Duration
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -76,8 +76,8 @@ describe("Duration", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              duration: DurationAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              duration: DurationAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/localdatetime.test.ts
+++ b/packages/graphql/tests/schema/types/localdatetime.test.ts
@@ -56,7 +56,7 @@ describe("Localdatetime", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -64,7 +64,7 @@ describe("Localdatetime", () => {
             \\"\\"\\"A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'\\"\\"\\"
             scalar LocalDateTime
 
-            type LocalDateTimeAggregateSelectionNullable {
+            type LocalDateTimeAggregateSelection {
               max: LocalDateTime
               min: LocalDateTime
             }
@@ -76,8 +76,8 @@ describe("Localdatetime", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              localDT: LocalDateTimeAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              localDT: LocalDateTimeAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/localtime.test.ts
+++ b/packages/graphql/tests/schema/types/localtime.test.ts
@@ -56,7 +56,7 @@ describe("Localtime", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -64,7 +64,7 @@ describe("Localtime", () => {
             \\"\\"\\"A local time, represented as a time string without timezone information\\"\\"\\"
             scalar LocalTime
 
-            type LocalTimeAggregateSelectionNullable {
+            type LocalTimeAggregateSelection {
               max: LocalTime
               min: LocalTime
             }
@@ -76,8 +76,8 @@ describe("Localtime", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              time: LocalTimeAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              time: LocalTimeAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/time.test.ts
+++ b/packages/graphql/tests/schema/types/time.test.ts
@@ -56,7 +56,7 @@ describe("Time", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -68,8 +68,8 @@ describe("Time", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              time: TimeAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              time: TimeAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -140,7 +140,7 @@ describe("Time", () => {
             \\"\\"\\"A time, represented as an RFC3339 time string\\"\\"\\"
             scalar Time
 
-            type TimeAggregateSelectionNullable {
+            type TimeAggregateSelection {
               max: Time
               min: Time
             }

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -74,7 +74,7 @@ describe("Unions", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input GenreConnectWhere {
@@ -116,7 +116,7 @@ describe("Unions", () => {
               id_STARTS_WITH: ID
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -130,7 +130,7 @@ describe("Unions", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -137,8 +137,8 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"];
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"]>;
               longest?: Maybe<Scalars[\\"String\\"]>;
             };
@@ -166,7 +166,7 @@ describe("generate", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UserCreateInput = {
@@ -204,13 +204,13 @@ describe("generate", () => {
               name_NOT_ENDS_WITH?: Maybe<Scalars[\\"String\\"]>;
             };
 
-            export interface StringAggregateInputNullable {
+            export interface StringAggregateInput {
               shortest?: boolean;
               longest?: boolean;
             }
             export interface UserAggregateInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: StringAggregateInput;
             }
 
             export declare class UserModel {
@@ -374,8 +374,8 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"];
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"]>;
               longest?: Maybe<Scalars[\\"String\\"]>;
             };
@@ -403,7 +403,7 @@ describe("generate", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UserCreateInput = {
@@ -450,13 +450,13 @@ describe("generate", () => {
               name_NOT_ENDS_WITH?: Maybe<Scalars[\\"String\\"]>;
             };
 
-            export interface StringAggregateInputNullable {
+            export interface StringAggregateInput {
               shortest?: boolean;
               longest?: boolean;
             }
             export interface UserAggregateInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: StringAggregateInput;
             }
 
             export declare class UserModel {
@@ -629,8 +629,8 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"];
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"]>;
               longest?: Maybe<Scalars[\\"String\\"]>;
             };
@@ -658,7 +658,7 @@ describe("generate", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UserCreateInput = {
@@ -696,13 +696,13 @@ describe("generate", () => {
               name_NOT_ENDS_WITH?: Maybe<Scalars[\\"String\\"]>;
             };
 
-            export interface StringAggregateInputNullable {
+            export interface StringAggregateInput {
               shortest?: boolean;
               longest?: boolean;
             }
             export interface UserAggregateInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: StringAggregateInput;
             }
 
             export declare class UserModel {
@@ -916,12 +916,12 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"];
             };
 
-            export type IntAggregateSelectionNonNullable = {
-              __typename?: \\"IntAggregateSelectionNonNullable\\";
-              max: Scalars[\\"Int\\"];
-              min: Scalars[\\"Int\\"];
-              average: Scalars[\\"Float\\"];
-              sum: Scalars[\\"Int\\"];
+            export type IntAggregateSelection = {
+              __typename?: \\"IntAggregateSelection\\";
+              max?: Maybe<Scalars[\\"Int\\"]>;
+              min?: Maybe<Scalars[\\"Int\\"]>;
+              average?: Maybe<Scalars[\\"Float\\"]>;
+              sum?: Maybe<Scalars[\\"Int\\"]>;
             };
 
             export type Movie = {
@@ -965,7 +965,7 @@ describe("generate", () => {
             export type MovieAggregateSelection = {
               __typename?: \\"MovieAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              title: StringAggregateSelectionNonNullable;
+              title: StringAggregateSelection;
             };
 
             export type MoviePersonActorsAggregationSelection = {
@@ -977,12 +977,12 @@ describe("generate", () => {
 
             export type MoviePersonActorsEdgeAggregateSelection = {
               __typename?: \\"MoviePersonActorsEdgeAggregateSelection\\";
-              screenTime: IntAggregateSelectionNonNullable;
+              screenTime: IntAggregateSelection;
             };
 
             export type MoviePersonActorsNodeAggregateSelection = {
               __typename?: \\"MoviePersonActorsNodeAggregateSelection\\";
-              name: StringAggregateSelectionNonNullable;
+              name: StringAggregateSelection;
             };
 
             /** Pagination information (Relay) */
@@ -1002,13 +1002,13 @@ describe("generate", () => {
             export type PersonAggregateSelection = {
               __typename?: \\"PersonAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              name: StringAggregateSelectionNonNullable;
+              name: StringAggregateSelection;
             };
 
-            export type StringAggregateSelectionNonNullable = {
-              __typename?: \\"StringAggregateSelectionNonNullable\\";
-              shortest: Scalars[\\"String\\"];
-              longest: Scalars[\\"String\\"];
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
+              shortest?: Maybe<Scalars[\\"String\\"]>;
+              longest?: Maybe<Scalars[\\"String\\"]>;
             };
 
             export type UpdateInfo = {
@@ -1272,13 +1272,13 @@ describe("generate", () => {
               name_NOT_ENDS_WITH?: Maybe<Scalars[\\"String\\"]>;
             };
 
-            export interface StringAggregateInputNonNullable {
+            export interface StringAggregateInput {
               shortest?: boolean;
               longest?: boolean;
             }
             export interface MovieAggregateInput {
               count?: boolean;
-              title?: StringAggregateInputNonNullable;
+              title?: StringAggregateInput;
             }
 
             export declare class MovieModel {
@@ -1326,13 +1326,13 @@ describe("generate", () => {
               }): Promise<MovieAggregateSelection>;
             }
 
-            export interface StringAggregateInputNonNullable {
+            export interface StringAggregateInput {
               shortest?: boolean;
               longest?: boolean;
             }
             export interface PersonAggregateInput {
               count?: boolean;
-              name?: StringAggregateInputNonNullable;
+              name?: StringAggregateInput;
             }
 
             export declare class PersonModel {

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -74,7 +74,8 @@ function createAggregationInput({
             return;
         }
 
-        if (type.endsWith(`AggregateSelectionNonNullable`) || type.endsWith(`AggregateSelectionNullable`)) {
+        if (type.endsWith(`AggregateSelection`)) {
+            // if (type.endsWith(`AggregateSelectionNonNullable`) || type.endsWith(`AggregateSelectionNullable`)) { // TODO: #605 Breaking change, uncomment for 3.0
             const newTypeName = `${type.replace(`Selection`, "Input")}`;
 
             if (!aggregateSelections[type]) {


### PR DESCRIPTION
# Description

This PR reverts a fix done in #605 to avoid breaking changes, instead of the correct types, all aggregation types will be nullable with the typename unchanged.

Comments on the breaking fix left for v 3.0.0