### PR TITLE
Add the ability to utilise context values in callbacks

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/autogeneration.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/autogeneration.adoc
@@ -143,7 +143,7 @@ directive @callback(
 
 === Usage
 
-Type Definitions: 
+Type Definitions:
 
 [source, graphql, indent=0]
 ----
@@ -153,7 +153,7 @@ type Product {
 }
 ----
 
-Schema Construction: 
+Schema Construction:
 
 > Note that the callback is asynchronous!
 
@@ -169,6 +169,39 @@ new Neo4jGraphQL({
     config: {
         callbacks: {
             slug: slugCallback
+        }
+    }
+})
+----
+
+==== Using GraphQL context values
+
+The GraphQL context for the request is available as the third argument in a callback. This maps to the argument pattern for GraphQL resolvers.
+
+For example, if you wanted a field `modifiedBy`:
+
+[source, graphql, indent=0]
+----
+type Record {
+    content: String!
+    modifiedBy: @callback(operations: [CREATE, UPDATE], name: "modifiedBy")
+}
+----
+
+If the username is located in `context.username`, you could define a callback such as:
+
+[source, javascript, indent=0]
+----
+const modifiedByCallback = async (_parent, _args, context) => {
+    return context.username;
+}
+
+new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    config: {
+        callbacks: {
+            modifiedBy: modifiedByCallback
         }
     }
 })

--- a/packages/graphql/src/classes/CallbackBucket.ts
+++ b/packages/graphql/src/classes/CallbackBucket.ts
@@ -47,9 +47,11 @@ export class CallbackBucket {
         await Promise.all(
             this.callbacks.map(async (cb) => {
                 const callbackFunction = (this.context?.callbacks as Neo4jGraphQLCallbacks)[cb.functionName] as (
-                    args?: Record<string, unknown>
+                    parent?: Record<string, unknown>,
+                    _args?: Record<string, unknown>,
+                    context?: Record<string, unknown>
                 ) => Promise<any>;
-                const param = await callbackFunction(cb.parent);
+                const param = await callbackFunction(cb.parent, {}, this.context);
 
                 if (param === undefined) {
                     cypher = cypher

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -380,7 +380,9 @@ export interface JwtPayload {
 export type CallbackReturnValue = string | number | boolean | undefined | null;
 
 export type Neo4jGraphQLCallback = (
-    parent: Record<string, unknown>
+    parent: Record<string, unknown>,
+    args: Record<string, never>,
+    context: Record<string, unknown>
 ) => CallbackReturnValue | Promise<CallbackReturnValue>;
 
 export type Neo4jGraphQLCallbacks = Record<string, Neo4jGraphQLCallback>;


### PR DESCRIPTION
# Description

Allows you to use the GraphQL context in callbacks, for example:

```gql
const modifiedByCallback = async (_parent, _args, context) => {
    return context.username;
}

new Neo4jGraphQL({
    typeDefs,
    driver,
    config: {
        callbacks: {
            modifiedBy: modifiedByCallback
        }
    }
})
```

# Issue

Closes #1358 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
