### PR TITLE
Fix: Toolbox - import Codemirror stylesheet

### DIFF
--- a/packages/graphql-toolbox/src/index.html
+++ b/packages/graphql-toolbox/src/index.html
@@ -4,8 +4,6 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Neo4j GraphQL Toolbox</title>
-        <link rel="stylesheet" href="https://codemirror.net/lib/codemirror.css" />
-        <link rel="stylesheet" href="https://codemirror.net/addon/hint/show-hint.css" />
 
         <style>
             * {

--- a/packages/graphql-toolbox/src/utils/utils.ts
+++ b/packages/graphql-toolbox/src/utils/utils.ts
@@ -41,6 +41,8 @@ import "codemirror-graphql/mode";
 import "codemirror/addon/lint/lint.css";
 import "codemirror/theme/dracula.css";
 import "codemirror/theme/neo.css";
+import "codemirror/lib/codemirror.css";
+import "codemirror/addon/hint/show-hint.css";
 
 // @ts-ignore - Needed for the tests
 document.CodeMirror = CodeMirror;


### PR DESCRIPTION
# Description

https://codemirror.net/lib/codemirror.css and https://codemirror.net/addon/hint/show-hint.css are not accessible anymore (404 Error). This implementation is a leftover from the prototype version of the Toolbox.
Instead, we import the css files directly in `packages/graphql-toolbox/src/utils/utils.ts`

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
