### PR TITLE
GitHub Actions: pipeline on `master` PRs, high priority label/comment

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - master
     paths:
       - "docs/modules/ROOT/**"
 

--- a/.github/workflows/docs-teardown.yml
+++ b/.github/workflows/docs-teardown.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - dev
+      - master
     paths:
       - "docs/modules/ROOT/**"
     types:

--- a/.github/workflows/feature-request.yml
+++ b/.github/workflows/feature-request.yml
@@ -1,0 +1,19 @@
+name: New feature requests
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  add-new-feature-requests-to-project:
+    if: contains(github.event.issue.labels.*.name, 'feature request')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: alex-page/github-project-automation-plus@v0.8.1
+        with:
+          project: Feature Requests
+          column: Feature requests
+          repo-token: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}
+          action: add

--- a/.github/workflows/issue-labeled.yml
+++ b/.github/workflows/issue-labeled.yml
@@ -1,4 +1,4 @@
-name: Bug confirmed comment
+name: Issue labeled
 
 on:
   issues:
@@ -18,3 +18,16 @@ jobs:
           issue-number: ${{ github.event.issue.number }}
           body: |
             We've been able to confirm this bug using the steps to reproduce that you provided - many thanks @${{ github.event.issue.user.login }}! :pray: We will now prioritise the bug and address it appropriately.
+  add_high_priority_comment:
+    if: ${{ github.event.label.name == 'high priority' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment
+        uses: peter-evans/create-or-update-comment@v1.4.5
+        with:
+          token: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            This bug report has been assigned high priority to fix. If you wish to contribute a fix, please branch from `master` and submit your PR with the base set to `master`. Thanks!

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
       - dev
+      - master
 
 jobs:
   label:

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - master
     paths:
       - "**/*.md"
 

--- a/.github/workflows/project-card-moved.yml
+++ b/.github/workflows/project-card-moved.yml
@@ -1,4 +1,4 @@
-name: Bug confirmed label
+name: Project card moved
 
 on:
   project_card:
@@ -16,4 +16,15 @@ jobs:
         uses: andymckay/labeler@1.0.4
         with:
           add-labels: "confirmed"
+          repo-token: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}
+  add_high_priority_label:
+    if: github.event.project_card.column_id == '17286751'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: add labels
+        uses: andymckay/labeler@1.0.4
+        with:
+          add-labels: "high priority"
           repo-token: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - master
     paths-ignore:
       - "docs/**"
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - dev
+      - master
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 


### PR DESCRIPTION
# Description

Pull request jobs will now run off pull requests to `master`.

If a bug is given high priority, add a label and create a comment about branching from `master`. Didn't see the point of doing this for low priority bugs as this is "business as usual".

Adds new feature requests to project just to keep things tidy whilst we decide what to do here.

Any other tweaks we need to make?