### PR TITLE
remove pending() from jest tests

### DIFF
--- a/examples/neo-push/server/package.json
+++ b/examples/neo-push/server/package.json
@@ -34,7 +34,7 @@
         "@types/node": "14.14.14",
         "@types/uuid": "8.3.0",
         "cross-env": "7.0.3",
-        "jest": "27.4.7",
+        "jest": "27.5.1",
         "nodemon": "2.0.6",
         "randomstring": "1.1.5",
         "ts-jest": "27.1.3",

--- a/packages/graphql/src/utils/utils.ts
+++ b/packages/graphql/src/utils/utils.ts
@@ -60,3 +60,10 @@ export function haveSharedElement(arr1: Array<any>, arr2: Array<any>): boolean {
 export function removeDuplicates<T>(arr: T[]): T[] {
     return Array.from(new Set(arr));
 }
+
+/** Awaitable version of setTimeout */
+export function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}

--- a/packages/graphql/tests/integration/indexes-and-constraints/fulltext.int.test.ts
+++ b/packages/graphql/tests/integration/indexes-and-constraints/fulltext.int.test.ts
@@ -24,6 +24,7 @@ import { gql } from "apollo-server";
 import neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { generateUniqueType } from "../../utils/graphql-types";
+import { delay } from "../../../src/utils/utils";
 
 describe("assertIndexesAndConstraints/fulltext", () => {
     let driver: Driver;
@@ -58,7 +59,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
             await session.close();
         }
 
-        await new Promise((x) => setTimeout(x, 5000));
+        await delay(5000);
     });
 
     afterAll(async () => {
@@ -79,8 +80,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should create index if it doesn't exist and then query using the index", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -175,8 +175,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should create two index's if they dont exist and then throw and error when users queries both at once", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -226,8 +225,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should create index if it doesn't exist (using node label) and then query using the index", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -323,8 +321,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should create index if it doesn't exist (using field alias) and then query using the index", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -420,8 +417,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should throw when missing index", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -448,8 +444,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should throw when index is missing fields", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -493,8 +488,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should throw when index is missing fields (using field alias)", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -541,8 +535,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should create index if it doesn't exist and not throw if it does exist, and then query using the index", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -623,8 +616,7 @@ describe("assertIndexesAndConstraints/fulltext", () => {
     test("should throw when index is missing fields when used with create option", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 

--- a/packages/graphql/tests/integration/indexes-and-constraints/unique.int.test.ts
+++ b/packages/graphql/tests/integration/indexes-and-constraints/unique.int.test.ts
@@ -77,8 +77,7 @@ describe("assertIndexesAndConstraints/unique", () => {
     test("should create a constraint if it doesn't exist and specified in options, and then throw an error in the event of constraint validation", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -172,8 +171,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should throw an error when all necessary constraints do not exist", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -197,8 +195,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should throw an error when all necessary constraints do not exist when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -222,8 +219,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not throw an error when all necessary constraints exist", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -257,8 +253,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not throw an error when all necessary constraints exist when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -292,8 +287,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should create a constraint if it doesn't exist and specified in options", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -339,8 +333,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should create a constraint if it doesn't exist and specified in options when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -392,8 +385,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should throw an error when all necessary constraints do not exist", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -417,8 +409,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should throw an error when all necessary constraints do not exist when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -442,8 +433,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not throw an error when unique argument is set to false", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -467,8 +457,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not throw an error when unique argument is set to false when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -492,8 +481,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not throw an error when all necessary constraints exist", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -527,8 +515,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not throw an error when all necessary constraints exist when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -562,8 +549,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should create a constraint if it doesn't exist and specified in options", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -609,8 +595,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should create a constraint if it doesn't exist and specified in options when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -659,8 +644,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not create a constraint if it doesn't exist and unique option is set to false", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 
@@ -706,8 +690,7 @@ describe("assertIndexesAndConstraints/unique", () => {
         test("should not create a constraint if it doesn't exist and unique option is set to false when used with @alias", async () => {
             // Skip if multi-db not supported
             if (!MULTIDB_SUPPORT) {
-                // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-                pending();
+                console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
                 return;
             }
 

--- a/packages/graphql/tests/integration/multi-database.int.test.ts
+++ b/packages/graphql/tests/integration/multi-database.int.test.ts
@@ -80,8 +80,7 @@ describe("multi-database", () => {
     test("should fail for non-existing database specified via context", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -112,8 +111,7 @@ describe("multi-database", () => {
     test("should specify the database via context", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -145,8 +143,7 @@ describe("multi-database", () => {
     test("should fail for non-existing database specified via neo4j construction", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -185,8 +182,7 @@ describe("multi-database", () => {
     test("should specify the database via neo4j construction", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 

--- a/packages/introspector/tests/integration/graphql/graphs.test.ts
+++ b/packages/introspector/tests/integration/graphql/graphs.test.ts
@@ -80,8 +80,7 @@ describe("GraphQL - Infer Schema on graphs", () => {
     test("Can introspect and generate on small graph with no rel properties", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -120,8 +119,7 @@ describe("GraphQL - Infer Schema on graphs", () => {
     test("Can introspect and generate multiple relationships (even with the same type)", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -178,8 +176,7 @@ describe("GraphQL - Infer Schema on graphs", () => {
     test("Can introspect and generate relationships with properties", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -244,8 +241,7 @@ describe("GraphQL - Infer Schema on graphs", () => {
     test("Can handle the larger character set from Neo4j", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 

--- a/packages/introspector/tests/integration/graphql/nodes.test.ts
+++ b/packages/introspector/tests/integration/graphql/nodes.test.ts
@@ -79,8 +79,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can introspect and generate single label with single property", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -107,8 +106,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can introspect and generate single label with multiple properties of different types", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -141,8 +139,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can introspect and generate multiple labels with multiple properties of different types", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -177,8 +174,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can introspect and generate additional labels", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -213,8 +209,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can introspect and generate label with unsupported characters in labels", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -249,8 +244,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can introspect and generate label that starts with a number", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -274,8 +268,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Should not include properties with ambiguous types", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -309,8 +302,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Should not include types with no fields or no labels", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -336,8 +328,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Should include types with no prop fields but relationship fields", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 
@@ -366,8 +357,7 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
     test("Can generate a readonly typeDefs and combine directives", async () => {
         // Skip if multi-db not supported
         if (!MULTIDB_SUPPORT) {
-            // eslint-disable-next-line jest/no-disabled-tests, jest/no-jasmine-globals
-            pending();
+            console.log("MULTIDB_SUPPORT NOT AVAILABLE - SKIPPING");
             return;
         }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1430,7 +1430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jest/core@npm:^27.4.7, @jest/core@npm:^27.5.1":
+"@jest/core@npm:^27.5.1":
   version: 27.5.1
   resolution: "@jest/core@npm:27.5.1"
   dependencies:
@@ -9816,7 +9816,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-cli@npm:^27.4.7, jest-cli@npm:^27.5.1":
+"jest-cli@npm:^27.5.1":
   version: 27.5.1
   resolution: "jest-cli@npm:27.5.1"
   dependencies:
@@ -10246,24 +10246,6 @@ __metadata:
     merge-stream: ^2.0.0
     supports-color: ^8.0.0
   checksum: 98cd68b696781caed61c983a3ee30bf880b5bd021c01d98f47b143d4362b85d0737f8523761e2713d45e18b4f9a2b98af1eaee77afade4111bb65c77d6f7c980
-  languageName: node
-  linkType: hard
-
-"jest@npm:27.4.7":
-  version: 27.4.7
-  resolution: "jest@npm:27.4.7"
-  dependencies:
-    "@jest/core": ^27.4.7
-    import-local: ^3.0.2
-    jest-cli: ^27.4.7
-  peerDependencies:
-    node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
-  peerDependenciesMeta:
-    node-notifier:
-      optional: true
-  bin:
-    jest: bin/jest.js
-  checksum: 28ce948b30c074907393f37553acac4422d0f60190776e62b3403e4c742d33dd6012e3a20748254a43e38b5b4ce52d813b13a3a5be1d43d6d12429bd08ce1a23
   languageName: node
   linkType: hard
 
@@ -11888,7 +11870,7 @@ __metadata:
     dotenv: ^10.0.0
     express: 4.17.1
     graphql: 16.3.0
-    jest: 27.4.7
+    jest: 27.5.1
     jsonwebtoken: 8.5.1
     neo4j-driver: 4.4.2
     nodemon: 2.0.6


### PR DESCRIPTION
# Description
Latest versions of jest do not support the usage of `pending()`, currently used for dynamically skipping MULTIDB tests.

This PR removes its usage by simply returning the test (and thus, counting it as **passed**) along with a log noting the test is skipped. This behaviour is not ideal, but keeping jest up to date is worth this minor inconvenience.

In the future, we could improve this by setting an environment variable to skip tests without needing to reach out to the database in the test itself


Additionally, `delay` utils were added to simplify and solve an EsLint error in tests