### PR TITLE
removes isNeoInt util

### DIFF
--- a/packages/graphql/src/schema/pagination.ts
+++ b/packages/graphql/src/schema/pagination.ts
@@ -19,9 +19,8 @@
 
 import { FieldNode, GraphQLResolveInfo, SelectionSetNode } from "graphql";
 import { getOffsetWithDefault, offsetToCursor } from "graphql-relay/connection/arrayConnection";
-import { Integer } from "neo4j-driver";
+import { Integer, isInt } from "neo4j-driver";
 import { ConnectionField, ConnectionQueryArgs } from "../types";
-import { isNeoInt } from "../utils/utils";
 
 function getAliasKey({ selectionSet, key }: { selectionSet: SelectionSetNode | undefined; key: string }): string {
     const selection = (selectionSet?.selections || []).find(
@@ -58,7 +57,7 @@ export function connectionFieldResolver({
     const { totalCount } = value;
 
     return {
-        [totalCountKey]: isNeoInt(totalCount) ? totalCount.toNumber() : totalCount,
+        [totalCountKey]: isInt(totalCount) ? totalCount.toNumber() : totalCount,
         ...createConnectionWithEdgeProperties({ source: value, selectionSet, args, totalCount }),
     };
 }
@@ -150,8 +149,8 @@ export function createOffsetLimitStr({
     }
 
     if (hasLimit && hasOffset) {
-        const sliceStart = isNeoInt(offset) ? offset.toNumber() : offset;
-        const itemsToGrab = isNeoInt(limit) ? limit.toNumber() : limit;
+        const sliceStart = isInt(offset) ? offset.toNumber() : offset;
+        const itemsToGrab = isInt(limit) ? limit.toNumber() : limit;
         const sliceEnd = (sliceStart as number) + (itemsToGrab as number);
         offsetLimitStr = `[${offset}..${sliceEnd}]`;
     }

--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { isInt } from "neo4j-driver";
 import { GraphQLResolveInfo } from "graphql";
 import { UnionTypeDefinitionNode } from "graphql/language/ast";
 import { execute } from "../../utils";
@@ -27,7 +28,6 @@ import createAuthParam from "../../translate/create-auth-param";
 import { AUTH_FORBIDDEN_ERROR } from "../../constants";
 import createProjectionAndParams from "../../translate/create-projection-and-params";
 import createConnectionAndParams from "../../translate/connection/create-connection-and-params";
-import { isNeoInt } from "../../utils/utils";
 import getNeo4jResolveTree from "../../utils/get-neo4j-resolve-tree";
 
 export default function cypherResolver({
@@ -230,7 +230,7 @@ export default function cypherResolver({
                 return undefined;
             }
 
-            if (isNeoInt(value)) {
+            if (isInt(value)) {
                 return Number(value);
             }
 

--- a/packages/graphql/src/schema/resolvers/id.ts
+++ b/packages/graphql/src/schema/resolvers/id.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
+import { isInt } from "neo4j-driver";
 import { GraphQLResolveInfo } from "graphql";
 import defaultFieldResolver from "./defaultField";
-import { isNeoInt } from "../../utils/utils";
 import { Context } from "../../types";
 
 function id(source, args, context: Context, info: GraphQLResolveInfo) {
     const value = defaultFieldResolver(source, args, context, info);
 
-    if (isNeoInt(value)) {
+    if (isInt(value)) {
         return value.toNumber();
     }
 

--- a/packages/graphql/src/schema/resolvers/numerical.ts
+++ b/packages/graphql/src/schema/resolvers/numerical.ts
@@ -18,13 +18,13 @@
  */
 
 import { GraphQLResolveInfo } from "graphql";
+import { isInt } from "neo4j-driver";
 import defaultFieldResolver from "./defaultField";
-import { isNeoInt } from "../../utils/utils";
 
 function numerical(source, args, context, info: GraphQLResolveInfo) {
     const value = defaultFieldResolver(source, args, context, info);
 
-    if (isNeoInt(value)) {
+    if (isInt(value)) {
         return value.toNumber();
     }
 

--- a/packages/graphql/src/utils/utils.ts
+++ b/packages/graphql/src/utils/utils.ts
@@ -17,16 +17,9 @@
  * limitations under the License.
  */
 
-import { Integer, isInt } from "neo4j-driver";
-
 /** Checks if value is string */
 export function isString(value: unknown): value is string {
     return typeof value === "string" || value instanceof String;
-}
-
-/** Checks if value is a Neo4j int object */
-export function isNeoInt(value: unknown): value is Integer {
-    return isInt(value);
 }
 
 /** Joins all strings with given separator, ignoring empty or undefined statements */


### PR DESCRIPTION
# Description

The reasoning behind `isNeoInt` util was to improve typings, this is no longer needed, as the base `isInt` now returns the correct typings
