### PR TITLE
Fix: Escape all @node directive labels

### DIFF
--- a/packages/graphql/src/classes/Node.test.ts
+++ b/packages/graphql/src/classes/Node.test.ts
@@ -132,8 +132,8 @@ describe("Node", () => {
             const labels = node.getLabels(context);
             const labelString = node.getLabelString(context);
 
-            expect(labels).toEqual(["Film", "`Movie`"]);
-            expect(labelString).toEqual(":Film:`Movie`");
+            expect(labels).toEqual(["`Film`", "`Movie`"]);
+            expect(labelString).toEqual(":`Film`:`Movie`");
         });
     });
 });

--- a/packages/graphql/src/classes/NodeDirective.test.ts
+++ b/packages/graphql/src/classes/NodeDirective.test.ts
@@ -27,28 +27,28 @@ describe("NodeDirective", () => {
         const instance = new NodeDirective({});
         const labelString = instance.getLabelsString("MyLabel", defaultContext);
 
-        expect(labelString).toEqual(":MyLabel");
+        expect(labelString).toEqual(":`MyLabel`");
     });
 
     test("should generate label string with directive label", () => {
         const instance = new NodeDirective({ label: "MyOtherLabel" });
         const labelString = instance.getLabelsString("MyLabel", defaultContext);
 
-        expect(labelString).toEqual(":MyOtherLabel");
+        expect(labelString).toEqual(":`MyOtherLabel`");
     });
 
     test("should generate label string adding additional labels to input typename", () => {
         const instance = new NodeDirective({ additionalLabels: ["Label1", "Label2"] });
         const labelString = instance.getLabelsString("MyLabel", defaultContext);
 
-        expect(labelString).toEqual(":MyLabel:Label1:Label2");
+        expect(labelString).toEqual(":`MyLabel`:`Label1`:`Label2`");
     });
 
     test("should generate label string adding additional labels to directive label", () => {
         const instance = new NodeDirective({ label: "MyOtherLabel", additionalLabels: ["Label1", "Label2"] });
         const labelString = instance.getLabelsString("MyLabel", defaultContext);
 
-        expect(labelString).toEqual(":MyOtherLabel:Label1:Label2");
+        expect(labelString).toEqual(":`MyOtherLabel`:`Label1`:`Label2`");
     });
 
     test("should throw an error if there are no labels", () => {
@@ -64,7 +64,7 @@ describe("NodeDirective", () => {
             additionalLabels: ["$context.escapeTest1", "$context.escapeTest2"],
         });
         const labelString = instance.getLabelsString("label", context);
-        expect(labelString).toEqual(":label:`123-321`:`He``l``lo`");
+        expect(labelString).toEqual(":`label`:`123-321`:`He``l``lo`");
     });
 
     test("should escape jwt labels", () => {
@@ -73,7 +73,7 @@ describe("NodeDirective", () => {
             additionalLabels: ["$jwt.escapeTest1", "$jwt.escapeTest2"],
         });
         const labelString = instance.getLabelsString("label", context);
-        expect(labelString).toEqual(":label:`123-321`:`He``l``lo`");
+        expect(labelString).toEqual(":`label`:`123-321`:`He``l``lo`");
     });
 
     test("should throw if jwt variable is missing in context", () => {

--- a/packages/graphql/src/classes/NodeDirective.ts
+++ b/packages/graphql/src/classes/NodeDirective.ts
@@ -49,7 +49,7 @@ export class NodeDirective {
     public getLabels(typeName: string, context: Context): string[] {
         const mainLabel = this.label || typeName;
         const labels = [mainLabel, ...this.additionalLabels];
-        return this.mapLabelsWithContext(labels, context);
+        return this.mapLabelsWithContext(labels, context).map((l) => this.escapeLabel(l));
     }
 
     private mapLabelsWithContext(labels: string[], context: Context): string[] {
@@ -61,7 +61,7 @@ export class NodeDirective {
             if (ctxPath) {
                 const mappedLabel = ContextParser.getProperty(ctxPath, context);
                 if (!mappedLabel) throw new Error(`Type value required.`);
-                return this.escapeLabel(mappedLabel);
+                return mappedLabel;
             }
             return label;
         });

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
@@ -73,8 +73,8 @@ describe("Field Level Aggregations Alias", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
-            RETURN this { actorsAggregate: { node: { name: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Person)
+            "MATCH (this:\`Film\`)
+            RETURN this { actorsAggregate: { node: { name: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:\`Person\`)
                     WITH n as n
                     ORDER BY size(n.name) DESC
                     WITH collect(n.name) as list

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/label.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/label.test.ts
@@ -82,7 +82,7 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             RETURN { _id: { _shortest: min(this.id), _longest: max(this.id) }, _title: { _shortest:
                                         reduce(shortest = collect(this.title)[0], current IN collect(this.title) | apoc.cypher.runFirstColumn(\\"
                                             RETURN
@@ -136,7 +136,7 @@ describe("Cypher Aggregations Many while Alias fields", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor:Person:Alien)
+            "MATCH (this:\`Actor\`:\`Person\`:\`Alien\`)
             RETURN { _id: { _shortest: min(this.id), _longest: max(this.id) }, _name: { _shortest:
                                         reduce(shortest = collect(this.name)[0], current IN collect(this.name) | apoc.cypher.runFirstColumn(\\"
                                             RETURN

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node.test.ts
@@ -61,8 +61,8 @@ describe("Cypher Where Aggregations with @node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:_Post:additionalPost)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[this_likesAggregate_edge:LIKES]-(this_likesAggregate_node:_User:additionalUser)
+            "MATCH (this:\`_Post\`:\`additionalPost\`)
+            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[this_likesAggregate_edge:LIKES]-(this_likesAggregate_node:\`_User\`:\`additionalUser\`)
             RETURN size(this_likesAggregate_node.someName) > $this_likesAggregate_node_someName_GT
             \\", { this: this, this_likesAggregate_node_someName_GT: $this_likesAggregate_node_someName_GT }, false )
             RETURN this { .content } as this"

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-additional-labels.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-additional-labels.test.ts
@@ -63,7 +63,7 @@ describe("Node directive with additionalLabels", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "MATCH (this:\`Film\`:\`Multimedia\`)
             RETURN this { .title } as this"
         `);
 
@@ -88,8 +88,8 @@ describe("Node directive with additionalLabels", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
-            RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor:Person)   | this_actors { .name } ] } as this"
+            "MATCH (this:\`Film\`:\`Multimedia\`)
+            RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:\`Actor\`:\`Person\`)   | this_actors { .name } ] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -118,19 +118,19 @@ describe("Node directive with additionalLabels", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
-            CREATE (this0:Film:Multimedia)
+            CREATE (this0:\`Film\`:\`Multimedia\`)
             SET this0.id = $this0_id
             WITH this0
-            CREATE (this0_actors0_node:Actor:Person)
+            CREATE (this0_actors0_node:\`Actor\`:\`Person\`)
             SET this0_actors0_node.name = $this0_actors0_node_name
             MERGE (this0)<-[:ACTED_IN]-(this0_actors0_node)
             RETURN this0
             }
             CALL {
-            CREATE (this1:Film:Multimedia)
+            CREATE (this1:\`Film\`:\`Multimedia\`)
             SET this1.id = $this1_id
             WITH this1
-            CREATE (this1_actors0_node:Actor:Person)
+            CREATE (this1_actors0_node:\`Actor\`:\`Person\`)
             SET this1_actors0_node.name = $this1_actors0_node_name
             MERGE (this1)<-[:ACTED_IN]-(this1_actors0_node)
             RETURN this1
@@ -165,7 +165,7 @@ describe("Node directive with additionalLabels", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "MATCH (this:\`Film\`:\`Multimedia\`)
             WHERE this.id = $this_id
             DETACH DELETE this"
         `);
@@ -194,7 +194,7 @@ describe("Node directive with additionalLabels", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "MATCH (this:\`Film\`:\`Multimedia\`)
             WHERE this.id = $this_id
             SET this.id = $this_update_id
             RETURN this { .id } AS this"
@@ -221,7 +221,7 @@ describe("Node directive with additionalLabels", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film:Multimedia)
+            "MATCH (this:\`Film\`:\`Multimedia\`)
             RETURN count(this)"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-label-jwt.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-label-jwt.test.ts
@@ -89,7 +89,7 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Actor:\`Person\`)
+            "MATCH (this:\`Actor\`:\`Person\`)
             WHERE this.age > $this_age_GT
             RETURN this { .name, movies: [ (this)-[:ACTED_IN]->(this_movies:\`Film\`)  WHERE this_movies.title = $this_movies_title | this_movies { .title } ] } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-label-union.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-label-union.test.ts
@@ -73,9 +73,9 @@ describe("Node directive with unions", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.title = $this_title
-            RETURN this { search:  [this_search IN [(this)-[:SEARCH]->(this_search) WHERE (\\"Category\\" IN labels(this_search) AND \\"ExtraLabel1\\" IN labels(this_search) AND \\"ExtraLabel2\\" IN labels(this_search)) OR (\\"Film\\" IN labels(this_search)) | head( [ this_search IN [this_search] WHERE (\\"Category\\" IN labels(this_search) AND \\"ExtraLabel1\\" IN labels(this_search) AND \\"ExtraLabel2\\" IN labels(this_search)) AND this_search.name = $this_search_Genre_name | this_search { __resolveType: \\"Genre\\",  .name } ] + [ this_search IN [this_search] WHERE (\\"Film\\" IN labels(this_search)) AND this_search.title = $this_search_Movie_title | this_search { __resolveType: \\"Movie\\",  .title } ] ) ] WHERE this_search IS NOT NULL] [1..11]  } as this"
+            RETURN this { search:  [this_search IN [(this)-[:SEARCH]->(this_search) WHERE (\\"\`Category\`\\" IN labels(this_search) AND \\"\`ExtraLabel1\`\\" IN labels(this_search) AND \\"\`ExtraLabel2\`\\" IN labels(this_search)) OR (\\"\`Film\`\\" IN labels(this_search)) | head( [ this_search IN [this_search] WHERE (\\"\`Category\`\\" IN labels(this_search) AND \\"\`ExtraLabel1\`\\" IN labels(this_search) AND \\"\`ExtraLabel2\`\\" IN labels(this_search)) AND this_search.name = $this_search_Genre_name | this_search { __resolveType: \\"Genre\\",  .name } ] + [ this_search IN [this_search] WHERE (\\"\`Film\`\\" IN labels(this_search)) AND this_search.title = $this_search_Movie_title | this_search { __resolveType: \\"Movie\\",  .title } ] ) ] WHERE this_search IS NOT NULL] [1..11]  } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
@@ -63,7 +63,7 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             RETURN this { .title } as this"
         `);
 
@@ -88,8 +88,8 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
-            RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Person)   | this_actors { .name } ] } as this"
+            "MATCH (this:\`Film\`)
+            RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:\`Person\`)   | this_actors { .name } ] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -117,10 +117,10 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             CALL {
             WITH this
-            MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Person)
+            MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:\`Person\`)
             WITH collect({ node: { name: this_actor.name } }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
             }
@@ -148,7 +148,7 @@ describe("Label in Node directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
-            CREATE (this0:Film)
+            CREATE (this0:\`Film\`)
             SET this0.id = $this0_id
             RETURN this0
             }
@@ -186,19 +186,19 @@ describe("Label in Node directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
-            CREATE (this0:Film)
+            CREATE (this0:\`Film\`)
             SET this0.id = $this0_id
             WITH this0
-            CREATE (this0_actors0_node:Person)
+            CREATE (this0_actors0_node:\`Person\`)
             SET this0_actors0_node.name = $this0_actors0_node_name
             MERGE (this0)<-[:ACTED_IN]-(this0_actors0_node)
             RETURN this0
             }
             CALL {
-            CREATE (this1:Film)
+            CREATE (this1:\`Film\`)
             SET this1.id = $this1_id
             WITH this1
-            CREATE (this1_actors0_node:Person)
+            CREATE (this1_actors0_node:\`Person\`)
             SET this1_actors0_node.name = $this1_actors0_node_name
             MERGE (this1)<-[:ACTED_IN]-(this1_actors0_node)
             RETURN this1
@@ -235,7 +235,7 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.id = $this_id
             SET this.id = $this_update_id
             RETURN this { .id } AS this"
@@ -271,10 +271,10 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.id = $this_id
             WITH this
-            OPTIONAL MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Person)
+            OPTIONAL MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:\`Person\`)
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
             SET this_actors0.name = $this_update_actors0_name
@@ -336,12 +336,12 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.id = $this_id
             WITH this
             CALL {
             	WITH this
-            	OPTIONAL MATCH (this_connect_actors0_node:Person)
+            	OPTIONAL MATCH (this_connect_actors0_node:\`Person\`)
             	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_name
             	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
             		FOREACH(_ IN CASE this_connect_actors0_node WHEN NULL THEN [] ELSE [1] END |
@@ -378,12 +378,12 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.id = $this_id
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Person)
+            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:\`Person\`)
             WHERE this_disconnect_actors0.name = $updateMovies.args.disconnect.actors[0].where.node.name
             FOREACH(_ IN CASE this_disconnect_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actors0_rel
@@ -430,7 +430,7 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.id = $this_id
             DETACH DELETE this"
         `);
@@ -457,10 +457,10 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             WHERE this.id = $this_id
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Person)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:\`Person\`)
             WHERE this_actors0.name = $this_deleteMovies.args.delete.actors[0].where.node.name
             WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
             FOREACH(x IN this_actors0_to_delete | DETACH DELETE x)
@@ -504,8 +504,8 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
-            WHERE EXISTS((this)<-[:ACTED_IN]-(:Person)) AND ANY(this_actors IN [(this)<-[:ACTED_IN]-(this_actors:Person) | this_actors] WHERE this_actors.name = $this_actors_name)
+            "MATCH (this:\`Film\`)
+            WHERE EXISTS((this)<-[:ACTED_IN]-(:\`Person\`)) AND ANY(this_actors IN [(this)<-[:ACTED_IN]-(this_actors:\`Person\`) | this_actors] WHERE this_actors.name = $this_actors_name)
             DETACH DELETE this"
         `);
 
@@ -529,7 +529,7 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Film)
+            "MATCH (this:\`Film\`)
             RETURN count(this)"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-plural.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-plural.test.ts
@@ -56,7 +56,7 @@ describe("Plural in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "MATCH (this:\`Tech\`)
             RETURN this { .name } as this"
         `);
 
@@ -76,7 +76,7 @@ describe("Plural in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "MATCH (this:\`Tech\`)
             RETURN count(this)"
         `);
 
@@ -98,7 +98,7 @@ describe("Plural in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "MATCH (this:\`Tech\`)
             RETURN { count: count(this) }"
         `);
 
@@ -123,7 +123,7 @@ describe("Plural in Node directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL {
-            CREATE (this0:Tech)
+            CREATE (this0:\`Tech\`)
             SET this0.name = $this0_name
             RETURN this0
             }
@@ -155,7 +155,7 @@ describe("Plural in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "MATCH (this:\`Tech\`)
             SET this.name = $this_update_name
             RETURN this { .name } AS this"
         `);
@@ -182,7 +182,7 @@ describe("Plural in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "MATCH (this:\`Tech\`)
             WHERE this.name = $this_name
             DETACH DELETE this"
         `);
@@ -209,7 +209,7 @@ describe("Plural in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Tech)
+            "MATCH (this:\`Tech\`)
             RETURN this { .name } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth-projection.test.ts
@@ -73,12 +73,12 @@ describe("Cypher Auth Projection On Connections", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "MATCH (this:\`Person\`)
             CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             WITH this
-            MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_post:Comment)
-            CALL apoc.util.validate(NOT(EXISTS((this_post)<-[:HAS_POST]-(:Person)) AND ANY(creator IN [(this_post)<-[:HAS_POST]-(creator:Person) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MATCH (this)-[this_has_post_relationship:HAS_POST]->(this_post:\`Comment\`)
+            CALL apoc.util.validate(NOT(EXISTS((this_post)<-[:HAS_POST]-(:\`Person\`)) AND ANY(creator IN [(this_post)<-[:HAS_POST]-(creator:\`Person\`) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { content: this_post.content } }) AS edges
             RETURN { edges: edges, totalCount: size(edges) } AS postsConnection
             }

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth.test.ts
@@ -69,7 +69,7 @@ describe("Node Directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Person)
+            "MATCH (this:\`Person\`)
             CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } as this"
         `);
@@ -96,8 +96,8 @@ describe("Node Directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
-            WHERE EXISTS((this)<-[:HAS_POST]-(:Person)) AND ANY(this_creator IN [(this)<-[:HAS_POST]-(this_creator:Person) | this_creator] WHERE this_creator.id = $this_creator_id)
+            "MATCH (this:\`Comment\`)
+            WHERE EXISTS((this)<-[:HAS_POST]-(:\`Person\`)) AND ANY(this_creator IN [(this)<-[:HAS_POST]-(this_creator:\`Person\`) | this_creator] WHERE this_creator.id = $this_creator_id)
             WITH this
             CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             DETACH DELETE this"


### PR DESCRIPTION
# Description

Escape all labels set in the @node directive label to ensure these are valid cypher labels