### PR TITLE
RFC: Successor for GraphQL Architect

### DIFF
--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -2,7 +2,8 @@
 
 ## Problem
 
-The [GraphQL Architect](https://grandstack.io/docs/graphql-architect-overview/#:~:text=GraphQL%20Architect%20is%20a%20graph,Neo4j%20Desktop%20Graph%20Apps%20Gallery) for usage in the Neo4j Desktop is due to be replaced. As an initial step a proof of concept of a successor shall be established.
+The [GraphQL Architect](https://grandstack.io/docs/graphql-architect-overview/#:~:text=GraphQL%20Architect%20is%20a%20graph,Neo4j%20Desktop%20Graph%20Apps%20Gallery) for usage in the Neo4j Desktop is due to be replaced. As an initial step a proof of concept of a successor shall be established.  
+The successor application will be made available to install as Graph App in Neo4j Desktop. If time permits it, would be favorable if we can add the successor to the 'Neo4j Developer Graph Apps Gallery' in Neo4j Desktop.
 
 ## Proposed Solution
 
@@ -37,6 +38,7 @@ The `@neo4j/graphql` lib's user audience are full stack developers who want a Gr
 Login:
 
 1. Input fields for username, password, connectURL for dbms
+2. _Nice to have_: Store credentials (encrypted!) in window [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
 
 Schema editor
 (An open-source editor shall be utlized)

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -17,7 +17,10 @@ Frame
 
 ### User audience
 
-The `@neo4j/graphql` lib's user audience are full stack developers who want a GraphQL API quickly without worrying about the database. This UI can further include developers wanting to experiment in general as well as experiment with/edit the introspected schema.
+The `@neo4j/graphql` lib's user audience are full stack developers who want a GraphQL API quickly without worrying about the database.  
+This UI can further include developers wanting to experiment in general as well as experiment with/edit the introspected schema.  
+The main aim is for prototyping and rapid development for both experinced as well as non-experienced users.
+
 
 ### Workflow (Graph App)
 
@@ -32,6 +35,15 @@ The `@neo4j/graphql` lib's user audience are full stack developers who want a Gr
     2. Execute queries
     3. Show results
 5. Logout - _Repeat_
+
+#### Metrics
+
+We want to track valuable events/actions of the UI to get an understanding and data of the usage (pattern) from the get go. This could include button clicks such as "generate typeDefs" or related things.  
+A spreasheet is to create to write down all the tracking events, their name, why we track it etc.  
+It is suggested to use [Segment](https://segment.com/docs/connections/sources/catalog/libraries/website/javascript/) as it is used by other products at Neo4j. 
+
+_Nice to have_: As a one-off, measure the time it takes to get started with the `@neo4j/graphql` library using the node (`index.ts`) script versus this successor application.
+
 
 ### Input
 
@@ -81,6 +93,15 @@ New packages in `@neo4j/graphql` monorepo:
 2. Schema Editor
 3. Query Editor
 4. _Nice to have_: Server
+
+
+## Documentation
+
+If the resulting application is of sufficient quality (team decision):  
+Include this application in the "getting started" (or related) documentation as an alternative to the currently described way.
+
+_Stretch_: Have this application publically available as demo online as part of the offical Neo4j GraphQL webpage: https://neo4j.com/product/graphql-library/ 
+
 
 ## Risks
 

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -6,15 +6,13 @@ The [GraphQL Architect](https://grandstack.io/docs/graphql-architect-overview/#:
 
 ## Proposed Solution
 
-_Name suggestions:_
-
+_Name suggestions:_  
+Explorer  
+Architect  
+Editor  
+UI  
+Frame  
 (Already taken: Studio, Playground, GraphiQL)
-
-Explorer
-
-Architect
-
-Editor
 
 ### User audience
 
@@ -22,7 +20,8 @@ The `@neo4j/graphql` lib's user audience are full stack developers who want a Gr
 
 ### Workflow (Graph App)
 
-1. Login page - Specify the database credentials (connectURL, username, password)
+1. Login page
+    1. Specify the database credentials (connectURL, username, password)
 2. Schema Editor page
     1. "Bring your own" typeDefs or introspect that database
     2. Show the generated schema if introspected
@@ -31,7 +30,7 @@ The `@neo4j/graphql` lib's user audience are full stack developers who want a Gr
     1. Write queries
     2. Execute queries
     3. Show results
-5. _Logout -_ Repeat
+5. Logout - _Repeat_
 
 ### Input
 
@@ -60,24 +59,22 @@ Query editor:
 Keybindings
 
 1. CTRL+ENTER - to run the query
-2. CTRL+SHIFT+P - Prettify code
-3. ... Other basic ones
+2. CTRL+SHIFT+P - to prettify the code
+3. _Nice to have_: Other common/basic ones
 
 ### Structure
 
 New packages in `@neo4j/graphql` monorepo:
 
-1. Schema Editor
-2. Query Editor
-3. Graph App (Neo4j GraphQL UI) - Must Have
-4. Server - Nice to have
+1. _Must have_: Graph App (Neo4j GraphQL UI)
+2. Schema Editor
+3. Query Editor
+4. _Nice to have_: Server
 
 ## Risks
 
-A polished UI can eat up too much time.
-
-Implementing a custom autocomplete functionality for the query editor.
-
+A polished UI can eat up too much time.  
+Implementing a custom autocomplete functionality for the query editor.  
 Docs generation and presentation could be a rabbit hole.
 
 Expose/build our own "Apollo Server" library that uses this UI:
@@ -100,10 +97,7 @@ This PoC leverage the `@neo4j/graphql` and does not alter any of its behaviours.
 
 ## Out of Scope
 
-Use components of the Neo4j Design System
-
-Write a schema builder
-
-Settings (connection setttings, env vars, etc.)
-
+Use components of the Neo4j Design System  
+Write a schema builder  
+Settings (connection setttings, env vars, etc.)  
 Query history

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -62,6 +62,14 @@ Keybindings
 2. CTRL+SHIFT+P - to prettify the code
 3. _Nice to have_: Other common/basic ones
 
+
+### Sketch
+
+![GraphQL_UI_v4](https://user-images.githubusercontent.com/8817964/155305646-2adbf310-079e-4348-9536-93cfb4da5215.png)
+
+[Link](https://excalidraw.com/#json=b4U6WUvi6icFdMQaXoDjo,EjqhTATzUC7GqqiAgFPSjw) to excalidraw drawing.
+
+
 ### Structure
 
 New packages in `@neo4j/graphql` monorepo:
@@ -77,7 +85,7 @@ A polished UI can eat up too much time.
 Implementing a custom autocomplete functionality for the query editor.  
 Docs generation and presentation could be a rabbit hole.
 
-Expose/build our own "Apollo Server" library that uses this UI:
+Spending time on building our own "Apollo Server" library that uses this UI:
 
 ```tsx
 import { Neo4jGraphQL }
@@ -93,11 +101,11 @@ await server.listen(4000);
 
 ### Security consideration
 
-This PoC leverage the `@neo4j/graphql` and does not alter any of its behaviours. If the credentials in the login page need to be stored then they are encrypted.
+This PoC leverage the `@neo4j/graphql` and does not alter any of its behaviours. If the credentials (login page) need to be stored then they are encrypted.
 
 ## Out of Scope
 
 Use components of the Neo4j Design System  
 Write a schema builder  
-Settings (connection setttings, env vars, etc.)  
+Settings (connection settings, env vars, etc.)  
 Query history

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -52,9 +52,10 @@ Query editor:
 2. Query parameters
 3. Query response
 4. Autocomplete for queries and mutations - [monaco-graphql editor](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql)
-5. _Nice to have_: Store latest queries&params in window [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
-6. _Nice to have_: Docs (utilize from [GraphQL Playground](https://github.com/graphql/graphql-playground)?)
-7. _Nice to have_: Tabs for query input and parameters (similar to Apollo Studio)
+5. _Nice to have_: [Explorer plugin](https://user-images.githubusercontent.com/476818/51567716-c00dfa00-1e4c-11e9-88f7-6d78b244d534.gif) (or similar) for/from GraphiQL. [Repo](https://github.com/OneGraph/graphiql-explorer)
+6. _Nice to have_: Store latest queries&params in window [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+7. _Nice to have_: Docs (utilize from [GraphQL Playground](https://github.com/graphql/graphql-playground)?)
+8. _Nice to have_: Tabs for query input and parameters (similar to Apollo Studio)
 
 Keybindings
 

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -86,9 +86,8 @@ New packages in `@neo4j/graphql` monorepo:
 
 A polished UI can eat up too much time.  
 Implementing a custom autocomplete functionality for the query editor.  
-Docs generation and presentation could be a rabbit hole.
 
-Spending time on building our own "Apollo Server" library that uses this UI:
+Spending too much time on building our own "Apollo Server" library that uses this UI:
 
 ```tsx
 import { Neo4jGraphQL }
@@ -101,6 +100,11 @@ const server = new Neo4jGraphQLServer(neoSchema);
 await server.listen(4000);
 // http://localhost:4000/playground
 ```
+
+### Rabbit holes
+
+Large databases could be slow to introspect, and so we need a way to cache the schema generation.   
+Docs generation and presentation.  
 
 ### Security consideration
 

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -7,9 +7,13 @@ The [GraphQL Architect](https://grandstack.io/docs/graphql-architect-overview/#:
 ## Proposed Solution
 
 _Name suggestions:_
+
 (Already taken: Studio, Playground, GraphiQL)
+
 Explorer
+
 Architect
+
 Editor
 
 ### User audience
@@ -71,7 +75,9 @@ New packages in `@neo4j/graphql` monorepo:
 ## Risks
 
 A polished UI can eat up too much time.
+
 Implementing a custom autocomplete functionality for the query editor.
+
 Docs generation and presentation could be a rabbit hole.
 
 Expose/build our own "Apollo Server" library that uses this UI:
@@ -95,6 +101,9 @@ This PoC leverage the `@neo4j/graphql` and does not alter any of its behaviours.
 ## Out of Scope
 
 Use components of the Neo4j Design System
+
 Write a schema builder
+
 Settings (connection setttings, env vars, etc.)
+
 Query history

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -1,0 +1,100 @@
+# GraphQL Graph App PoC
+
+## Problem
+
+The [GraphQL Architect](https://grandstack.io/docs/graphql-architect-overview/#:~:text=GraphQL%20Architect%20is%20a%20graph,Neo4j%20Desktop%20Graph%20Apps%20Gallery) for usage in the Neo4j Desktop is due to be replaced. As an initial step a proof of concept of a successor shall be established.
+
+## Proposed Solution
+
+_Name suggestions:_
+(Already taken: Studio, Playground, GraphiQL)
+Explorer
+Architect
+Editor
+
+### User audience
+
+The `@neo4j/graphql` lib's user audience are full stack developers who want a GraphQL API quickly without worrying about the database. This UI can further include developers wanting to experiment in general as well as experiment with/edit the introspected schema.
+
+### Workflow (Graph App)
+
+1. Login page - Specify the database credentials (connectURL, username, password)
+2. Schema Editor page
+    1. "Bring your own" typeDefs or introspect that database
+    2. Show the generated schema if introspected
+3. Build Neo4j GraphQL schema
+4. Query Editor page
+    1. Write queries
+    2. Execute queries
+    3. Show results
+5. _Logout -_ Repeat
+
+### Input
+
+Login:
+
+1. Input fields for username, password, connectURL for dbms
+
+Schema editor
+(An open-source editor shall be utlized)
+
+1. Introspect part
+2. "Bring your own" typeDefs part
+3. _Nice to have_: Store latest typeDefs in window [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+
+Query editor:
+(An open-source editor shall be utlized where applicable)
+
+1. Query input
+2. Query parameters
+3. Query response
+4. Autocomplete for queries and mutations - [monaco-graphql editor](https://github.com/graphql/graphiql/tree/main/packages/monaco-graphql)
+5. _Nice to have_: Store latest queries&params in window [localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage)
+6. _Nice to have_: Docs (utilize from [GraphQL Playground](https://github.com/graphql/graphql-playground)?)
+7. _Nice to have_: Tabs for query input and parameters (similar to Apollo Studio)
+
+Keybindings
+
+1. CTRL+ENTER - to run the query
+2. CTRL+SHIFT+P - Prettify code
+3. ... Other basic ones
+
+### Structure
+
+New packages in `@neo4j/graphql` monorepo:
+
+1. Schema Editor
+2. Query Editor
+3. Graph App (Neo4j GraphQL UI) - Must Have
+4. Server - Nice to have
+
+## Risks
+
+A polished UI can eat up too much time.
+Implementing a custom autocomplete functionality for the query editor.
+Docs generation and presentation could be a rabbit hole.
+
+Expose/build our own "Apollo Server" library that uses this UI:
+
+```tsx
+import { Neo4jGraphQL }
+import { Neo4jGraphQLServer }
+
+const neoSchema = new Neo4jGraphQL();
+
+const server = new Neo4jGraphQLServer(neoSchema);
+
+await server.listen(4000);
+// http://localhost:4000/playground
+```
+
+### Security consideration
+
+This PoC leverage the `@neo4j/graphql` and does not alter any of its behaviours. If the credentials in the login page need to be stored then they are encrypted.
+
+## Out of Scope
+
+Use components of the Neo4j Design System
+Write a schema builder
+Settings (connection setttings, env vars, etc.)
+Query history

--- a/docs/rfcs/rfc-009-graphql-ui-poc.md
+++ b/docs/rfcs/rfc-009-graphql-ui-poc.md
@@ -65,7 +65,7 @@ Keybindings
 
 ### Sketch
 
-![GraphQL_UI_v4](https://user-images.githubusercontent.com/8817964/155305646-2adbf310-079e-4348-9536-93cfb4da5215.png)
+![GraphQL_UI_v5](https://user-images.githubusercontent.com/8817964/155744938-2ec1b531-3b83-44e1-9fd0-371022150274.png)
 
 [Link](https://excalidraw.com/#json=b4U6WUvi6icFdMQaXoDjo,EjqhTATzUC7GqqiAgFPSjw) to excalidraw drawing.
 


### PR DESCRIPTION
# Description
 
RFC for a successor of the [GraphQL Architect](https://grandstack.io/docs/graphql-architect-overview/#:~:text=GraphQL%20Architect%20is%20a%20graph,Neo4j%20Desktop%20Graph%20Apps%20Gallery).
