### PR TITLE
Fix 1115: Cypher error in multiple child connectOrCreate and auth

### DIFF
--- a/packages/graphql/src/translate/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-or-create-and-params.ts
@@ -66,11 +66,12 @@ export function createConnectOrCreateAndParams({
     });
 
     const query = statements.reduce((result, statement) => {
-        result.concat(statement);
+        const wrappedQuery = new CypherBuilder.Call(statement, withVars);
+        result.concat(wrappedQuery);
         return result;
     }, new CypherBuilder.Query());
-
-    return new CypherBuilder.Call(query, withVars).build(`${varName}_`);
+    return query.build(`${varName}_`);
+    // return new CypherBuilder.Call(query, withVars).build(`${varName}_`);
 }
 
 function createConnectOrCreatePartialStatement({

--- a/packages/graphql/src/translate/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-or-create-and-params.ts
@@ -70,8 +70,8 @@ export function createConnectOrCreateAndParams({
         result.concat(wrappedQuery);
         return result;
     }, new CypherBuilder.Query());
+
     return query.build(`${varName}_`);
-    // return new CypherBuilder.Call(query, withVars).build(`${varName}_`);
 }
 
 function createConnectOrCreatePartialStatement({

--- a/packages/graphql/tests/integration/issues/1115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1115.int.test.ts
@@ -69,7 +69,8 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
     });
 
     test("should not throw on multiple connectOrCreate with auth", async () => {
-        runCypher(driver, `CREATE (:${parentType})<-[:HAS]-(:${childType} {tcId: "123"})`);
+        await runCypher(driver, `CREATE (:${parentType})<-[:HAS]-(:${childType} {tcId: "123"})`);
+
         const req = createJwtRequest("secret", { roles: ["upstream"] });
         const query = `
         mutation {

--- a/packages/graphql/tests/integration/issues/1115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1115.int.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql, GraphQLSchema } from "graphql";
+import { Driver } from "neo4j-driver";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { generateUniqueType } from "../../utils/graphql-types";
+import { runCypher } from "../../utils/run-cypher";
+import { createJwtRequest } from "../../utils/create-jwt-request";
+
+describe("https://github.com/neo4j/graphql/issues/1115", () => {
+    const parentType = generateUniqueType("Parent");
+    const childType = generateUniqueType("Child");
+
+    let schema: GraphQLSchema;
+    let driver: Driver;
+
+    beforeAll(async () => {
+        driver = await neo4j();
+
+        const typeDefs = `
+            type ${parentType} {
+                children: [${childType}!]! @relationship(type: "HAS", direction: IN)
+            }
+            type ${childType} {
+                tcId: String @unique
+            }
+
+            extend type ${childType}
+                @auth(
+                    rules: [
+                        { operations: [READ, CREATE, UPDATE, DELETE, CONNECT, DISCONNECT], roles: ["upstream"] }
+                        { operations: [READ], roles: ["downstream"] }
+                    ]
+                )
+        `;
+        const neoGraphql = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret: "secret",
+                }),
+            },
+        });
+        schema = await neoGraphql.getSchema();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should not throw on multiple connectOrCreate with auth", async () => {
+        runCypher(driver, `CREATE (:${parentType})<-[:HAS]-(:${childType} {tcId: "123"})`);
+        const req = createJwtRequest("secret", { roles: ["upstream"] });
+        const query = `
+        mutation {
+          ${parentType.operations.update}(
+            connectOrCreate: {
+              children: [
+                {
+                  where: { node: { tcId: "123" } }
+                  onCreate: { node: { tcId: "123" } }
+                }
+                {
+                  where: { node: { tcId: "456" } }
+                  onCreate: { node: { tcId: "456" } }
+                }
+              ]
+            }
+          ) {
+            info {
+              nodesCreated
+            }
+          }
+        }
+        `;
+
+        const res = await graphql({
+            schema,
+            source: query,
+            contextValue: {
+                driver,
+                req,
+            },
+        });
+
+        expect(res.errors).toBeUndefined();
+        expect(res.data).toEqual({
+            [parentType.operations.update]: { info: { nodesCreated: 1 } },
+        });
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/issues/1115.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1115.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/1115", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Parent {
+                children: [Child!]! @relationship(type: "HAS", direction: IN)
+            }
+            type Child {
+                tcId: String @unique
+            }
+
+            extend type Child
+                @auth(
+                    rules: [
+                        { operations: [READ, CREATE, UPDATE, DELETE, CONNECT, DISCONNECT], roles: ["upstream"] }
+                        { operations: [READ], roles: ["downstream"] }
+                    ]
+                )
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            config: { enableRegex: true },
+        });
+    });
+
+    test("multiple connectOrCreate operations with auth", async () => {
+        const query = gql`
+            mutation UpdateParents {
+                updateParents(
+                    connectOrCreate: {
+                        children: [
+                            { where: { node: { tcId: "123" } }, onCreate: { node: { tcId: "123" } } }
+                            { where: { node: { tcId: "456" } }, onCreate: { node: { tcId: "456" } } }
+                        ]
+                    }
+                ) {
+                    info {
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", {});
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Parent)
+            	WITH this
+            CALL {
+            	WITH this
+            	CALL apoc.util.validate(NOT(ANY(r IN [\\"upstream\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this_connectOrCreate_children_this1:\`Child\` { tcId: $this_connectOrCreate_children_param0 })
+            ON CREATE SET
+                    this_connectOrCreate_children_this1.tcId = $this_connectOrCreate_children_param1
+            MERGE (this_connectOrCreate_children_this1)-[this_connectOrCreate_children_this0:\`HAS\`]->(this)
+            	RETURN COUNT(*)
+            }
+            	WITH this
+            CALL {
+            	WITH this
+            	CALL apoc.util.validate(NOT(ANY(r IN [\\"upstream\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this_connectOrCreate_children_this3:\`Child\` { tcId: $this_connectOrCreate_children_param2 })
+            ON CREATE SET
+                    this_connectOrCreate_children_this3.tcId = $this_connectOrCreate_children_param3
+            MERGE (this_connectOrCreate_children_this3)-[this_connectOrCreate_children_this2:\`HAS\`]->(this)
+            	RETURN COUNT(*)
+            }
+            RETURN 'Query cannot conclude with CALL'"
+        `);
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this_connectOrCreate_children_param0\\": \\"123\\",
+                \\"this_connectOrCreate_children_param1\\": \\"123\\",
+                \\"this_connectOrCreate_children_param2\\": \\"456\\",
+                \\"this_connectOrCreate_children_param3\\": \\"456\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": false,
+                    \\"roles\\": []
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/utils/run-cypher.ts
+++ b/packages/graphql/tests/utils/run-cypher.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Driver, Result } from "neo4j-driver";
+
+/** Runs cypher safetly, cleaning session afterwars */
+export async function runCypher(driver: Driver, cypher: string): Promise<Result> {
+    const session = driver.session();
+    try {
+        const result = await session.run(cypher);
+        await session.close();
+        return result;
+    } catch (err: unknown) {
+        await session.close();
+        throw err;
+    }
+}


### PR DESCRIPTION
# Description
Issue #1115 

Solved by wrapping each nested connectOrCreate statement in a `CALL` block.

Additionally, test utility `runCypher` to make easier run custom cypher in tests