### PR TITLE
Pin graphql-compose to 9.0.4 until we have upgraded to GraphQL 16.x

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -73,7 +73,7 @@
         "debug": "^4.3.2",
         "deep-equal": "^2.0.5",
         "dot-prop": "^6.0.1",
-        "graphql-compose": "^9.0.4",
+        "graphql-compose": "9.0.4",
         "graphql-parse-resolve-info": "^4.12.0",
         "graphql-relay": "^0.8.0",
         "jsonwebtoken": "^8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2080,7 +2080,7 @@ __metadata:
     deep-equal: ^2.0.5
     dot-prop: ^6.0.1
     faker: 5.2.0
-    graphql-compose: ^9.0.4
+    graphql-compose: 9.0.4
     graphql-parse-resolve-info: ^4.12.0
     graphql-relay: ^0.8.0
     graphql-tag: 2.11.0
@@ -9307,7 +9307,7 @@ fsevents@^1.2.7:
   languageName: node
   linkType: hard
 
-"graphql-compose@npm:^9.0.4":
+"graphql-compose@npm:9.0.4":
   version: 9.0.4
   resolution: "graphql-compose@npm:9.0.4"
   dependencies:


### PR DESCRIPTION
# Description

It appears that the 9.0.5 release of `graphql-compose` expects GraphQL 16.x, as can be seen in the recent failures of our package tests. This PR pins it to 9.0.4 for now - this should be undone when we upgrade to GraphQL 16.x.