### PR TITLE
Fix Issue 1348: Missing results when querying interface relationships

### DIFF
--- a/packages/graphql/src/translate/create-interface-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-interface-projection-and-params.ts
@@ -57,7 +57,7 @@ function createInterfaceProjectionAndParams({
     );
 
     let whereArgs: { _on?: any; [str: string]: any } = {};
-    console.log("here");
+
     const subqueries = referenceNodes.map((refNode) => {
         const param = `${nodeVariable}_${refNode.name}`;
         const subquery = [
@@ -210,11 +210,17 @@ function createInterfaceProjectionAndParams({
 
         return subquery.join("\n");
     });
+    // console.log("subqueries", subqueries);
     const interfaceProjection = [`WITH ${fullWithVars.join(", ")}`, "CALL {", subqueries.join("\nUNION\n"), "}"];
+    console.log("interfaceProjection PRE", interfaceProjection);
 
     if (field.typeMeta.array) {
-        interfaceProjection.push(`WITH ${fullWithVars.join(", ")}, collect(${field.fieldName}) AS ${field.fieldName}`);
+        // interfaceProjection.push(`WITH ${fullWithVars.join(", ")}, collect(${field.fieldName}) AS ${field.fieldName}`);
+        interfaceProjection.push(`RETURN collect(${field.fieldName}) AS ${field.fieldName}`);
+        interfaceProjection.unshift("CALL {");
+        interfaceProjection.push("}");
     }
+    console.log("interfaceProjection AFTER", interfaceProjection);
 
     if (Object.keys(whereArgs).length) {
         params.args = { where: whereArgs };

--- a/packages/graphql/src/translate/create-interface-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-interface-projection-and-params.ts
@@ -57,7 +57,7 @@ function createInterfaceProjectionAndParams({
     );
 
     let whereArgs: { _on?: any; [str: string]: any } = {};
-
+    console.log("here");
     const subqueries = referenceNodes.map((refNode) => {
         const param = `${nodeVariable}_${refNode.name}`;
         const subquery = [

--- a/packages/graphql/src/translate/create-interface-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-interface-projection-and-params.ts
@@ -210,17 +210,17 @@ function createInterfaceProjectionAndParams({
 
         return subquery.join("\n");
     });
-    // console.log("subqueries", subqueries);
-    const interfaceProjection = [`WITH ${fullWithVars.join(", ")}`, "CALL {", subqueries.join("\nUNION\n"), "}"];
-    console.log("interfaceProjection PRE", interfaceProjection);
+    let interfaceProjection = [`WITH ${fullWithVars.join(", ")}`, "CALL {", subqueries.join("\nUNION\n"), "}"];
 
     if (field.typeMeta.array) {
-        // interfaceProjection.push(`WITH ${fullWithVars.join(", ")}, collect(${field.fieldName}) AS ${field.fieldName}`);
-        interfaceProjection.push(`RETURN collect(${field.fieldName}) AS ${field.fieldName}`);
-        interfaceProjection.unshift("CALL {");
-        interfaceProjection.push("}");
+        interfaceProjection = [
+            `WITH ${fullWithVars.join(", ")}`,
+            "CALL {",
+            ...interfaceProjection,
+            `RETURN collect(${field.fieldName}) AS ${field.fieldName}`,
+            "}",
+        ];
     }
-    console.log("interfaceProjection AFTER", interfaceProjection);
 
     if (Object.keys(whereArgs).length) {
         params.args = { where: whereArgs };

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
         await driver.close();
     });
 
-    test("should also return empty relationship in result set", async () => {
+    test("should also return node with no relationship in result set", async () => {
         const createProgrammeItems = `
             mutation {
                 ${testProgrammeItem.operations.create}(input: [

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql, GraphQLSchema } from "graphql";
+import { Driver, Session } from "neo4j-driver";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { generateUniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/1348", () => {
+    const testSeries = generateUniqueType("Series");
+    const testSeason = generateUniqueType("Season");
+    const testProgrammeItem = generateUniqueType("ProgrameItem");
+
+    let schema: GraphQLSchema;
+    let driver: Driver;
+    let session: Session;
+
+    async function graphqlQuery(query: string) {
+        return graphql({
+            schema,
+            source: query,
+            contextValue: {
+                driver,
+            },
+        });
+    }
+
+    beforeAll(async () => {
+        driver = await neo4j();
+
+        const typeDefs = `
+            interface Product {
+                productTitle: String!
+                releatsTo: [Product!]!
+            }
+            
+            type ${testSeries} implements Product {
+                productTitle: String!
+                releatsTo: [Product!]!  @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
+            
+                seasons: [${testSeason}!]!
+            }
+            
+            type ${testSeason} implements Product {
+                productTitle: String!
+                releatsTo: [Product!]!  @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
+            
+                seasonNumber: Int
+                episodes: [${testProgrammeItem}!]!
+            }
+            
+            type ${testProgrammeItem} implements Product {
+                productTitle: String!
+                releatsTo: [Product!]!  @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
+            
+                episodeNumber: Int
+            }
+        `;
+        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver });
+        schema = await neoGraphql.getSchema();
+    });
+
+    beforeEach(() => {
+        session = driver.session();
+    });
+
+    afterEach(async () => {
+        await session.run(`MATCH (s:${testSeries}) DETACH DELETE s`);
+        await session.run(`MATCH (s:${testSeason}) DETACH DELETE s`);
+        await session.run(`MATCH (p:${testProgrammeItem}) DETACH DELETE p`);
+
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should also return empty relationship in result set", async () => {
+        const createProgrammeItems = `
+            mutation {
+                ${testProgrammeItem.operations.create}(input: [
+                    {
+                        productTitle: "TestEpisode1",
+                        episodeNumber: 1
+                    },
+                    {
+                        productTitle: "TestEpisode2",
+                        episodeNumber: 2
+                    },
+                    {
+                        productTitle: "TestFilm1"
+                    }
+                ]) {
+                    ${testProgrammeItem.plural} {
+                        productTitle
+                        episodeNumber
+                    }
+                }
+            }
+        `;
+        const updateProgrammeItems = `
+            mutation {
+                ${testProgrammeItem.operations.update}(
+                    where: { productTitle: "TestFilm1" }
+                    connect: { releatsTo: { where: { node: { productTitle: "TestEpisode1" } } } }
+                ) {
+                    ${testProgrammeItem.plural} {
+                        productTitle
+                        episodeNumber
+                        releatsTo {
+                            __typename
+                            productTitle
+                        }
+                    }
+                }
+            }
+        `;
+        const createProgrammeItemsResults = await graphqlQuery(createProgrammeItems);
+        expect(createProgrammeItemsResults.errors).toBeUndefined();
+
+        const updateProgrammeItemsResults = await graphqlQuery(updateProgrammeItems);
+        expect(updateProgrammeItemsResults.errors).toBeUndefined();
+
+        const query = `
+            query {
+                ${testProgrammeItem.plural} {
+                    productTitle
+                    episodeNumber
+                    releatsTo {
+                        __typename
+                        productTitle
+                    }
+                }
+            }
+        `;
+        const queryResults = await graphqlQuery(query);
+        expect(queryResults.errors).toBeUndefined();
+        expect(queryResults.data as any).toEqual({
+            [testProgrammeItem.plural]: [
+                {
+                    productTitle: "TestEpisode2",
+                    episodeNumber: 2,
+                    releatsTo: [],
+                },
+                {
+                    productTitle: "TestEpisode1",
+                    episodeNumber: 1,
+                    releatsTo: [
+                        {
+                            __typename: testProgrammeItem.name,
+                            productTitle: "TestFilm1",
+                        },
+                    ],
+                },
+                {
+                    productTitle: "TestFilm1",
+                    episodeNumber: null,
+                    releatsTo: [
+                        {
+                            __typename: testProgrammeItem.name,
+                            productTitle: "TestEpisode1",
+                        },
+                    ],
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -26,7 +26,7 @@ import { generateUniqueType } from "../../utils/graphql-types";
 describe("https://github.com/neo4j/graphql/issues/1348", () => {
     const testSeries = generateUniqueType("Series");
     const testSeason = generateUniqueType("Season");
-    const testProgrammeItem = generateUniqueType("ProgrameItem");
+    const testProgrammeItem = generateUniqueType("ProgrammeItem");
 
     let schema: GraphQLSchema;
     let driver: Driver;

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -100,6 +100,8 @@ describe("@auth allow on specific interface implementation", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             RETURN { __resolveType: \\"Comment\\", id: this_Comment.id, content: this_Comment.content } AS content
             UNION
@@ -108,7 +110,8 @@ describe("@auth allow on specific interface implementation", () => {
             CALL apoc.util.validate(NOT(EXISTS((this_Post)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Post)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Post\\", id: this_Post.id, content: this_Post.content } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN this { .id, content: content } as this"
         `);
 
@@ -146,6 +149,8 @@ describe("@auth allow on specific interface implementation", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             WHERE this_Comment.id = $this_content.args.where.id
             RETURN { __resolveType: \\"Comment\\" } AS content
@@ -156,7 +161,8 @@ describe("@auth allow on specific interface implementation", () => {
             WHERE this_Post.id = $this_content.args.where.id
             RETURN { __resolveType: \\"Post\\", comments: [ (this_Post)-[:HAS_COMMENT]->(this_Post_comments:Comment)  WHERE this_Post_comments.id = $this_Post_comments_id | this_Post_comments { .content } ] } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN this { .id, content: content } as this"
         `);
 
@@ -246,6 +252,8 @@ describe("@auth allow on specific interface implementation", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             RETURN { __resolveType: \\"Comment\\", id: this_Comment.id } AS content
             UNION
@@ -254,7 +262,8 @@ describe("@auth allow on specific interface implementation", () => {
             CALL apoc.util.validate(NOT(EXISTS((this_Post)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Post)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Post\\", id: this_Post.id } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN collect(DISTINCT this { .id, content: content }) AS data"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -108,6 +108,8 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             CALL apoc.util.validate(NOT(EXISTS((this_Comment)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Comment)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Comment_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Comment\\", id: this_Comment.id, content: this_Comment.content } AS content
@@ -117,7 +119,8 @@ describe("@auth allow with interface relationships", () => {
             CALL apoc.util.validate(NOT(EXISTS((this_Post)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Post)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Post\\", id: this_Post.id, content: this_Post.content } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN this { .id, content: content } as this"
         `);
 
@@ -158,6 +161,8 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             CALL apoc.util.validate(NOT(EXISTS((this_Comment)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Comment)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Comment_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WHERE this_Comment.id = $this_content.args.where.id
@@ -169,7 +174,8 @@ describe("@auth allow with interface relationships", () => {
             WHERE this_Post.id = $this_content.args.where.id
             RETURN { __resolveType: \\"Post\\", comments: [ (this_Post)-[:HAS_COMMENT]->(this_Post_comments:Comment)  WHERE this_Post_comments.id = $this_Post_comments_id AND apoc.util.validatePredicate(NOT(EXISTS((this_Post_comments)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Post_comments)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_comments_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_Post_comments { .content } ] } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN this { .id, content: content } as this"
         `);
 
@@ -266,6 +272,8 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             CALL apoc.util.validate(NOT(EXISTS((this_Comment)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Comment)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Comment_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Comment\\", id: this_Comment.id } AS content
@@ -275,7 +283,8 @@ describe("@auth allow with interface relationships", () => {
             CALL apoc.util.validate(NOT(EXISTS((this_Post)<-[:HAS_CONTENT]-(:User)) AND ANY(creator IN [(this_Post)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Post\\", id: this_Post.id } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN collect(DISTINCT this { .id, content: content }) AS data"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -166,6 +166,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             RETURN { __resolveType: \\"Comment\\" } AS content
             UNION
@@ -174,7 +176,8 @@ describe("Cypher Auth Where", () => {
             WHERE EXISTS((this_Post)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_Post)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_where0_creator_id)
             RETURN { __resolveType: \\"Post\\", id: this_Post.id } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN this { .id, content: content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -166,6 +166,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:HAS_CONTENT]->(this_Comment:Comment)
             WHERE EXISTS((this_Comment)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_Comment)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Comment_auth_where0_creator_id)
             RETURN { __resolveType: \\"Comment\\" } AS content
@@ -175,7 +177,8 @@ describe("Cypher Auth Where", () => {
             WHERE EXISTS((this_Post)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_Post)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_Post_auth_where0_creator_id)
             RETURN { __resolveType: \\"Post\\", id: this_Post.id } AS content
             }
-            WITH this, collect(content) AS content
+            RETURN collect(content) AS content
+            }
             RETURN this { .id, content: content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/projection-interface-relationships.test.ts
@@ -95,6 +95,8 @@ describe("Auth projections for interface relationship fields", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", runtime: this_Movie.runtime, title: this_Movie.title } AS actedIn
             UNION
@@ -103,7 +105,8 @@ describe("Auth projections for interface relationship fields", () => {
             CALL apoc.util.validate(NOT(this_Series.episodes IS NOT NULL AND this_Series.episodes = $this_Series_auth_allow0_episodes), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { __resolveType: \\"Series\\", episodes: this_Series.episodes, title: this_Series.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { actedIn: actedIn } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/create/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/create/connect.test.ts
@@ -126,6 +126,8 @@ describe("Interface Relationships - Create connect", () => {
             WITH this0
             CALL {
             WITH this0
+            CALL {
+            WITH this0
             MATCH (this0)-[:ACTED_IN]->(this0_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", runtime: this0_Movie.runtime, title: this0_Movie.title } AS actedIn
             UNION
@@ -133,7 +135,8 @@ describe("Interface Relationships - Create connect", () => {
             MATCH (this0)-[:ACTED_IN]->(this0_Series:Series)
             RETURN { __resolveType: \\"Series\\", episodes: this0_Series.episodes, title: this0_Series.title } AS actedIn
             }
-            WITH this0, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN [
             this0 { .name, actedIn: actedIn }] AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/create/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/create/create.test.ts
@@ -111,6 +111,8 @@ describe("Interface Relationships - Create create", () => {
             WITH this0
             CALL {
             WITH this0
+            CALL {
+            WITH this0
             MATCH (this0)-[:ACTED_IN]->(this0_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", runtime: this0_Movie.runtime, title: this0_Movie.title } AS actedIn
             UNION
@@ -118,7 +120,8 @@ describe("Interface Relationships - Create create", () => {
             MATCH (this0)-[:ACTED_IN]->(this0_Series:Series)
             RETURN { __resolveType: \\"Series\\", episodes: this0_Series.episodes, title: this0_Series.title } AS actedIn
             }
-            WITH this0, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN [
             this0 { .name, actedIn: actedIn }] AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/read.test.ts
@@ -87,6 +87,8 @@ describe("Interface Relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", runtime: this_Movie.runtime, title: this_Movie.title } AS actedIn
             UNION
@@ -94,7 +96,8 @@ describe("Interface Relationships", () => {
             MATCH (this)-[:ACTED_IN]->(this_Series:Series)
             RETURN { __resolveType: \\"Series\\", episodes: this_Series.episodes, title: this_Series.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { actedIn: actedIn } as this"
         `);
 
@@ -168,6 +171,8 @@ describe("Interface Relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", runtime: this_Movie.runtime, title: this_Movie.title } AS actedIn
             UNION
@@ -175,7 +180,8 @@ describe("Interface Relationships", () => {
             MATCH (this)-[:ACTED_IN]->(this_Series:Series)
             RETURN { __resolveType: \\"Series\\", episodes: this_Series.episodes, title: this_Series.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { actedIn: apoc.coll.sortMulti(actedIn, ['title'])[5..15] } as this"
         `);
 
@@ -206,11 +212,14 @@ describe("Interface Relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             WHERE this_Movie.title STARTS WITH $this_actedIn.args.where._on.Movie.title_STARTS_WITH
             RETURN { __resolveType: \\"Movie\\", runtime: this_Movie.runtime, title: this_Movie.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { actedIn: actedIn } as this"
         `);
 
@@ -258,6 +267,8 @@ describe("Interface Relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             WHERE this_Movie.title STARTS WITH $this_actedIn.args.where._on.Movie.title_STARTS_WITH
             RETURN { __resolveType: \\"Movie\\", runtime: this_Movie.runtime, title: this_Movie.title } AS actedIn
@@ -267,7 +278,8 @@ describe("Interface Relationships", () => {
             WHERE this_Series.title STARTS WITH $this_actedIn.args.where.title_STARTS_WITH
             RETURN { __resolveType: \\"Series\\", episodes: this_Series.episodes, title: this_Series.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { actedIn: actedIn } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/create.test.ts
@@ -98,6 +98,8 @@ describe("Interface Relationships - Update create", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", runtime: this_Movie.runtime, title: this_Movie.title } AS actedIn
             UNION
@@ -105,7 +107,8 @@ describe("Interface Relationships - Update create", () => {
             MATCH (this)-[:ACTED_IN]->(this_Series:Series)
             RETURN { __resolveType: \\"Series\\", episodes: this_Series.episodes, title: this_Series.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN collect(DISTINCT this { .name, actedIn: actedIn }) AS data"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1348.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/1348", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Product {
+                productTitle: String!
+                releatsTo: [Product!]!
+            }
+
+            type Series implements Product {
+                productTitle: String!
+                releatsTo: [Product!]!
+                    @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
+
+                seasons: [Season!]!
+            }
+
+            type Season implements Product {
+                productTitle: String!
+                releatsTo: [Product!]!
+                    @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
+
+                seasonNumber: Int
+                episodes: [ProgrammeItem!]!
+            }
+
+            type ProgrammeItem implements Product {
+                productTitle: String!
+                releatsTo: [Product!]!
+                    @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
+
+                episodeNumber: Int
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("XXXXXX", async () => {
+        const query = gql`
+            query {
+                programmeItems {
+                    productTitle
+                    episodeNumber
+                    releatsTo {
+                        __typename
+                        productTitle
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:ProgrammeItem)
+            WITH this
+            CALL {
+            WITH this
+            MATCH (this)-[:RELATES_TO]-(this_Series:Series)
+            RETURN { __resolveType: \\"Series\\", productTitle: this_Series.productTitle } AS releatsTo
+            UNION
+            WITH this
+            MATCH (this)-[:RELATES_TO]-(this_Season:Season)
+            RETURN { __resolveType: \\"Season\\", productTitle: this_Season.productTitle } AS releatsTo
+            UNION
+            WITH this
+            MATCH (this)-[:RELATES_TO]-(this_ProgrammeItem:ProgrammeItem)
+            RETURN { __resolveType: \\"ProgrammeItem\\", productTitle: this_ProgrammeItem.productTitle } AS releatsTo
+            }
+            WITH this, collect(releatsTo) AS releatsTo
+            RETURN this { .productTitle, .episodeNumber, releatsTo: releatsTo } as this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("XXXXXX as Relay connection", async () => {
+        const query = gql`
+            query {
+                programmeItems {
+                    productTitle
+                    episodeNumber
+                    releatsToConnection {
+                        edges {
+                            node {
+                                ... on ProgrammeItem {
+                                    productTitle
+                                }
+                                ... on Season {
+                                    productTitle
+                                }
+                                ... on Series {
+                                    productTitle
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:ProgrammeItem)
+            CALL {
+            WITH this
+            CALL {
+            WITH this
+            MATCH (this)-[this_relates_to_relationship:RELATES_TO]-(this_Series:Series)
+            WITH { node: { __resolveType: \\"Series\\", productTitle: this_Series.productTitle } } AS edge
+            RETURN edge
+            UNION
+            WITH this
+            MATCH (this)-[this_relates_to_relationship:RELATES_TO]-(this_Season:Season)
+            WITH { node: { __resolveType: \\"Season\\", productTitle: this_Season.productTitle } } AS edge
+            RETURN edge
+            UNION
+            WITH this
+            MATCH (this)-[this_relates_to_relationship:RELATES_TO]-(this_ProgrammeItem:ProgrammeItem)
+            WITH { node: { __resolveType: \\"ProgrammeItem\\", productTitle: this_ProgrammeItem.productTitle } } AS edge
+            RETURN edge
+            }
+            WITH collect(edge) as edges
+            RETURN { edges: edges, totalCount: size(edges) } AS releatsToConnection
+            }
+            RETURN this { .productTitle, .episodeNumber, releatsToConnection } as this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1348.test.ts
@@ -64,7 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
         });
     });
 
-    test("XXXXXX", async () => {
+    test("should also return node with no relationship in result set", async () => {
         const query = gql`
             query {
                 programmeItems {
@@ -85,6 +85,8 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:RELATES_TO]-(this_Series:Series)
             RETURN { __resolveType: \\"Series\\", productTitle: this_Series.productTitle } AS releatsTo
             UNION
@@ -96,14 +98,15 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
             MATCH (this)-[:RELATES_TO]-(this_ProgrammeItem:ProgrammeItem)
             RETURN { __resolveType: \\"ProgrammeItem\\", productTitle: this_ProgrammeItem.productTitle } AS releatsTo
             }
-            WITH this, collect(releatsTo) AS releatsTo
+            RETURN collect(releatsTo) AS releatsTo
+            }
             RETURN this { .productTitle, .episodeNumber, releatsTo: releatsTo } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
     });
 
-    test("XXXXXX as Relay connection", async () => {
+    test("should return node with no relationship (edge) in result set, as Relay connection", async () => {
         const query = gql`
             query {
                 programmeItems {

--- a/packages/graphql/tests/tck/tck-test-files/issues/583.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/583.test.ts
@@ -90,6 +90,8 @@ describe("#583", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]->(this_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", title: this_Movie.title, awardsGiven: this_Movie.awardsGiven } AS actedIn
             UNION
@@ -101,7 +103,8 @@ describe("#583", () => {
             MATCH (this)-[:ACTED_IN]->(this_ShortFilm:ShortFilm)
             RETURN { __resolveType: \\"ShortFilm\\", title: this_ShortFilm.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { .name, actedIn: actedIn } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/issues/847.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/847.test.ts
@@ -72,6 +72,8 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)<-[:ACTED_IN]-(this_Person:Person)
             RETURN { __resolveType: \\"Person\\", id: this_Person.id } AS subjects
             UNION
@@ -79,7 +81,10 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
             MATCH (this)<-[:ACTED_IN]-(this_Place:Place)
             RETURN { __resolveType: \\"Place\\", id: this_Place.id } AS subjects
             }
-            WITH this, collect(subjects) AS subjects
+            RETURN collect(subjects) AS subjects
+            }
+            WITH subjects, this
+            CALL {
             WITH subjects, this
             CALL {
             WITH subjects, this
@@ -90,7 +95,8 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
             MATCH (this)-[:ACTED_IN]->(this_Place:Place)
             RETURN { __resolveType: \\"Place\\", id: this_Place.id } AS objects
             }
-            WITH subjects, this, collect(objects) AS objects
+            RETURN collect(objects) AS objects
+            }
             RETURN this { .id, subjects: subjects, objects: objects } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/undirected-relationships/undirected-relationships.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/undirected-relationships/undirected-relationships.test.ts
@@ -184,6 +184,8 @@ describe("Undirected relationships", () => {
             WITH this
             CALL {
             WITH this
+            CALL {
+            WITH this
             MATCH (this)-[:ACTED_IN]-(this_Movie:Movie)
             RETURN { __resolveType: \\"Movie\\", title: this_Movie.title } AS actedIn
             UNION
@@ -191,7 +193,8 @@ describe("Undirected relationships", () => {
             MATCH (this)-[:ACTED_IN]-(this_Series:Series)
             RETURN { __resolveType: \\"Series\\", title: this_Series.title } AS actedIn
             }
-            WITH this, collect(actedIn) AS actedIn
+            RETURN collect(actedIn) AS actedIn
+            }
             RETURN this { actedIn: actedIn } as this"
         `);
 


### PR DESCRIPTION
# Description

Wrap the subqueries call (The UNIONs) in an additional CALL to prevent altering the original input (the `this` variable).

# Issue

#1348

Closes:

- #1348

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] New files have copyright header
