### PR TITLE
Write details to transaction metadata instead of useragent

### DIFF
--- a/packages/graphql/src/utils/execute.test.ts
+++ b/packages/graphql/src/utils/execute.test.ts
@@ -102,12 +102,6 @@ describe("execute", () => {
                 });
 
                 expect(executeResult.records).toEqual([{ title }]);
-                // @ts-ignore
-                expect(driver._userAgent).toBe(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
-                // @ts-ignore
-                expect(driver._config.userAgent).toBe(
-                    `${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`
-                );
             })
         );
     });
@@ -178,10 +172,6 @@ describe("execute", () => {
             });
 
             expect(executeResult.records).toEqual([{ title }]);
-            // @ts-ignore
-            expect(driver._userAgent).toBe(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
-            // @ts-ignore
-            expect(driver._config.userAgent).toBe(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
         });
 
         test("one of each query option", async () => {
@@ -264,10 +254,6 @@ describe("execute", () => {
             });
 
             expect(executeResult.records).toEqual([{ title }]);
-            // @ts-ignore
-            expect(driver._userAgent).toBe(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
-            // @ts-ignore
-            expect(driver._config.userAgent).toBe(`${environment.NPM_PACKAGE_NAME}/${environment.NPM_PACKAGE_VERSION}`);
         });
     });
 });

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -18,6 +18,7 @@
  */
 
 import { SessionMode, Transaction, QueryResult, Neo4jError } from "neo4j-driver";
+import { TransactionConfig } from "neo4j-driver-core";
 import Debug from "debug";
 import {
     Neo4jGraphQLForbiddenError,
@@ -34,7 +35,6 @@ import {
 import createAuthParam from "../translate/create-auth-param";
 import { Context, DriverConfig } from "../types";
 import environment from "../environment";
-import { TransactionConfig } from "neo4j-driver-core";
 
 const debug = Debug(DEBUG_EXECUTE);
 

--- a/packages/graphql/src/utils/execute.ts
+++ b/packages/graphql/src/utils/execute.ts
@@ -18,7 +18,6 @@
  */
 
 import { SessionMode, Transaction, QueryResult, Neo4jError } from "neo4j-driver";
-import { TransactionConfig } from "neo4j-driver-core";
 import Debug from "debug";
 import {
     Neo4jGraphQLForbiddenError,
@@ -93,7 +92,7 @@ async function execute(input: {
 
         let result: QueryResult | undefined;
         const transactionWork = (tx: Transaction) => tx.run(cypher, input.params);
-        const transactionConfig: TransactionConfig = {
+        const transactionConfig = {
             metadata: {
                 app,
                 type: "user-transpiled",


### PR DESCRIPTION
# Description

Overriding the driver useragent is not a reliable way of getting the details of the Neo4j GraphQL Library into the Neo4j query log. This instead writes those details to the transaction metadata, which are also available to view in logs.
