### PR TITLE
Renovate automerge and labelling

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -17,12 +17,9 @@ labels:
   - label: graphql
     files:
       - packages/graphql/src/.*
-      - packages/graphql/package.json
   - label: ogm
     files:
       - packages/ogm/src/.*
-      - packages/ogm/package.json
   - label: introspector
     files:
       - packages/introspector/src/.*
-      - packages/introspector/package.json

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -39,6 +39,24 @@ jobs:
           fail_on_error: true
           eslint_flags: "."
 
+  package-tests:
+    needs:
+      - cache-dependencies
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: Install dependencies
+        run: yarn
+      - run: yarn build
+      - name: Run @neo4j/graphql package tests
+        run: yarn --cwd packages/graphql run test:package-tests
+
   typescript-changes:
     runs-on: ubuntu-latest
 

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,5 +2,8 @@
     "default": true,
     "MD004": {
         "style": "asterisk"
+    },
+    "MD033": {
+        "allowed_elements": ["a", "img", "p"]
     }
 }

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@
 
 ## Contributing
 
-Want to contribute to `@neo4j/graphql`? See our [contributing guide](./docs/markdown/CONTRIBUTING.md) and [development guide](./docs/markdown/DEVELOPING.md) to get started!
+The default branch for this repository is `dev`, which contains changes for the next
+release. This is what you should base your work on if you want to make changes.
+
+Want to check out the code from the last release? Checkout `master` instead, which
+is only ever merged into on releases.
+
+Want to contribute to `@neo4j/graphql`? See our [contributing guide](./CONTRIBUTING.md)
+and [development guide](./docs/contributing/DEVELOPING.md) to get started!
 
 ## Links
 
@@ -25,14 +32,20 @@ Want to contribute to `@neo4j/graphql`? See our [contributing guide](./docs/mark
 
 ## Navigating
 
-This is a TypeScript Monorepo managed with [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/). To learn more on how to; setup, test and contribute to Neo4j GraphQL then please visit the [Contributing Guide](./CONTRIBUTING.md).
+This is a TypeScript Monorepo managed with [Yarn Workspaces](https://classic.yarnpkg.com/en/docs/workspaces/).
+To learn more on how to; setup, test and contribute to Neo4j GraphQL then please
+visit the [Contributing Guide](./CONTRIBUTING.md).
 
-1. [`@neo4j/graphql`](./packages/graphql) - Familiar GraphQL generation, for usage with an API such as [Apollo Server](https://www.apollographql.com/docs/apollo-server/)
-2. [`@neo4j/graphql-ogm`](./packages/ogm) - Use GraphQL Type Definitions to drive interactions with the database
+1. [`@neo4j/graphql`](./packages/graphql) - Familiar GraphQL generation, for usage
+with an API such as [Apollo Server](https://www.apollographql.com/docs/apollo-server/)
+2. [`@neo4j/graphql-ogm`](./packages/ogm) - Use GraphQL Type Definitions to drive
+interactions with the database
 
 ## Media
 
-Blogs, talks and other content surrounding Neo4j GraphQL. Sign up for [NODES 2021](https://neo4j.brand.live/c/2021nodes-live) to view even more Neo4j GraphQL content.
+Blogs, talks and other content surrounding Neo4j GraphQL. Sign up for
+[NODES 2021](https://neo4j.brand.live/c/2021nodes-live) to view even more Neo4j
+GraphQL content.
 
 1. [Neo4j and GraphQL The Past, Present and Future](https://youtu.be/sZ-eBznM71M)
 2. [Securing Your Graph With Neo4j GraphQL](https://medium.com/neo4j/securing-your-graph-with-neo4j-graphql-91a2d7b08631)
@@ -45,6 +58,8 @@ Blogs, talks and other content surrounding Neo4j GraphQL. Sign up for [NODES 202
 
 Love this project and want to work on it full-time? We're hiring!
 
-We're currently looking for backend, full-stack and DevOps engineers to join the GraphQL Team at Neo4j.
+We're currently looking for backend, full-stack and DevOps engineers to join the
+GraphQL Team at Neo4j.
 
-Search for "GraphQL Team" at https://neo4j.com/careers/ or [drop us an email](mailto:team-graphql@neo4j.com) if you're interested.
+Search for "GraphQL Team" at <https://neo4j.com/careers/> or
+[drop us an email](mailto:team-graphql@neo4j.com) if you're interested.

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
     "extends": ["config:js-lib"],
+    "baseBranches": ["dev"],
     "rebaseWhen": "auto",
     "packageRules": [
         {

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,18 @@
 {
-    "extends": [
-        "config:js-lib"
-    ],
-    "baseBranches": [
-        "dev"
+    "extends": ["config:js-lib"],
+    "rebaseWhen": "auto",
+    "packageRules": [
+        {
+            "matchDepTypes": ["dependencies"],
+            "addLabels": ["dependency upgrade"]
+        },
+        {
+            "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+            "automerge": true
+        },
+        {
+            "matchDepTypes": ["devDependencies"],
+            "automerge": true
+        }
     ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,18 @@
     "packageRules": [
         {
             "matchDepTypes": ["dependencies"],
-            "addLabels": ["dependency upgrade"]
+            "matchFiles": ["packages/graphql/package.json"],
+            "labels": ["dependency upgrade", "graphql"]
+        },
+        {
+            "matchDepTypes": ["dependencies"],
+            "matchFiles": ["packages/introspector/package.json"],
+            "labels": ["dependency upgrade", "introspector"]
+        },
+        {
+            "matchDepTypes": ["dependencies"],
+            "matchFiles": ["packages/ogm/package.json"],
+            "labels": ["dependency upgrade", "ogm"]
         },
         {
             "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
# Description

- Turn on Renovate automerge for all but major dependency upgrades
- Add "dependency upgrade" label to PRs for releasable dependency upgrades (not dev dependencies)
- Only add package labels for releasable dependency upgrades (not dev dependencies)
- Run package tests in pull requests - these have previously caught bad dependency upgrades

Also added a little line to the README for dev and master.