### PR TITLE
Docs: GRANDstack and GraphQL Architect deprecation page

### DIFF
--- a/docs/modules/ROOT/content-nav.adoc
+++ b/docs/modules/ROOT/content-nav.adoc
@@ -86,3 +86,4 @@
 *** xref:troubleshooting/security.adoc[]
 ** xref:appendix/index.adoc[]
 *** xref:appendix/preventing-overfetching.adoc[]
+** xref:deprecations.adoc[Deprecations]

--- a/docs/modules/ROOT/pages/deprecations.adoc
+++ b/docs/modules/ROOT/pages/deprecations.adoc
@@ -16,16 +16,16 @@ Its main value was to show how Apollo client works in the context of React and G
 It was very appealing to junior developers with very little experience in building applications.
 It was a great channel to bring a new audience to Neo4j, but it unveiled gaps in the developer experience with the overall product where these newbie developers often need more support,
 exposing little annoyances that experienced developers can work around which end up being big blockers for junior users who needed more hand holding in understanding the product and the technology.
-These users are not our main target audience, as we’re working on other ways to bring new audiences to Neo4j. 
-The downside of this tool is that it needs maintenance of a front-end framework we have little control over and it represents a dependency we don’t have the capacity to maintain.
-This is something we don’t want to pursue anymore. 
+These users are not our main target audience, as we're working on other ways to bring new audiences to Neo4j. 
+The downside of this tool is that it needs maintenance of a front-end framework we have little control over and it represents a dependency we don't have the capacity to maintain.
+This is something we don't want to pursue anymore. 
 
 The successor of this product will focus on providing an example backend service for users, which is more valuable to our audience of fullstack and frontend developers and to us.
 This might take the shape of a Starter kit for a GraphQL API. 
 There is a need for users who have an existing front end and need a new backend.
 They need a way to initiate a server, so we can bring value by providing an opinionated mechanism that can help users get started with Neo4j GraphQL. 
 
-Our aim in Q3 2022 is to provide a “starter kit” set of instructions that potentially is:
+Our aim in Q3 2022 is to provide a "starter kit" set of instructions that potentially is:
 
 - Compatible with other, more mature, starter apps 
 - Agnostic to other tools 
@@ -47,17 +47,17 @@ GraphQL Architect was a Graph App for Neo4j Desktop that enabled developers to b
 
 We decided it was time to give this tool a new purpose and expand its potential to attract our target audience. 
 Successor of GraphQL Architect Graph App, the new Neo4j GraphQL Toolbox (the name is a placeholder) will be part of the GraphQL for Neo4j holistic product offering. 
-It is currently available at http://graphql-toolbox.neo4j.io/, however we haven't publicized it yet as we’re working on demoing it at GraphConnect, and we’re still writing documentation and marketing pieces on it. 
+It is currently available at https://graphql-toolbox.neo4j.io/, however we haven't publicized it yet as we're working on demoing it at GraphConnect, and we're still writing documentation and marketing pieces on it. 
 
 The vision for this is to build an embeddable tool that we can integrate into the Neo4j workspace which will help onboarding developers into GraphQL. 
-It’s meant to be a low code GraphQL solution to get started for developers who are either new to Neo4j, or GraphQL, or both, and they’re seeking a way to get started easily and quickly with their project from scratch. 
+It's meant to be a low code GraphQL solution to get started for developers who are either new to Neo4j, or GraphQL, or both, and they're seeking a way to get started easily and quickly with their project from scratch. 
 
-We want to make it easily configurable so that it’s at developers’ fingertips ready and available for users without requiring them to have credentials to access a live Neo4j instance when they are in a prototyping stage.
-It’s also a great way to discover the GraphQL library capabilities.
+We want to make it easily configurable so that it's at developers' fingertips ready and available for users without requiring them to have credentials to access a live Neo4j instance when they are in a prototyping stage.
+It's also a great way to discover the GraphQL library capabilities.
 
 We are working with the docs team to see if there is a product opportunity to integrate the GraphQL Toolbox in our documentation to make examples more interactive.
 
-It’s very useful for debugging errors and problems users may encounter using the library so they can use the GraphQL Toolbox to reproduce the problem in GitHub issues.
+It's very useful for debugging errors and problems users may encounter using the library so they can use the GraphQL Toolbox to reproduce the problem in GitHub issues.
 
 In the future we see this as a key tool to attract new users: this can be a potential entry point for our Neo4j GraphQLaaS by providing a publish API option to integrate with a backend managed service and work with your application in production. 
 
@@ -69,6 +69,6 @@ GraphQL developers already think in graphs about their application data and feat
 
 == What has happened to the GraphQL Architect?
 
-From a technical perspective we have deprecated and removed the GraphQL Architect Graph App from npm the Graph App gallery and it is no longer available to be installed in Neo4j Desktop.
+From a technical perspective we have deprecated and removed the GraphQL Architect Graph App from npm and the https://install.graphapp.io/[Graph App gallery], it is no longer available to be installed in Neo4j Desktop.
 The associated GitHub repositories have been archived.
 

--- a/docs/modules/ROOT/pages/deprecations.adoc
+++ b/docs/modules/ROOT/pages/deprecations.adoc
@@ -1,0 +1,74 @@
+[[Deprecations]]
+
+
+= Deprecations
+
+The following products and applications are deprecated:
+
+- GRANDstack starter app
+- GraphQL Architect (a https://neo4j.com/developer/graph-apps/[Neo4j Desktop Graph App])
+
+
+== Why have we deprecated the GRANDstack starter app?
+
+The GRANDstack starter app has been a marketing and product effort to drive user adoption of the Neo4j GraphQL library at its early stages. 
+Its main value was to show how Apollo client works in the context of React and GraphQL, and it was a great tool to build PoCs.
+It was very appealing to junior developers with very little experience in building applications.
+It was a great channel to bring a new audience to Neo4j, but it unveiled gaps in the developer experience with the overall product where these newbie developers often need more support,
+exposing little annoyances that experienced developers can work around which end up being big blockers for junior users who needed more hand holding in understanding the product and the technology.
+These users are not our main target audience, as we’re working on other ways to bring new audiences to Neo4j. 
+The downside of this tool is that it needs maintenance of a front-end framework we have little control over and it represents a dependency we don’t have the capacity to maintain.
+This is something we don’t want to pursue anymore. 
+
+The successor of this product will focus on providing an example backend service for users, which is more valuable to our audience of fullstack and frontend developers and to us.
+This might take the shape of a Starter kit for a GraphQL API. 
+There is a need for users who have an existing front end and need a new backend.
+They need a way to initiate a server, so we can bring value by providing an opinionated mechanism that can help users get started with Neo4j GraphQL. 
+
+Our aim in Q3 2022 is to provide a “starter kit” set of instructions that potentially is:
+
+- Compatible with other, more mature, starter apps 
+- Agnostic to other tools 
+- Can support multiple servers
+- Provides optional plugins & features (subscriptions, auth)
+
+
+== What has happened to the GRANDstack starter app?
+
+From a technical perspective the `create-grandstack-app` npm package has been marked as deprecated - it can still be used to skeleton a GRANDstack app, however the user will be warned that the package is deprecated.
+The associated GRANDstack starter GitHub repository has been archived, meaning that it is still available as a reference, but is now read-only.
+The associated npm packages (such as `graphql-auth-directives` and the `grandstack-cli`) have also been deprecated and archived on GitHub. 
+
+
+== Why have we deprecated the GraphQL Architect Graph App? 
+
+The main purpose of the Neo4j GraphQL Architect was to provide users with a Low-Code way to build GraphQL APIs powered by Neo4j. 
+GraphQL Architect was a Graph App for Neo4j Desktop that enabled developers to build, query, and deploy GraphQL APIs backed by the Neo4j graph database, all from within Neo4j Desktop.
+
+We decided it was time to give this tool a new purpose and expand its potential to attract our target audience. 
+Successor of GraphQL Architect Graph App, the new Neo4j GraphQL Toolbox (the name is a placeholder) will be part of the GraphQL for Neo4j holistic product offering. 
+It is currently available at http://graphql-toolbox.neo4j.io/, however we haven't publicized it yet as we’re working on demoing it at GraphConnect, and we’re still writing documentation and marketing pieces on it. 
+
+The vision for this is to build an embeddable tool that we can integrate into the Neo4j workspace which will help onboarding developers into GraphQL. 
+It’s meant to be a low code GraphQL solution to get started for developers who are either new to Neo4j, or GraphQL, or both, and they’re seeking a way to get started easily and quickly with their project from scratch. 
+
+We want to make it easily configurable so that it’s at developers’ fingertips ready and available for users without requiring them to have credentials to access a live Neo4j instance when they are in a prototyping stage.
+It’s also a great way to discover the GraphQL library capabilities.
+
+We are working with the docs team to see if there is a product opportunity to integrate the GraphQL Toolbox in our documentation to make examples more interactive.
+
+It’s very useful for debugging errors and problems users may encounter using the library so they can use the GraphQL Toolbox to reproduce the problem in GitHub issues.
+
+In the future we see this as a key tool to attract new users: this can be a potential entry point for our Neo4j GraphQLaaS by providing a publish API option to integrate with a backend managed service and work with your application in production. 
+
+This can also serve as an educational piece to help developers understand our competitive advantage compared to other players in the market by showcasing the GraphQL and Graph database natural marriage.
+We can communicate to the developers market that there is no mismatch between the API model and the data model (in the database).
+We are graph from top to bottom.
+GraphQL developers already think in graphs about their application data and features, but we need to help them understand that they can store that information in graphs (using a graph DB).  
+
+
+== What has happened to the GraphQL Architect?
+
+From a technical perspective we have deprecated and removed the GraphQL Architect Graph App from npm the Graph App gallery and it is no longer available to be installed in Neo4j Desktop.
+The associated GitHub repositories have been archived.
+

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 > This is the documentation for the Neo4j GraphQL Library version 3.0, authored by the Neo4j GraphQL Team.
 
-TIP: Hi GRANDstack companion! We have deprecated the GRANDstack starter app, find more information xref::deprecations.adoc[here].
+TIP: Are you a GRANDstack user? We have deprecated the GRANDstack starter app, find more information xref::deprecations.adoc[here].
 
 This documentation covers the following topics:
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -20,6 +20,8 @@ endif::[]
 
 > This is the documentation for the Neo4j GraphQL Library version 3.0, authored by the Neo4j GraphQL Team.
 
+TIP: Hi GRANDstack companion! We have deprecated the GRANDstack starter app, find more information xref::deprecations.adoc[here].
+
 This documentation covers the following topics:
 
 - xref::introduction.adoc[Introduction] - Introduction to the Neo4j GraphQL Library.
@@ -41,5 +43,6 @@ This documentation covers the following topics:
 - xref::driver-configuration.adoc[Driver Configuration] - How to configure a database driver for use with this library.
 - xref::guides/index.adoc[Guides] - Guides for usage of the library, including migration guides for moving between versions.
 - xref::troubleshooting/index.adoc[Troubleshooting] - Having problems with the library? See if your problem has been found and solved before.
+- xref::deprecations.adoc[Deprecations] - Overview and information regarding deprecated products and applications.
 
 This manual is primarily written for software engineers building an API using the Neo4j GraphQL Library.


### PR DESCRIPTION
# Description

On request of @helenesanche we're adding information regarding the deprecation of the GRANDstack starter app and the GraphQL Architect.
The text in `docs/modules/ROOT/pages/deprecations.adoc` is based on a document created by @helenesanche. Reach out if you need the link to the document.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
