### PR TITLE
fix '(intermediate value) is not iterable' in custom-resolvers.adoc

### DIFF
--- a/docs/modules/ROOT/pages/ogm/examples/custom-resolvers.adoc
+++ b/docs/modules/ROOT/pages/ogm/examples/custom-resolvers.adoc
@@ -65,7 +65,7 @@ const resolvers = {
                 throw new Error(`User with username ${username} already exists!`);
             }
 
-            const [user] = await User.create({
+            const { users } = await User.create({
                 input: [
                     {
                         username,
@@ -74,7 +74,7 @@ const resolvers = {
                 ]
             });
 
-            return createJWT({ sub: user.id });
+            return createJWT({ sub: users[0].id });
         },
         signIn: async (_source, { username, password }) => {
             const [user] = await User.find({


### PR DESCRIPTION
# Description

Extra brackets in `const [user] = await User.create({..`. were leading to the following error message: "(intermediate value) is not iterable".  I changed it to `const { users } = await User.create({...` and accordingly changed `user.id` to `users[0].id` in order to access the id property properly.

Btw, `const [user] = await User.find({...` is working properly in the signIn custom resolver.

# Issue

Not an issue, but it has been discussed in this pull request : [https://github.com/neo4j/graphql/pull/533](url).

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
