### PR TITLE
Resolve fields on interfaces returned by custom cypher

### DIFF
--- a/packages/graphql/src/schema/resolvers/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/cypher.ts
@@ -249,8 +249,15 @@ export default function cypherResolver({
 
         if (isPrimitive || isEnum || isScalar) {
             cypherStrs.push(`RETURN this`);
-        } else if (referenceUnion || referenceInterface) {
+        } else if (referenceUnion) {
             cypherStrs.push(`RETURN head( ${projectionStr} ) AS this`);
+        } else if (referenceInterface) {
+            cypherStrs.push(`CALL { ${projectionStr} }`);
+            if (expectMultipleValues) {
+                cypherStrs.push(`RETURN ${field.fieldName} AS this`)
+            } else {
+                cypherStrs.push(`RETURN head(collect( ${field.fieldName} )) AS this`)
+            }
         } else {
             cypherStrs.push(`RETURN this ${projectionStr} AS this`);
         }


### PR DESCRIPTION
# Description

As an extension of #495 and #487, I tried to resolve interface fields that use a custom cypher query. The implementation is similar to that for unions (#495). It generally works, but I don't know enough about the code to be sure. I'm sure there is still work to be done, but I still wanted to share my insights.

I found the following disadvantages/problems with my implementation (These actually also apply to the implementation of unions #495):
- If you use a sorting, things get mixed up again, because in a further step sorting is done according to the types of the interface.
- The comparison on Labels and AdditionalLabels is very inefficient if the interface has been implemented by many types and/or multiple additionallabels have been created. This is used to properly generate the __resolveType property.

# Issue

Closes #487

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
