### PR TITLE
Query max limit

### DIFF
--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -35,12 +35,12 @@ import type {
     BaseField,
     Context,
     FullText,
-    QueryOptions,
 } from "../types";
 import Exclude from "./Exclude";
 import { GraphElement, GraphElementConstructor } from "./GraphElement";
 import { NodeDirective } from "./NodeDirective";
 import { lowerFirst } from "../utils/lower-first";
+import { QueryOptionsDirective } from "./QueryOptionsDirective";
 
 export interface NodeConstructor extends GraphElementConstructor {
     name: string;
@@ -63,7 +63,7 @@ export interface NodeConstructor extends GraphElementConstructor {
     exclude?: Exclude;
     nodeDirective?: NodeDirective;
     description?: string;
-    queryOptionsDirective?: QueryOptions;
+    queryOptionsDirective?: QueryOptionsDirective;
 }
 
 type MutableField =
@@ -104,7 +104,7 @@ class Node extends GraphElement {
     public fulltextDirective?: FullText;
     public auth?: Auth;
     public description?: string;
-    public queryOptions?: QueryOptions;
+    public queryOptions?: QueryOptionsDirective;
 
     constructor(input: NodeConstructor) {
         super(input);

--- a/packages/graphql/src/classes/QueryOptionsDirective.ts
+++ b/packages/graphql/src/classes/QueryOptionsDirective.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Integer } from "neo4j-driver";
+import { Neo4jGraphQLError } from "./Error";
+
+type QueryOptionsDirectiveConstructor = {
+    limit: {
+        default?: Integer;
+        max?: Integer;
+    };
+};
+
+export class QueryOptionsDirective {
+    public readonly limit: QueryOptionsDirectiveConstructor["limit"];
+
+    constructor(args: QueryOptionsDirectiveConstructor) {
+        this.limit = args.limit;
+    }
+
+    public getLimit(optionsLimit?: Integer): Integer | undefined {
+        if (optionsLimit) {
+            if (this.limit.max && optionsLimit.greaterThan(this.limit.max)) {
+                throw new Neo4jGraphQLError(`Invalid limit ${optionsLimit}`);
+            }
+            return optionsLimit;
+        }
+
+        return this.limit.default || this.limit.max;
+    }
+}

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -49,7 +49,7 @@ import { Exclude, Node } from "../classes";
 import { NodeDirective } from "../classes/NodeDirective";
 import Relationship from "../classes/Relationship";
 import * as constants from "../constants";
-import { Auth, BaseField, FullText, PrimitiveField, QueryOptions } from "../types";
+import { Auth, BaseField, FullText, PrimitiveField } from "../types";
 import { isString } from "../utils/utils";
 import createConnectionFields from "./create-connection-fields";
 import createRelationshipFields from "./create-relationship-fields";
@@ -77,6 +77,7 @@ import getUniqueFields from "./get-unique-fields";
 import { AggregationTypesMapper } from "./aggregations/aggregation-types-mapper";
 import { upperFirst } from "../utils/upper-first";
 import { parseQueryOptionsDirective } from "./parse/parse-query-options-directive";
+import { QueryOptionsDirective } from "../classes/QueryOptionsDirective";
 
 function makeAugmentedSchema(
     typeDefs: TypeSource,
@@ -292,7 +293,7 @@ function makeAugmentedSchema(
             });
         }
 
-        let queryOptionsDirective: QueryOptions | undefined;
+        let queryOptionsDirective: QueryOptionsDirective | undefined;
         if (queryOptionsDirectiveDefinition) {
             queryOptionsDirective = parseQueryOptionsDirective({
                 directive: queryOptionsDirectiveDefinition,

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -76,7 +76,7 @@ import { validateDocument } from "./validation";
 import getUniqueFields from "./get-unique-fields";
 import { AggregationTypesMapper } from "./aggregations/aggregation-types-mapper";
 import { upperFirst } from "../utils/upper-first";
-import parseQueryOptionsDirective from "./parse/parse-query-options-directive";
+import { parseQueryOptionsDirective } from "./parse/parse-query-options-directive";
 
 function makeAugmentedSchema(
     typeDefs: TypeSource,

--- a/packages/graphql/src/schema/parse/parse-query-options-directive.test.ts
+++ b/packages/graphql/src/schema/parse/parse-query-options-directive.test.ts
@@ -21,29 +21,28 @@
 import { gql } from "apollo-server-core";
 import * as neo4j from "neo4j-driver";
 import { DirectiveNode, ObjectTypeDefinitionNode } from "graphql";
-import parseQueryOptionsDirective from "./parse-query-options-directive";
+import { parseQueryOptionsDirective } from "./parse-query-options-directive";
 
 describe("parseQueryOptionsDirective", () => {
-    test("should throw error when default limit is less than or equal to 0", () => {
-        [-10, -100, 0].forEach((i) => {
-            const typeDefs = gql`
-                type Movie @queryOptions(limit: {default: ${i}}) {
-                    id: ID
-                }
-            `;
+    test("max and default argument", () => {
+        const maxLimit = 100;
+        const defaultLimit = 10;
 
-            const definition = typeDefs.definitions[0] as unknown as ObjectTypeDefinitionNode;
-            const directive = (definition.directives || [])[0] as DirectiveNode;
+        const typeDefs = gql`
+            type Movie @queryOptions(limit: {max: ${maxLimit}, default: ${defaultLimit}} ) {
+                id: ID
+            }
+        `;
 
-            expect(() =>
-                parseQueryOptionsDirective({
-                    directive,
-                    definition,
-                })
-            ).toThrow(
-                `${definition.name.value} @queryOptions(limit: {default: ${i}}) invalid value: '${i}' try a number greater than 0`
-            );
+        const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+        const directive = (definition.directives || [])[0] as DirectiveNode;
+
+        const result = parseQueryOptionsDirective({
+            directive,
+            definition,
         });
+
+        expect(result).toEqual({ limit: { max: neo4j.int(maxLimit), default: neo4j.int(defaultLimit) } });
     });
 
     test("should return correct object if default limit is undefined", () => {
@@ -53,7 +52,7 @@ describe("parseQueryOptionsDirective", () => {
             }
         `;
 
-        const definition = typeDefs.definitions[0] as unknown as ObjectTypeDefinitionNode;
+        const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
         const directive = (definition.directives || [])[0] as DirectiveNode;
 
         const result = parseQueryOptionsDirective({
@@ -63,27 +62,130 @@ describe("parseQueryOptionsDirective", () => {
         expect(result).toEqual({
             limit: {
                 default: undefined,
+                max: undefined,
             },
         });
     });
 
-    test("should parse and return correct meta data", () => {
+    test("fail if default argument is bigger than max", () => {
+        const maxLimit = 10;
         const defaultLimit = 100;
 
         const typeDefs = gql`
+            type Movie @queryOptions(limit: {max: ${maxLimit}, default: ${defaultLimit}} ) {
+                id: ID
+            }
+        `;
+
+        const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+        const directive = (definition.directives || [])[0] as DirectiveNode;
+
+        expect(() =>
+            parseQueryOptionsDirective({
+                directive,
+                definition,
+            })
+        ).toThrow(
+            `Movie @queryOptions(limit: {max: ${maxLimit}, default: ${defaultLimit}}) invalid default value, 'default' must be smaller than 'max'`
+        );
+    });
+
+    describe("default argument", () => {
+        test("should throw error when default limit is less than or equal to 0", () => {
+            [-10, -100, 0].forEach((i) => {
+                const typeDefs = gql`
+                type Movie @queryOptions(limit: {default: ${i}}) {
+                    id: ID
+                }
+            `;
+
+                const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+                const directive = (definition.directives || [])[0] as DirectiveNode;
+                expect(() =>
+                    parseQueryOptionsDirective({
+                        directive,
+                        definition,
+                    })
+                ).toThrow(
+                    `Movie @queryOptions(limit: {default: ${i}}) invalid value: '${i}' try a number greater than 0`
+                );
+            });
+        });
+
+        test("should parse and return correct meta data", () => {
+            const defaultLimit = 100;
+
+            const typeDefs = gql`
                 type Movie @queryOptions(limit: {default: ${defaultLimit}} ) {
                     id: ID
                 }
             `;
 
-        const definition = typeDefs.definitions[0] as unknown as ObjectTypeDefinitionNode;
-        const directive = (definition.directives || [])[0] as DirectiveNode;
+            const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+            const directive = (definition.directives || [])[0] as DirectiveNode;
 
-        const result = parseQueryOptionsDirective({
-            directive,
-            definition,
+            const result = parseQueryOptionsDirective({
+                directive,
+                definition,
+            });
+
+            expect(result).toEqual({ limit: { default: neo4j.int(defaultLimit) } });
+        });
+    });
+
+    describe("max argument", () => {
+        test("should parse max metadata", () => {
+            const maxLimit = 100;
+
+            const typeDefs = gql`
+                type Movie @queryOptions(limit: {max: ${maxLimit}} ) {
+                    id: ID
+                }
+            `;
+
+            const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+            const directive = (definition.directives || [])[0] as DirectiveNode;
+
+            const result = parseQueryOptionsDirective({
+                directive,
+                definition,
+            });
+
+            expect(result).toEqual({ limit: { max: neo4j.int(maxLimit) } });
         });
 
-        expect(result).toEqual({ limit: { default: neo4j.int(defaultLimit) } });
+        test("should fail if value is 0", () => {
+            const typeDefs = gql`
+                type Movie @queryOptions(limit: { max: 0 }) {
+                    id: ID
+                }
+            `;
+
+            const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+            const directive = (definition.directives || [])[0] as DirectiveNode;
+            expect(() =>
+                parseQueryOptionsDirective({
+                    directive,
+                    definition,
+                })
+            ).toThrow(`Movie @queryOptions(limit: {max: 0}) invalid value: '0' try a number greater than 0`);
+        });
+
+        test("should fail if value is less 0", () => {
+            const typeDefs = gql`
+                type Movie @queryOptions(limit: { max: -10 }) {
+                    id: ID
+                }
+            `;
+
+            const definition = typeDefs.definitions[0] as ObjectTypeDefinitionNode;
+            const directive = (definition.directives || [])[0] as DirectiveNode;
+            expect(() =>
+                parseQueryOptionsDirective({
+                    directive,
+                    definition,
+                })
+            ).toThrow(`Movie @queryOptions(limit: {max: -10}) invalid value: '-10' try a number greater than 0`);
+        });
     });
 });

--- a/packages/graphql/src/schema/parse/parse-query-options-directive.ts
+++ b/packages/graphql/src/schema/parse/parse-query-options-directive.ts
@@ -19,8 +19,8 @@
 
 import { DirectiveNode, ObjectFieldNode, ObjectTypeDefinitionNode, ObjectValueNode } from "graphql";
 import * as neo4j from "neo4j-driver";
+import { QueryOptionsDirective } from "../../classes/QueryOptionsDirective";
 import { Neo4jGraphQLError } from "../../classes/Error";
-import { QueryOptions } from "../../types";
 import parseValueNode from "../parse-value-node";
 
 export function parseQueryOptionsDirective({
@@ -29,7 +29,7 @@ export function parseQueryOptionsDirective({
 }: {
     directive: DirectiveNode;
     definition: ObjectTypeDefinitionNode;
-}): QueryOptions {
+}): QueryOptionsDirective {
     const limitArgument = directive.arguments?.find((direc) => direc.name.value === "limit");
     const limitValue = limitArgument?.value as ObjectValueNode | undefined;
     const defaultLimitArgument = limitValue?.fields.find((field) => field.name.value === "default");
@@ -41,9 +41,7 @@ export function parseQueryOptionsDirective({
     const queryOptionsLimit = { default: defaultLimit, max: maxLimit };
     validateLimitArguments(queryOptionsLimit, definition.name.value);
 
-    return {
-        limit: queryOptionsLimit,
-    };
+    return new QueryOptionsDirective({ limit: queryOptionsLimit });
 }
 
 function parseArgumentToInt(field: ObjectFieldNode | undefined): neo4j.Integer | undefined {
@@ -54,7 +52,7 @@ function parseArgumentToInt(field: ObjectFieldNode | undefined): neo4j.Integer |
     return undefined;
 }
 
-function validateLimitArguments(arg: QueryOptions["limit"], typeName: string): void {
+function validateLimitArguments(arg: QueryOptionsDirective["limit"], typeName: string): void {
     const maxLimit = arg.max?.toNumber();
     const defaultLimit = arg.default?.toNumber();
 

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -267,6 +267,10 @@ export const queryOptions = new GraphQLDirective({
                         description: "If no limit argument is supplied on query will fallback to this value.",
                         type: GraphQLInt,
                     },
+                    max: {
+                        description: "Maximum limit to be used for queries.",
+                        type: GraphQLInt,
+                    },
                 },
             }),
         },

--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -406,10 +406,10 @@ function createConnectionAndParams({
 
     const returnValues: string[] = [];
 
-    if (relatedNode && relatedNode?.queryOptions?.limit?.default) {
+    if (relatedNode && relatedNode?.queryOptions?.getLimit()) {
         subquery = [
             ...subquery,
-            ...createLimitedReturnSubquery(resolveTree.alias, relatedNode.queryOptions.limit.default, afterInput),
+            ...createLimitedReturnSubquery(resolveTree.alias, relatedNode.queryOptions.getLimit(), afterInput),
         ];
     } else if (!firstInput && !afterInput) {
         if (connection.edges || connection.pageInfo) {

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -332,8 +332,8 @@ function createProjectionAndParams({
         if (relationField) {
             const referenceNode = context.neoSchema.nodes.find((x) => x.name === relationField.typeMeta.name) as Node;
 
-            if (referenceNode?.queryOptions?.limit?.default && !optionsInput.limit) {
-                optionsInput.limit = referenceNode.queryOptions.limit.default;
+            if (referenceNode?.queryOptions) {
+                optionsInput.limit = referenceNode.queryOptions.getLimit(optionsInput.limit);
             }
 
             const nodeMatchStr = `(${chainStr || varName})`;

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -44,8 +44,8 @@ function translateRead({ node, context }: { context: Context; node: Node }): [st
     const connectionStrs: string[] = [];
     const interfaceStrs: string[] = [];
 
-    if (node.queryOptions?.limit?.default && !optionsInput.limit) {
-        optionsInput.limit = node.queryOptions.limit.default;
+    if (node.queryOptions) {
+        optionsInput.limit = node.queryOptions.getLimit(optionsInput.limit);
     }
 
     const topLevelMatch = translateTopLevelMatch({ node, context, varName, operation: "READ" });
@@ -115,14 +115,13 @@ function translateRead({ node, context }: { context: Context; node: Node }): [st
 
     if (optionsInput) {
         const hasOffset = Boolean(optionsInput.offset) || optionsInput.offset === 0;
-        const hasLimit = Boolean(optionsInput.limit) || optionsInput.limit === 0;
 
         if (hasOffset) {
             offsetStr = `SKIP $${varName}_offset`;
             cypherParams[`${varName}_offset`] = optionsInput.offset;
         }
 
-        if (hasLimit) {
+        if (optionsInput.limit) {
             limitStr = `LIMIT $${varName}_limit`;
             cypherParams[`${varName}_limit`] = optionsInput.limit;
         }

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -317,5 +317,6 @@ export interface NestedRecord<T> extends Record<string | symbol | number, T | Ne
 export type QueryOptions = {
     limit: {
         default?: Integer;
+        max?: Integer;
     };
 };

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -207,7 +207,7 @@ export interface ConnectionQueryArgs {
  * passed to resolvers.
  */
 export interface GraphQLOptionsArg {
-    limit?: number | Integer;
+    limit?: Integer;
     offset?: number | Integer;
     sort?: GraphQLSortArg[];
 }
@@ -313,10 +313,3 @@ export interface CypherQueryOptions {
 
 /** Nested Records helper type, supports any level of recursion. Ending in properties of type T */
 export interface NestedRecord<T> extends Record<string | symbol | number, T | NestedRecord<T>> {} // Using interface to allow recursive types
-
-export type QueryOptions = {
-    limit: {
-        default?: Integer;
-        max?: Integer;
-    };
-};


### PR DESCRIPTION
# Description

This PR adds support for a `max` argument in `queryOptions.limit` to set the maximum valid limit for a certain query type, following the specs at [rfc 005](https://github.com/neo4j/graphql/blob/dev/docs/rfcs/rfc-005-query-limits.md)

## Example

```graphql
type Movie @queryOptions(limit: { max: 2 }) {
    name: String
}
```

This way, any query without limit will default to 2 (unless a different default is set)
Any query with a higher limit than the one defined will return the given max instead
