### PR TITLE
Fix parse value not accepting Neo4J types which causes problems in OGM

### DIFF
--- a/packages/graphql/src/schema/types/scalars/LocalDateTime.ts
+++ b/packages/graphql/src/schema/types/scalars/LocalDateTime.ts
@@ -18,7 +18,7 @@
  */
 
 import { GraphQLError, GraphQLScalarType, Kind, ValueNode } from "graphql";
-import neo4j from "neo4j-driver";
+import neo4j, { isLocalDateTime, LocalDateTime } from "neo4j-driver";
 
 // Matching YYYY-MM-DDTHH:MM:SS(.sss+)
 const LOCAL_DATE_TIME_REGEX =
@@ -57,12 +57,16 @@ export const parseLocalDateTime = (value: any) => {
 };
 
 const parse = (value: any) => {
+    if (isLocalDateTime(value)) {
+        return value as unknown as LocalDateTime<number>;
+    }
+
     const { year, month, day, hour, minute, second, nanosecond } = parseLocalDateTime(value);
 
     return new neo4j.types.LocalDateTime(year, month, day, hour, minute, second, nanosecond);
 };
 
-export const GraphQLLocalDateTime = new GraphQLScalarType({
+export const GraphQLLocalDateTime = new GraphQLScalarType<LocalDateTime<number>, string>({
     name: "LocalDateTime",
     description: "A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'",
     serialize: (value: unknown) => {

--- a/packages/graphql/src/schema/types/scalars/LocalTime.ts
+++ b/packages/graphql/src/schema/types/scalars/LocalTime.ts
@@ -18,7 +18,7 @@
  */
 
 import { GraphQLError, GraphQLScalarType, Kind, ValueNode } from "graphql";
-import neo4j from "neo4j-driver";
+import neo4j, { isLocalTime, LocalTime } from "neo4j-driver";
 
 export const LOCAL_TIME_REGEX =
     /^(?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d)(\.(?<fraction>\d{1}(?:\d{0,8})))?$/;
@@ -52,12 +52,16 @@ export const parseLocalTime = (value: any) => {
 };
 
 const parse = (value: any) => {
+    if (isLocalTime(value)) {
+        return value as LocalTime<number>;
+    }
+
     const { hour, minute, second, nanosecond } = parseLocalTime(value);
 
     return new neo4j.types.LocalTime(hour, minute, second, nanosecond);
 };
 
-export const GraphQLLocalTime = new GraphQLScalarType({
+export const GraphQLLocalTime = new GraphQLScalarType<LocalTime<number>, string>({
     name: "LocalTime",
     description: "A local time, represented as a time string without timezone information",
     serialize: (value: unknown) => {

--- a/packages/graphql/src/schema/types/scalars/Time.ts
+++ b/packages/graphql/src/schema/types/scalars/Time.ts
@@ -18,7 +18,7 @@
  */
 
 import { GraphQLError, GraphQLScalarType, Kind, ValueNode } from "graphql";
-import neo4j from "neo4j-driver";
+import neo4j, { isTime, Time } from "neo4j-driver";
 
 export const RFC_3339_REGEX =
     /^(?<hour>[01]\d|2[0-3]):(?<minute>[0-5]\d):(?<second>[0-5]\d)(\.(?<fraction>\d{1}(?:\d{0,8})))?((?:[Zz])|((?<offsetDirection>[-|+])(?<offsetHour>[01]\d|2[0-3]):(?<offsetMinute>[0-5]\d)))?$/;
@@ -61,12 +61,16 @@ export const parseTime = (value: any) => {
 };
 
 const parse = (value: any) => {
+    if (isTime(value)) {
+        return value as unknown as Time<number>;
+    }
+
     const { hour, minute, second, nanosecond, timeZoneOffsetSeconds } = parseTime(value);
 
     return new neo4j.types.Time(hour, minute, second, nanosecond, timeZoneOffsetSeconds);
 };
 
-export const GraphQLTime = new GraphQLScalarType({
+export const GraphQLTime = new GraphQLScalarType<Time<number>, string>({
     name: "Time",
     description: "A time, represented as an RFC3339 time string",
     serialize: (value: unknown) => {


### PR DESCRIPTION
# Description

In our project we have some custom mutations that accept some input types with Date and DateTime scalars. Eventually these will be passed in to the OGM to make changes to the database. This used to work just fine before 3.0.

3.0 introduced parseLiteral functions into the custom scalars, which means that strings the client gives will now be parsed to Date/DateTime objects. When passing these into the OGM however, parseValue gets called which currently only accepts strings and will throw an error. We could call toString on all Date/DateTime objects but this would make typing things in our custom resolvers very difficult because the Date scalar for example is now sometimes a string (when interacting with the OGM) and sometimes a Neo4JDate (when reading input types).

I changed parseValue to also accept Date/DateTime/Time/etc which fixes this issue.
