### PR TITLE
Fix/use __typename when looking for other types

### DIFF
--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -209,8 +209,8 @@ class Node extends GraphElement {
 
     public get aggregateTypeNames(): AggregateTypeNames {
         return {
-            selection: `${this.name}AggregateSelection`,
-            input: `${this.name}AggregateSelectionInput`,
+            selection: `${this.pascalCaseSingular}AggregateSelection`,
+            input: `${this.pascalCaseSingular}AggregateSelectionInput`,
         };
     }
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -97,6 +97,11 @@ export type RootTypeFieldNames = {
     aggregate: string;
 };
 
+export type AggregateTypeNames = {
+    selection: string;
+    input: string;
+};
+
 export type MutationResponseTypeNames = {
     create: string;
     update: string;
@@ -199,6 +204,13 @@ class Node extends GraphElement {
             update: `update${pascalCasePlural}`,
             delete: `delete${pascalCasePlural}`,
             aggregate: `${this.plural}Aggregate`,
+        };
+    }
+
+    public get aggregateTypeNames(): AggregateTypeNames {
+        return {
+            selection: `${this.name}AggregateSelection`,
+            input: `${this.name}AggregateSelectionInput`,
         };
     }
 

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -209,8 +209,8 @@ class Node extends GraphElement {
 
     public get aggregateTypeNames(): AggregateTypeNames {
         return {
-            selection: `${this.pascalCaseSingular}AggregateSelection`,
-            input: `${this.pascalCaseSingular}AggregateSelectionInput`,
+            selection: `${this.name}AggregateSelection`,
+            input: `${this.name}AggregateSelectionInput`,
         };
     }
 

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -796,7 +796,7 @@ function makeAugmentedSchema(
         };
 
         composer.createObjectTC({
-            name: `${node.name}AggregateSelection`,
+            name: node.aggregateTypeNames.selection,
             fields: {
                 count: countField,
                 ...[...node.primitiveFields, ...node.temporalFields].reduce((res, field) => {

--- a/packages/graphql/src/schema/resolvers/aggregate.ts
+++ b/packages/graphql/src/schema/resolvers/aggregate.ts
@@ -45,7 +45,7 @@ export default function aggregateResolver({ node }: { node: Node }) {
     }
 
     return {
-        type: `${node.name}AggregateSelection!`,
+        type: `${node.aggregateTypeNames.selection}!`,
         resolve,
         args: { where: `${node.name}Where`, ...(node.fulltextDirective ? { fulltext: `${node.name}Fulltext` } : {}) },
     };

--- a/packages/graphql/src/translate/translate-aggregate.ts
+++ b/packages/graphql/src/translate/translate-aggregate.ts
@@ -48,7 +48,7 @@ function translateAggregate({ node, context }: { node: Node; context: Context })
         cypherParams = { ...cypherParams, ...allowAuth[1] };
     }
 
-    const selections = fieldsByTypeName[`${node.name}AggregateSelection`];
+    const selections = fieldsByTypeName[node.aggregateTypeNames.selection];
     const projections: string[] = [];
     const authStrs: string[] = [];
 

--- a/packages/ogm/tests/issues/1130.test.ts
+++ b/packages/ogm/tests/issues/1130.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generate, OGM } from "../../src";
+
+describe("issues/1130", () => {
+    test("should re-create issue and return types without throwing", async () => {
+        const typeDefs = `
+            type Company {
+              name: String!
+              industries: [SICIndustry!]! @relationship(type: "CONDUCTS_BUSINESS_IN", direction: OUT)
+            }
+            
+            # <-- Changing the name to "SicIndustry" works
+            type SICIndustry {
+              code: ID! @id(autogenerate: false)
+              title: String!
+              companies: [Company!]! @relationship(type: "CONDUCTS_BUSINESS_IN", direction: IN)
+            }
+        `;
+
+        const ogm = new OGM({
+            typeDefs,
+            // @ts-ignore
+            driver: {},
+        });
+
+        const generated = (await generate({
+            ogm,
+            noWrite: true,
+        })) as string;
+
+        expect(generated).toContain(`export interface SICIndustryAggregateSelectionInput`);
+    });
+});


### PR DESCRIPTION
# Description

Supersedes #1200 

Changes look at the `__typename` field on the generated types over the 'top level type name`, this is because GraphQL Codegen is not preserving the type names. I have raised an issue about that here https://github.com/dotansimha/graphql-code-generator/issues/7714

Some refactors to the aggregation types - centrally storing them in the `Node` class. 

# Issue

#1130 

Closes: #1130 
