### PR TITLE
Fix TypeScript build

### DIFF
--- a/packages/graphql/src/tsconfig.json
+++ b/packages/graphql/src/tsconfig.json
@@ -3,6 +3,7 @@
     "compilerOptions": {
         "outDir": "../dist"
     },
+    "exclude": ["**/*.test.ts"],
     "references": [
         { "path": "../" } // for package.json import
     ]


### PR DESCRIPTION
# Description

Through various merges, the TypeScript build somehow became broken. Fixed by adding `"exclude": ["**/*.test.ts"]` to the `tsconfig.json` file in `packages/graphql/src`. This, however, is not the right fix for this problem, because ESLint requires these files to be included in the TypeScript build.

The correct solution would be to add the test directory as a project reference, however this results in a circular dependency. This is because of the builders which are used by files in both `src` and `tests`, and they also use files from `src`. This needs addressing.

However, this gets us unblocked for now. 