### PR TITLE
Fix: OGM generate, optional rootValue for delete arguments

### DIFF
--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -241,7 +241,7 @@ describe("generate", () => {
                 where?: UserWhere;
 
                 context?: any;
-                rootValue: any;
+                rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
                 where?: UserWhere;
@@ -483,7 +483,7 @@ describe("generate", () => {
                 where?: UserWhere;
 
                 context?: any;
-                rootValue: any;
+                rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
                 where?: UserWhere;
@@ -723,7 +723,7 @@ describe("generate", () => {
                 where?: UserWhere;
 
                 context?: any;
-                rootValue: any;
+                rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
                 where?: UserWhere;
@@ -1309,7 +1309,7 @@ describe("generate", () => {
                 where?: MovieWhere;
                 delete?: MovieDeleteInput;
                 context?: any;
-                rootValue: any;
+                rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
                 where?: MovieWhere;
@@ -1359,7 +1359,7 @@ describe("generate", () => {
                 where?: PersonWhere;
 
                 context?: any;
-                rootValue: any;
+                rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
                 where?: PersonWhere;

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -183,7 +183,7 @@ async function generate(options: IGenerateOptions): Promise<undefined | string> 
                     where?: ${node.name}Where;
                     ${node.relationFields.length ? `delete?: ${node.name}DeleteInput` : ""}
                     context?: any;
-                    rootValue: any;
+                    rootValue?: any;
                 }): Promise<{ nodesDeleted: number; relationshipsDeleted: number; }>
                 public aggregate(args: {
                     where?: ${node.name}Where;


### PR DESCRIPTION
# Description

The `rootValue` property for the delete method arguments in the OGM generate shall be optional instead of required.

Closes:

- https://github.com/neo4j/graphql/issues/1019

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] unit tests have been updated
