### PR TITLE
Extend @readonly to prevent creation

### DIFF
--- a/packages/graphql/src/schema/get-obj-field-meta.ts
+++ b/packages/graphql/src/schema/get-obj-field-meta.ts
@@ -122,6 +122,8 @@ function getObjFieldMeta({
             const coalesceDirective = directives.find((x) => x.name.value === "coalesce");
             const timestampDirective = directives.find((x) => x.name.value === "timestamp");
             const aliasDirective = directives.find((x) => x.name.value === "alias");
+            const readonlyDirective = directives.find((x) => x.name.value === "readonly");
+            const writeonlyDirective = directives.find((x) => x.name.value === "writeonly");
 
             const unique = getUniqueMeta(directives, obj, field.name.value);
 
@@ -155,12 +157,8 @@ function getObjFieldMeta({
                 arguments: [...(field.arguments || [])],
                 ...(authDirective ? { auth: getAuth(authDirective) } : {}),
                 description: field.description?.value,
-                readonly:
-                    directives.some((d) => d.name.value === "readonly") ||
-                    interfaceField?.directives?.some((x) => x.name.value === "readonly"),
-                writeonly:
-                    directives.some((d) => d.name.value === "writeonly") ||
-                    interfaceField?.directives?.some((x) => x.name.value === "writeonly"),
+                readonly: !!readonlyDirective,
+                writeonly: !!writeonlyDirective,
                 ...(unique ? { unique } : {}),
             };
 

--- a/packages/graphql/src/schema/get-obj-field-meta.ts
+++ b/packages/graphql/src/schema/get-obj-field-meta.ts
@@ -37,6 +37,7 @@ import getCypherMeta from "./get-cypher-meta";
 import getFieldTypeMeta from "./get-field-type-meta";
 import getIgnoreMeta from "./get-ignore-meta";
 import getRelationshipMeta from "./get-relationship-meta";
+import getReadonlyMeta from "./parse/get-readonly-meta";
 import getUniqueMeta from "./parse/get-unique-meta";
 import { SCALAR_TYPES } from "../constants";
 import {
@@ -122,10 +123,10 @@ function getObjFieldMeta({
             const coalesceDirective = directives.find((x) => x.name.value === "coalesce");
             const timestampDirective = directives.find((x) => x.name.value === "timestamp");
             const aliasDirective = directives.find((x) => x.name.value === "alias");
-            const readonlyDirective = directives.find((x) => x.name.value === "readonly");
             const writeonlyDirective = directives.find((x) => x.name.value === "writeonly");
 
             const unique = getUniqueMeta(directives, obj, field.name.value);
+            const readonly = getReadonlyMeta(directives);
 
             const fieldInterface = interfaces.find((x) => x.name.value === typeMeta.name);
             const fieldUnion = unions.find((x) => x.name.value === typeMeta.name);
@@ -157,7 +158,8 @@ function getObjFieldMeta({
                 arguments: [...(field.arguments || [])],
                 ...(authDirective ? { auth: getAuth(authDirective) } : {}),
                 description: field.description?.value,
-                readonly: !!readonlyDirective,
+                readonly: !!readonly,
+                ...(readonly ? { enableCreation: readonly.enableCreation } : {}),
                 writeonly: !!writeonlyDirective,
                 ...(unique ? { unique } : {}),
             };

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -470,7 +470,7 @@ function makeAugmentedSchema(
             name: `${relationship.name.value}CreateInput`,
             // TODO - This reduce duplicated when creating node CreateInput - put into shared function?
             fields: [
-                ...relFields.primitiveFields.filter((field) => !field.autogenerate),
+                ...relFields.primitiveFields.filter((field) => !field.autogenerate && field.enableCreation !== false),
                 ...relFields.scalarFields,
                 ...relFields.enumFields,
                 ...relFields.temporalFields.filter((field) => !field.timestamps),
@@ -867,7 +867,7 @@ function makeAugmentedSchema(
                 ...node.temporalFields.filter((field) => !field.timestamps),
                 ...node.pointFields,
             ].reduce((res, f) => {
-                if ((f as PrimitiveField)?.autogenerate) {
+                if (f?.enableCreation === false || (f as PrimitiveField)?.autogenerate) {
                     return res;
                 }
 

--- a/packages/graphql/src/schema/parse/get-readonly-meta.test.ts
+++ b/packages/graphql/src/schema/parse/get-readonly-meta.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DirectiveNode, Kind } from "graphql";
+import getReadonlyMeta from "./get-readonly-meta";
+
+describe("getReadonlyMeta", () => {
+    test("should return undefined if no directive found", () => {
+        const directives: DirectiveNode[] = [
+            {
+                // @ts-ignore
+                name: { value: "RANDOM 1" },
+            },
+            {
+                // @ts-ignore
+                name: { value: "RANDOM 2" },
+            },
+        ];
+
+        const result = getReadonlyMeta(directives);
+
+        expect(result).toBeUndefined();
+    });
+
+    test("should return the correct meta if no enableCreation argument", () => {
+        const directives: DirectiveNode[] = [
+            {
+                // @ts-ignore
+                name: { value: "readonly" },
+            },
+            {
+                // @ts-ignore
+                name: { value: "RANDOM 2" },
+            },
+        ];
+
+        const result = getReadonlyMeta(directives);
+
+        expect(result).toMatchObject({
+            enableCreation: true,
+        });
+    });
+
+    test("should return the correct meta if enableCreation is explicitly true", () => {
+        const directives: DirectiveNode[] = [
+            {
+                // @ts-ignore
+                name: { value: "readonly" },
+                arguments: [
+                  {
+                    // @ts-ignore
+                    name: { value: "enableCreation" },
+                    // @ts-ignore
+                    value: {
+                      kind: Kind.BOOLEAN,
+                      value: true
+                    }
+                  }
+                ]
+            },
+            {
+                // @ts-ignore
+                name: { value: "RANDOM 2" },
+            },
+        ];
+
+        const result = getReadonlyMeta(directives);
+
+        expect(result).toMatchObject({
+            enableCreation: true,
+        });
+    });
+
+    test("should return the correct meta if enableCreation is explicitly false", () => {
+        const directives: DirectiveNode[] = [
+            {
+                // @ts-ignore
+                name: { value: "readonly" },
+                arguments: [
+                  {
+                    // @ts-ignore
+                    name: { value: "enableCreation" },
+                    // @ts-ignore
+                    value: {
+                      kind: Kind.BOOLEAN,
+                      value: false
+                    }
+                  }
+                ]
+            },
+            {
+                // @ts-ignore
+                name: { value: "RANDOM 2" },
+            },
+        ];
+
+        const result = getReadonlyMeta(directives);
+
+        expect(result).toMatchObject({
+            enableCreation: false,
+        });
+    });
+});

--- a/packages/graphql/src/schema/parse/get-readonly-meta.ts
+++ b/packages/graphql/src/schema/parse/get-readonly-meta.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DirectiveNode, BooleanValueNode } from "graphql";
+
+type ReadonlyMeta = {
+    enableCreation: boolean;
+};
+
+function getReadonlyMeta(directives: DirectiveNode[]): ReadonlyMeta | undefined {
+    const directive = directives.find((x) => x.name.value === "readonly");
+
+    if (!directive) {
+        return undefined;
+    }
+
+    const enableCreation = directive.arguments?.find((arg) => arg.name.value === "enableCreation");
+
+    if (!enableCreation) {
+        return {
+            enableCreation: true,
+        };
+    }
+
+    return {
+        enableCreation: (enableCreation.value as BooleanValueNode).value,
+    };
+}
+
+export default getReadonlyMeta;

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -164,6 +164,12 @@ export const readonlyDirective = new GraphQLDirective({
     description:
         "Instructs @neo4j/graphql to only include a field in generated input type for creating, and in the object type within which the directive is applied.",
     locations: [DirectiveLocation.FIELD_DEFINITION],
+    args: {
+        enableCreation: {
+            defaultValue: true,
+            type: GraphQLBoolean,
+        }
+    }
 });
 
 export const relationshipDirective = new GraphQLDirective({

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -168,6 +168,7 @@ export const readonlyDirective = new GraphQLDirective({
         enableCreation: {
             defaultValue: true,
             type: GraphQLBoolean,
+            description: "Set to false to exclude this field from the generated input type as well."
         }
     }
 });

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -118,6 +118,7 @@ export interface BaseField {
     auth?: Auth;
     description?: string;
     readonly?: boolean;
+    enableCreation?: boolean;
     writeonly?: boolean;
     ignored?: boolean;
     dbPropertyName?: string;

--- a/packages/graphql/tests/schema/directives/readonly.test.ts
+++ b/packages/graphql/tests/schema/directives/readonly.test.ts
@@ -308,4 +308,288 @@ describe("@readonly directive", () => {
             }"
         `);
     });
+
+    test("removes a readonly field from create input", () => {
+        const typeDefs = gql`
+            type User {
+                id: ID! @readonly(enableCreation: false)
+                username: String!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(neoSchema.schema));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateUsersMutationResponse {
+              info: CreateInfo!
+              users: [User!]!
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type IDAggregateSelectionNonNullable {
+              longest: ID!
+              shortest: ID!
+            }
+
+            type Mutation {
+              createUsers(input: [UserCreateInput!]!): CreateUsersMutationResponse!
+              deleteUsers(where: UserWhere): DeleteInfo!
+              updateUsers(update: UserUpdateInput, where: UserWhere): UpdateUsersMutationResponse!
+            }
+
+            type Query {
+              users(options: UserOptions, where: UserWhere): [User!]!
+              usersAggregate(where: UserWhere): UserAggregateSelection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String!
+              shortest: String!
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateUsersMutationResponse {
+              info: UpdateInfo!
+              users: [User!]!
+            }
+
+            type User {
+              id: ID!
+              username: String!
+            }
+
+            type UserAggregateSelection {
+              count: Int!
+              id: IDAggregateSelectionNonNullable!
+              username: StringAggregateSelectionNonNullable!
+            }
+
+            input UserCreateInput {
+              username: String!
+            }
+
+            input UserOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [UserSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Users by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserSort object.
+            \\"\\"\\"
+            input UserSort {
+              id: SortDirection
+              username: SortDirection
+            }
+
+            input UserUpdateInput {
+              username: String
+            }
+
+            input UserWhere {
+              AND: [UserWhere!]
+              OR: [UserWhere!]
+              id: ID
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_IN: [ID!]
+              id_NOT: ID
+              id_NOT_CONTAINS: ID
+              id_NOT_ENDS_WITH: ID
+              id_NOT_IN: [ID!]
+              id_NOT_STARTS_WITH: ID
+              id_STARTS_WITH: ID
+              username: String
+              username_CONTAINS: String
+              username_ENDS_WITH: String
+              username_IN: [String!]
+              username_NOT: String
+              username_NOT_CONTAINS: String
+              username_NOT_ENDS_WITH: String
+              username_NOT_IN: [String!]
+              username_NOT_STARTS_WITH: String
+              username_STARTS_WITH: String
+            }"
+        `);
+    });
+
+    test("removes an inherited readonly field from create input", () => {
+        const typeDefs = gql`
+            interface UserInterface {
+                id: ID! @readonly(enableCreation: false)
+                username: String!
+            }
+
+            type User implements UserInterface {
+                id: ID!
+                username: String!
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(neoSchema.schema));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateUsersMutationResponse {
+              info: CreateInfo!
+              users: [User!]!
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type IDAggregateSelectionNonNullable {
+              longest: ID!
+              shortest: ID!
+            }
+
+            type Mutation {
+              createUsers(input: [UserCreateInput!]!): CreateUsersMutationResponse!
+              deleteUsers(where: UserWhere): DeleteInfo!
+              updateUsers(update: UserUpdateInput, where: UserWhere): UpdateUsersMutationResponse!
+            }
+
+            type Query {
+              users(options: UserOptions, where: UserWhere): [User!]!
+              usersAggregate(where: UserWhere): UserAggregateSelection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String!
+              shortest: String!
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateUsersMutationResponse {
+              info: UpdateInfo!
+              users: [User!]!
+            }
+
+            type User implements UserInterface {
+              id: ID!
+              username: String!
+            }
+
+            type UserAggregateSelection {
+              count: Int!
+              id: IDAggregateSelectionNonNullable!
+              username: StringAggregateSelectionNonNullable!
+            }
+
+            input UserCreateInput {
+              username: String!
+            }
+
+            interface UserInterface {
+              id: ID!
+              username: String!
+            }
+
+            input UserOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [UserSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Users by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserSort object.
+            \\"\\"\\"
+            input UserSort {
+              id: SortDirection
+              username: SortDirection
+            }
+
+            input UserUpdateInput {
+              username: String
+            }
+
+            input UserWhere {
+              AND: [UserWhere!]
+              OR: [UserWhere!]
+              id: ID
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_IN: [ID!]
+              id_NOT: ID
+              id_NOT_CONTAINS: ID
+              id_NOT_ENDS_WITH: ID
+              id_NOT_IN: [ID!]
+              id_NOT_STARTS_WITH: ID
+              id_STARTS_WITH: ID
+              username: String
+              username_CONTAINS: String
+              username_ENDS_WITH: String
+              username_IN: [String!]
+              username_NOT: String
+              username_NOT_CONTAINS: String
+              username_NOT_ENDS_WITH: String
+              username_NOT_IN: [String!]
+              username_NOT_STARTS_WITH: String
+              username_STARTS_WITH: String
+            }"
+        `);
+    });
 });


### PR DESCRIPTION
# Description

This PR addresses the feature request in #916, adding a `enableCreation` argument to the `@readonly` directive. If this argument is not set (or set to `true`), fields are added to the create input type as before:

```graphql
type SomeObj {
  id: ID!
  name: String @readonly
}

input SomeObjCreateInput {
  id: ID!
  name: String
}

input SomeObjUpdateInput {
  id: ID
}
```

If the argument is added and _explicitly set to false_, the field is omitted from both the create and update input types:

```graphql
type SomeObj {
  id: ID!
  name: String @readonly(enableCreation: false)
}

input SomeObjCreateInput {
  id: ID!
}

input SomeObjUpdateInput {
  id: ID
}
```

# Issue

This PR directly addresses #916. It adds schema and unit tests to cover the new use case, but I'm not entirely sure where to put integration or tck tests (or if it needs them). I'd definitely appreciate your inputs on that! Also, it seems like adding a description to the directive definition makes it show up in the documentation, is that accurate?

Closes:

- #916

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
