### PR TITLE
Add tests on time parse and update regex

### DIFF
--- a/packages/graphql/src/schema/types/scalars/Time.test.ts
+++ b/packages/graphql/src/schema/types/scalars/Time.test.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { parseTime } from "./Time";
+
+describe("Time Scalar", () => {
+    describe("parseTime", () => {
+        test.each(["22:20:00", "22:20"])("should properly parse %s", (input: string) => {
+            const parsedTime = parseTime(input);
+            expect(parsedTime).toEqual({
+                hour: 22,
+                minute: 20,
+                second: 0,
+                nanosecond: 0,
+                timeZoneOffsetSeconds: 0,
+            });
+        });
+
+        test("should properly parse time in RFC3339 format", () => {
+            const parsedTime = parseTime("22:10:15.555-01:02");
+
+            expect(parsedTime).toEqual({
+                hour: 22,
+                minute: 10,
+                second: 15,
+                nanosecond: 555000000,
+                timeZoneOffsetSeconds: -3720,
+            });
+        });
+
+        test.each(["22", "22:00.555"])("should not parse %s", (input: string) => {
+            expect(() => parseTime(input)).toThrow();
+        });
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/types/time.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/types/time.test.ts
@@ -183,4 +183,44 @@ describe("Cypher Time", () => {
             }"
         `);
     });
+
+    test("Create with HH:MM format", async () => {
+        const query = gql`
+            mutation {
+                createMovies(input: [{ time: "22:00" }]) {
+                    movies {
+                        time
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", {});
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:Movie)
+            SET this0.time = $this0_time
+            RETURN this0
+            }
+            RETURN [
+            this0 { .time }] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_time\\": {
+                    \\"hour\\": 22,
+                    \\"minute\\": 0,
+                    \\"second\\": 0,
+                    \\"nanosecond\\": 0,
+                    \\"timeZoneOffsetSeconds\\": 0
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
 });


### PR DESCRIPTION
# Description
Updates time regex to support `HH:MM` format, some tests added to ensure valid and invalid formats

Note: Variable `RFC_3339_REGEX` renamed to `TIME_REGEX` to avoid confusion, as the regex does not strictly follow RFC_3339 format.

# Issue

#1234 
