### PR TITLE
WIP: Interface relation query fixes

### DIFF
--- a/packages/graphql/src/classes/Interface.ts
+++ b/packages/graphql/src/classes/Interface.ts
@@ -17,10 +17,14 @@
  * limitations under the License.
  */
 
-export { default as Node, NodeConstructor } from "./Node";
-export { default as Interface, InterfaceContructor } from "./Interface";
-export { default as Relationship } from "./Relationship";
-export { GraphElement } from "./GraphElement";
-export { default as Exclude, ExcludeConstructor } from "./Exclude";
-export { default as Neo4jGraphQL, Neo4jGraphQLConstructor, Neo4jGraphQLConfig } from "./Neo4jGraphQL";
-export * from "./Error";
+import { GraphElement, GraphElementConstructor } from './GraphElement';
+
+export interface InterfaceContructor extends GraphElementConstructor {
+
+}
+
+class Interface extends GraphElement {
+
+}
+
+export default Interface;

--- a/packages/graphql/src/classes/Interface.ts
+++ b/packages/graphql/src/classes/Interface.ts
@@ -18,13 +18,25 @@
  */
 
 import { GraphElement, GraphElementConstructor } from './GraphElement';
+import Node from './Node';
+import type { Context } from '../types';
 
-export interface InterfaceContructor extends GraphElementConstructor {
-
+export interface InterfaceConstructor extends GraphElementConstructor {
+    implementations: Node[];
 }
 
 class Interface extends GraphElement {
+    public implementations: Node[];
 
+    constructor(input: InterfaceConstructor) {
+        super(input);
+        this.implementations = input.implementations;
+    }
+
+    getLabelStrings(context: Context) : string[] {
+        //return [':' + this.name];
+        return this.implementations.map(impl => impl.getLabelString(context));
+    }
 }
 
 export default Interface;

--- a/packages/graphql/src/classes/index.ts
+++ b/packages/graphql/src/classes/index.ts
@@ -18,7 +18,7 @@
  */
 
 export { default as Node, NodeConstructor } from "./Node";
-export { default as Interface, InterfaceContructor } from "./Interface";
+export { default as Interface, InterfaceConstructor } from "./Interface";
 export { default as Relationship } from "./Relationship";
 export { GraphElement } from "./GraphElement";
 export { default as Exclude, ExcludeConstructor } from "./Exclude";

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -318,8 +318,11 @@ function makeAugmentedSchema(
             objects: objectTypes,
         });
 
+        let implementations = nodes.filter((n) => n.interfaces.filter(i => i.name.value === definition.name.value).length);
+
         const iface = new Interface({
             name: definition.name.value,
+            implementations,
             ...nodeFields,
         });
 

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -47,7 +47,7 @@ import {
 import { AggregationTypesMapper } from "./aggregations/aggregation-types-mapper";
 import * as constants from "../constants";
 import * as Scalars from "./types/scalars";
-import { Exclude, Node } from "../classes";
+import { Exclude, Interface, Node } from "../classes";
 import Relationship from "../classes/Relationship";
 import createConnectionFields from "./create-connection-fields";
 import createRelationshipFields from "./create-relationship-fields";
@@ -92,7 +92,7 @@ import { CartesianPointDistance } from "./types/input-objects/CartesianPointDist
 function makeAugmentedSchema(
     typeDefs: TypeSource,
     { enableRegex, skipValidateTypeDefs }: { enableRegex?: boolean; skipValidateTypeDefs?: boolean } = {}
-): { nodes: Node[]; relationships: Relationship[]; typeDefs: DocumentNode; resolvers: IResolvers } {
+): { nodes: Node[]; relationships: Relationship[]; interfaces: Interface[]; typeDefs: DocumentNode; resolvers: IResolvers } {
     const document = getDocument(typeDefs);
 
     if (!skipValidateTypeDefs) {
@@ -306,6 +306,25 @@ function makeAugmentedSchema(
 
         return node;
     });
+
+
+    const interfaces = interfaceTypes.map((definition) => {
+        const nodeFields = getObjFieldMeta({
+            obj: definition,
+            enums: enumTypes,
+            interfaces: interfaceTypes,
+            scalars: scalarTypes,
+            unions: unionTypes,
+            objects: objectTypes,
+        });
+
+        const iface = new Interface({
+            name: definition.name.value,
+            ...nodeFields,
+        });
+
+        return iface;
+    })
 
     const relationshipProperties = interfaceTypes.filter((i) => relationshipPropertyInterfaceNames.has(i.name.value));
     const interfaceRelationships = interfaceTypes.filter((i) => interfaceRelationshipNames.has(i.name.value));
@@ -1044,6 +1063,7 @@ function makeAugmentedSchema(
     return {
         nodes,
         relationships,
+        interfaces,
         typeDefs: parsedDoc,
         resolvers: generatedResolvers,
     };

--- a/packages/graphql/src/schema/resolvers/wrapper.ts
+++ b/packages/graphql/src/schema/resolvers/wrapper.ts
@@ -20,7 +20,7 @@
 import Debug from "debug";
 import { GraphQLResolveInfo, GraphQLSchema, print } from "graphql";
 import { Driver } from "neo4j-driver";
-import { Neo4jGraphQLAuthenticationError, Neo4jGraphQLConfig, Node, Relationship } from "../../classes";
+import { Neo4jGraphQLAuthenticationError, Neo4jGraphQLConfig, Node, Interface, Relationship } from "../../classes";
 import { DEBUG_GRAPHQL } from "../../constants";
 import createAuthParam from "../../translate/create-auth-param";
 import { Context, Neo4jGraphQLPlugins, JwtPayload } from "../../types";
@@ -33,6 +33,7 @@ export const wrapResolver =
         driver,
         config,
         nodes,
+        interfaces,
         relationships,
         schema,
         plugins,
@@ -40,6 +41,7 @@ export const wrapResolver =
         driver?: Driver;
         config: Neo4jGraphQLConfig;
         nodes: Node[];
+        interfaces: Interface[];
         relationships: Relationship[];
         schema: GraphQLSchema;
         plugins?: Neo4jGraphQLPlugins;
@@ -71,6 +73,7 @@ export const wrapResolver =
         }
 
         context.nodes = nodes;
+        context.interfaces = interfaces;
         context.relationships = relationships;
         context.schema = schema;
         context.plugins = plugins;

--- a/packages/graphql/src/translate/where/create-connection-where-and-params.ts
+++ b/packages/graphql/src/translate/where/create-connection-where-and-params.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { Node, Relationship } from "../../classes";
+import { GraphElement, Node, Relationship } from "../../classes";
 import { ConnectionWhereArg, Context } from "../../types";
 import createElementWhereAndParams from "./create-element-where-and-params";
 
@@ -32,7 +32,7 @@ function createConnectionWhereAndParams({
 }: {
     whereInput: ConnectionWhereArg;
     context: Context;
-    node: Node;
+    node: GraphElement;
     nodeVariable: string;
     relationship: Relationship;
     relationshipVariable: string;

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -20,7 +20,7 @@
 import { InputValueDefinitionNode, DirectiveNode, TypeNode, GraphQLSchema } from "graphql";
 import { ResolveTree } from "graphql-parse-resolve-info";
 import { Driver, Integer } from "neo4j-driver";
-import { Node, Relationship } from "./classes";
+import { Interface, Node, Relationship } from "./classes";
 import { RelationshipQueryDirectionOption } from "./constants";
 
 export type DriverConfig = {
@@ -39,6 +39,7 @@ export interface Context {
     driverConfig?: DriverConfig;
     resolveTree: ResolveTree;
     nodes: Node[];
+    interfaces: Interface[];
     relationships: Relationship[];
     schema: GraphQLSchema;
     auth?: AuthContext;


### PR DESCRIPTION
# Description

Fixes a server error when filtering by connection fields in a where clause when the target of the relation is an interface.

# Issue

This is a proof of concept to resolve https://github.com/neo4j/graphql/issues/1049 and may well not be an acceptable final solution.

This PR makes interfaces more of a first-class citizen by passing information about them down through the `Context` object which may be a useful starting point to solve various other bugs querying interfaces (of which there are many).

Note that the generated cypher query tends to be slow if an interface has many implementors. I would be happy to attempt to optimize the query, add unit tests, docs etc if this approach of making interface information available in the `Context` seems sensible. I expect it would also be helpful in supporting feature requests such as https://github.com/neo4j/graphql/issues/146

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
