### PR TITLE
Fix: #923 connectOrCreate throws error when used with auth

### DIFF
--- a/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
@@ -62,7 +62,6 @@ export function createConnectOrCreateAndParams({
             context,
         });
     });
-    console.log("8", statements);
     return joinStatements(statements);
 }
 
@@ -101,8 +100,6 @@ function createConnectOrCreatePartialStatement({
         context,
         nodeName: baseName,
     });
-    console.log("9", authStatement, mergeRelatedNodeStatement, mergeRelationStatement);
-
     return joinStatements([authStatement, mergeRelatedNodeStatement, mergeRelationStatement]);
 }
 

--- a/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
@@ -51,20 +51,18 @@ export function createConnectOrCreateAndParams({
     refNode: Node;
     context: Context;
 }): CypherStatement {
-    const statements = asArray(input).map(
-        (inputItem, index): CypherStatement => {
-            const subqueryBaseName = `${varName}${index}`;
-            return createConnectOrCreatePartialStatement({
-                input: inputItem,
-                baseName: subqueryBaseName,
-                parentVar,
-                relationField,
-                refNode,
-                context,
-            });
-        }
-    );
-
+    const statements = asArray(input).map((inputItem, index): CypherStatement => {
+        const subqueryBaseName = `${varName}${index}`;
+        return createConnectOrCreatePartialStatement({
+            input: inputItem,
+            baseName: subqueryBaseName,
+            parentVar,
+            relationField,
+            refNode,
+            context,
+        });
+    });
+    console.log("8", statements);
     return joinStatements(statements);
 }
 
@@ -103,6 +101,7 @@ function createConnectOrCreatePartialStatement({
         context,
         nodeName: baseName,
     });
+    console.log("9", authStatement, mergeRelatedNodeStatement, mergeRelationStatement);
 
     return joinStatements([authStatement, mergeRelatedNodeStatement, mergeRelationStatement]);
 }

--- a/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
@@ -25,6 +25,7 @@ import { joinStatements } from "../utils/join-statements";
 import createAuthAndParams from "../create-auth-and-params";
 import { AUTH_FORBIDDEN_ERROR } from "../../constants";
 import { asArray } from "../../utils/utils";
+import { wrapInCall } from "../utils/wrap-in-call";
 
 type CreateOrConnectInput = {
     where?: {
@@ -64,8 +65,8 @@ export function createConnectOrCreateAndParams({
             });
         }
     );
-
-    return joinStatements(statements);
+    const [statement, params] = joinStatements(statements);
+    return [wrapInCall(statement, parentVar), params];
 }
 
 function createConnectOrCreatePartialStatement({

--- a/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/connect-or-create/create-connect-or-create-and-params.ts
@@ -51,17 +51,20 @@ export function createConnectOrCreateAndParams({
     refNode: Node;
     context: Context;
 }): CypherStatement {
-    const statements = asArray(input).map((inputItem, index): CypherStatement => {
-        const subqueryBaseName = `${varName}${index}`;
-        return createConnectOrCreatePartialStatement({
-            input: inputItem,
-            baseName: subqueryBaseName,
-            parentVar,
-            relationField,
-            refNode,
-            context,
-        });
-    });
+    const statements = asArray(input).map(
+        (inputItem, index): CypherStatement => {
+            const subqueryBaseName = `${varName}${index}`;
+            return createConnectOrCreatePartialStatement({
+                input: inputItem,
+                baseName: subqueryBaseName,
+                parentVar,
+                relationField,
+                refNode,
+                context,
+            });
+        }
+    );
+
     return joinStatements(statements);
 }
 
@@ -100,6 +103,7 @@ function createConnectOrCreatePartialStatement({
         context,
         nodeName: baseName,
     });
+
     return joinStatements([authStatement, mergeRelatedNodeStatement, mergeRelationStatement]);
 }
 

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -25,7 +25,6 @@ import { AUTH_FORBIDDEN_ERROR } from "../constants";
 import createSetRelationshipPropertiesAndParams from "./create-set-relationship-properties-and-params";
 import mapToDbProperty from "../utils/map-to-db-property";
 import { createConnectOrCreateAndParams } from "./connect-or-create/create-connect-or-create-and-params";
-import { wrapInCall } from "./utils/wrap-in-call";
 
 interface Res {
     creates: string[];
@@ -155,7 +154,7 @@ function createCreateAndParams({
                         refNode,
                         context,
                     });
-                    res.creates.push(wrapInCall(connectOrCreateQuery, varName));
+                    res.creates.push(connectOrCreateQuery);
                     res.params = { ...res.params, ...connectOrCreateParams };
                 }
             });

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -112,9 +112,9 @@ function createCreateAndParams({
                         res.creates.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
                         if (relationField.properties) {
-                            const relationship = (context.neoSchema.relationships.find(
+                            const relationship = context.neoSchema.relationships.find(
                                 (x) => x.properties === relationField.properties
-                            ) as unknown) as Relationship;
+                            ) as unknown as Relationship;
 
                             const setA = createSetRelationshipPropertiesAndParams({
                                 properties: create.edge ?? {},
@@ -154,6 +154,11 @@ function createCreateAndParams({
                         refNode,
                         context,
                     });
+                    console.log("7", connectOrCreateQuery);
+                    if (connectOrCreateQuery.startsWith("CALL")) {
+                        res.creates.push(`WITH ${varName}`);
+                    }
+
                     res.creates.push(connectOrCreateQuery);
                     res.params = { ...res.params, ...connectOrCreateParams };
                 }
@@ -208,7 +213,7 @@ function createCreateAndParams({
 
             return res;
         }
-
+        console.log("3");
         res.creates.push(`SET ${varName}.${dbFieldName} = $${varNameKey}`);
         res.params[varNameKey] = value;
 
@@ -236,6 +241,7 @@ function createCreateAndParams({
         creates: initial,
         params: {},
     });
+    console.log("6", creates, params, meta);
 
     const forbiddenString = insideDoWhen ? `\\"${AUTH_FORBIDDEN_ERROR}\\"` : `"${AUTH_FORBIDDEN_ERROR}"`;
 
@@ -248,12 +254,13 @@ function createCreateAndParams({
             escapeQuotes: Boolean(insideDoWhen),
         });
         if (bindAndParams[0]) {
+            console.log("5");
+
             creates.push(`WITH ${withVars.join(", ")}`);
             creates.push(`CALL apoc.util.validate(NOT(${bindAndParams[0]}), ${forbiddenString}, [0])`);
             params = { ...params, ...bindAndParams[1] };
         }
     }
-
     if (meta?.authStrs.length) {
         creates.push(`WITH ${withVars.join(", ")}`);
         creates.push(`CALL apoc.util.validate(NOT(${meta.authStrs.join(" AND ")}), ${forbiddenString}, [0])`);

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -113,9 +113,9 @@ function createCreateAndParams({
                         res.creates.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
                         if (relationField.properties) {
-                            const relationship = context.neoSchema.relationships.find(
+                            const relationship = (context.neoSchema.relationships.find(
                                 (x) => x.properties === relationField.properties
-                            ) as unknown as Relationship;
+                            ) as unknown) as Relationship;
 
                             const setA = createSetRelationshipPropertiesAndParams({
                                 properties: create.edge ?? {},
@@ -155,16 +155,7 @@ function createCreateAndParams({
                         refNode,
                         context,
                     });
-                    // if (connectOrCreateQuery.startsWith("CALL")) {
-                    //     res.creates.push(`WITH ${varName}`);
-                    // }
-
-                    let connectOrCreateQueryStatement = connectOrCreateQuery;
-                    // if (connectOrCreateQuery.startsWith("CALL")) {
-                    connectOrCreateQueryStatement = wrapInCall(connectOrCreateQuery, varName);
-                    // }
-
-                    res.creates.push(connectOrCreateQueryStatement);
+                    res.creates.push(wrapInCall(connectOrCreateQuery, varName));
                     res.params = { ...res.params, ...connectOrCreateParams };
                 }
             });

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -82,9 +82,9 @@ function createUpdateAndParams({
         if (relationField) {
             const refNodes: Node[] = [];
 
-            const relationship = (context.neoSchema.relationships.find(
+            const relationship = context.neoSchema.relationships.find(
                 (x) => x.properties === relationField.properties
-            ) as unknown) as Relationship;
+            ) as unknown as Relationship;
 
             if (relationField.union) {
                 Object.keys(value).forEach((unionTypeName) => {
@@ -483,7 +483,11 @@ function createUpdateAndParams({
     }
 
     // eslint-disable-next-line prefer-const
-    let { strs, params, meta = { preAuthStrs: [], postAuthStrs: [] } } = Object.entries(updateInput).reduce(reducer, {
+    let {
+        strs,
+        params,
+        meta = { preAuthStrs: [], postAuthStrs: [] },
+    } = Object.entries(updateInput).reduce(reducer, {
         strs: [],
         params: {},
     });

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -82,9 +82,9 @@ function createUpdateAndParams({
         if (relationField) {
             const refNodes: Node[] = [];
 
-            const relationship = context.neoSchema.relationships.find(
+            const relationship = (context.neoSchema.relationships.find(
                 (x) => x.properties === relationField.properties
-            ) as unknown as Relationship;
+            ) as unknown) as Relationship;
 
             if (relationField.union) {
                 Object.keys(value).forEach((unionTypeName) => {
@@ -483,11 +483,7 @@ function createUpdateAndParams({
     }
 
     // eslint-disable-next-line prefer-const
-    let {
-        strs,
-        params,
-        meta = { preAuthStrs: [], postAuthStrs: [] },
-    } = Object.entries(updateInput).reduce(reducer, {
+    let { strs, params, meta = { preAuthStrs: [], postAuthStrs: [] } } = Object.entries(updateInput).reduce(reducer, {
         strs: [],
         params: {},
     });

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -30,7 +30,6 @@ import createSetRelationshipProperties from "./create-set-relationship-propertie
 import createConnectionWhereAndParams from "./where/create-connection-where-and-params";
 import mapToDbProperty from "../utils/map-to-db-property";
 import { createConnectOrCreateAndParams } from "./connect-or-create/create-connect-or-create-and-params";
-import { wrapInCall } from "./utils/wrap-in-call";
 
 interface Res {
     strs: string[];
@@ -324,7 +323,7 @@ function createUpdateAndParams({
                             refNode,
                             context,
                         });
-                        subquery.push(wrapInCall(connectOrCreateQuery, varName));
+                        subquery.push(connectOrCreateQuery);
                         res.params = { ...res.params, ...connectOrCreateParams };
                     }
 

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -262,9 +262,9 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
                     createStrs.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
                     if (relationField.properties) {
-                        const relationship = context.neoSchema.relationships.find(
+                        const relationship = (context.neoSchema.relationships.find(
                             (x) => x.properties === relationField.properties
-                        ) as unknown as Relationship;
+                        ) as unknown) as Relationship;
 
                         const setA = createSetRelationshipPropertiesAndParams({
                             properties: create.edge ?? {},

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -262,9 +262,9 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
                     createStrs.push(`MERGE (${varName})${inStr}${relTypeStr}${outStr}(${nodeName})`);
 
                     if (relationField.properties) {
-                        const relationship = (context.neoSchema.relationships.find(
+                        const relationship = context.neoSchema.relationships.find(
                             (x) => x.properties === relationField.properties
-                        ) as unknown) as Relationship;
+                        ) as unknown as Relationship;
 
                         const setA = createSetRelationshipPropertiesAndParams({
                             properties: create.edge ?? {},

--- a/packages/graphql/tests/integration/connect-or-create/connect-or-create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/connect-or-create-auth.int.test.ts
@@ -93,8 +93,6 @@ describe("Update -> ConnectOrCreate", () => {
                     }
                 }
             }
-
-            
             `;
 
         neoSchema = new Neo4jGraphQL({

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -23,11 +23,9 @@ import { gql } from "apollo-server";
 import neo4j from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 import { Neo4jGraphQL } from "../../../src";
-import { generateUniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/923", () => {
-    // const testBlogpost = generateUniqueType("Blogpost");
-    //const testCategory = generateUniqueType("Category");
+    // TODO: convert to use generateUniqueType()
     const testBlogpost = {
         name: "BlogPost923",
     };

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { graphql, GraphQLSchema } from "graphql";
-import { Driver, Session } from "neo4j-driver";
+import { Driver, Session, Integer } from "neo4j-driver";
 import { gql } from "apollo-server";
 import neo4j from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
@@ -116,5 +116,11 @@ describe("https://github.com/neo4j/graphql/issues/923", () => {
             },
         });
         expect(result.errors).toBeUndefined();
+
+        const blogPostCount = await session.run(`
+          MATCH (m:${testBlogpost.name} { slug: "myslug" })
+          RETURN COUNT(m) as count
+        `);
+        expect((blogPostCount.records[0].toObject().count as Integer).toNumber()).toBe(1);
     });
 });

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -72,8 +72,8 @@ describe("https://github.com/neo4j/graphql/issues/923", () => {
     });
 
     afterEach(async () => {
-        await session.run(`MATCH (node:${testBlogpost.name}) DETACH DELETE node`);
-        await session.run(`MATCH (n:${testCategory.name}) DETACH DELETE n`);
+        await session.run(`MATCH (b:${testBlogpost.name}) DETACH DELETE b`);
+        await session.run(`MATCH (c:${testCategory.name}) DETACH DELETE c`);
 
         await session.close();
     });

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql, GraphQLSchema } from "graphql";
+import { Driver, Session } from "neo4j-driver";
+import { gql } from "apollo-server";
+import neo4j from "../neo4j";
+import { getQuerySource } from "../../utils/get-query-source";
+import { Neo4jGraphQL } from "../../../src";
+import { generateUniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/923", () => {
+    // const testBlogpost = generateUniqueType("Blogpost");
+    //const testCategory = generateUniqueType("Category");
+    const testBlogpost = {
+        name: "BlogPost923",
+    };
+    const testCategory = {
+        name: "Category923",
+        operations: { create: "createCategory923s" },
+    };
+
+    let schema: GraphQLSchema;
+    let driver: Driver;
+    let session: Session;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+
+        const typeDefs = gql`
+            type ${testBlogpost.name} @fulltext(indexes: [{ name: "BlogTitle", fields: ["title"] }]) {
+                title: String!
+                slug: String! @unique
+            }
+            type ${testCategory.name} {
+                name: String! @unique
+                blogs: [${testBlogpost.name}!]! @relationship(type: "IN_CATEGORY", direction: IN)
+            }
+            extend type ${testBlogpost.name}
+                @auth(
+                    rules: [
+                        { operations: [UPDATE], allow: { author: { id: "$jwt.sub" } } }
+                        { operations: [UPDATE], bind: { author: "$jwt.sub" } }
+                        { operations: [CREATE, UPDATE, CONNECT, DISCONNECT, DELETE], isAuthenticated: true }
+                    ]
+                )
+            extend type ${testCategory.name}
+                @auth(rules: [{ operations: [CREATE, UPDATE, DELETE, DISCONNECT, CONNECT], isAuthenticated: true }])
+        `;
+        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver });
+        schema = neoGraphql.schema;
+    });
+
+    beforeEach(() => {
+        session = driver.session();
+    });
+
+    afterEach(async () => {
+        await session.run(`MATCH (node:${testBlogpost.name}) DETACH DELETE node`);
+        await session.run(`MATCH (n:${testCategory.name}) DETACH DELETE n`);
+
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should query nested connection", async () => {
+        const query = gql`
+            mutation {
+                ${testCategory.operations.create}(
+                    input: [
+                        {
+                            blogs: {
+                                connectOrCreate: [
+                                    {
+                                        where: { node: { slug: "dsa" } }
+                                        onCreate: { node: { title: "mytitle", slug: "myslug" } }
+                                    }
+                                ]
+                            }
+                            name: "myname"
+                        }
+                    ]
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema,
+            source: getQuerySource(query),
+            contextValue: {
+                driver,
+                jwt: {
+                    sub: "test",
+                },
+            },
+        });
+        expect(result.errors).toBeUndefined();
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
@@ -77,12 +77,17 @@ describe("connectOrCreate", () => {
                 "CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this0
+                CALL {
+                	WITH this0
+                	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 MERGE (this0_genres_connectOrCreate0:Genre { name: $this0_genres_connectOrCreate0_node_name })
                 ON CREATE
                 SET
                 this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate0_on_create_name
                 MERGE (this0)-[this0_relationship_this0_genres_connectOrCreate0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -120,12 +125,17 @@ describe("connectOrCreate", () => {
                 "CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this0
+                CALL {
+                	WITH this0
+                	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 MERGE (this0_genres_connectOrCreate0:Genre { name: $this0_genres_connectOrCreate0_node_name })
                 ON CREATE
                 SET
                 this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate0_on_create_name
                 MERGE (this0)-[this0_relationship_this0_genres_connectOrCreate0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -163,12 +173,17 @@ describe("connectOrCreate", () => {
                 "CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this0
+                CALL {
+                	WITH this0
+                	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 MERGE (this0_genres_connectOrCreate0:Genre { name: $this0_genres_connectOrCreate0_node_name })
                 ON CREATE
                 SET
                 this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate0_on_create_name
                 MERGE (this0)-[this0_relationship_this0_genres_connectOrCreate0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -206,11 +221,16 @@ describe("connectOrCreate", () => {
                 "CALL {
                 CREATE (this0:Movie)
                 SET this0.title = $this0_title
-                MERGE (this0_genres_connectOrCreate0:Genre { name: $this0_genres_connectOrCreate0_node_name })
+                WITH this0
+                CALL {
+                	WITH this0
+                	MERGE (this0_genres_connectOrCreate0:Genre { name: $this0_genres_connectOrCreate0_node_name })
                 ON CREATE
                 SET
                 this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate0_on_create_name
                 MERGE (this0)-[this0_relationship_this0_genres_connectOrCreate0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -379,7 +399,7 @@ describe("connectOrCreate", () => {
             `);
         });
 
-        test.only("Create with createOrConnect and DELETE operation rule", async () => {
+        test("Create with createOrConnect and DELETE operation rule", async () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs: createTypedef("[DELETE]"),
                 config: { enableRegex: true, jwt: { secret } },

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
@@ -379,7 +379,7 @@ describe("connectOrCreate", () => {
             `);
         });
 
-        test("Create with createOrConnect and DELETE operation rule", async () => {
+        test.only("Create with createOrConnect and DELETE operation rule", async () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs: createTypedef("[DELETE]"),
                 config: { enableRegex: true, jwt: { secret } },

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
@@ -466,12 +466,17 @@ describe("connectOrCreate", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:Movie)
                 SET this.title = $this_update_title
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this
+                CALL {
+                	WITH this
+                	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 MERGE (this_connectOrCreate_genres0:Genre { name: $this_connectOrCreate_genres0_node_name })
                 ON CREATE
                 SET
                 this_connectOrCreate_genres0.name = $this_connectOrCreate_genres0_on_create_name
                 MERGE (this)-[this_relationship_this_connectOrCreate_genres0:IN_GENRE]->(this_connectOrCreate_genres0)
+                	RETURN COUNT(*)
+                }
                 RETURN this { .title } AS this"
             `);
 
@@ -505,12 +510,17 @@ describe("connectOrCreate", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:Movie)
                 SET this.title = $this_update_title
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this
+                CALL {
+                	WITH this
+                	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 MERGE (this_connectOrCreate_genres0:Genre { name: $this_connectOrCreate_genres0_node_name })
                 ON CREATE
                 SET
                 this_connectOrCreate_genres0.name = $this_connectOrCreate_genres0_on_create_name
                 MERGE (this)-[this_relationship_this_connectOrCreate_genres0:IN_GENRE]->(this_connectOrCreate_genres0)
+                	RETURN COUNT(*)
+                }
                 RETURN this { .title } AS this"
             `);
 
@@ -544,12 +554,17 @@ describe("connectOrCreate", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:Movie)
                 SET this.title = $this_update_title
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this
+                CALL {
+                	WITH this
+                	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 MERGE (this_connectOrCreate_genres0:Genre { name: $this_connectOrCreate_genres0_node_name })
                 ON CREATE
                 SET
                 this_connectOrCreate_genres0.name = $this_connectOrCreate_genres0_on_create_name
                 MERGE (this)-[this_relationship_this_connectOrCreate_genres0:IN_GENRE]->(this_connectOrCreate_genres0)
+                	RETURN COUNT(*)
+                }
                 RETURN this { .title } AS this"
             `);
 
@@ -583,11 +598,16 @@ describe("connectOrCreate", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:Movie)
                 SET this.title = $this_update_title
-                MERGE (this_connectOrCreate_genres0:Genre { name: $this_connectOrCreate_genres0_node_name })
+                WITH this
+                CALL {
+                	WITH this
+                	MERGE (this_connectOrCreate_genres0:Genre { name: $this_connectOrCreate_genres0_node_name })
                 ON CREATE
                 SET
                 this_connectOrCreate_genres0.name = $this_connectOrCreate_genres0_on_create_name
                 MERGE (this)-[this_relationship_this_connectOrCreate_genres0:IN_GENRE]->(this_connectOrCreate_genres0)
+                	RETURN COUNT(*)
+                }
                 RETURN this { .title } AS this"
             `);
 

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-unions.test.ts
@@ -107,7 +107,10 @@ describe("Create or connect with unions", () => {
             "CALL {
             CREATE (this0:Actor)
             SET this0.name = $this0_name
-            MERGE (this0_actedIn_Movie_connectOrCreate0:Movie { isan: $this0_actedIn_Movie_connectOrCreate0_node_isan })
+            WITH this0
+            CALL {
+            	WITH this0
+            	MERGE (this0_actedIn_Movie_connectOrCreate0:Movie { isan: $this0_actedIn_Movie_connectOrCreate0_node_isan })
             ON CREATE
             SET
             this0_actedIn_Movie_connectOrCreate0.title = $this0_actedIn_Movie_connectOrCreate0_on_create_title,
@@ -116,7 +119,12 @@ describe("Create or connect with unions", () => {
             ON CREATE
             SET
             this0_relationship_this0_actedIn_Movie_connectOrCreate0.screentime = $this0_relationship_this0_actedIn_Movie_connectOrCreate0_on_create_screentime
-            MERGE (this0_actedIn_Series_connectOrCreate0:Series { isan: $this0_actedIn_Series_connectOrCreate0_node_isan })
+            	RETURN COUNT(*)
+            }
+            WITH this0
+            CALL {
+            	WITH this0
+            	MERGE (this0_actedIn_Series_connectOrCreate0:Series { isan: $this0_actedIn_Series_connectOrCreate0_node_isan })
             ON CREATE
             SET
             this0_actedIn_Series_connectOrCreate0.title = $this0_actedIn_Series_connectOrCreate0_on_create_title,
@@ -125,6 +133,8 @@ describe("Create or connect with unions", () => {
             ON CREATE
             SET
             this0_relationship_this0_actedIn_Series_connectOrCreate0.screentime = $this0_relationship_this0_actedIn_Series_connectOrCreate0_on_create_screentime
+            	RETURN COUNT(*)
+            }
             RETURN this0
             }
             RETURN

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create.test.ts
@@ -84,7 +84,10 @@ describe("Create or Connect", () => {
                 "CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
-                MERGE (this0_movies_connectOrCreate0:Movie { title: $this0_movies_connectOrCreate0_node_title })
+                WITH this0
+                CALL {
+                	WITH this0
+                	MERGE (this0_movies_connectOrCreate0:Movie { title: $this0_movies_connectOrCreate0_node_title })
                 ON CREATE
                 SET
                 this0_movies_connectOrCreate0.title = $this0_movies_connectOrCreate0_on_create_title
@@ -92,6 +95,8 @@ describe("Create or Connect", () => {
                 ON CREATE
                 SET
                 this0_relationship_this0_movies_connectOrCreate0.screentime = $this0_relationship_this0_movies_connectOrCreate0_on_create_screentime
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -235,7 +240,10 @@ describe("Create or Connect", () => {
                 "CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
-                MERGE (this0_movies_connectOrCreate0:Movie { title: $this0_movies_connectOrCreate0_node_title })
+                WITH this0
+                CALL {
+                	WITH this0
+                	MERGE (this0_movies_connectOrCreate0:Movie { title: $this0_movies_connectOrCreate0_node_title })
                 ON CREATE
                 SET
                 this0_movies_connectOrCreate0.id = randomUUID(),
@@ -245,6 +253,8 @@ describe("Create or Connect", () => {
                 ON CREATE
                 SET
                 this0_relationship_this0_movies_connectOrCreate0.screentime = $this0_relationship_this0_movies_connectOrCreate0_on_create_screentime
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -296,7 +306,10 @@ describe("Create or Connect", () => {
                 "CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
-                MERGE (this0_movies_connectOrCreate0:Movie { id: $this0_movies_connectOrCreate0_node_id })
+                WITH this0
+                CALL {
+                	WITH this0
+                	MERGE (this0_movies_connectOrCreate0:Movie { id: $this0_movies_connectOrCreate0_node_id })
                 ON CREATE
                 SET
                 this0_movies_connectOrCreate0.createdAt = datetime(),
@@ -305,6 +318,8 @@ describe("Create or Connect", () => {
                 ON CREATE
                 SET
                 this0_relationship_this0_movies_connectOrCreate0.screentime = $this0_relationship_this0_movies_connectOrCreate0_on_create_screentime
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN
@@ -513,7 +528,10 @@ describe("Create or Connect", () => {
                 "CALL {
                 CREATE (this0:Actor)
                 SET this0.name = $this0_name
-                MERGE (this0_movies_connectOrCreate0:Movie { title: $this0_movies_connectOrCreate0_node_title })
+                WITH this0
+                CALL {
+                	WITH this0
+                	MERGE (this0_movies_connectOrCreate0:Movie { title: $this0_movies_connectOrCreate0_node_title })
                 ON CREATE
                 SET
                 this0_movies_connectOrCreate0.title = $this0_movies_connectOrCreate0_on_create_title
@@ -523,6 +541,8 @@ describe("Create or Connect", () => {
                 this0_relationship_this0_movies_connectOrCreate0.id = randomUUID(),
                 this0_relationship_this0_movies_connectOrCreate0.createdAt = datetime(),
                 this0_relationship_this0_movies_connectOrCreate0.screentime = $this0_relationship_this0_movies_connectOrCreate0_on_create_screentime
+                	RETURN COUNT(*)
+                }
                 RETURN this0
                 }
                 RETURN


### PR DESCRIPTION
# Description

Wraps the created cypher statement for connectOrCreate mutations in create-create-and-params with a CALL subquery lead by a WITH.

# Issue

Fixes #923

Closes:

- #923

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] New files have copyright header
