### PR TITLE
Fix: #1132, CONNECT and DISCONNECT auth rules check allow rules against target node instead of source

### DIFF
--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -159,8 +159,13 @@ function createConnectAndParams({
             subquery.push(`\tWHERE ${whereStrs.join(" AND ")}`);
         }
 
-        const preAuth = [...(!fromCreate ? [parentNode] : []), relatedNode].reduce(
-            (result: Res, node, i) => {
+        const nodeMatrix: { node: Node; name: string }[] = [
+            ...(!fromCreate ? [{ node: parentNode, name: parentVar }] : []),
+            { node: relatedNode, name: nodeName },
+        ];
+
+        const preAuth = nodeMatrix.reduce(
+            (result: Res, { node, name }, i) => {
                 if (!node.auth) {
                     return result;
                 }
@@ -170,7 +175,7 @@ function createConnectAndParams({
                     operations: "CONNECT",
                     context,
                     escapeQuotes: Boolean(insideDoWhen),
-                    allow: { parentNode: node, varName: nodeName, chainStr: `${nodeName}${node.name}${i}_allow` },
+                    allow: { parentNode: node, varName: name, chainStr: `${name}${node.name}${i}_allow` },
                 });
 
                 if (!str) {

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -159,10 +159,8 @@ function createConnectAndParams({
             subquery.push(`\tWHERE ${whereStrs.join(" AND ")}`);
         }
 
-        const nodeMatrix: { node: Node; name: string }[] = [
-            ...(!fromCreate ? [{ node: parentNode, name: parentVar }] : []),
-            { node: relatedNode, name: nodeName },
-        ];
+        const nodeMatrix: Array<{ node: Node; name: string }> = [ { node: relatedNode, name: nodeName }];
+        if (fromCreate) nodeMatrix.push({ node: parentNode, name: parentVar });
 
         const preAuth = nodeMatrix.reduce(
             (result: Res, { node, name }, i) => {

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -159,8 +159,8 @@ function createConnectAndParams({
             subquery.push(`\tWHERE ${whereStrs.join(" AND ")}`);
         }
 
-        const nodeMatrix: Array<{ node: Node; name: string }> = [ { node: relatedNode, name: nodeName }];
-        if (fromCreate) nodeMatrix.push({ node: parentNode, name: parentVar });
+        const nodeMatrix: Array<{ node: Node; name: string }> = [{ node: relatedNode, name: nodeName }];
+        if (!fromCreate) nodeMatrix.push({ node: parentNode, name: parentVar });
 
         const preAuth = nodeMatrix.reduce(
             (result: Res, { node, name }, i) => {

--- a/packages/graphql/src/translate/create-disconnect-and-params.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.ts
@@ -114,8 +114,13 @@ function createDisconnectAndParams({
             subquery.push(`WHERE ${whereStrs.join(" AND ")}`);
         }
 
-        const preAuth = [parentNode, relatedNode].reduce(
-            (result: Res, node, i) => {
+        const nodeMatrix: { node: Node; name: string }[] = [
+            { node: parentNode, name: parentVar },
+            { node: relatedNode, name: _varName },
+        ];
+
+        const preAuth = nodeMatrix.reduce(
+            (result: Res, { node, name }, i) => {
                 if (!node.auth) {
                     return result;
                 }
@@ -125,7 +130,7 @@ function createDisconnectAndParams({
                     operations: "DISCONNECT",
                     context,
                     escapeQuotes: Boolean(insideDoWhen),
-                    allow: { parentNode: node, varName: _varName, chainStr: `${_varName}${node.name}${i}_allow` },
+                    allow: { parentNode: node, varName: name, chainStr: `${name}${node.name}${i}_allow` },
                 });
 
                 if (!str) {

--- a/packages/graphql/tests/integration/issues/1132.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1132.int.test.ts
@@ -1,0 +1,318 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql } from "graphql";
+import { Driver, Session } from "neo4j-driver";
+import { generate } from "randomstring";
+import { gql } from "apollo-server";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import neo4j from "../neo4j";
+import { getQuerySource } from "../../utils/get-query-source";
+import { generateUniqueType } from "../../utils/graphql-types";
+import { Neo4jGraphQL } from "../../../src";
+import { createJwtRequest } from "../../utils/create-jwt-request";
+
+describe("https://github.com/neo4j/graphql/issues/1050", () => {
+    const secret = "secret";
+
+    let driver: Driver;
+    let session: Session;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+    });
+
+    beforeEach(() => {
+        session = driver.session();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    describe("CONNECT", () => {
+        test("should assert that the error is associated with the correct node", async () => {
+            const testSource = generateUniqueType("Source");
+            const testTarget = generateUniqueType("Target");
+
+            const typeDefs = gql`
+                type ${testSource.name} @auth(rules: [{ operations: [CONNECT], allow: { id: "$jwt.sub" } }]) {
+                    id: ID!
+                    targets: [${testTarget.name}!]! @relationship(type: "HAS_TARGET", direction: OUT)
+                }
+            
+                type ${testTarget.name} {
+                    id: ID!
+                }
+            `;
+
+            const neoGraphql = new Neo4jGraphQL({
+                typeDefs,
+                driver,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({
+                        secret,
+                    }),
+                },
+            });
+            const schema = await neoGraphql.getSchema();
+
+            const sourceId = generate({
+                charset: "alphabetic",
+            });
+            const sub = generate({
+                charset: "alphabetic",
+            });
+            const query = gql`
+                mutation {
+                    ${testSource.operations.update}(where: { id: "${sourceId}" }, connect: { targets: { where: { node: { id: 1 } } } }) {
+                        ${testSource.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            await session.run(`
+                CREATE (:${testSource.name} { id: "${sourceId}" })
+            `);
+
+            const req = createJwtRequest(secret, { sub });
+
+            const result = await graphql({
+                schema,
+                source: getQuerySource(query),
+                contextValue: {
+                    driver,
+                    req,
+                },
+            });
+            expect((result.errors as any[])[0].message).toBe("Forbidden");
+        });
+
+        test("should allow user to connect when associated with the correct node", async () => {
+            const testSource = generateUniqueType("Source");
+            const testTarget = generateUniqueType("Target");
+
+            const typeDefs = gql`
+                type ${testSource.name} @auth(rules: [{ operations: [CONNECT], allow: { id: "$jwt.sub" } }]) {
+                    id: ID!
+                    targets: [${testTarget.name}!]! @relationship(type: "HAS_TARGET", direction: OUT)
+                }
+            
+                type ${testTarget.name} {
+                    id: ID!
+                }
+            `;
+
+            const neoGraphql = new Neo4jGraphQL({
+                typeDefs,
+                driver,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({
+                        secret,
+                    }),
+                },
+            });
+            const schema = await neoGraphql.getSchema();
+
+            const sourceId = generate({
+                charset: "alphabetic",
+            });
+            const targetId = generate({
+                charset: "alphabetic",
+            });
+            const query = gql`
+                mutation {
+                    ${testSource.operations.update}(where: { id: "${sourceId}" }, connect: { targets: { where: { node: { id: "${targetId}" } } } }) {
+                        ${testSource.plural} {
+                            id
+                            targets {
+                                id
+                            }
+                        }
+                    }
+                }
+            `;
+
+            await session.run(`
+                CREATE (:${testSource.name} { id: "${sourceId}" })
+                CREATE (:${testTarget.name} { id: "${targetId}" })
+            `);
+
+            const req = createJwtRequest(secret, { sub: sourceId });
+
+            const result = await graphql({
+                schema,
+                source: getQuerySource(query),
+                contextValue: {
+                    driver,
+                    req,
+                },
+            });
+            expect(result.errors).toBeUndefined();
+            expect(result.data as any).toEqual({
+                [testSource.operations.update]: {
+                    [testSource.plural]: [
+                        {
+                            id: sourceId,
+                            targets: [{ id: targetId }],
+                        },
+                    ],
+                },
+            });
+        });
+    });
+
+    describe("DISCONNECT", () => {
+        test("should assert that the error is associated with the correct node", async () => {
+            const testSource = generateUniqueType("Source");
+            const testTarget = generateUniqueType("Target");
+
+            const typeDefs = gql`
+                type ${testSource.name} {
+                    id: ID!
+                    targets: [${testTarget.name}!]! @relationship(type: "HAS_TARGET", direction: OUT)
+                }
+            
+                type ${testTarget.name} @auth(rules: [{ operations: [DISCONNECT], allow: { id: "$jwt.sub" } }]) {
+                    id: ID!
+                }
+            `;
+
+            const neoGraphql = new Neo4jGraphQL({
+                typeDefs,
+                driver,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({
+                        secret,
+                    }),
+                },
+            });
+            const schema = await neoGraphql.getSchema();
+
+            const sourceId = generate({
+                charset: "alphabetic",
+            });
+            const targetId = generate({
+                charset: "alphabetic",
+            });
+            const sub = generate({
+                charset: "alphabetic",
+            });
+            const query = gql`
+                mutation {
+                    ${testSource.operations.update}(where: { id: "${sourceId}" }, disconnect: { targets: { where: { node: { id: "${targetId}" } } } }) {
+                        ${testSource.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            await session.run(`
+                CREATE (:${testSource.name} { id: "${sourceId}" })-[:HAS_TARGET]->(:${testTarget.name} { id: "${targetId}" })
+            `);
+
+            const req = createJwtRequest(secret, { sub });
+
+            const result = await graphql({
+                schema,
+                source: getQuerySource(query),
+                contextValue: {
+                    driver,
+                    req,
+                },
+            });
+            expect((result.errors as any[])[0].message).toBe("Forbidden");
+        });
+
+        test("should allow the disconnect when jwt.sub is associated with the correct node", async () => {
+            const testSource = generateUniqueType("Source");
+            const testTarget = generateUniqueType("Target");
+
+            const typeDefs = gql`
+                type ${testSource.name} {
+                    id: ID!
+                    targets: [${testTarget.name}!]! @relationship(type: "HAS_TARGET", direction: OUT)
+                }
+            
+                type ${testTarget.name} @auth(rules: [{ operations: [DISCONNECT], allow: { id: "$jwt.sub" } }]) {
+                    id: ID!
+                }
+            `;
+
+            const neoGraphql = new Neo4jGraphQL({
+                typeDefs,
+                driver,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({
+                        secret,
+                    }),
+                },
+            });
+            const schema = await neoGraphql.getSchema();
+
+            const sourceId = generate({
+                charset: "alphabetic",
+            });
+            const targetId = generate({
+                charset: "alphabetic",
+            });
+            const query = gql`
+                mutation {
+                    ${testSource.operations.update}(where: { id: "${sourceId}" }, disconnect: { targets: { where: { node: { id: "${targetId}" } } } }) {
+                        ${testSource.plural} {
+                            id
+                            targets {
+                                id
+                            }
+                        }
+                    }
+                }
+            `;
+
+            await session.run(`
+                CREATE (:${testSource.name} { id: "${sourceId}" })-[:HAS_TARGET]->(:${testTarget.name} { id: "${targetId}" })
+            `);
+
+            const req = createJwtRequest(secret, { sub: targetId });
+
+            const result = await graphql({
+                schema,
+                source: getQuerySource(query),
+                contextValue: {
+                    driver,
+                    req,
+                },
+            });
+            expect(result.errors).toBeUndefined();
+            expect(result.data as any).toEqual({
+                [testSource.operations.update]: {
+                    [testSource.plural]: [
+                        {
+                            id: sourceId,
+                            targets: [],
+                        },
+                    ],
+                },
+            });
+        });
+    });
+});

--- a/packages/graphql/tests/integration/issues/1132.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1132.int.test.ts
@@ -28,7 +28,7 @@ import { generateUniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src";
 import { createJwtRequest } from "../../utils/create-jwt-request";
 
-describe("https://github.com/neo4j/graphql/issues/1050", () => {
+describe("https://github.com/neo4j/graphql/issues/1132", () => {
     const secret = "secret";
 
     let driver: Driver;

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
@@ -580,7 +580,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             WHERE this_disconnect_posts0.id = $updateUsers.args.disconnect.posts[0].where.node.id
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT(this_disconnect_posts0.id IS NOT NULL AND this_disconnect_posts0.id = $this_disconnect_posts0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
@@ -592,7 +592,7 @@ describe("Cypher Auth Allow", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
-                \\"this_disconnect_posts0User0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_disconnect_posts0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
@@ -644,7 +644,7 @@ describe("Cypher Auth Allow", () => {
             WITH this
             OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
             WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
-            CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Comment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $thisComment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_post0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_disconnect0_rel
             )
@@ -654,7 +654,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
             WHERE this_post0_disconnect0_creator0.id = $updateComments.args.update.post.disconnect.disconnect.creator.where.node.id
             WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0_creator0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id) AND this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post0_allow_auth_allow0_creator_id) AND this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_post0_disconnect0_creator0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_disconnect0_creator0_rel
             )
@@ -683,9 +683,9 @@ describe("Cypher Auth Allow", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"comment-id\\",
-                \\"this_post0_disconnect0Comment0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"thisComment0_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_post0_disconnect0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
-                \\"this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"this_post0_disconnect0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_post0_disconnect0_creator0User1_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateComments\\": {
@@ -736,7 +736,7 @@ describe("Cypher Auth Allow", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
             	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT(this_connect_posts0_node.id IS NOT NULL AND this_connect_posts0_node.id = $this_connect_posts0_nodeUser0_allow_auth_allow0_id AND EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
             		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
@@ -751,7 +751,7 @@ describe("Cypher Auth Allow", () => {
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_posts0_node_id\\": \\"post-id\\",
-                \\"this_connect_posts0_nodeUser0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_connect_posts0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
             }"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
@@ -728,24 +728,24 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
-            WHERE this.id = $this_id
-            WITH this
-            CALL {
-                WITH this
-                OPTIONAL MATCH (this_connect_posts0_node:Post)
-                WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
-                WITH this, this_connect_posts0_node
-                CALL apoc.util.validate(NOT(EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            RETURN this { .id } AS this"
-            `);
+"MATCH (this:User)
+WHERE this.id = $this_id
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT(EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
@@ -732,28 +732,28 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $this_id
             WITH this
             CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_posts0_node:Post)
+                WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
+                WITH this, this_connect_posts0_node
+                CALL apoc.util.validate(NOT(EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+                    )
+                )
+                RETURN count(*)
             }
             RETURN this { .id } AS this"
-        `);
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_posts0_node_id\\": \\"post-id\\",
-                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
-                \\"this_connect_posts0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
+                \\"this_connect_posts0_nodePost0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"thisUser1_allow_auth_allow0_id\\": \\"user-id\\"
             }"
-        `);
+            `);
     });
 });

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
@@ -573,7 +573,7 @@ describe("@auth allow when inherited from interface", () => {
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             WHERE this_disconnect_posts0.id = $updateUsers.args.disconnect.posts[0].where.node.id
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT(this_disconnect_posts0.id IS NOT NULL AND this_disconnect_posts0.id = $this_disconnect_posts0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_disconnect_posts0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_disconnect_posts0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_posts0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
@@ -585,7 +585,7 @@ describe("@auth allow when inherited from interface", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
-                \\"this_disconnect_posts0User0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_disconnect_posts0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
@@ -637,7 +637,7 @@ describe("@auth allow when inherited from interface", () => {
             WITH this
             OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
             WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
-            CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Comment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(EXISTS((this)<-[:HAS_COMMENT]-(:User)) AND ANY(creator IN [(this)<-[:HAS_COMMENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $thisComment0_allow_auth_allow0_creator_id) AND EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_post0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_disconnect0_rel
             )
@@ -647,7 +647,7 @@ describe("@auth allow when inherited from interface", () => {
             OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
             WHERE this_post0_disconnect0_creator0.id = $updateComments.args.update.post.disconnect.disconnect.creator.where.node.id
             WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0_creator0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id) AND this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(EXISTS((this_post0_disconnect0)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_post0_disconnect0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post0_disconnect0Post0_allow_auth_allow0_creator_id) AND this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0User1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_post0_disconnect0_creator0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_disconnect0_creator0_rel
             )
@@ -676,9 +676,9 @@ describe("@auth allow when inherited from interface", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"comment-id\\",
-                \\"this_post0_disconnect0Comment0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"thisComment0_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_post0_disconnect0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
-                \\"this_post0_disconnect0_creator0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"this_post0_disconnect0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_post0_disconnect0_creator0User1_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateComments\\": {
@@ -729,7 +729,7 @@ describe("@auth allow when inherited from interface", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
             	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT(this_connect_posts0_node.id IS NOT NULL AND this_connect_posts0_node.id = $this_connect_posts0_nodeUser0_allow_auth_allow0_id AND EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
             		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
@@ -744,7 +744,7 @@ describe("@auth allow when inherited from interface", () => {
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_posts0_node_id\\": \\"post-id\\",
-                \\"this_connect_posts0_nodeUser0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_connect_posts0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
             }"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
@@ -721,24 +721,24 @@ describe("@auth allow when inherited from interface", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
-            WHERE this.id = $this_id
-            WITH this
-            CALL {
-                WITH this
-                OPTIONAL MATCH (this_connect_posts0_node:Post)
-                WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
-                WITH this, this_connect_posts0_node
-                CALL apoc.util.validate(NOT(EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            RETURN this { .id } AS this"
-            `);
+"MATCH (this:User)
+WHERE this.id = $this_id
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT(EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
@@ -725,28 +725,28 @@ describe("@auth allow when inherited from interface", () => {
             WHERE this.id = $this_id
             WITH this
             CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_posts0_node:Post)
+                WHERE this_connect_posts0_node.id = $this_connect_posts0_node_id
+                WITH this, this_connect_posts0_node
+                CALL apoc.util.validate(NOT(EXISTS((this_connect_posts0_node)<-[:HAS_POST]-(:User)) AND ANY(creator IN [(this_connect_posts0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_posts0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+                    )
+                )
+                RETURN count(*)
             }
             RETURN this { .id } AS this"
-        `);
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_posts0_node_id\\": \\"post-id\\",
-                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
-                \\"this_connect_posts0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
+                \\"this_connect_posts0_nodePost0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"thisUser1_allow_auth_allow0_id\\": \\"user-id\\"
             }"
-        `);
+            `);
     });
 });

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -536,37 +536,37 @@ describe("@auth allow on specific interface implementation", () => {
             WHERE this.id = $this_id
             WITH this
             CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_content0_node:Comment)
+                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+                    )
+                )
+                RETURN count(*)
             UNION
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_content0_node:Post)
+                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+                WITH this, this_connect_content0_node
+                CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost0_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+                    )
+                )
+                RETURN count(*)
             }
             RETURN this { .id } AS this"
-        `);
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_content0_node_id\\": \\"post-id\\",
-                \\"this_connect_content0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
+                \\"this_connect_content0_nodePost0_allow_auth_allow0_creator_id\\": \\"user-id\\"
             }"
-        `);
+            `);
     });
 });

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -463,7 +463,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
             WHERE this_disconnect_content0_comments0.id = $updateUsers.args.disconnect.content[0].disconnect._on.Post[0].comments[0].where.node.id
             WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            CALL apoc.util.validate(NOT(EXISTS((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0_comments0Post0_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post0_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_content0_comments0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_comments0_rel
             )
@@ -478,7 +478,7 @@ describe("@auth allow on specific interface implementation", () => {
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_disconnect_content0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
-                \\"this_disconnect_content0_comments0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"this_disconnect_content0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -532,34 +532,34 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
-            WHERE this.id = $this_id
-            WITH this
-            CALL {
-                WITH this
-                OPTIONAL MATCH (this_connect_content0_node:Comment)
-                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-                    )
-                )
-                RETURN count(*)
-            UNION
-                WITH this
-                OPTIONAL MATCH (this_connect_content0_node:Post)
-                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-                WITH this, this_connect_content0_node
-                CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost0_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            RETURN this { .id } AS this"
-            `);
+"MATCH (this:User)
+WHERE this.id = $this_id
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		)
+	)
+	RETURN count(*)
+UNION
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost0_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -656,41 +656,41 @@ describe("@auth allow with interface relationships", () => {
             WHERE this.id = $this_id
             WITH this
             CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_content0_node:Comment)
+                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+                WITH this, this_connect_content0_node
+                CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+                    )
+                )
+                RETURN count(*)
             UNION
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_content0_node:Post)
+                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+                WITH this, this_connect_content0_node
+                CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+                    )
+                )
+                RETURN count(*)
             }
             RETURN this { .id } AS this"
-        `);
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_content0_node_id\\": \\"post-id\\",
-                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
-                \\"this_connect_content0_nodeComment1_allow_auth_allow0_creator_id\\": \\"user-id\\",
-                \\"this_connect_content0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
+                \\"this_connect_content0_nodeComment0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"thisUser1_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"this_connect_content0_nodePost0_allow_auth_allow0_creator_id\\": \\"user-id\\"
             }"
-        `);
+            `);
     });
 });

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -652,36 +652,36 @@ describe("@auth allow with interface relationships", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
-            WHERE this.id = $this_id
-            WITH this
-            CALL {
-                WITH this
-                OPTIONAL MATCH (this_connect_content0_node:Comment)
-                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-                WITH this, this_connect_content0_node
-                CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-                    )
-                )
-                RETURN count(*)
-            UNION
-                WITH this
-                OPTIONAL MATCH (this_connect_content0_node:Post)
-                WHERE this_connect_content0_node.id = $this_connect_content0_node_id
-                WITH this, this_connect_content0_node
-                CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            RETURN this { .id } AS this"
-            `);
+"MATCH (this:User)
+WHERE this.id = $this_id
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		)
+	)
+	RETURN count(*)
+UNION
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT(EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost0_allow_auth_allow0_creator_id) AND this.id IS NOT NULL AND this.id = $thisUser1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -481,7 +481,7 @@ describe("@auth allow with interface relationships", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers.args.disconnect.content[0].where.node.id
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Comment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Comment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
@@ -491,7 +491,7 @@ describe("@auth allow with interface relationships", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers.args.disconnect.content[0].where.node.id
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
@@ -503,7 +503,7 @@ describe("@auth allow with interface relationships", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
-                \\"this_disconnect_content0User0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_disconnect_content0Comment1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_disconnect_content0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateUsers\\": {
@@ -560,7 +560,7 @@ describe("@auth allow with interface relationships", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers.args.disconnect.content[0].where.node.id
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Comment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Comment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
@@ -570,7 +570,7 @@ describe("@auth allow with interface relationships", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers.args.disconnect.content[0].where.node.id
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
@@ -580,7 +580,7 @@ describe("@auth allow with interface relationships", () => {
             OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
             WHERE this_disconnect_content0_comments0.id = $updateUsers.args.disconnect.content[0].disconnect._on.Post[0].comments[0].where.node.id
             WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            CALL apoc.util.validate(NOT(EXISTS((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0_comments0Post0_allow_auth_allow0_creator_id) AND EXISTS((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0_comments0Comment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT(EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post0_allow_auth_allow0_creator_id) AND EXISTS((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0_comments0Comment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             FOREACH(_ IN CASE this_disconnect_content0_comments0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_comments0_rel
             )
@@ -594,10 +594,10 @@ describe("@auth allow with interface relationships", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_id\\": \\"user-id\\",
-                \\"this_disconnect_content0User0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_disconnect_content0Comment1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_disconnect_content0Post1_allow_auth_allow0_creator_id\\": \\"user-id\\",
-                \\"this_disconnect_content0_comments0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
+                \\"this_disconnect_content0Post0_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_disconnect_content0_comments0Comment1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
@@ -660,7 +660,7 @@ describe("@auth allow with interface relationships", () => {
             	OPTIONAL MATCH (this_connect_content0_node:Comment)
             	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
             	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT(this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeUser0_allow_auth_allow0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
             		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
@@ -672,7 +672,7 @@ describe("@auth allow with interface relationships", () => {
             	OPTIONAL MATCH (this_connect_content0_node:Post)
             	WHERE this_connect_content0_node.id = $this_connect_content0_node_id
             	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT(this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeUser0_allow_auth_allow0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisUser0_allow_auth_allow0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost1_allow_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
             		FOREACH(_ IN CASE this_connect_content0_node WHEN NULL THEN [] ELSE [1] END |
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
@@ -687,7 +687,7 @@ describe("@auth allow with interface relationships", () => {
             "{
                 \\"this_id\\": \\"user-id\\",
                 \\"this_connect_content0_node_id\\": \\"post-id\\",
-                \\"this_connect_content0_nodeUser0_allow_auth_allow0_id\\": \\"user-id\\",
+                \\"thisUser0_allow_auth_allow0_id\\": \\"user-id\\",
                 \\"this_connect_content0_nodeComment1_allow_auth_allow0_creator_id\\": \\"user-id\\",
                 \\"this_connect_content0_nodePost1_allow_auth_allow0_creator_id\\": \\"user-id\\"
             }"

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
@@ -410,22 +410,22 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:User)
-            WITH this
-            CALL {
-                WITH this
-                OPTIONAL MATCH (this_connect_posts0_node:Post)
-                WITH this, this_connect_posts0_node
-                CALL apoc.util.validate(NOT(ANY(r IN [\\"super-admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            RETURN this { .id } AS this"
-            `);
+"MATCH (this:User)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT(ANY(r IN [\\"super-admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -466,45 +466,45 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Comment)
-            WITH this
-            OPTIONAL MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
-            CALL apoc.do.when(this_post0 IS NOT NULL, \\"
-            WITH this, this_post0
-            CALL {
-                WITH this, this_post0
-                OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
-                WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_id
-                WITH this, this_post0, this_post0_creator0_connect0_node
-                CALL apoc.util.validate(NOT(ANY(r IN [\\\\\\"admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\\\\\"super-admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
-                FOREACH(_ IN CASE this_post0 WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_post0_creator0_connect0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            WITH this, this_post0
-            CALL {
-                WITH this_post0
-                MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
-                WITH count(this_post0_creator_User_unique) as c
-                CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
-                RETURN c AS this_post0_creator_User_unique_ignored
-            }
-            RETURN count(*)
-            \\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,this_post0_creator0_connect0_node_id:$this_post0_creator0_connect0_node_id})
-            YIELD value as _
-            WITH this
-            CALL {
-                WITH this
-                MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
-                WITH count(this_post_Post_unique) as c
-                CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
-                RETURN c AS this_post_Post_unique_ignored
-            }
-            RETURN this { .content } AS this"
-            `);
+"MATCH (this:Comment)
+WITH this
+OPTIONAL MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+CALL apoc.do.when(this_post0 IS NOT NULL, \\"
+WITH this, this_post0
+CALL {
+	WITH this, this_post0
+	OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
+	WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_id
+	WITH this, this_post0, this_post0_creator0_connect0_node
+	CALL apoc.util.validate(NOT(ANY(r IN [\\\\\\"admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\\\\\"super-admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
+	FOREACH(_ IN CASE this_post0 WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_post0_creator0_connect0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
+		)
+	)
+	RETURN count(*)
+}
+WITH this, this_post0
+CALL {
+	WITH this_post0
+	MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+	WITH count(this_post0_creator_User_unique) as c
+	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
+	RETURN c AS this_post0_creator_User_unique_ignored
+}
+RETURN count(*)
+\\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,this_post0_creator0_connect0_node_id:$this_post0_creator0_connect0_node_id})
+YIELD value as _
+WITH this
+CALL {
+	WITH this
+	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+	WITH count(this_post_Post_unique) as c
+	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
+	RETURN c AS this_post_Post_unique_ignored
+}
+RETURN this { .content } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
@@ -413,19 +413,19 @@ describe("Cypher Auth Roles", () => {
             "MATCH (this:User)
             WITH this
             CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT(ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\"super-admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this
+                OPTIONAL MATCH (this_connect_posts0_node:Post)
+                WITH this, this_connect_posts0_node
+                CALL apoc.util.validate(NOT(ANY(r IN [\\"super-admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_posts0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+                    )
+                )
+                RETURN count(*)
             }
             RETURN this { .id } AS this"
-        `);
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -472,39 +472,39 @@ describe("Cypher Auth Roles", () => {
             CALL apoc.do.when(this_post0 IS NOT NULL, \\"
             WITH this, this_post0
             CALL {
-            	WITH this, this_post0
-            	OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
-            	WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_id
-            	WITH this, this_post0, this_post0_creator0_connect0_node
-            	CALL apoc.util.validate(NOT(ANY(r IN [\\\\\\"super-admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\\\\\"admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
-            	FOREACH(_ IN CASE this_post0 WHEN NULL THEN [] ELSE [1] END |
-            		FOREACH(_ IN CASE this_post0_creator0_connect0_node WHEN NULL THEN [] ELSE [1] END |
-            			MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
-            		)
-            	)
-            	RETURN count(*)
+                WITH this, this_post0
+                OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
+                WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_id
+                WITH this, this_post0, this_post0_creator0_connect0_node
+                CALL apoc.util.validate(NOT(ANY(r IN [\\\\\\"admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND ANY(r IN [\\\\\\"super-admin\\\\\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
+                FOREACH(_ IN CASE this_post0 WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_post0_creator0_connect0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
+                    )
+                )
+                RETURN count(*)
             }
             WITH this, this_post0
             CALL {
-            	WITH this_post0
-            	MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
-            	WITH count(this_post0_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
-            	RETURN c AS this_post0_creator_User_unique_ignored
+                WITH this_post0
+                MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+                WITH count(this_post0_creator_User_unique) as c
+                CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
+                RETURN c AS this_post0_creator_User_unique_ignored
             }
             RETURN count(*)
             \\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,this_post0_creator0_connect0_node_id:$this_post0_creator0_connect0_node_id})
             YIELD value as _
             WITH this
             CALL {
-            	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
-            	WITH count(this_post_Post_unique) as c
-            	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
-            	RETURN c AS this_post_Post_unique_ignored
+                WITH this
+                MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+                WITH count(this_post_Post_unique) as c
+                CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
+                RETURN c AS this_post_Post_unique_ignored
             }
             RETURN this { .content } AS this"
-        `);
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "apollo-server";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/1132", () => {
+    test("Auth CONNECT rules checked against correct property", async () => {
+        const typeDefs = gql`
+            type Source @auth(rules: [{ operations: [CONNECT], allow: { id: "$jwt.sub" } }]) {
+                id: ID!
+                targets: [Target!]! @relationship(type: "HAS_TARGET", direction: OUT)
+            }
+
+            type Target {
+                id: ID!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            config: { enableRegex: true },
+            plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "secret" }) },
+        });
+
+        const query = gql`
+            mutation {
+                updateSources(connect: { targets: { where: { node: { id: 1 } } } }) {
+                    sources {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "1" });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+"MATCH (this:Source)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_targets0_node:Target)
+	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_id
+	WITH this, this_connect_targets0_node
+	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisSource0_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_targets0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this_connect_targets0_node_id\\": \\"1\\",
+                \\"thisSource0_allow_auth_allow0_id\\": \\"1\\"
+            }"
+        `);
+    });
+
+    test("Auth DISCONNECT rules checked against correct property", async () => {
+        const typeDefs = gql`
+            type Source @auth(rules: [{ operations: [DISCONNECT], allow: { id: "$jwt.sub" } }]) {
+                id: ID!
+                targets: [Target!]! @relationship(type: "HAS_TARGET", direction: OUT)
+            }
+
+            type Target {
+                id: ID!
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            config: { enableRegex: true },
+            plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "secret" }) },
+        });
+
+        const query = gql`
+            mutation {
+                updateSources(disconnect: { targets: { where: { node: { id: 1 } } } }) {
+                    sources {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "1" });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+"MATCH (this:Source)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_targets0_rel:HAS_TARGET]->(this_disconnect_targets0:Target)
+WHERE this_disconnect_targets0.id = $updateSources.args.disconnect.targets[0].where.node.id
+WITH this, this_disconnect_targets0, this_disconnect_targets0_rel
+CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisSource0_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+FOREACH(_ IN CASE this_disconnect_targets0 WHEN NULL THEN [] ELSE [1] END |
+DELETE this_disconnect_targets0_rel
+)
+RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"thisSource0_allow_auth_allow0_id\\": \\"1\\",
+                \\"updateSources\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"targets\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"1\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
@@ -58,23 +58,23 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:Source)
-            WITH this
-            CALL {
-                WITH this
-                OPTIONAL MATCH (this_connect_targets0_node:Target)
-                WHERE this_connect_targets0_node.id = $this_connect_targets0_node_id
-                WITH this, this_connect_targets0_node
-                CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisSource1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-                    FOREACH(_ IN CASE this_connect_targets0_node WHEN NULL THEN [] ELSE [1] END |
-                        MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
-                    )
-                )
-                RETURN count(*)
-            }
-            RETURN this { .id } AS this"
-            `);
+"MATCH (this:Source)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_targets0_node:Target)
+	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_id
+	WITH this, this_connect_targets0_node
+	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisSource1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+		FOREACH(_ IN CASE this_connect_targets0_node WHEN NULL THEN [] ELSE [1] END |
+			MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
+		)
+	)
+	RETURN count(*)
+}
+RETURN this { .id } AS this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
@@ -58,30 +58,30 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:Source)
-WITH this
-CALL {
-	WITH this
-	OPTIONAL MATCH (this_connect_targets0_node:Target)
-	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_id
-	WITH this, this_connect_targets0_node
-	CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisSource0_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-	FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
-		FOREACH(_ IN CASE this_connect_targets0_node WHEN NULL THEN [] ELSE [1] END |
-			MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
-		)
-	)
-	RETURN count(*)
-}
-RETURN this { .id } AS this"
-`);
+            "MATCH (this:Source)
+            WITH this
+            CALL {
+                WITH this
+                OPTIONAL MATCH (this_connect_targets0_node:Target)
+                WHERE this_connect_targets0_node.id = $this_connect_targets0_node_id
+                WITH this, this_connect_targets0_node
+                CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $thisSource1_allow_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                FOREACH(_ IN CASE this WHEN NULL THEN [] ELSE [1] END |
+                    FOREACH(_ IN CASE this_connect_targets0_node WHEN NULL THEN [] ELSE [1] END |
+                        MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
+                    )
+                )
+                RETURN count(*)
+            }
+            RETURN this { .id } AS this"
+            `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"this_connect_targets0_node_id\\": \\"1\\",
-                \\"thisSource0_allow_auth_allow0_id\\": \\"1\\"
+                \\"thisSource1_allow_auth_allow0_id\\": \\"1\\"
             }"
-        `);
+            `);
     });
 
     test("Auth DISCONNECT rules checked against correct property", async () => {


### PR DESCRIPTION
# Description

`Allow` rule is checked against target node rather than the source node.

# Issue

The issue: https://github.com/neo4j/graphql/issues/1132

Closes:

- https://github.com/neo4j/graphql/issues/1132

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
