### PR TITLE
Fix: Aliases in query fails when interfaces are used in schema

### DIFF
--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -403,7 +403,7 @@ function createProjectionAndParams({
                     }
                 }
 
-                res.projection.push(`${field.alias}: ${field.alias}${offsetLimitStr}`);
+                res.projection.push(`${field.alias}: ${field.name || field.alias}${offsetLimitStr}`);
 
                 return res;
             }

--- a/packages/graphql/tests/integration/issues/1535.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1535.int.test.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql, GraphQLSchema } from "graphql";
+import { Driver } from "neo4j-driver";
+import neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { generateUniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/1535", () => {
+    const testTenant = generateUniqueType("Tenant");
+    const testBooking = generateUniqueType("Booking");
+
+    let schema: GraphQLSchema;
+    let driver: Driver;
+
+    async function graphqlQuery(query: string) {
+        return graphql({
+            schema,
+            source: query,
+            contextValue: {
+                driver,
+            },
+        });
+    }
+
+    beforeAll(async () => {
+        driver = await neo4j();
+
+        const typeDefs = `
+            type ${testTenant} {
+                id: ID! @id
+                name: String!
+                events: [Event!]! @relationship(type: "HOSTED_BY", direction: IN)
+                fooBars: [FooBar!]! @relationship(type: "HAS_FOOBARS", direction: OUT)
+            }
+            
+            interface Event {
+                id: ID!
+                title: String
+                beginsAt: DateTime!
+            }
+            
+            type Screening implements Event {
+                id: ID! @id
+                title: String
+                beginsAt: DateTime!
+            }
+            
+            type ${testBooking} implements Event {
+                id: ID!
+                title: String
+                beginsAt: DateTime!
+                duration: Int!
+            }
+            
+            type FooBar {
+                id: ID! @id
+                name: String!
+            }
+        `;
+
+        const session = driver.session();
+
+        await session.run(`
+            CREATE (:${testTenant} { id: "12", name: "Tenant1" })<-[:HOSTED_BY]-(:${testBooking} { id: "212" })
+        `);
+
+        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver });
+        schema = await neoGraphql.getSchema();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should not throw error when using alias in result projection for a field using an interface", async () => {
+        const query = `
+            query { 
+                ${testTenant.plural} {
+                    id
+                    name
+                    events232: events {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const queryResult = await graphqlQuery(query);
+        expect(queryResult.errors).toBeUndefined();
+
+        expect(queryResult.data as any).toEqual({
+            [`${testTenant.plural}`]: [{ id: "12", name: "Tenant1", events232: [{ id: "212" }] }],
+        });
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/issues/1535.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1535.test.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/1535", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Tenant {
+                id: ID! @id
+                name: String!
+                events: [Event!]! @relationship(type: "HOSTED_BY", direction: IN)
+                fooBars: [FooBar!]! @relationship(type: "HAS_FOOBARS", direction: OUT)
+            }
+
+            interface Event {
+                id: ID!
+                title: String
+                beginsAt: DateTime!
+            }
+
+            type Screening implements Event {
+                id: ID! @id
+                title: String
+                beginsAt: DateTime!
+            }
+
+            type Booking implements Event {
+                id: ID!
+                title: String
+                beginsAt: DateTime!
+                duration: Int!
+            }
+
+            type FooBar {
+                id: ID! @id
+                name: String!
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("should use alias in result projection for a field using an interface", async () => {
+        const query = gql`
+            query {
+                tenants {
+                    id
+                    name
+                    events232: events {
+                        id
+                    }
+                }
+            }
+        `;
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Tenant)
+            WITH this
+            CALL {
+            WITH this
+            CALL {
+            WITH this
+            MATCH (this)<-[:HOSTED_BY]-(this_Screening:Screening)
+            RETURN { __resolveType: \\"Screening\\", id: this_Screening.id } AS events
+            UNION
+            WITH this
+            MATCH (this)<-[:HOSTED_BY]-(this_Booking:Booking)
+            RETURN { __resolveType: \\"Booking\\", id: this_Booking.id } AS events
+            }
+            RETURN collect(events) AS events
+            }
+            RETURN this { .id, .name, events232: events } as this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});


### PR DESCRIPTION
# Description

Use the field's name, if present, rather than the field's alias as the data value, see `packages/graphql/src/translate/create-projection-and-params.ts`.

# Issue

Regarding: #1535

Closes:

- #1535

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
