### PR TITLE
Remove pointless casting in getDocument

### DIFF
--- a/packages/graphql/src/schema/get-document.ts
+++ b/packages/graphql/src/schema/get-document.ts
@@ -22,5 +22,5 @@ import { TypeSource } from "@graphql-tools/utils";
 import { DocumentNode } from "graphql";
 
 export function getDocument(typeDefs: TypeSource): DocumentNode {
-    return mergeTypeDefs(Array.isArray(typeDefs) ? (typeDefs as string[]) : [typeDefs as string]);
+    return mergeTypeDefs(typeDefs);
 }


### PR DESCRIPTION
# Description

It was reported on Discord that merging of type definitions was failing in certain scenarios, and I wonder if our excessive casting to strings is responsible...