### PR TITLE
chore(graphql-toolbox): needle improvements

### DIFF
--- a/packages/graphql-toolbox/src/components/Filename.tsx
+++ b/packages/graphql-toolbox/src/components/Filename.tsx
@@ -74,7 +74,7 @@ export const FileName = ({ extension, name, buttons }: Props) => {
                 <Icon extension={extension}></Icon> <span className="pl-1">{name}</span>
                 <Ending extension={extension}></Ending>
             </div>
-            {buttons ? <div className="flex items-center">{buttons}</div> : null}
+            {buttons ? <div className="flex items-center mr-4">{buttons}</div> : null}
         </div>
     );
 };

--- a/packages/graphql-toolbox/src/modules/EditorView/Editor.tsx
+++ b/packages/graphql-toolbox/src/modules/EditorView/Editor.tsx
@@ -20,7 +20,8 @@
 import { useCallback, useState, useRef, useEffect, useContext, Fragment } from "react";
 import { graphql, GraphQLSchema } from "graphql";
 import GraphiQLExplorer from "graphiql-explorer";
-import { Button, HeroIcon } from "@neo4j-ndl/react";
+import { Button, HeroIcon, IconButton } from "@neo4j-ndl/react";
+import tokens from "@neo4j-ndl/base/lib/tokens/js/tokens";
 import { EditorFromTextArea } from "codemirror";
 import debounce from "lodash.debounce";
 import { JSONEditor } from "./JSONEditor";
@@ -157,29 +158,37 @@ export const Editor = (props: Props) => {
                                     buttons={
                                         <Fragment>
                                             <ProTooltip tooltipText="Prettify" width={60} left={-10} top={38}>
-                                                <Button
-                                                    className="p-2"
-                                                    color={theme.theme === Theme.DARK ? "success" : "neutral"}
-                                                    fill="text"
+                                                <IconButton
+                                                    clean
                                                     buttonSize="small"
-                                                    style={{ padding: "0.5rem", display: "flex" }}
                                                     onClick={formatTheCode}
                                                     disabled={loading}
                                                 >
-                                                    <HeroIcon className="h-6 w-6" iconName="CodeIcon" type="outline" />
-                                                </Button>
+                                                    <HeroIcon
+                                                        className={theme.theme === Theme.DARK ? "text-white" : ""}
+                                                        iconName="CodeIcon"
+                                                        type="outline"
+                                                    />
+                                                </IconButton>
                                             </ProTooltip>
-                                            <Button
+                                            <IconButton
                                                 data-test-editor-query-button
-                                                className="mr-4 ml-2"
                                                 color="primary"
-                                                fill="text"
-                                                style={{ padding: "0.5rem" }}
+                                                clean
                                                 onClick={() => onSubmit()}
                                                 disabled={!props.schema || loading}
                                             >
-                                                <HeroIcon className="h-7 w-7" iconName="PlayIcon" type="outline" />
-                                            </Button>
+                                                <HeroIcon
+                                                    style={{
+                                                        color:
+                                                            theme.theme === Theme.DARK
+                                                                ? tokens.colors.neutral[10]
+                                                                : tokens.colors.primary[50],
+                                                    }}
+                                                    iconName="PlayIcon"
+                                                    type="outline"
+                                                />
+                                            </IconButton>
                                         </Fragment>
                                     }
                                 />

--- a/packages/graphql-toolbox/src/modules/Login/FormInput.tsx
+++ b/packages/graphql-toolbox/src/modules/Login/FormInput.tsx
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+import { TextInput } from "@neo4j-ndl/react";
+
 export interface Props {
     name: string;
     label: string;
@@ -36,22 +38,5 @@ export const FormInput = (props: Props) => {
     if (props.testTag) {
         options[props.testTag] = true;
     }
-    return (
-        <div>
-            <label className="block text-gray-700 text-sm font-bold mb-2">{props.label}</label>
-            <input
-                value={props.value}
-                className="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
-                name={props.name}
-                type={props.type}
-                placeholder={props.placeholder}
-                required={true}
-                defaultValue={props.defaultValue}
-                disabled={props.disabled}
-                autoComplete={props.autoComplete || ""}
-                onChange={props.onChange}
-                {...options}
-            />
-        </div>
-    );
+    return <TextInput fluid {...props} {...options} />;
 };

--- a/packages/graphql-toolbox/src/modules/Login/Login.tsx
+++ b/packages/graphql-toolbox/src/modules/Login/Login.tsx
@@ -20,7 +20,7 @@
 import { useCallback } from "react";
 import { useContext, useState } from "react";
 import { FormInput } from "./FormInput";
-import { Button } from "@neo4j-ndl/react";
+import { Button, Checkbox } from "@neo4j-ndl/react";
 import { DEFAULT_BOLT_URL } from "../../constants";
 // @ts-ignore - SVG Import
 import Icon from "../../assets/neo4j-color.svg";
@@ -49,7 +49,7 @@ export const Login = () => {
                     username,
                     password,
                     url,
-                    secure
+                    secure,
                 });
             } catch (error) {
                 setError((error as Error).message as string);
@@ -67,51 +67,58 @@ export const Login = () => {
                     <img src={Icon} alt="d.s" className="h-12 w-12 mx-auto" />
                     <h2 className="mt-1 text-3xl">Neo4j GraphQL Toolbox</h2>
                 </div>
-                <form onSubmit={onSubmit}>
-                    <div className="mb-4">
-                        <FormInput
-                            testTag="data-test-login-username"
-                            label="Username"
-                            name="username"
-                            placeholder="neo4j"
-                            required={true}
-                            type="text"
-                            disabled={loading}
-                            autoComplete="username"
-                        ></FormInput>
-                    </div>
-                    <div className="mb-6">
-                        <FormInput
-                            testTag="data-test-login-password"
-                            label="Password"
-                            name="password"
-                            placeholder="password"
-                            required={true}
-                            type="password"
-                            disabled={loading}
-                            autoComplete="current-password"
-                        ></FormInput>
-                    </div>
-                    <div className="mb-6">
-                        <FormInput
-                            testTag="data-test-login-url"
-                            label="Connection URI"
-                            name="url"
-                            value={url}
-                            onChange={(event) => setUrl(event.currentTarget.value)}
-                            placeholder={DEFAULT_BOLT_URL}
-                            required={true}
-                            type="text"
-                            disabled={loading}
-                        ></FormInput>
-                    </div>
-                    <div className="mb-4">
-                        <label className="text-gray-700 text-sm font-bold mb-2 mr-2">Secure connection:</label>
-                        <input data-test-login-secure="true" type="checkbox" name="secure" checked={secure} onChange={(event) => setSecure(event.currentTarget.checked)}/>
-                    </div>
+                <form onSubmit={onSubmit} className="flex flex-col gap-4">
+                    <FormInput
+                        testTag="data-test-login-username"
+                        label="Username"
+                        name="username"
+                        placeholder="neo4j"
+                        required={true}
+                        type="text"
+                        disabled={loading}
+                        autoComplete="username"
+                    ></FormInput>
+
+                    <FormInput
+                        testTag="data-test-login-password"
+                        label="Password"
+                        name="password"
+                        placeholder="password"
+                        required={true}
+                        type="password"
+                        disabled={loading}
+                        autoComplete="current-password"
+                    ></FormInput>
+
+                    <FormInput
+                        testTag="data-test-login-url"
+                        label="Connection URI"
+                        name="url"
+                        value={url}
+                        onChange={(event) => setUrl(event.currentTarget.value)}
+                        placeholder={DEFAULT_BOLT_URL}
+                        required={true}
+                        type="text"
+                        disabled={loading}
+                    ></FormInput>
+                    <Checkbox
+                        data-test-login-secure="true"
+                        label="Secure Connection:"
+                        labelBefore
+                        name="secure"
+                        checked={secure}
+                        onChange={(event) => setSecure(event.currentTarget.checked)}
+                    />
                     <div className="flex items-center justify-between">
-                        <Button data-test-login-button color="neutral" fill="outlined" type="submit" disabled={loading}>
-                            {loading ? <>Connecting...</> : <span>Connect</span>}
+                        <Button
+                            data-test-login-button
+                            color="neutral"
+                            fill="outlined"
+                            type="submit"
+                            loading={loading}
+                            disabled={loading}
+                        >
+                            Connect
                         </Button>
                     </div>
 

--- a/packages/graphql-toolbox/src/modules/SchemaView/ActionElementsBar.tsx
+++ b/packages/graphql-toolbox/src/modules/SchemaView/ActionElementsBar.tsx
@@ -19,7 +19,7 @@
 
 import { ProTooltip } from "../../components/ProTooltip";
 import { ViewSelectorComponent } from "../../components/ViewSelectorComponent";
-import { Button, HeroIcon } from "@neo4j-ndl/react";
+import { Button, HeroIcon, IconButton } from "@neo4j-ndl/react";
 
 interface Props {
     hasSchema: boolean;
@@ -56,37 +56,34 @@ export const ActionElementsBar = ({
                     />
                 </ProTooltip>
             </div>
-            <div className="flex-1 flex justify-end">
+            <div className="flex-1 flex justify-end gap-2">
                 <ProTooltip tooltipText="Save as Favorite" width={120} left={-35} top={45}>
-                    <Button
+                    <IconButton
                         data-test-schema-editor-favourite-button
-                        className="mr-4"
+                        // Icon button background should be white, remove bg-white
+                        // as soon as it's fixed
+                        className="bg-white"
                         color="neutral"
-                        fill="outlined"
-                        style={{ padding: "0.75rem" }}
                         onClick={saveAsFavorite}
                         disabled={loading}
                     >
-                        <HeroIcon className="h-6 w-6" iconName="StarIcon" type="outline" />
-                    </Button>
+                        <HeroIcon iconName="StarIcon" type="outline" />
+                    </IconButton>
                 </ProTooltip>
                 <ProTooltip tooltipText="Prettify" width={60} left={-2} top={45}>
-                    <Button
+                    <IconButton
                         data-test-schema-editor-prettify-button
-                        className="mr-4"
+                        className="bg-white"
                         color="neutral"
-                        fill="outlined"
-                        style={{ padding: "0.75rem" }}
                         onClick={formatTheCode}
                         disabled={loading}
                     >
-                        <HeroIcon className="h-7 w-7" iconName="CodeIcon" type="outline" />
-                    </Button>
+                        <HeroIcon iconName="CodeIcon" type="outline" />
+                    </IconButton>
                 </ProTooltip>
                 <ProTooltip tooltipText="This will overwrite your current typeDefs!" width={260} left={-40} top={45}>
                     <Button
                         data-test-schema-editor-introspect-button
-                        className="mr-4"
                         color="neutral"
                         fill="outlined"
                         onClick={introspect}

--- a/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
+++ b/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Fragment, useContext } from "react";
-import { Button, HeroIcon } from "@neo4j-ndl/react";
+import { Button, HeroIcon, IconButton } from "@neo4j-ndl/react";
 // @ts-ignore - SVG Import
 import Neo4jLogoIcon from "../../assets/Neo4j-logo-color.svg";
 import { AuthContext } from "../../contexts/auth";
@@ -90,30 +90,18 @@ export const TopBar = () => {
                                     auth?.logout();
                                 }}
                             >
-                                <div className="flex items-center">
-                                    <HeroIcon className="h-7 w-7 mr-3" iconName="LogoutIcon" type="outline" />
-                                    <div className="pt-02">Disconnect</div>
-                                </div>
+                                <HeroIcon className="w-full h-full" iconName="LogoutIcon" type="outline" />
+                                <span>Disconnect</span>
                             </Button>
                         </div>
                     ) : null}
-                    <div className="flex items-center">
-                        <div className="cursor-pointer mr-4">
-                            <HeroIcon
-                                data-test-topbar-help-button
-                                onClick={handleHelpClick}
-                                className="h-7 w-7"
-                                iconName="QuestionMarkCircleIcon"
-                                type="outline"
-                            />
-                        </div>
-                        <div
-                            className="ml-2 mr-6 cursor-pointer"
-                            data-test-topbar-settings-button
-                            onClick={handleSettingsClick}
-                        >
-                            <HeroIcon className="h-7 w-7" iconName="CogIcon" type="outline" />
-                        </div>
+                    <div className="flex items-center mr-6">
+                        <IconButton data-test-topbar-help-button onClick={handleHelpClick} clean>
+                            <HeroIcon iconName="QuestionMarkCircleIcon" type="outline" />
+                        </IconButton>
+                        <IconButton clean data-test-topbar-settings-button onClick={handleSettingsClick}>
+                            <HeroIcon iconName="CogIcon" type="outline" />
+                        </IconButton>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
# Description

Refactor some parts of the toolbox to consume appropriately Needle 🪡 

I am adding Liza also, to create increase the knowledge sharing from this PR 🧠 

## Fixes

### Login Page
1. For the login page, all the inputs are refactored to the new [TextInput elements](https://storybook-components-build.appspot.com/?path=/story/uicomponents-text-input--default-input) from Needle

2. Checkbox for secure connection is using the native Checkbox from Needle

3. The `Connect` button was having a loading state with `Connecting...` as a text content. I think as we have a native loading state in Needle's button, we should use this without the dots for indication. Check the attached video

https://user-images.githubusercontent.com/12672541/171868954-31c3d026-2dbd-4551-85de-9e15ff941cd8.mp4

4. Something I did not refactor but would be nice is the error in the login to use the [Alert component](https://storybook-components-build.appspot.com/?path=/story/uicomponents-alert--default-alert&args=type:danger) from Needle

### Top navigation

1. Top right navigation buttons are refactored to native [IconButtons](https://storybook-components-build.appspot.com/?path=/story/uicomponents-icon-buttons--clean-icon-button).

Before
<img width="298" alt="image" src="https://user-images.githubusercontent.com/12672541/171869608-7d0bf836-276d-495f-9849-64b08ce68394.png">


After
<img width="344" alt="image" src="https://user-images.githubusercontent.com/12672541/171869570-94aad094-d8c0-4988-843f-f366b5683d73.png">

2. Fixed Disconnect icon dimensions so it will be smart and get the 100% of the heigh of the button container

### Main App

1. Provide spacing with the flex, and change action icon buttons to native 🪡  ones.

Before
<img width="576" alt="image" src="https://user-images.githubusercontent.com/12672541/171869903-e35fef42-3109-4768-b123-d9ab04bde295.png">

After
<img width="516" alt="image" src="https://user-images.githubusercontent.com/12672541/171869833-103095cd-08a3-432b-a788-7bfff070ccbf.png">

2. Change action icons inside the text editor

Before
<img width="826" alt="image" src="https://user-images.githubusercontent.com/12672541/171870144-69c587f2-b3df-4cd9-b364-034157ac4876.png">

After
<img width="1363" alt="image" src="https://user-images.githubusercontent.com/12672541/171870193-f25baa02-6f12-4489-8dd7-7824a34f700c.png">


## Notes

1. One thing that we should take into consideration for some components @shkirando is the need for dark theme options rather sooner than later and how we can do this without ugly hacks. For example in the Query editor, the icons are changing based on the theme, but in our case the hover effect is not so much effective 🤔 

2. @tbwiss you use tailwind but did not extend the 🪡  configuration, thus in the query editor I used the JS tokens, where we could use tailwind classes. I think extending the tailwind config would be the best choice so you will not have to refactor too much stuff in the long run


# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
