### PR TITLE
Reintroduce camelcase for generating field names

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
@@ -58,7 +58,7 @@ directive @node(
     label: String
     """Map the GraphQL type to match additional Neo4j node labels"""
     additionalLabels: [String]
-    """Allows for the specification of the plural of the type name if the type name is non-English."""
+    """Allows for the specification of the plural of the type name."""
     plural: String
 ) on OBJECT
 ----

--- a/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
@@ -58,6 +58,8 @@ directive @node(
     label: String
     """Map the GraphQL type to match additional Neo4j node labels"""
     additionalLabels: [String]
+    """Allows for the specification of the plural of the type name if the type name is non-English."""
+    plural: String
 ) on OBJECT
 ----
 
@@ -198,6 +200,7 @@ type User @node(additionalLabels: ["$jwt.username"]) {
 ----
 
 ==== `plural`
+
 The parameter `plural` redefines how to compose the plural of the type for the generated operations. This is particularly
 useful for types that are not correctly pluralized or are non-English words.
 

--- a/packages/graphql/src/classes/Node.test.ts
+++ b/packages/graphql/src/classes/Node.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import Node, { NodeConstructor, RootTypeFieldNames } from "./Node";
+import Node, { MutationResponseTypeNames, NodeConstructor, RootTypeFieldNames } from "./Node";
 import { ContextBuilder } from "../../tests/utils/builders/context-builder";
 import { NodeBuilder } from "../../tests/utils/builders/node-builder";
 import { NodeDirective } from "./NodeDirective";
@@ -263,6 +263,159 @@ describe("Node", () => {
                 }).instance();
 
                 expect(node.rootTypeFieldNames).toStrictEqual(rootTypeFieldNames);
+            }
+        );
+    });
+
+    describe("mutation response type names", () => {
+        test.each<[string, MutationResponseTypeNames]>([
+            [
+                "Account",
+                {
+                    create: "CreateAccountsMutationResponse",
+                    update: "UpdateAccountsMutationResponse",
+                },
+            ],
+            [
+                "AWSAccount",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "AWS_ACCOUNT",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "aws-account",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "aws_account",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "account",
+                {
+                    create: "CreateAccountsMutationResponse",
+                    update: "UpdateAccountsMutationResponse",
+                },
+            ],
+            [
+                "ACCOUNT",
+                {
+                    create: "CreateAccountsMutationResponse",
+                    update: "UpdateAccountsMutationResponse",
+                },
+            ],
+            [
+                "A",
+                {
+                    create: "CreateAsMutationResponse",
+                    update: "UpdateAsMutationResponse",
+                },
+            ],
+            [
+                "_2number",
+                {
+                    create: "Create_2NumbersMutationResponse",
+                    update: "Update_2NumbersMutationResponse",
+                },
+            ],
+            [
+                "__2number",
+                {
+                    create: "Create__2NumbersMutationResponse",
+                    update: "Update__2NumbersMutationResponse",
+                },
+            ],
+            [
+                "_number",
+                {
+                    create: "Create_numbersMutationResponse",
+                    update: "Update_numbersMutationResponse",
+                },
+            ],
+        ])(
+            "should generate mutation response type names for %s as expected",
+            (typename: string, mutationResponseTypeNames: MutationResponseTypeNames) => {
+                const node = new NodeBuilder({
+                    name: typename,
+                }).instance();
+
+                expect(node.mutationResponseTypeNames).toStrictEqual(mutationResponseTypeNames);
+            }
+        );
+
+        test.each<[string, MutationResponseTypeNames]>([
+            [
+                "Accounts",
+                {
+                    create: "CreateAccountsMutationResponse",
+                    update: "UpdateAccountsMutationResponse",
+                },
+            ],
+            [
+                "AWSAccounts",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "AWS_ACCOUNTS",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "aws-accounts",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "aws_accounts",
+                {
+                    create: "CreateAwsAccountsMutationResponse",
+                    update: "UpdateAwsAccountsMutationResponse",
+                },
+            ],
+            [
+                "accounts",
+                {
+                    create: "CreateAccountsMutationResponse",
+                    update: "UpdateAccountsMutationResponse",
+                },
+            ],
+            [
+                "ACCOUNTS",
+                {
+                    create: "CreateAccountsMutationResponse",
+                    update: "UpdateAccountsMutationResponse",
+                },
+            ],
+        ])(
+            "should generate mutation response type names for %s as expected with plural specified in @node directive",
+            (plural: string, mutationResponseTypeNames: MutationResponseTypeNames) => {
+                const node = new NodeBuilder({
+                    name: "Test",
+                    nodeDirective: new NodeDirective({ plural }),
+                }).instance();
+
+                expect(node.mutationResponseTypeNames).toStrictEqual(mutationResponseTypeNames);
             }
         );
     });

--- a/packages/graphql/src/classes/Node.test.ts
+++ b/packages/graphql/src/classes/Node.test.ts
@@ -17,9 +17,10 @@
  * limitations under the License.
  */
 
-import Node, { NodeConstructor } from "./Node";
+import Node, { NodeConstructor, RootTypeFieldNames } from "./Node";
 import { ContextBuilder } from "../../tests/utils/builders/context-builder";
 import { NodeBuilder } from "../../tests/utils/builders/node-builder";
+import { NodeDirective } from "./NodeDirective";
 
 describe("Node", () => {
     const defaultContext = new ContextBuilder().instance();
@@ -62,12 +63,208 @@ describe("Node", () => {
         expect(node.getLabels(defaultContext)).toEqual(["Movie"]);
     });
 
-    test("should return plural with underscores", () => {
-        const node = new NodeBuilder({
-            name: "super_movie",
-        }).instance();
+    describe("root type field names", () => {
+        test.each<[string, RootTypeFieldNames]>([
+            [
+                "Account",
+                {
+                    create: "createAccounts",
+                    read: "accounts",
+                    update: "updateAccounts",
+                    delete: "deleteAccounts",
+                    aggregate: "accountsAggregate",
+                },
+            ],
+            [
+                "AWSAccount",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "AWS_ACCOUNT",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "aws-account",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "aws_account",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "account",
+                {
+                    create: "createAccounts",
+                    read: "accounts",
+                    update: "updateAccounts",
+                    delete: "deleteAccounts",
+                    aggregate: "accountsAggregate",
+                },
+            ],
+            [
+                "ACCOUNT",
+                {
+                    create: "createAccounts",
+                    read: "accounts",
+                    update: "updateAccounts",
+                    delete: "deleteAccounts",
+                    aggregate: "accountsAggregate",
+                },
+            ],
+            [
+                "A",
+                {
+                    create: "createAs",
+                    read: "as",
+                    update: "updateAs",
+                    delete: "deleteAs",
+                    aggregate: "asAggregate",
+                },
+            ],
+            [
+                "_2number",
+                {
+                    create: "create_2Numbers",
+                    read: "_2Numbers",
+                    update: "update_2Numbers",
+                    delete: "delete_2Numbers",
+                    aggregate: "_2NumbersAggregate",
+                },
+            ],
+            [
+                "__2number",
+                {
+                    create: "create__2Numbers",
+                    read: "__2Numbers",
+                    update: "update__2Numbers",
+                    delete: "delete__2Numbers",
+                    aggregate: "__2NumbersAggregate",
+                },
+            ],
+            [
+                "_number",
+                {
+                    create: "create_numbers",
+                    read: "_numbers",
+                    update: "update_numbers",
+                    delete: "delete_numbers",
+                    aggregate: "_numbersAggregate",
+                },
+            ],
+        ])("should pluralize %s as expected", (typename: string, rootTypeFieldNames: RootTypeFieldNames) => {
+            const node = new NodeBuilder({
+                name: typename,
+            }).instance();
 
-        expect(node.plural).toBe("super_movies");
+            expect(node.rootTypeFieldNames).toStrictEqual(rootTypeFieldNames);
+        });
+
+        test.each<[string, RootTypeFieldNames]>([
+            [
+                "Accounts",
+                {
+                    create: "createAccounts",
+                    read: "accounts",
+                    update: "updateAccounts",
+                    delete: "deleteAccounts",
+                    aggregate: "accountsAggregate",
+                },
+            ],
+            [
+                "AWSAccounts",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "AWS_ACCOUNTS",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "aws-accounts",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "aws_accounts",
+                {
+                    create: "createAwsAccounts",
+                    read: "awsAccounts",
+                    update: "updateAwsAccounts",
+                    delete: "deleteAwsAccounts",
+                    aggregate: "awsAccountsAggregate",
+                },
+            ],
+            [
+                "accounts",
+                {
+                    create: "createAccounts",
+                    read: "accounts",
+                    update: "updateAccounts",
+                    delete: "deleteAccounts",
+                    aggregate: "accountsAggregate",
+                },
+            ],
+            [
+                "ACCOUNTS",
+                {
+                    create: "createAccounts",
+                    read: "accounts",
+                    update: "updateAccounts",
+                    delete: "deleteAccounts",
+                    aggregate: "accountsAggregate",
+                },
+            ],
+        ])(
+            "should pluralize %s as expected with plural specified in @node directive",
+            (plural: string, rootTypeFieldNames: RootTypeFieldNames) => {
+                const node = new NodeBuilder({
+                    name: "Test",
+                    nodeDirective: new NodeDirective({ plural }),
+                }).instance();
+
+                expect(node.rootTypeFieldNames).toStrictEqual(rootTypeFieldNames);
+            }
+        );
     });
 
     describe("NodeDirective", () => {

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -186,28 +186,28 @@ class Node extends GraphElement {
         return this.constrainableFields.filter((field) => field.unique);
     }
 
-    public get rootTypeFieldNames(): RootTypeFieldNames {
-        const pluralValue = this.plural;
+    private get pascalCasePlural(): string {
+        return upperFirst(this.plural);
+    }
 
-        const pluralValueUpperFirst = upperFirst(pluralValue);
+    public get rootTypeFieldNames(): RootTypeFieldNames {
+        const pascalCasePlural = this.pascalCasePlural;
 
         return {
-            create: `create${pluralValueUpperFirst}`,
-            read: pluralValue,
-            update: `update${pluralValueUpperFirst}`,
-            delete: `delete${pluralValueUpperFirst}`,
-            aggregate: `${pluralValue}Aggregate`,
+            create: `create${pascalCasePlural}`,
+            read: this.plural,
+            update: `update${pascalCasePlural}`,
+            delete: `delete${pascalCasePlural}`,
+            aggregate: `${this.plural}Aggregate`,
         };
     }
 
     public get mutationResponseTypeNames() {
-        const pluralValue = this.plural;
-
-        const pluralValueUpperFirst = upperFirst(pluralValue);
+        const pascalCasePlural = this.pascalCasePlural;
 
         return {
-            create: `Create${pluralValueUpperFirst}MutationResponse`,
-            update: `Update${pluralValueUpperFirst}MutationResponse`,
+            create: `Create${pascalCasePlural}MutationResponse`,
+            update: `Update${pascalCasePlural}MutationResponse`,
         };
     }
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -140,7 +140,7 @@ class Node extends GraphElement {
     private generatePlural(): string {
         const name = this.nodeDirective?.plural || this.name;
 
-        const re = /^(_+).+/gm;
+        const re = /^(_+).+/;
         const match = re.exec(name);
         const leadingUnderscores = match?.[1] || "";
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -202,7 +202,7 @@ class Node extends GraphElement {
         };
     }
 
-    public get mutationResponseTypeNames() {
+    public get mutationResponseTypeNames(): MutationResponseTypeNames {
         const pascalCasePlural = this.pascalCasePlural;
 
         return {

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -18,6 +18,7 @@
  */
 
 import { DirectiveNode, NamedTypeNode } from "graphql";
+import camelcase from "camelcase";
 import pluralize from "pluralize";
 import type {
     Auth,
@@ -39,8 +40,8 @@ import type {
 import Exclude from "./Exclude";
 import { GraphElement, GraphElementConstructor } from "./GraphElement";
 import { NodeDirective } from "./NodeDirective";
-import { lowerFirst } from "../utils/lower-first";
 import { QueryOptionsDirective } from "./QueryOptionsDirective";
+import { upperFirst } from "../utils/upper-first";
 
 export interface NodeConstructor extends GraphElementConstructor {
     name: string;
@@ -88,6 +89,19 @@ type AuthableField =
 
 type ConstrainableField = PrimitiveField | TemporalField | PointField;
 
+export type RootTypeFieldNames = {
+    create: string;
+    read: string;
+    update: string;
+    delete: string;
+    aggregate: string;
+};
+
+export type MutationResponseTypeNames = {
+    create: string;
+    update: string;
+};
+
 class Node extends GraphElement {
     public relationFields: RelationField[];
     public connectionFields: ConnectionField[];
@@ -103,6 +117,7 @@ class Node extends GraphElement {
     public auth?: Auth;
     public description?: string;
     public queryOptions?: QueryOptionsDirective;
+    public plural: string;
 
     constructor(input: NodeConstructor) {
         super(input);
@@ -119,6 +134,19 @@ class Node extends GraphElement {
         this.fulltextDirective = input.fulltextDirective;
         this.auth = input.auth;
         this.queryOptions = input.queryOptionsDirective;
+        this.plural = this.generatePlural();
+    }
+
+    private generatePlural(): string {
+        const name = this.nodeDirective?.plural || this.name;
+
+        const re = /^(_+).+/gm;
+        const match = re.exec(name);
+        const leadingUnderscores = match?.[1] || "";
+
+        const plural = this.nodeDirective?.plural ? camelcase(name) : pluralize(camelcase(name));
+
+        return `${leadingUnderscores}${plural}`;
     }
 
     // Fields you can set in a create or update mutation
@@ -158,9 +186,29 @@ class Node extends GraphElement {
         return this.constrainableFields.filter((field) => field.unique);
     }
 
-    public get plural(): string {
-        const pluralValue = this.nodeDirective?.plural ? this.nodeDirective.plural : pluralize(this.name);
-        return lowerFirst(pluralValue);
+    public get rootTypeFieldNames(): RootTypeFieldNames {
+        const pluralValue = this.plural;
+
+        const pluralValueUpperFirst = upperFirst(pluralValue);
+
+        return {
+            create: `create${pluralValueUpperFirst}`,
+            read: pluralValue,
+            update: `update${pluralValueUpperFirst}`,
+            delete: `delete${pluralValueUpperFirst}`,
+            aggregate: `${pluralValue}Aggregate`,
+        };
+    }
+
+    public get mutationResponseTypeNames() {
+        const pluralValue = this.plural;
+
+        const pluralValueUpperFirst = upperFirst(pluralValue);
+
+        return {
+            create: `Create${pluralValueUpperFirst}MutationResponse`,
+            update: `Update${pluralValueUpperFirst}MutationResponse`,
+        };
     }
 
     public getLabelString(context: Context): string {

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -890,15 +890,23 @@ function makeAugmentedSchema(
             ]),
         });
 
-        ["Create", "Update"].map((operation) =>
-            composer.createObjectTC({
-                name: `${operation}${upperFirst(node.plural)}MutationResponse`,
-                fields: {
-                    info: `${operation}Info!`,
-                    [node.plural]: `[${node.name}!]!`,
-                },
-            })
-        );
+        const mutationResponseTypeNames = node.mutationResponseTypeNames;
+
+        composer.createObjectTC({
+            name: mutationResponseTypeNames.create,
+            fields: {
+                info: `CreateInfo!`,
+                [node.plural]: `[${node.name}!]!`,
+            },
+        });
+
+        composer.createObjectTC({
+            name: mutationResponseTypeNames.update,
+            fields: {
+                info: `UpdateInfo!`,
+                [node.plural]: `[${node.name}!]!`,
+            },
+        });
 
         createRelationshipFields({
             relationshipFields: node.relationFields,
@@ -923,31 +931,33 @@ function makeAugmentedSchema(
         ensureNonEmptyInput(`${node.name}UpdateInput`);
         ensureNonEmptyInput(`${node.name}CreateInput`);
 
+        const rootTypeFieldNames = node.rootTypeFieldNames;
+
         if (!node.exclude?.operations.includes("read")) {
             composer.Query.addFields({
-                [node.plural]: findResolver({ node }),
+                [rootTypeFieldNames.read]: findResolver({ node }),
             });
 
             composer.Query.addFields({
-                [`${node.plural}Aggregate`]: aggregateResolver({ node }),
+                [rootTypeFieldNames.aggregate]: aggregateResolver({ node }),
             });
         }
 
         if (!node.exclude?.operations.includes("create")) {
             composer.Mutation.addFields({
-                [`create${upperFirst(node.plural)}`]: createResolver({ node }),
+                [rootTypeFieldNames.create]: createResolver({ node }),
             });
         }
 
         if (!node.exclude?.operations.includes("delete")) {
             composer.Mutation.addFields({
-                [`delete${upperFirst(node.plural)}`]: deleteResolver({ node }),
+                [rootTypeFieldNames.delete]: deleteResolver({ node }),
             });
         }
 
         if (!node.exclude?.operations.includes("update")) {
             composer.Mutation.addFields({
-                [`update${upperFirst(node.plural)}`]: updateResolver({
+                [rootTypeFieldNames.update]: updateResolver({
                     node,
                     schemaComposer: composer,
                 }),

--- a/packages/graphql/src/schema/resolvers/create.ts
+++ b/packages/graphql/src/schema/resolvers/create.ts
@@ -54,7 +54,7 @@ export default function createResolver({ node }: { node: Node }) {
     }
 
     return {
-        type: `Create${upperFirst(node.plural)}MutationResponse!`,
+        type: `${node.mutationResponseTypeNames.create}!`,
         resolve,
         args: { input: `[${node.name}CreateInput!]!` },
     };

--- a/packages/graphql/src/schema/resolvers/update.ts
+++ b/packages/graphql/src/schema/resolvers/update.ts
@@ -65,7 +65,7 @@ export default function updateResolver({ node, schemaComposer }: { node: Node; s
         relationFields.connectOrCreate = `${node.name}ConnectOrCreateInput`;
     }
     return {
-        type: `Update${upperFirst(node.plural)}MutationResponse!`,
+        type: `${node.mutationResponseTypeNames.update}!`,
         resolve,
         args: {
             where: `${node.name}Where`,

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -176,7 +176,7 @@ export const nodeDirective = new GraphQLDirective({
             type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
         },
         plural: {
-            description: "Defines a custom plural for the Node API",
+            description: "Allows for the specification of the plural of the type name if the type name is non-English.",
             type: GraphQLString,
         },
     },

--- a/packages/graphql/src/schema/validation/directives.ts
+++ b/packages/graphql/src/schema/validation/directives.ts
@@ -176,7 +176,7 @@ export const nodeDirective = new GraphQLDirective({
             type: new GraphQLList(new GraphQLNonNull(GraphQLString)),
         },
         plural: {
-            description: "Allows for the specification of the plural of the type name if the type name is non-English.",
+            description: "Allows for the specification of the plural of the type name.",
             type: GraphQLString,
         },
     },

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -33,7 +33,7 @@ function translateCreate({ context, node }: { context: Context; node: Node }): [
     let connectionParams: any;
     let interfaceParams: any;
 
-    const mutationResponse = resolveTree.fieldsByTypeName[`Create${upperFirst(node.plural)}MutationResponse`];
+    const mutationResponse = resolveTree.fieldsByTypeName[node.mutationResponseTypeNames.create];
 
     const nodeProjection = Object.values(mutationResponse).find((field) => field.name === node.plural);
 

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -63,7 +63,7 @@ function translateUpdate({ node, context }: { node: Node; context: Context }): [
     const interfaceStrs: string[] = [];
     let updateArgs = {};
 
-    const mutationResponse = resolveTree.fieldsByTypeName[`Update${upperFirst(node.plural)}MutationResponse`];
+    const mutationResponse = resolveTree.fieldsByTypeName[node.mutationResponseTypeNames.update];
 
     const nodeProjection = Object.values(mutationResponse).find((field) => field.name === node.plural);
 

--- a/packages/graphql/tests/integration/issues/235.int.test.ts
+++ b/packages/graphql/tests/integration/issues/235.int.test.ts
@@ -64,19 +64,19 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
 
         const c = generate({ charset: "alphabetic" });
 
-        const createBS = `
+        const createBs = `
             mutation CreateBS($b1: String!, $b2: String!) {
-                createBS(input: [{ name: $b1 }, { name: $b2 }]) {
-                    bS {
+                createBs(input: [{ name: $b1 }, { name: $b2 }]) {
+                    bs {
                         name
                     }
                 }
             }
         `;
 
-        const createAS = `
+        const createAs = `
             mutation CreateAS($a: String!, $b1: String!, $b2: String!, $c: String!) {
-                createAS(
+                createAs(
                     input: [
                         {
                             name: $a
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
                         }
                     ]
                 ) {
-                    aS {
+                    as {
                         name
                         rel_b {
                             name
@@ -100,7 +100,7 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
 
         const as = `
             query As($a: String) {
-                aS(where: { name: $a }) {
+                as(where: { name: $a }) {
                     name
                     rel_b {
                         name
@@ -113,30 +113,30 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
             }
         `;
 
-        const createBSResult = await graphql({
+        const createBsResult = await graphql({
             schema: await neoSchema.getSchema(),
-            source: createBS,
+            source: createBs,
             variableValues: { b1, b2 },
             contextValue: { driver },
         });
 
-        expect(createBSResult.errors).toBeFalsy();
-        expect((createBSResult.data as any)?.createBS.bS).toEqual([{ name: b1 }, { name: b2 }]);
+        expect(createBsResult.errors).toBeFalsy();
+        expect((createBsResult.data as any)?.createBs.bs).toEqual([{ name: b1 }, { name: b2 }]);
 
-        const createASResult = await graphql({
+        const createAsResult = await graphql({
             schema: await neoSchema.getSchema(),
-            source: createAS,
+            source: createAs,
             variableValues: { a, b1, b2, c },
             contextValue: { driver },
         });
 
-        expect(createASResult.errors).toBeFalsy();
-        expect((createASResult.data as any)?.createAS.aS).toHaveLength(1);
-        expect((createASResult.data as any)?.createAS.aS[0].name).toEqual(a);
-        expect((createASResult.data as any)?.createAS.aS[0].rel_b).toHaveLength(2);
-        expect((createASResult.data as any)?.createAS.aS[0].rel_b).toContainEqual({ name: b1 });
-        expect((createASResult.data as any)?.createAS.aS[0].rel_b).toContainEqual({ name: b2 });
-        expect((createASResult.data as any)?.createAS.aS[0].rel_c).toEqual([{ name: c }]);
+        expect(createAsResult.errors).toBeFalsy();
+        expect((createAsResult.data as any)?.createAs.as).toHaveLength(1);
+        expect((createAsResult.data as any)?.createAs.as[0].name).toEqual(a);
+        expect((createAsResult.data as any)?.createAs.as[0].rel_b).toHaveLength(2);
+        expect((createAsResult.data as any)?.createAs.as[0].rel_b).toContainEqual({ name: b1 });
+        expect((createAsResult.data as any)?.createAs.as[0].rel_b).toContainEqual({ name: b2 });
+        expect((createAsResult.data as any)?.createAs.as[0].rel_c).toEqual([{ name: c }]);
 
         const asResult = await graphql({
             schema: await neoSchema.getSchema(),
@@ -146,12 +146,12 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
         });
 
         expect(asResult.errors).toBeFalsy();
-        expect((asResult.data as any)?.aS).toHaveLength(1);
-        expect((asResult.data as any)?.aS[0].name).toEqual(a);
-        expect((asResult.data as any)?.aS[0].rel_b).toHaveLength(2);
-        expect((asResult.data as any)?.aS[0].rel_b).toContainEqual({ name: b1 });
-        expect((asResult.data as any)?.aS[0].rel_b).toContainEqual({ name: b2 });
-        expect((asResult.data as any)?.aS[0].rel_c).toHaveLength(1);
-        expect((asResult.data as any)?.aS[0].rel_c[0].name).toEqual(c);
+        expect((asResult.data as any)?.as).toHaveLength(1);
+        expect((asResult.data as any)?.as[0].name).toEqual(a);
+        expect((asResult.data as any)?.as[0].rel_b).toHaveLength(2);
+        expect((asResult.data as any)?.as[0].rel_b).toContainEqual({ name: b1 });
+        expect((asResult.data as any)?.as[0].rel_b).toContainEqual({ name: b2 });
+        expect((asResult.data as any)?.as[0].rel_c).toHaveLength(1);
+        expect((asResult.data as any)?.as[0].rel_c[0].name).toEqual(c);
     });
 });

--- a/packages/graphql/tests/integration/issues/288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/288.int.test.ts
@@ -57,8 +57,8 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
 
         const createMutation = `
             mutation {
-                createUSERS(input: { USERID: "${userid}", COMPANYID: "${companyid1}" }) {
-                    uSERS {
+                createUsers(input: { USERID: "${userid}", COMPANYID: "${companyid1}" }) {
+                    users {
                         USERID
                         COMPANYID
                     }
@@ -68,8 +68,8 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
 
         const updateMutation = `
             mutation {
-                updateUSERS(where: { USERID: "${userid}" }, update: { COMPANYID: "${companyid2}" }) {
-                    uSERS {
+                updateUsers(where: { USERID: "${userid}" }, update: { COMPANYID: "${companyid2}" }) {
+                    users {
                         USERID
                         COMPANYID
                     }
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
 
             expect(createResult.errors).toBeFalsy();
 
-            expect((createResult?.data as any)?.createUSERS?.uSERS).toEqual([
+            expect((createResult?.data as any)?.createUsers?.users).toEqual([
                 { USERID: userid, COMPANYID: companyid1 },
             ]);
 
@@ -100,7 +100,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
 
             expect(updateResult.errors).toBeFalsy();
 
-            expect((updateResult?.data as any)?.updateUSERS?.uSERS).toEqual([
+            expect((updateResult?.data as any)?.updateUsers?.users).toEqual([
                 { USERID: userid, COMPANYID: companyid2 },
             ]);
 

--- a/packages/graphql/tests/schema/issues/1038.test.ts
+++ b/packages/graphql/tests/schema/issues/1038.test.ts
@@ -1,0 +1,242 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { gql } from "apollo-server";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("https://github.com/neo4j/graphql/issues/1038", () => {
+    test("AWSAccount and DNSZone should be cased correctly", async () => {
+        const typeDefs = gql`
+            type AWSAccount {
+                code: String
+                accountName: String
+            }
+
+            type DNSZone {
+                awsId: String
+                zoneType: String
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type AWSAccount {
+              accountName: String
+              code: String
+            }
+
+            type AWSAccountAggregateSelection {
+              accountName: StringAggregateSelectionNullable!
+              code: StringAggregateSelectionNullable!
+              count: Int!
+            }
+
+            input AWSAccountCreateInput {
+              accountName: String
+              code: String
+            }
+
+            input AWSAccountOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more AWSAccountSort objects to sort AwsAccounts by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [AWSAccountSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort AwsAccounts by. The order in which sorts are applied is not guaranteed when specifying many fields in one AWSAccountSort object.
+            \\"\\"\\"
+            input AWSAccountSort {
+              accountName: SortDirection
+              code: SortDirection
+            }
+
+            input AWSAccountUpdateInput {
+              accountName: String
+              code: String
+            }
+
+            input AWSAccountWhere {
+              AND: [AWSAccountWhere!]
+              OR: [AWSAccountWhere!]
+              accountName: String
+              accountName_CONTAINS: String
+              accountName_ENDS_WITH: String
+              accountName_IN: [String]
+              accountName_NOT: String
+              accountName_NOT_CONTAINS: String
+              accountName_NOT_ENDS_WITH: String
+              accountName_NOT_IN: [String]
+              accountName_NOT_STARTS_WITH: String
+              accountName_STARTS_WITH: String
+              code: String
+              code_CONTAINS: String
+              code_ENDS_WITH: String
+              code_IN: [String]
+              code_NOT: String
+              code_NOT_CONTAINS: String
+              code_NOT_ENDS_WITH: String
+              code_NOT_IN: [String]
+              code_NOT_STARTS_WITH: String
+              code_STARTS_WITH: String
+            }
+
+            type CreateAwsAccountsMutationResponse {
+              awsAccounts: [AWSAccount!]!
+              info: CreateInfo!
+            }
+
+            type CreateDnsZonesMutationResponse {
+              dnsZones: [DNSZone!]!
+              info: CreateInfo!
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type DNSZone {
+              awsId: String
+              zoneType: String
+            }
+
+            type DNSZoneAggregateSelection {
+              awsId: StringAggregateSelectionNullable!
+              count: Int!
+              zoneType: StringAggregateSelectionNullable!
+            }
+
+            input DNSZoneCreateInput {
+              awsId: String
+              zoneType: String
+            }
+
+            input DNSZoneOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more DNSZoneSort objects to sort DnsZones by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [DNSZoneSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort DnsZones by. The order in which sorts are applied is not guaranteed when specifying many fields in one DNSZoneSort object.
+            \\"\\"\\"
+            input DNSZoneSort {
+              awsId: SortDirection
+              zoneType: SortDirection
+            }
+
+            input DNSZoneUpdateInput {
+              awsId: String
+              zoneType: String
+            }
+
+            input DNSZoneWhere {
+              AND: [DNSZoneWhere!]
+              OR: [DNSZoneWhere!]
+              awsId: String
+              awsId_CONTAINS: String
+              awsId_ENDS_WITH: String
+              awsId_IN: [String]
+              awsId_NOT: String
+              awsId_NOT_CONTAINS: String
+              awsId_NOT_ENDS_WITH: String
+              awsId_NOT_IN: [String]
+              awsId_NOT_STARTS_WITH: String
+              awsId_STARTS_WITH: String
+              zoneType: String
+              zoneType_CONTAINS: String
+              zoneType_ENDS_WITH: String
+              zoneType_IN: [String]
+              zoneType_NOT: String
+              zoneType_NOT_CONTAINS: String
+              zoneType_NOT_ENDS_WITH: String
+              zoneType_NOT_IN: [String]
+              zoneType_NOT_STARTS_WITH: String
+              zoneType_STARTS_WITH: String
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Mutation {
+              createAwsAccounts(input: [AWSAccountCreateInput!]!): CreateAwsAccountsMutationResponse!
+              createDnsZones(input: [DNSZoneCreateInput!]!): CreateDnsZonesMutationResponse!
+              deleteAwsAccounts(where: AWSAccountWhere): DeleteInfo!
+              deleteDnsZones(where: DNSZoneWhere): DeleteInfo!
+              updateAwsAccounts(update: AWSAccountUpdateInput, where: AWSAccountWhere): UpdateAwsAccountsMutationResponse!
+              updateDnsZones(update: DNSZoneUpdateInput, where: DNSZoneWhere): UpdateDnsZonesMutationResponse!
+            }
+
+            type Query {
+              awsAccounts(options: AWSAccountOptions, where: AWSAccountWhere): [AWSAccount!]!
+              awsAccountsAggregate(where: AWSAccountWhere): AWSAccountAggregateSelection!
+              dnsZones(options: DNSZoneOptions, where: DNSZoneWhere): [DNSZone!]!
+              dnsZonesAggregate(where: DNSZoneWhere): DNSZoneAggregateSelection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNullable {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateAwsAccountsMutationResponse {
+              awsAccounts: [AWSAccount!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateDnsZonesMutationResponse {
+              dnsZones: [DNSZone!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -49,14 +49,14 @@ describe("Pluralize consistency", () => {
               relationshipsCreated: Int!
             }
 
-            type CreateSuper_friendsMutationResponse {
+            type CreateSuperFriendsMutationResponse {
               info: CreateInfo!
-              super_friends: [super_friend!]!
+              superFriends: [super_friend!]!
             }
 
-            type CreateSuper_usersMutationResponse {
+            type CreateSuperUsersMutationResponse {
               info: CreateInfo!
-              super_users: [super_user!]!
+              superUsers: [super_user!]!
             }
 
             type DeleteInfo {
@@ -66,12 +66,12 @@ describe("Pluralize consistency", () => {
             }
 
             type Mutation {
-              createSuper_friends(input: [super_friendCreateInput!]!): CreateSuper_friendsMutationResponse!
-              createSuper_users(input: [super_userCreateInput!]!): CreateSuper_usersMutationResponse!
-              deleteSuper_friends(where: super_friendWhere): DeleteInfo!
-              deleteSuper_users(delete: super_userDeleteInput, where: super_userWhere): DeleteInfo!
-              updateSuper_friends(update: super_friendUpdateInput, where: super_friendWhere): UpdateSuper_friendsMutationResponse!
-              updateSuper_users(connect: super_userConnectInput, create: super_userRelationInput, delete: super_userDeleteInput, disconnect: super_userDisconnectInput, update: super_userUpdateInput, where: super_userWhere): UpdateSuper_usersMutationResponse!
+              createSuperFriends(input: [super_friendCreateInput!]!): CreateSuperFriendsMutationResponse!
+              createSuperUsers(input: [super_userCreateInput!]!): CreateSuperUsersMutationResponse!
+              deleteSuperFriends(where: super_friendWhere): DeleteInfo!
+              deleteSuperUsers(delete: super_userDeleteInput, where: super_userWhere): DeleteInfo!
+              updateSuperFriends(update: super_friendUpdateInput, where: super_friendWhere): UpdateSuperFriendsMutationResponse!
+              updateSuperUsers(connect: super_userConnectInput, create: super_userRelationInput, delete: super_userDeleteInput, disconnect: super_userDisconnectInput, update: super_userUpdateInput, where: super_userWhere): UpdateSuperUsersMutationResponse!
             }
 
             \\"\\"\\"Pagination information (Relay)\\"\\"\\"
@@ -83,10 +83,10 @@ describe("Pluralize consistency", () => {
             }
 
             type Query {
-              super_friends(options: super_friendOptions, where: super_friendWhere): [super_friend!]!
-              super_friendsAggregate(where: super_friendWhere): super_friendAggregateSelection!
-              super_users(options: super_userOptions, where: super_userWhere): [super_user!]!
-              super_usersAggregate(where: super_userWhere): super_userAggregateSelection!
+              superFriends(options: super_friendOptions, where: super_friendWhere): [super_friend!]!
+              superFriendsAggregate(where: super_friendWhere): super_friendAggregateSelection!
+              superUsers(options: super_userOptions, where: super_userWhere): [super_user!]!
+              superUsersAggregate(where: super_userWhere): super_userAggregateSelection!
             }
 
             enum SortDirection {
@@ -109,14 +109,14 @@ describe("Pluralize consistency", () => {
               relationshipsDeleted: Int!
             }
 
-            type UpdateSuper_friendsMutationResponse {
+            type UpdateSuperFriendsMutationResponse {
               info: UpdateInfo!
-              super_friends: [super_friend!]!
+              superFriends: [super_friend!]!
             }
 
-            type UpdateSuper_usersMutationResponse {
+            type UpdateSuperUsersMutationResponse {
               info: UpdateInfo!
-              super_users: [super_user!]!
+              superUsers: [super_user!]!
             }
 
             type super_friend {
@@ -140,13 +140,13 @@ describe("Pluralize consistency", () => {
               limit: Int
               offset: Int
               \\"\\"\\"
-              Specify one or more super_friendSort objects to sort Super_friends by. The sorts will be applied in the order in which they are arranged in the array.
+              Specify one or more super_friendSort objects to sort SuperFriends by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [super_friendSort!]
             }
 
             \\"\\"\\"
-            Fields to sort Super_friends by. The order in which sorts are applied is not guaranteed when specifying many fields in one super_friendSort object.
+            Fields to sort SuperFriends by. The order in which sorts are applied is not guaranteed when specifying many fields in one super_friendSort object.
             \\"\\"\\"
             input super_friendSort {
               name: SortDirection
@@ -296,7 +296,7 @@ describe("Pluralize consistency", () => {
               limit: Int
               offset: Int
               \\"\\"\\"
-              Specify one or more super_userSort objects to sort Super_users by. The sorts will be applied in the order in which they are arranged in the array.
+              Specify one or more super_userSort objects to sort SuperUsers by. The sorts will be applied in the order in which they are arranged in the array.
               \\"\\"\\"
               sort: [super_userSort!]
             }
@@ -306,7 +306,7 @@ describe("Pluralize consistency", () => {
             }
 
             \\"\\"\\"
-            Fields to sort Super_users by. The order in which sorts are applied is not guaranteed when specifying many fields in one super_userSort object.
+            Fields to sort SuperUsers by. The order in which sorts are applied is not guaranteed when specifying many fields in one super_userSort object.
             \\"\\"\\"
             input super_userSort {
               name: SortDirection

--- a/packages/graphql/tests/tck/tck-test-files/issues/288.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/288.test.ts
@@ -49,8 +49,8 @@ describe("#288", () => {
     test("Can create a USER and COMPANYID is populated", async () => {
         const query = gql`
             mutation {
-                createUSERS(input: { USERID: "userid", COMPANYID: "companyid" }) {
-                    uSERS {
+                createUsers(input: { USERID: "userid", COMPANYID: "companyid" }) {
+                    users {
                         USERID
                         COMPANYID
                     }
@@ -85,8 +85,8 @@ describe("#288", () => {
     test("Can update a USER and COMPANYID is populated", async () => {
         const query = gql`
             mutation {
-                updateUSERS(where: { USERID: "userid" }, update: { COMPANYID: "companyid2" }) {
-                    uSERS {
+                updateUsers(where: { USERID: "userid" }, update: { COMPANYID: "companyid2" }) {
+                    users {
                         USERID
                         COMPANYID
                     }

--- a/packages/graphql/tests/utils/graphql-types.ts
+++ b/packages/graphql/tests/utils/graphql-types.ts
@@ -21,7 +21,7 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { generate } from "randomstring";
 import pluralize from "pluralize";
-import { lowerFirst } from "../../src/utils/lower-first";
+import camelcase from "camelcase";
 import { upperFirst } from "../../src/utils/upper-first";
 
 export function generateUniqueType(baseName: string) {
@@ -31,7 +31,7 @@ export function generateUniqueType(baseName: string) {
         readable: true,
     })}${baseName}`;
 
-    const plural = lowerFirst(pluralize(type));
+    const plural = pluralize(camelcase(type));
     const pascalCasePlural = upperFirst(plural);
 
     return {

--- a/packages/introspector/tests/integration/graphql/nodes.test.ts
+++ b/packages/introspector/tests/integration/graphql/nodes.test.ts
@@ -255,8 +255,6 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
 
         const typeDefs = await toGraphQLTypeDefs(sessionFactory(bm));
 
-        console.log(typeDefs);
-
         expect(typeDefs).toMatchInlineSnapshot(`
             "type _2number @node(label: \\"2number\\") {
             	prop: BigInt!

--- a/packages/introspector/tests/integration/graphql/nodes.test.ts
+++ b/packages/introspector/tests/integration/graphql/nodes.test.ts
@@ -255,6 +255,8 @@ describe("GraphQL - Infer Schema nodes basic tests", () => {
 
         const typeDefs = await toGraphQLTypeDefs(sessionFactory(bm));
 
+        console.log(typeDefs);
+
         expect(typeDefs).toMatchInlineSnapshot(`
             "type _2number @node(label: \\"2number\\") {
             	prop: BigInt!

--- a/packages/ogm/package.json
+++ b/packages/ogm/package.json
@@ -36,8 +36,6 @@
         "@graphql-codegen/typescript": "^2.4.2",
         "@graphql-tools/merge": "^8.2.1",
         "@neo4j/graphql": "^3.0.0",
-        "camelcase": "^6.2.0",
-        "pluralize": "^8.0.0",
         "prettier": "^2.5.1"
     },
     "peerDependencies": {
@@ -48,11 +46,13 @@
         "@neo4j/graphql-plugin-auth": "^1.0.0",
         "@types/jest": "27.4.0",
         "@types/node": "16.11.25",
+        "camelcase": "^6.2.0",
         "graphql-tag": "2.12.6",
         "jest": "27.5.1",
         "jsonwebtoken": "8.5.1",
         "libnpmsearch": "4.0.1",
         "npm-run-all": "4.1.5",
+        "pluralize": "^8.0.0",
         "randomstring": "1.2.2",
         "semver": "7.3.5",
         "ts-jest": "27.1.3",

--- a/packages/ogm/src/classes/Model.ts
+++ b/packages/ogm/src/classes/Model.ts
@@ -19,9 +19,9 @@
 
 import { DocumentNode, graphql, GraphQLSchema, parse, print, SelectionSetNode } from "graphql";
 import pluralize from "pluralize";
+import camelcase from "camelcase";
 import { GraphQLOptionsArg, GraphQLWhereArg, DeleteInfo } from "../types";
 import { upperFirst } from "../utils/upper-first";
-import { lowerFirst } from "../utils/lower-first";
 
 function printSelectionSet(selectionSet: string | DocumentNode | SelectionSetNode): string {
     if (typeof selectionSet === "string") {
@@ -40,7 +40,7 @@ class Model {
 
     constructor(name: string) {
         this.name = name;
-        this.namePluralized = lowerFirst(pluralize(this.name));
+        this.namePluralized = pluralize(camelcase(this.name));
     }
 
     public set selectionSet(selectionSet: string | DocumentNode) {

--- a/packages/ogm/src/classes/Model.ts
+++ b/packages/ogm/src/classes/Model.ts
@@ -38,12 +38,12 @@ type RootTypeFieldNames = {
 
 class Model {
     public name: string;
-    private namePluralized!: string;
+    private _namePluralized?: string;
 
     private _selectionSet?: string;
     private schema?: GraphQLSchema;
 
-    private rootTypeFieldNames!: RootTypeFieldNames;
+    private _rootTypeFieldNames?: RootTypeFieldNames;
 
     constructor(name: string) {
         this.name = name;
@@ -51,6 +51,22 @@ class Model {
 
     public set selectionSet(selectionSet: string | DocumentNode) {
         this._selectionSet = printSelectionSet(selectionSet);
+    }
+
+    private get namePluralized(): string {
+        if (!this._namePluralized) {
+            throw new Error("Must execute `OGM.init()` method before using Model instances");
+        }
+
+        return this._namePluralized;
+    }
+
+    private get rootTypeFieldNames(): RootTypeFieldNames {
+        if (!this._rootTypeFieldNames) {
+            throw new Error("Must execute `OGM.init()` method before using Model instances");
+        }
+
+        return this.rootTypeFieldNames;
     }
 
     init({
@@ -66,8 +82,8 @@ class Model {
     }) {
         this.selectionSet = selectionSet;
         this.schema = schema;
-        this.namePluralized = namePluralized;
-        this.rootTypeFieldNames = rootTypeFieldNames;
+        this._namePluralized = namePluralized;
+        this._rootTypeFieldNames = rootTypeFieldNames;
     }
 
     async find<T = any[]>({

--- a/packages/ogm/src/classes/Model.ts
+++ b/packages/ogm/src/classes/Model.ts
@@ -66,7 +66,7 @@ class Model {
             throw new Error("Must execute `OGM.init()` method before using Model instances");
         }
 
-        return this.rootTypeFieldNames;
+        return this._rootTypeFieldNames;
     }
 
     init({

--- a/packages/ogm/src/classes/OGM.ts
+++ b/packages/ogm/src/classes/OGM.ts
@@ -112,7 +112,12 @@ class OGM<ModelMap = {}> {
                     }
                 `;
 
-        model.init({ schema: this.schema, selectionSet });
+        model.init({
+            schema: this.schema,
+            selectionSet,
+            namePluralized: node.plural,
+            rootTypeFieldNames: node.rootTypeFieldNames,
+        });
     }
 
     private createInitializer(): Promise<void> {

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -20,7 +20,6 @@
 import { codegen } from "@graphql-codegen/core";
 import * as typescriptPlugin from "@graphql-codegen/typescript";
 import { Types } from "@graphql-codegen/plugin-helpers";
-import { Neo4jGraphQL } from "@neo4j/graphql";
 import * as fs from "fs";
 import * as graphql from "graphql";
 import prettier from "prettier";

--- a/packages/ogm/tests/utils.ts
+++ b/packages/ogm/tests/utils.ts
@@ -23,8 +23,8 @@ import { IncomingMessage } from "http";
 import jsonwebtoken from "jsonwebtoken";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { generate } from "randomstring";
+import camelcase from "camelcase";
 import pluralize from "pluralize";
-import { lowerFirst } from "../src/utils/lower-first";
 
 /** Creates a JWT valid request with the given secret and the extraData in the JWT token */
 
@@ -50,7 +50,7 @@ export function generateUniqueType(baseName: string) {
         readable: true,
     })}${baseName}`;
 
-    const plural = lowerFirst(pluralize(type));
+    const plural = pluralize(camelcase(type));
     return {
         name: type,
         plural,

--- a/packages/ogm/tests/utils.ts
+++ b/packages/ogm/tests/utils.ts
@@ -23,7 +23,9 @@ import { IncomingMessage } from "http";
 import jsonwebtoken from "jsonwebtoken";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { generate } from "randomstring";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import camelcase from "camelcase";
+// eslint-disable-next-line import/no-extraneous-dependencies
 import pluralize from "pluralize";
 
 /** Creates a JWT valid request with the given secret and the extraData in the JWT token */


### PR DESCRIPTION
# Description

We made some glaring oversights in how we generate plural strings of type names in 3.0.0. This PR attempts to rationalise that behaviour, and add more tests.

# Issue

Closes #1038 