### PR TITLE
Make sure aliases are checked against connectOrCreate where input

### DIFF
--- a/packages/graphql/src/translate/cypher-builder/build-merge-statement.ts
+++ b/packages/graphql/src/translate/cypher-builder/build-merge-statement.ts
@@ -65,6 +65,7 @@ export function buildMergeStatement({
     context: Context;
 }): CypherStatement {
     const onCreateStatements: Array<CypherStatement> = [];
+    let parameters: Record<string, any> | undefined;
     let leftStatement: CypherStatement | undefined;
     let relationOnCreateStatement: CypherStatement | undefined;
 
@@ -88,6 +89,15 @@ export function buildMergeStatement({
                     {},
                 ]);
             });
+    }
+
+    if (sourceNode.parameters) {
+        parameters = sourceNode.node?.constrainableFields.reduce((params, field) => {
+            if (Object.keys(sourceNode.parameters!).includes(field.fieldName)) {
+                params[field.dbPropertyName || field.fieldName] = sourceNode.parameters![field.fieldName];
+            }
+            return params;
+        }, {} as Record<string, any>);
     }
 
     if (sourceNode.onCreate) {
@@ -148,6 +158,7 @@ export function buildMergeStatement({
     } else {
         leftStatement = buildNodeStatement({
             ...sourceNode,
+            parameters,
             context,
         });
     }

--- a/packages/graphql/src/translate/cypher-builder/build-merge-statement.ts
+++ b/packages/graphql/src/translate/cypher-builder/build-merge-statement.ts
@@ -95,6 +95,7 @@ export function buildMergeStatement({
     if (nodeParameters) {
         parameters = sourceNode.node?.constrainableFields.reduce((params, field) => {
             if (Object.keys(nodeParameters).includes(field.fieldName)) {
+                // eslint-disable-next-line no-param-reassign
                 params[field.dbPropertyName || field.fieldName] = nodeParameters[field.fieldName];
             }
             return params;

--- a/packages/graphql/src/translate/cypher-builder/build-merge-statement.ts
+++ b/packages/graphql/src/translate/cypher-builder/build-merge-statement.ts
@@ -91,10 +91,11 @@ export function buildMergeStatement({
             });
     }
 
-    if (sourceNode.parameters) {
+    const nodeParameters = sourceNode.parameters;
+    if (nodeParameters) {
         parameters = sourceNode.node?.constrainableFields.reduce((params, field) => {
-            if (Object.keys(sourceNode.parameters!).includes(field.fieldName)) {
-                params[field.dbPropertyName || field.fieldName] = sourceNode.parameters![field.fieldName];
+            if (Object.keys(nodeParameters).includes(field.fieldName)) {
+                params[field.dbPropertyName || field.fieldName] = nodeParameters[field.fieldName];
             }
             return params;
         }, {} as Record<string, any>);

--- a/packages/graphql/src/translate/cypher-builder/build-node-statement.ts
+++ b/packages/graphql/src/translate/cypher-builder/build-node-statement.ts
@@ -43,6 +43,6 @@ export function buildNodeStatement({ varName = "", node, context, parameters }: 
 }
 
 function parseNodeParameters(nodeVar: string, parameters: CypherParams | undefined): CypherStatement {
-    if (!nodeVar && parameters) throw new Error("noveVar not defined with parameters");
+    if (!nodeVar && parameters) throw new Error("nodeVar not defined with parameters");
     return serializeParameters(`${nodeVar}_node`, parameters);
 }

--- a/packages/graphql/tests/tck/tck-test-files/issues/1131.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1131.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/988", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type BibliographicReference @node(additionalLabels: ["Resource"]) {
+                iri: ID! @unique @alias(property: "uri")
+                prefLabel: [String]
+                isInPublication: [Concept!]! @relationship(type: "isInPublication", direction: OUT)
+            }
+
+            type Concept @node(additionalLabels: ["Resource"]) {
+                iri: ID! @unique @alias(property: "uri")
+                prefLabel: [String]!
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            config: { enableRegex: true },
+        });
+    });
+
+    test("where with multiple filters and params", async () => {
+        const query = gql`
+            mutation {
+                updateBibliographicReferences(
+                    where: { iri: "urn:myiri2" }
+                    update: {
+                        prefLabel: "Updated Label:My BRS with Resource"
+                        isInPublication: [
+                            {
+                                connectOrCreate: {
+                                    where: { node: { iri: "new-g" } }
+                                    onCreate: { node: { iri: "new-g", prefLabel: "pub" } }
+                                }
+                            }
+                            {
+                                connectOrCreate: {
+                                    where: { node: { iri: "new-f" } }
+                                    onCreate: { node: { iri: "new-f", prefLabel: "pub" } }
+                                }
+                            }
+                        ]
+                    }
+                ) {
+                    bibliographicReferences {
+                        iri
+                        prefLabel
+                        isInPublication(where: { iri_IN: ["new-f", "new-e"] }) {
+                            iri
+                            prefLabel
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", {});
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`BibliographicReference\`:\`Resource\`)
+            WHERE this.uri = $this_iri
+            SET this.prefLabel = $this_update_prefLabel
+            WITH this
+            CALL {
+            	WITH this
+            	MERGE (this_isInPublication0_connectOrCreate0:\`Concept\`:\`Resource\` { uri: $this_isInPublication0_connectOrCreate0_node_uri })
+            ON CREATE
+            SET
+            this_isInPublication0_connectOrCreate0.uri = $this_isInPublication0_connectOrCreate0_on_create_uri,
+            this_isInPublication0_connectOrCreate0.prefLabel = $this_isInPublication0_connectOrCreate0_on_create_prefLabel
+            MERGE (this)-[this_relationship_this_isInPublication0_connectOrCreate0:isInPublication]->(this_isInPublication0_connectOrCreate0)
+            	RETURN COUNT(*)
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MERGE (this_isInPublication1_connectOrCreate0:\`Concept\`:\`Resource\` { uri: $this_isInPublication1_connectOrCreate0_node_uri })
+            ON CREATE
+            SET
+            this_isInPublication1_connectOrCreate0.uri = $this_isInPublication1_connectOrCreate0_on_create_uri,
+            this_isInPublication1_connectOrCreate0.prefLabel = $this_isInPublication1_connectOrCreate0_on_create_prefLabel
+            MERGE (this)-[this_relationship_this_isInPublication1_connectOrCreate0:isInPublication]->(this_isInPublication1_connectOrCreate0)
+            	RETURN COUNT(*)
+            }
+            RETURN this { iri: this.uri, .prefLabel, isInPublication: [ (this)-[:isInPublication]->(this_isInPublication:\`Concept\`:\`Resource\`)  WHERE this_isInPublication.uri IN $this_isInPublication_iri_IN | this_isInPublication { iri: this_isInPublication.uri, .prefLabel } ] } AS this"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this_iri\\": \\"urn:myiri2\\",
+                \\"this_update_prefLabel\\": [
+                    \\"Updated Label:My BRS with Resource\\"
+                ],
+                \\"this_isInPublication0_connectOrCreate0_node_uri\\": \\"new-g\\",
+                \\"this_isInPublication0_connectOrCreate0_on_create_uri\\": \\"new-g\\",
+                \\"this_isInPublication0_connectOrCreate0_on_create_prefLabel\\": [
+                    \\"pub\\"
+                ],
+                \\"this_isInPublication1_connectOrCreate0_node_uri\\": \\"new-f\\",
+                \\"this_isInPublication1_connectOrCreate0_on_create_uri\\": \\"new-f\\",
+                \\"this_isInPublication1_connectOrCreate0_on_create_prefLabel\\": [
+                    \\"pub\\"
+                ],
+                \\"this_isInPublication_iri_IN\\": [
+                    \\"new-f\\",
+                    \\"new-e\\"
+                ]
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/issues/1131.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1131.test.ts
@@ -23,7 +23,7 @@ import { Neo4jGraphQL } from "../../../../src";
 import { createJwtRequest } from "../../../utils/create-jwt-request";
 import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
 
-describe("https://github.com/neo4j/graphql/issues/988", () => {
+describe("https://github.com/neo4j/graphql/issues/1131", () => {
     let typeDefs: DocumentNode;
     let neoSchema: Neo4jGraphQL;
 


### PR DESCRIPTION
# Description

When generating the initial `MERGE` in a `connectOrCreate`, the input `where` object was not being checked against aliases for database properties. This adds that check.

# Issue

Closes #1131.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
