### PR TITLE
Fix/ogm node import

### DIFF
--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -32,6 +32,7 @@ export {
     CypherRuntime,
     Neo4jGraphQLAuthPlugin,
     CypherUpdateStrategy,
+    Node,
 } from "./types";
 export {
     Neo4jGraphQL,

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -23,6 +23,8 @@ import { Driver, Integer } from "neo4j-driver";
 import { Node, Relationship } from "./classes";
 import { RelationshipQueryDirectionOption } from "./constants";
 
+export { Node } from "./classes";
+
 export type DriverConfig = {
     database?: string;
     bookmarks?: string | string[];

--- a/packages/ogm/src/classes/OGM.ts
+++ b/packages/ogm/src/classes/OGM.ts
@@ -18,6 +18,7 @@
  */
 
 import { Neo4jGraphQL, Neo4jGraphQLConstructor } from "@neo4j/graphql";
+import { Node } from "@neo4j/graphql/src/classes";
 import { GraphQLSchema } from "graphql";
 import Model from "./Model";
 import { filterDocument } from "../utils";
@@ -61,7 +62,7 @@ class OGM<ModelMap = {}> {
         return this._schema;
     }
 
-    public get nodes() {
+    public get nodes(): Node[] {
         try {
             return this.neoSchema.nodes;
         } catch {

--- a/packages/ogm/src/classes/OGM.ts
+++ b/packages/ogm/src/classes/OGM.ts
@@ -17,8 +17,7 @@
  * limitations under the License.
  */
 
-import { Neo4jGraphQL, Neo4jGraphQLConstructor } from "@neo4j/graphql";
-import { Node } from "@neo4j/graphql/src/classes";
+import { Neo4jGraphQL, Neo4jGraphQLConstructor, Node } from "@neo4j/graphql";
 import { GraphQLSchema } from "graphql";
 import Model from "./Model";
 import { filterDocument } from "../utils";
@@ -27,13 +26,9 @@ export type OGMConstructor = Neo4jGraphQLConstructor;
 
 class OGM<ModelMap = {}> {
     public checkNeo4jCompat: () => Promise<void>;
-
     private models: Model[];
-
     private neoSchema: Neo4jGraphQL;
-
     private _schema?: GraphQLSchema;
-
     private initializer?: Promise<void>;
 
     constructor(input: OGMConstructor) {


### PR DESCRIPTION
# Description
We need to export the class `Node` from `@neo4j/graphql` so it is available on the OGM.

Because `this.neoSchema.nodes` is part of the public interface, there is really no way around exporting `Node`, until we change the public interface of Neo4jGraphql
