### PR TITLE
Adds timestamp to subscriptions response

### DIFF
--- a/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
+++ b/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
@@ -24,6 +24,7 @@ import { generateSubscriptionWhereType } from "./generate-subscription-where-typ
 import { generateEventPayloadType } from "./generate-event-payload-type";
 import { generateSubscribeMethod, subscriptionResolve } from "../resolvers/subscriptions/subscribe";
 import { SubscriptionsEvent } from "../../types";
+import { GraphQLFloat, GraphQLInt, GraphQLNonNull } from "graphql";
 
 export function generateSubscriptionTypes({
     schemaComposer,
@@ -50,6 +51,10 @@ export function generateSubscriptionTypes({
                     type: eventTypeEnum.NonNull,
                     resolve: () => EventType.getValue("CREATE")?.value,
                 },
+                timestamp: {
+                    type: new GraphQLNonNull(GraphQLFloat),
+                    resolve: (source: SubscriptionsEvent) => source.timestamp,
+                },
             },
         });
 
@@ -60,6 +65,10 @@ export function generateSubscriptionTypes({
                     type: eventTypeEnum.NonNull,
                     resolve: () => EventType.getValue("UPDATE")?.value,
                 },
+                timestamp: {
+                    type: new GraphQLNonNull(GraphQLFloat),
+                    resolve: (source: SubscriptionsEvent) => source.timestamp,
+                },
             },
         });
 
@@ -69,6 +78,10 @@ export function generateSubscriptionTypes({
                 event: {
                     type: eventTypeEnum.NonNull,
                     resolve: () => EventType.getValue("DELETE")?.value,
+                },
+                timestamp: {
+                    type: new GraphQLNonNull(GraphQLFloat),
+                    resolve: (source: SubscriptionsEvent) => source.timestamp,
                 },
             },
         });

--- a/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
+++ b/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import { GraphQLFloat, GraphQLNonNull } from "graphql";
 import { SchemaComposer } from "graphql-compose";
 import { Node } from "../../classes";
 import { EventType } from "../../graphql/enums/EventType";
@@ -24,7 +25,6 @@ import { generateSubscriptionWhereType } from "./generate-subscription-where-typ
 import { generateEventPayloadType } from "./generate-event-payload-type";
 import { generateSubscribeMethod, subscriptionResolve } from "../resolvers/subscriptions/subscribe";
 import { SubscriptionsEvent } from "../../types";
-import { GraphQLFloat, GraphQLInt, GraphQLNonNull } from "graphql";
 
 export function generateSubscriptionTypes({
     schemaComposer,

--- a/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
@@ -72,6 +72,7 @@ describe("Create Subscription", () => {
                                         title
                                     }
                                     event
+                                    timestamp
                                 }
                             }
                             `);
@@ -84,12 +85,14 @@ describe("Create Subscription", () => {
                 [typeMovie.operations.subscribe.created]: {
                     [typeMovie.operations.subscribe.payload.created]: { title: "movie1" },
                     event: "CREATE",
+                    timestamp: expect.any(Number),
                 },
             },
             {
                 [typeMovie.operations.subscribe.created]: {
                     [typeMovie.fieldNames.subscriptions.created]: { title: "movie2" },
                     event: "CREATE",
+                    timestamp: expect.any(Number),
                 },
             },
         ]);

--- a/packages/graphql/tests/e2e/subscriptions/delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete.e2e.test.ts
@@ -72,6 +72,7 @@ describe("Delete Subscription", () => {
                         title
                     }
                     event
+                    timestamp
                 }
             }
         `);
@@ -87,12 +88,14 @@ describe("Delete Subscription", () => {
                 [typeMovie.operations.subscribe.deleted]: {
                     [typeMovie.fieldNames.subscriptions.deleted]: { title: "movie1" },
                     event: "DELETE",
+                    timestamp: expect.any(Number),
                 },
             },
             {
                 [typeMovie.operations.subscribe.deleted]: {
                     [typeMovie.fieldNames.subscriptions.deleted]: { title: "movie2" },
                     event: "DELETE",
+                    timestamp: expect.any(Number),
                 },
             },
         ]);

--- a/packages/graphql/tests/e2e/subscriptions/update.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/update.e2e.test.ts
@@ -84,6 +84,7 @@ describe("Update Subscriptions", () => {
                         title
                     }
                     event
+                    timestamp
                 }
             }
         `);
@@ -100,6 +101,7 @@ describe("Update Subscriptions", () => {
                     [typeMovie.fieldNames.subscriptions.updated]: { title: "movie3" },
                     previousState: { title: "movie1" },
                     event: "UPDATE",
+                    timestamp: expect.any(Number),
                 },
             },
             {
@@ -107,6 +109,7 @@ describe("Update Subscriptions", () => {
                     [typeMovie.fieldNames.subscriptions.updated]: { title: "movie4" },
                     previousState: { title: "movie2" },
                     event: "UPDATE",
+                    timestamp: expect.any(Number),
                 },
             },
         ]);

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -79,11 +79,13 @@ describe("Subscriptions", () => {
             type ActorCreatedEvent {
               createdActor: ActorEventPayload!
               event: EventType!
+              timestamp: Float!
             }
 
             type ActorDeletedEvent {
               deletedActor: ActorEventPayload!
               event: EventType!
+              timestamp: Float!
             }
 
             type ActorEdge {
@@ -122,6 +124,7 @@ describe("Subscriptions", () => {
             type ActorUpdatedEvent {
               event: EventType!
               previousState: ActorEventPayload!
+              timestamp: Float!
               updatedActor: ActorEventPayload!
             }
 
@@ -326,6 +329,7 @@ describe("Subscriptions", () => {
             type MovieCreatedEvent {
               createdMovie: MovieEventPayload!
               event: EventType!
+              timestamp: Float!
             }
 
             input MovieDeleteInput {
@@ -335,6 +339,7 @@ describe("Subscriptions", () => {
             type MovieDeletedEvent {
               deletedMovie: MovieEventPayload!
               event: EventType!
+              timestamp: Float!
             }
 
             input MovieDisconnectInput {
@@ -394,6 +399,7 @@ describe("Subscriptions", () => {
             type MovieUpdatedEvent {
               event: EventType!
               previousState: MovieEventPayload!
+              timestamp: Float!
               updatedMovie: MovieEventPayload!
             }
 
@@ -575,6 +581,7 @@ describe("Subscriptions", () => {
 
             type ActorCreatedEvent {
               event: EventType!
+              timestamp: Float!
             }
 
             input ActorDeleteInput {
@@ -583,6 +590,7 @@ describe("Subscriptions", () => {
 
             type ActorDeletedEvent {
               event: EventType!
+              timestamp: Float!
             }
 
             input ActorDisconnectInput {
@@ -748,6 +756,7 @@ describe("Subscriptions", () => {
 
             type ActorUpdatedEvent {
               event: EventType!
+              timestamp: Float!
             }
 
             input ActorWhere {
@@ -930,6 +939,7 @@ describe("Subscriptions", () => {
             type MovieCreatedEvent {
               createdMovie: MovieEventPayload!
               event: EventType!
+              timestamp: Float!
             }
 
             input MovieDeleteInput {
@@ -939,6 +949,7 @@ describe("Subscriptions", () => {
             type MovieDeletedEvent {
               deletedMovie: MovieEventPayload!
               event: EventType!
+              timestamp: Float!
             }
 
             input MovieDisconnectInput {
@@ -998,6 +1009,7 @@ describe("Subscriptions", () => {
             type MovieUpdatedEvent {
               event: EventType!
               previousState: MovieEventPayload!
+              timestamp: Float!
               updatedMovie: MovieEventPayload!
             }
 


### PR DESCRIPTION
# Description
Timestamp is missing from subscriptions payload. This PR adds the timestamp from the subscription event
