### PR TITLE
Get Renovate to update example dependencies (hopefully)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
     "baseBranches": ["dev"],
     "rebaseWhen": "auto",
     "automerge": true,
+    "ignorePaths": [
+        "**/node_modules/**",
+        "**/bower_components/**",
+        "**/vendor/**",
+        "**/__tests__/**",
+        "**/test/**",
+        "**/tests/**",
+        "**/__fixtures__/**"
+    ],
     "packageRules": [
         {
             "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
# Description

This was really starting to bug me, so I did some digging... Turns out by extending `config:js-lib`, you are extending `config:base`, which in turn extends `:ignoreModulesAndTests`... [Which ignores `**/examples/**`](https://docs.renovatebot.com/presets-default/#ignoremodulesandtests)! I've now overridden this not to ignore that pattern, so hopefully when this is merged we should start seeing our examples auto-updated.