### PR TITLE
Update auth docs

### DIFF
--- a/docs/modules/ROOT/pages/auth/authorization/where.adoc
+++ b/docs/modules/ROOT/pages/auth/authorization/where.adoc
@@ -46,6 +46,8 @@ Where is used on the following operations;
 - `DELETE`
 
 
+Note that `where` rules are not supported when applied over nested xref::type-definitions/unions.adoc[unions] or xref::type-definitions/interfaces.adoc[interfaces].
+
 == Combining `where` with `roles`
 
 The `where` argument can be combined with `roles` within auth rules to support rule based filtering of results.
@@ -60,9 +62,9 @@ type User {
 }
 
 extend type User @auth(rules: [
-    { 
+    {
         roles: ["user"]
-        where: { id: "$jwt.id" } 
+        where: { id: "$jwt.id" }
     }
     {
         roles: ["admin"]
@@ -86,7 +88,7 @@ extend type User @auth(rules: [
         OR: [
             {
                 roles: ["user"]
-                where: { id: "$jwt.id" } 
+                where: { id: "$jwt.id" }
             },
             {
                 roles: ["admin"]

--- a/docs/modules/ROOT/pages/queries.adoc
+++ b/docs/modules/ROOT/pages/queries.adoc
@@ -1,11 +1,10 @@
 [[queries]]
 = Queries
 
-Each node defined in type definitions will have three Query fields generated for it:
+Each node defined in type definitions will have two Query fields generated for it:
 
 1. One for querying data
-2. One for counting data
-3. One for aggregating data
+2. One for aggregating data
 
 The examples in this chapter will use the following type definitions:
 
@@ -36,11 +35,9 @@ For which the following Query fields will be generated:
 ----
 type Query {
     posts(where: PostWhere, options: PostOptions): [Post!]!
-    postsCount(where: PostWhere): Int!
     postsAggregate(where: PostWhere): PostAggregationSelection!
 
     users(where: UserWhere, options: UserOptions): [User!]!
-    usersCount(where: UserWhere): Int!
     usersAggregate(where: UserWhere): UserAggregationSelection!
 }
 ----


### PR DESCRIPTION
# Description

This PR adds a disclaimer regarding auth with unions or interfaces in reference to #508 

Additionally, an outdated reference to top-level count has been removed
