### PR TITLE
5.0 requires `RETURN` clauses in subqueries to be aliased

### DIFF
--- a/packages/graphql/src/translate/create-connect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.test.ts
@@ -111,10 +111,10 @@ describe("createConnectAndParams", () => {
                                 MERGE (this0_node)-[:SIMILAR]->(this0_node_similarMovies0_node)
                             )
                         )
-                        RETURN count(*)
+                        RETURN count(*) AS _
                     }
 
-                    RETURN count(*)
+                    RETURN count(*) AS _
                 }
             `)
         );

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -403,7 +403,7 @@ function createConnectAndParams({
             params = { ...params, ...postAuth.params };
         }
 
-        subquery.push("\tRETURN count(*)");
+        subquery.push("\tRETURN count(*) AS _");
 
         return { subquery: subquery.join("\n"), params };
     }

--- a/packages/graphql/src/translate/create-disconnect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.test.ts
@@ -113,10 +113,10 @@ describe("createDisconnectAndParams", () => {
                     OPTIONAL MATCH (this0)-[this0_similarMovies0_rel:SIMILAR]->(this0_similarMovies0:Movie)
                     WHERE this0_similarMovies0.title = $this[0].disconnect.similarMovies[0].where.node.title
                     FOREACH(_ IN CASE this0_similarMovies0 WHEN NULL THEN [] ELSE [1] END | DELETE this0_similarMovies0_rel )
-                    RETURN count(*)
+                    RETURN count(*) AS _
                 }
 
-                RETURN count(*)
+                RETURN count(*) AS _
             }
             `)
         );

--- a/packages/graphql/src/translate/create-disconnect-and-params.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.ts
@@ -324,7 +324,7 @@ function createDisconnectAndParams({
             params = { ...params, ...postAuth.params };
         }
 
-        subquery.push("RETURN count(*)");
+        subquery.push("RETURN count(*) AS _");
 
         return { subquery: subquery.join("\n"), params };
     }

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -238,7 +238,7 @@ function createUpdateAndParams({
                             if (context.subscriptionsEnabled) {
                                 updateStrs.push(`RETURN ${META_CYPHER_VARIABLE}`);
                             } else {
-                                updateStrs.push("RETURN count(*)");
+                                updateStrs.push("RETURN count(*) AS _");
                             }
                             const apocArgs = `{${withVars.map((withVar) => `${withVar}:${withVar}`).join(", ")}, ${
                                 parameterPrefix?.split(".")[0]
@@ -278,7 +278,7 @@ function createUpdateAndParams({
                                 }${relationField.typeMeta.array ? `[${index}]` : ``}.update.edge`,
                             });
 
-                            const updateStrs = [escapeQuery(setProperties), escapeQuery("RETURN count(*)")];
+                            const updateStrs = [escapeQuery(setProperties), escapeQuery("RETURN count(*) AS _")];
 
                             const apocArgs = `{${relationshipVariable}:${relationshipVariable}, ${
                                 parameterPrefix?.split(".")[0]
@@ -415,7 +415,7 @@ function createUpdateAndParams({
                     }
 
                     if (relationField.interface) {
-                        subquery.push("RETURN count(*)");
+                        subquery.push("RETURN count(*) AS _");
                     }
                 });
 

--- a/packages/graphql/src/translate/cypher-builder/CypherBuilder.test.ts
+++ b/packages/graphql/src/translate/cypher-builder/CypherBuilder.test.ts
@@ -211,7 +211,7 @@ describe("CypherBuilder", () => {
                 	CREATE (this0:\`Movie\`)
                 SET this0.id = $param0
                 RETURN this0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }"
             `);
             expect(queryResult.params).toMatchInlineSnapshot(`
@@ -237,9 +237,9 @@ describe("CypherBuilder", () => {
                 	CREATE (this0:\`Movie\`)
 
                 RETURN this0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }"
             `);
             expect(queryResult.params).toMatchInlineSnapshot(`Object {}`);

--- a/packages/graphql/src/translate/cypher-builder/README.md
+++ b/packages/graphql/src/translate/cypher-builder/README.md
@@ -249,7 +249,7 @@ CALL {
     CREATE (this0:\`Movie\`)
     SET this0.id = $param0
     RETURN this0
-    RETURN COUNT(*)
+    RETURN COUNT(*) AS _
 }
 ```
 

--- a/packages/graphql/src/translate/cypher-builder/statements/Call.ts
+++ b/packages/graphql/src/translate/cypher-builder/statements/Call.ts
@@ -25,7 +25,7 @@ export class Call extends Query {
     private withStatement: Array<string>;
     private returnStatement: string;
 
-    constructor(query: Query, withVars: Array<string> = [], returnStatement = "RETURN COUNT(*)", parent?: Query) {
+    constructor(query: Query, withVars: Array<string> = [], returnStatement = "RETURN COUNT(*) AS _", parent?: Query) {
         super(parent);
         this.withStatement = withVars;
         this.returnStatement = returnStatement;

--- a/packages/graphql/src/translate/utils/wrap-in-call.ts
+++ b/packages/graphql/src/translate/utils/wrap-in-call.ts
@@ -20,7 +20,7 @@
 import { joinStrings } from "../../utils/utils";
 
 /** Wraps a string in a CALL statement */
-export function wrapInCall(statement: string, withVars: string[], returnStatement = "RETURN COUNT(*)"): string {
+export function wrapInCall(statement: string, withVars: string[], returnStatement = "RETURN COUNT(*) AS _"): string {
     const withString = `WITH ${withVars.join(", ")}`;
     return joinStrings([withString, "CALL {", `\t${withString}`, `\t${statement}`, `\t${returnStatement}`, "}"]);
 }

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-auth.test.ts
@@ -91,7 +91,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this0_genres_connectOrCreate_this2.name = $this0_genres_connectOrCreate_param1
                 MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -144,7 +144,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this0_genres_connectOrCreate_this2.name = $this0_genres_connectOrCreate_param1
                 MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -197,7 +197,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this0_genres_connectOrCreate_this2.name = $this0_genres_connectOrCreate_param1
                 MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -249,7 +249,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this0_genres_connectOrCreate_this2.name = $this0_genres_connectOrCreate_param1
                 MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -315,7 +315,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_genres0_connectOrCreate_this2.name = $this_genres0_connectOrCreate_param1
                 MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -364,7 +364,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_genres0_connectOrCreate_this2.name = $this_genres0_connectOrCreate_param1
                 MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -413,7 +413,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_genres0_connectOrCreate_this2.name = $this_genres0_connectOrCreate_param1
                 MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -461,7 +461,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_genres0_connectOrCreate_this2.name = $this_genres0_connectOrCreate_param1
                 MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -520,7 +520,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_connectOrCreate_genres_this2.name = $this_connectOrCreate_genres_param1
                 MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -569,7 +569,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_connectOrCreate_genres_this2.name = $this_connectOrCreate_genres_param1
                 MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -618,7 +618,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_connectOrCreate_genres_this2.name = $this_connectOrCreate_genres_param1
                 MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -666,7 +666,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_connectOrCreate_genres_this2.name = $this_connectOrCreate_genres_param1
                 MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);
@@ -723,7 +723,7 @@ describe("connectOrCreate", () => {
                 ON CREATE SET
                         this_connectOrCreate_genres_this2.name = $this_connectOrCreate_genres_param2
                 MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres_this2)
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
             `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create-unions.test.ts
@@ -123,7 +123,7 @@ describe("Create or connect with unions", () => {
             MERGE (this0)-[this0_actedIn_Movie_connectOrCreate_this0:\`ACTED_IN\`]->(this0_actedIn_Movie_connectOrCreate_this2)
             ON CREATE SET
                     this0_actedIn_Movie_connectOrCreate_this0.screentime = $this0_actedIn_Movie_connectOrCreate_param0
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             	WITH this0
             CALL {
@@ -135,7 +135,7 @@ describe("Create or connect with unions", () => {
             MERGE (this0)-[this0_actedIn_Series_connectOrCreate_this0:\`ACTED_IN\`]->(this0_actedIn_Series_connectOrCreate_this2)
             ON CREATE SET
                     this0_actedIn_Series_connectOrCreate_this0.screentime = $this0_actedIn_Series_connectOrCreate_param0
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             RETURN this0
             }
@@ -219,7 +219,7 @@ describe("Create or connect with unions", () => {
             MERGE (this)-[this_actedIn_Movie0_connectOrCreate_this0:\`ACTED_IN\`]->(this_actedIn_Movie0_connectOrCreate_this2)
             ON CREATE SET
                     this_actedIn_Movie0_connectOrCreate_this0.screentime = $this_actedIn_Movie0_connectOrCreate_param0
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             	WITH this
             CALL {
@@ -231,7 +231,7 @@ describe("Create or connect with unions", () => {
             MERGE (this)-[this_actedIn_Series0_connectOrCreate_this0:\`ACTED_IN\`]->(this_actedIn_Series0_connectOrCreate_this2)
             ON CREATE SET
                     this_actedIn_Series0_connectOrCreate_this0.screentime = $this_actedIn_Series0_connectOrCreate_param0
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/connect-or-create/connect-or-create.test.ts
@@ -99,7 +99,7 @@ describe("Create or Connect", () => {
                 MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate_this2)
                 ON CREATE SET
                         this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -161,7 +161,7 @@ describe("Create or Connect", () => {
                 MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate_this2)
                 ON CREATE SET
                         this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .name }) AS data"
             `);
@@ -260,7 +260,7 @@ describe("Create or Connect", () => {
                 MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate_this2)
                 ON CREATE SET
                         this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -324,7 +324,7 @@ describe("Create or Connect", () => {
                 MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate_this2)
                 ON CREATE SET
                         this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -388,7 +388,7 @@ describe("Create or Connect", () => {
                 MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate_this2)
                 ON CREATE SET
                         this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .name }) AS data"
             `);
@@ -449,7 +449,7 @@ describe("Create or Connect", () => {
                 MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate_this2)
                 ON CREATE SET
                         this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .name }) AS data"
             `);
@@ -549,7 +549,7 @@ describe("Create or Connect", () => {
                         this0_movies_connectOrCreate_this0.createdAt = datetime(),
                 this0_movies_connectOrCreate_this0.id = randomUUID(),
                 this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN this0
                 }
@@ -613,7 +613,7 @@ describe("Create or Connect", () => {
                         this_movies0_connectOrCreate_this0.createdAt = datetime(),
                 this_movies0_connectOrCreate_this0.id = randomUUID(),
                 this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param0
-                	RETURN COUNT(*)
+                	RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .name }) AS data"
             `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/connect.test.ts
@@ -95,7 +95,7 @@ describe("Relationship Properties Connect Cypher", () => {
             SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -167,7 +167,7 @@ describe("Relationship Properties Connect Cypher", () => {
             SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -231,7 +231,7 @@ describe("Relationship Properties Connect Cypher", () => {
             SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -296,7 +296,7 @@ describe("Relationship Properties Connect Cypher", () => {
             SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/update.test.ts
@@ -79,7 +79,7 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_acted_in0_relationship IS NOT NULL, \\"
             SET this_acted_in0_relationship.screenTime = $updateMovies.args.update.actors[0].update.edge.screenTime
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this_acted_in0_relationship:this_acted_in0_relationship, updateMovies: $updateMovies, resolvedCallbacks: $resolvedCallbacks})
             YIELD value AS this_acted_in0_relationship_actors0_edge
             RETURN collect(DISTINCT this { .title }) AS data"
@@ -150,12 +150,12 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
             SET this_actors0.name = $this_update_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
             YIELD value AS _
             CALL apoc.do.when(this_acted_in0_relationship IS NOT NULL, \\"
             SET this_acted_in0_relationship.screenTime = $updateMovies.args.update.actors[0].update.edge.screenTime
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this_acted_in0_relationship:this_acted_in0_relationship, updateMovies: $updateMovies, resolvedCallbacks: $resolvedCallbacks})
             YIELD value AS this_acted_in0_relationship_actors0_edge
             RETURN collect(DISTINCT this { .title }) AS data"

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/allow.test.ts
@@ -345,7 +345,7 @@ describe("Cypher Auth Allow", () => {
             WITH this, this_creator0
             CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
             SET this_creator0.id = $this_update_creator0_id
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updatePosts: $updatePosts, this_creator0:this_creator0, auth:$auth,this_update_creator0_id:$this_update_creator0_id,this_creator0_auth_allow0_id:$this_creator0_auth_allow0_id})
             YIELD value AS _
             WITH this
@@ -425,7 +425,7 @@ describe("Cypher Auth Allow", () => {
             WITH this, this_creator0
             CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id AND this_creator0.id IS NOT NULL AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
             SET this_creator0.password = $this_update_creator0_password
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updatePosts: $updatePosts, this_creator0:this_creator0, auth:$auth,this_update_creator0_password:$this_update_creator0_password,this_update_creator0_password_auth_allow0_id:$this_update_creator0_password_auth_allow0_id,this_creator0_auth_allow0_id:$this_creator0_auth_allow0_id})
             YIELD value AS _
             WITH this
@@ -588,7 +588,7 @@ describe("Cypher Auth Allow", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -663,9 +663,9 @@ describe("Cypher Auth Allow", () => {
             FOREACH(_ IN CASE this_post0_disconnect0_creator0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_disconnect0_creator0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -748,7 +748,7 @@ describe("Cypher Auth Allow", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/inherited.test.ts
@@ -338,7 +338,7 @@ describe("@auth allow when inherited from interface", () => {
             WITH this, this_creator0
             CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
             SET this_creator0.id = $this_update_creator0_id
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updatePosts: $updatePosts, this_creator0:this_creator0, auth:$auth,this_update_creator0_id:$this_update_creator0_id,this_creator0_auth_allow0_id:$this_creator0_auth_allow0_id})
             YIELD value AS _
             WITH this
@@ -418,7 +418,7 @@ describe("@auth allow when inherited from interface", () => {
             WITH this, this_creator0
             CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id AND this_creator0.id IS NOT NULL AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
             SET this_creator0.password = $this_update_creator0_password
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updatePosts: $updatePosts, this_creator0:this_creator0, auth:$auth,this_update_creator0_password:$this_update_creator0_password,this_update_creator0_password_auth_allow0_id:$this_update_creator0_password_auth_allow0_id,this_creator0_auth_allow0_id:$this_creator0_auth_allow0_id})
             YIELD value AS _
             WITH this
@@ -581,7 +581,7 @@ describe("@auth allow when inherited from interface", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -656,9 +656,9 @@ describe("@auth allow when inherited from interface", () => {
             FOREACH(_ IN CASE this_post0_disconnect0_creator0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_disconnect0_creator0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -741,7 +741,7 @@ describe("@auth allow when inherited from interface", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -225,10 +225,10 @@ describe("@auth allow on specific interface implementation", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
             	RETURN c AS this_content0_post_Post_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
@@ -244,10 +244,10 @@ describe("@auth allow on specific interface implementation", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id,this_content0_auth_allow0_creator_id:$this_content0_auth_allow0_creator_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -387,7 +387,7 @@ describe("@auth allow on specific interface implementation", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -397,7 +397,7 @@ describe("@auth allow on specific interface implementation", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -461,7 +461,7 @@ describe("@auth allow on specific interface implementation", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -481,9 +481,9 @@ describe("@auth allow on specific interface implementation", () => {
             FOREACH(_ IN CASE this_disconnect_content0_comments0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_comments0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -559,7 +559,7 @@ describe("@auth allow on specific interface implementation", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -571,7 +571,7 @@ describe("@auth allow on specific interface implementation", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -245,10 +245,10 @@ describe("@auth allow with interface relationships", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
             	RETURN c AS this_content0_post_Post_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id,this_content0_auth_allow0_creator_id:$this_content0_auth_allow0_creator_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
@@ -264,10 +264,10 @@ describe("@auth allow with interface relationships", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id,this_content0_auth_allow0_creator_id:$this_content0_auth_allow0_creator_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -358,7 +358,7 @@ describe("@auth allow with interface relationships", () => {
             WITH this, this_creator0
             CALL apoc.util.validate(NOT(this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0_auth_allow0_id AND this_creator0.id IS NOT NULL AND this_creator0.id = $this_update_creator0_password_auth_allow0_id), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
             SET this_creator0.password = $this_update_creator0_password
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updatePosts: $updatePosts, this_creator0:this_creator0, auth:$auth,this_update_creator0_password:$this_update_creator0_password,this_update_creator0_password_auth_allow0_id:$this_update_creator0_password_auth_allow0_id,this_creator0_auth_allow0_id:$this_creator0_auth_allow0_id})
             YIELD value AS _
             WITH this
@@ -499,7 +499,7 @@ describe("@auth allow with interface relationships", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -509,7 +509,7 @@ describe("@auth allow with interface relationships", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -579,7 +579,7 @@ describe("@auth allow with interface relationships", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -599,9 +599,9 @@ describe("@auth allow with interface relationships", () => {
             FOREACH(_ IN CASE this_disconnect_content0_comments0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_comments0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -682,7 +682,7 @@ describe("@auth allow with interface relationships", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -694,7 +694,7 @@ describe("@auth allow with interface relationships", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/bind/bind.test.ts
@@ -246,7 +246,7 @@ describe("Cypher Auth Allow", () => {
             SET this_posts0_creator0.id = $this_update_posts0_creator0_id
             WITH this, this_posts0, this_posts0_creator0
             CALL apoc.util.validate(NOT(this_posts0_creator0.id IS NOT NULL AND this_posts0_creator0.id = $this_posts0_creator0_auth_bind0_id), \\\\\\\\\\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\\\\\\\\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_posts0:this_posts0, updateUsers: $updateUsers, this_posts0_creator0:this_posts0_creator0, auth:$auth,this_update_posts0_creator0_id:$this_update_posts0_creator0_id,this_posts0_creator0_auth_bind0_id:$this_posts0_creator0_auth_bind0_id})
             YIELD value AS _
             WITH this, this_posts0
@@ -257,7 +257,7 @@ describe("Cypher Auth Allow", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_posts0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_posts0:this_posts0, auth:$auth,this_update_posts0_creator0_id:$this_update_posts0_creator0_id,this_posts0_creator0_auth_bind0_id:$this_posts0_creator0_auth_bind0_id})
             YIELD value AS _
             WITH this
@@ -345,7 +345,7 @@ describe("Cypher Auth Allow", () => {
             	)
             	WITH this, this_connect_creator0_node
             	CALL apoc.util.validate(NOT(EXISTS((this_connect_creator0_node)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_connect_creator0_node)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_creator0_nodePost0_bind_auth_bind0_creator_id) AND this_connect_creator0_node.id IS NOT NULL AND this_connect_creator0_node.id = $this_connect_creator0_nodeUser1_bind_auth_bind0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -398,7 +398,7 @@ describe("Cypher Auth Allow", () => {
             )
             WITH this, this_disconnect_creator0
             CALL apoc.util.validate(NOT(EXISTS((this_disconnect_creator0)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_disconnect_creator0)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_creator0Post0_bind_auth_bind0_creator_id) AND this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0User1_bind_auth_bind0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -272,7 +272,7 @@ describe("Cypher Auth Allow", () => {
             SET this_content0_creator0.id = $this_update_content0_creator0_id
             WITH this, this_content0, this_content0_creator0
             CALL apoc.util.validate(NOT(this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0_auth_bind0_id), \\\\\\\\\\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\\\\\\\\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_content0:this_content0, updateUsers: $updateUsers, this_content0_creator0:this_content0_creator0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
             WITH this, this_content0
@@ -283,10 +283,10 @@ describe("Cypher Auth Allow", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
@@ -298,7 +298,7 @@ describe("Cypher Auth Allow", () => {
             SET this_content0_creator0.id = $this_update_content0_creator0_id
             WITH this, this_content0, this_content0_creator0
             CALL apoc.util.validate(NOT(this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0_auth_bind0_id), \\\\\\\\\\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\\\\\\\\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_content0:this_content0, updateUsers: $updateUsers, this_content0_creator0:this_content0_creator0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
             WITH this, this_content0
@@ -311,10 +311,10 @@ describe("Cypher Auth Allow", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id,this_content0_auth_bind0_creator_id:$this_content0_auth_bind0_creator_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_bind0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -402,7 +402,7 @@ describe("Cypher Auth Allow", () => {
             	)
             	WITH this, this_connect_content0_node
             	CALL apoc.util.validate(NOT(this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeUser0_bind_auth_bind0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -414,7 +414,7 @@ describe("Cypher Auth Allow", () => {
             	)
             	WITH this, this_connect_content0_node
             	CALL apoc.util.validate(NOT(this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeUser0_bind_auth_bind0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost1_bind_auth_bind0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -462,7 +462,7 @@ describe("Cypher Auth Allow", () => {
             )
             WITH this, this_disconnect_content0
             CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_bind_auth_bind0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -472,7 +472,7 @@ describe("Cypher Auth Allow", () => {
             )
             WITH this, this_disconnect_content0
             CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_bind_auth_bind0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post1_bind_auth_bind0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
@@ -189,7 +189,7 @@ describe("Cypher Auth Allow", () => {
             SET this_content0_creator0.id = $this_update_content0_creator0_id
             WITH this, this_content0, this_content0_creator0
             CALL apoc.util.validate(NOT(this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0_auth_bind0_id), \\\\\\\\\\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\\\\\\\\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_content0:this_content0, updateUsers: $updateUsers, this_content0_creator0:this_content0_creator0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
             WITH this, this_content0
@@ -200,10 +200,10 @@ describe("Cypher Auth Allow", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
@@ -215,7 +215,7 @@ describe("Cypher Auth Allow", () => {
             SET this_content0_creator0.id = $this_update_content0_creator0_id
             WITH this, this_content0, this_content0_creator0
             CALL apoc.util.validate(NOT(this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0_auth_bind0_id), \\\\\\\\\\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\\\\\\\\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_content0:this_content0, updateUsers: $updateUsers, this_content0_creator0:this_content0_creator0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
             WITH this, this_content0
@@ -226,10 +226,10 @@ describe("Cypher Auth Allow", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_creator0_id:$this_update_content0_creator0_id,this_content0_creator0_auth_bind0_id:$this_content0_creator0_auth_bind0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL apoc.util.validate(NOT(this.id IS NOT NULL AND this.id = $this_auth_bind0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -316,7 +316,7 @@ describe("Cypher Auth Allow", () => {
             	)
             	WITH this, this_connect_content0_node
             	CALL apoc.util.validate(NOT(this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeUser0_bind_auth_bind0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodeComment1_bind_auth_bind0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -328,7 +328,7 @@ describe("Cypher Auth Allow", () => {
             	)
             	WITH this, this_connect_content0_node
             	CALL apoc.util.validate(NOT(this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeUser0_bind_auth_bind0_id AND EXISTS((this_connect_content0_node)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_connect_content0_nodePost1_bind_auth_bind0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -377,7 +377,7 @@ describe("Cypher Auth Allow", () => {
             )
             WITH this, this_disconnect_content0
             CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_bind_auth_bind0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Comment1_bind_auth_bind0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -387,7 +387,7 @@ describe("Cypher Auth Allow", () => {
             )
             WITH this, this_disconnect_content0
             CALL apoc.util.validate(NOT(this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0User0_bind_auth_bind0_id AND EXISTS((this_disconnect_content0)<-[:HAS_CONTENT]-(:User)) AND ALL(creator IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_disconnect_content0Post1_bind_auth_bind0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
@@ -263,7 +263,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -274,7 +274,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -323,7 +323,7 @@ describe("Cypher Auth isAuthenticated", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -332,7 +332,7 @@ describe("Cypher Auth isAuthenticated", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
@@ -212,7 +212,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -223,7 +223,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -274,7 +274,7 @@ describe("Cypher Auth isAuthenticated", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -283,7 +283,7 @@ describe("Cypher Auth isAuthenticated", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
@@ -420,7 +420,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -471,7 +471,7 @@ describe("Cypher Auth isAuthenticated", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles-where.test.ts
@@ -696,7 +696,7 @@ describe("Cypher Auth Where with Roles", () => {
             	CALL apoc.util.validate(NOT(c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator must be less than or equal to one', [0])
             	RETURN c AS this_posts0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_posts0:this_posts0, auth:$auth,this_update_posts0_id:$this_update_posts0_id})
             YIELD value AS _
             RETURN collect(DISTINCT this { .id, posts: [ (this)-[:HAS_POST]->(this_posts:Post)  WHERE (((ANY(r IN [\\"user\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)) AND EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_where0_creator_id))) OR (ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr)))) AND apoc.util.validatePredicate(NOT(((ANY(r IN [\\"user\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))) OR (ANY(r IN [\\"admin\\"] WHERE ANY(rr IN $auth.roles WHERE r = rr))))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_posts { .id } ] }) AS data"
@@ -868,7 +868,7 @@ describe("Cypher Auth Where with Roles", () => {
             			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -942,7 +942,7 @@ describe("Cypher Auth Where with Roles", () => {
             			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -1009,7 +1009,7 @@ describe("Cypher Auth Where with Roles", () => {
             			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1070,7 +1070,7 @@ describe("Cypher Auth Where with Roles", () => {
             			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1130,7 +1130,7 @@ describe("Cypher Auth Where with Roles", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1189,7 +1189,7 @@ describe("Cypher Auth Where with Roles", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1249,7 +1249,7 @@ describe("Cypher Auth Where with Roles", () => {
             FOREACH(_ IN CASE this_posts0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_posts0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1308,7 +1308,7 @@ describe("Cypher Auth Where with Roles", () => {
             FOREACH(_ IN CASE this_posts0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_posts0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1384,7 +1384,7 @@ describe("Cypher Auth Where with Roles", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1452,7 +1452,7 @@ describe("Cypher Auth Where with Roles", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
@@ -426,7 +426,7 @@ describe("Cypher Auth Roles", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -487,7 +487,7 @@ describe("Cypher Auth Roles", () => {
             			MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this, this_post0
             CALL {
@@ -497,7 +497,7 @@ describe("Cypher Auth Roles", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_post0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,this_post0_creator0_connect0_node_id:$this_post0_creator0_connect0_node_id})
             YIELD value AS _
             WITH this
@@ -579,7 +579,7 @@ describe("Cypher Auth Roles", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -647,7 +647,7 @@ describe("Cypher Auth Roles", () => {
             FOREACH(_ IN CASE this_post0_creator0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_post0_creator0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this, this_post0
             CALL {
@@ -657,7 +657,7 @@ describe("Cypher Auth Roles", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_post0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth})
             YIELD value AS _
             WITH this

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -421,10 +421,10 @@ describe("Cypher Auth Where", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
@@ -439,10 +439,10 @@ describe("Cypher Auth Where", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -611,7 +611,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Post)
@@ -621,7 +621,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -681,7 +681,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Post)
@@ -691,7 +691,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -743,9 +743,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -759,9 +759,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -808,9 +808,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -824,9 +824,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -871,7 +871,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -881,7 +881,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -926,7 +926,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -936,7 +936,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -981,9 +981,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -995,9 +995,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1042,9 +1042,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -1056,9 +1056,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1119,7 +1119,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -1127,7 +1127,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1181,7 +1181,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -1189,7 +1189,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -427,10 +427,10 @@ describe("Cypher Auth Where", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
@@ -445,10 +445,10 @@ describe("Cypher Auth Where", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_content0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_content0:this_content0, auth:$auth,this_update_content0_id:$this_update_content0_id})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -620,7 +620,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Post)
@@ -630,7 +630,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -690,7 +690,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Post)
@@ -700,7 +700,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -753,9 +753,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -769,9 +769,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -818,9 +818,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -834,9 +834,9 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -882,7 +882,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -892,7 +892,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -937,7 +937,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Post)
@@ -947,7 +947,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -993,9 +993,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -1007,9 +1007,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1054,9 +1054,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             WHERE this.id IS NOT NULL AND this.id = $this_auth_where0_id
@@ -1068,9 +1068,9 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_content0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_content0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1132,7 +1132,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -1140,7 +1140,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1194,7 +1194,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
@@ -1202,7 +1202,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_content0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_content0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/where.test.ts
@@ -532,7 +532,7 @@ describe("Cypher Auth Where", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
             	RETURN c AS this_posts0_creator_User_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateUsers: $updateUsers, this_posts0:this_posts0, auth:$auth,this_update_posts0_id:$this_update_posts0_id})
             YIELD value AS _
             RETURN collect(DISTINCT this { .id, posts: [ (this)-[:HAS_POST]->(this_posts:Post)  WHERE EXISTS((this_posts)<-[:HAS_POST]-(:User)) AND ALL(creator IN [(this_posts)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_posts_auth_where0_creator_id) | this_posts { .id } ] }) AS data"
@@ -700,7 +700,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -760,7 +760,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -811,7 +811,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -856,7 +856,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -902,7 +902,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -947,7 +947,7 @@ describe("Cypher Auth Where", () => {
             			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -991,7 +991,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_posts0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_posts0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1034,7 +1034,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_posts0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_posts0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1096,7 +1096,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -1150,7 +1150,7 @@ describe("Cypher Auth Where", () => {
             FOREACH(_ IN CASE this_disconnect_posts0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_posts0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
@@ -287,7 +287,7 @@ describe("Label in Node directive", () => {
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
             SET this_actors0.name = $this_update_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
             YIELD value AS _
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -358,7 +358,7 @@ describe("Label in Node directive", () => {
             			MERGE (this)<-[:ACTED_IN]-(this_connect_actors0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -399,7 +399,7 @@ describe("Label in Node directive", () => {
             FOREACH(_ IN CASE this_disconnect_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/create/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/create/connect.test.ts
@@ -108,7 +108,7 @@ describe("Interface Relationships - Create connect", () => {
             SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this0
             	OPTIONAL MATCH (this0_actedIn_connect0_node:Series)
@@ -119,7 +119,7 @@ describe("Interface Relationships - Create connect", () => {
             SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/connect.test.ts
@@ -93,7 +93,7 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
@@ -104,7 +104,7 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -169,9 +169,9 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
@@ -193,9 +193,9 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -269,9 +269,9 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
@@ -282,7 +282,7 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -362,9 +362,9 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             UNION
             	WITH this
             	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
@@ -386,9 +386,9 @@ describe("Interface Relationships - Update connect", () => {
             SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/disconnect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/disconnect.test.ts
@@ -88,7 +88,7 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
@@ -96,7 +96,7 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -164,9 +164,9 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
@@ -182,9 +182,9 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -263,9 +263,9 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
@@ -273,7 +273,7 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -361,9 +361,9 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
@@ -379,9 +379,9 @@ describe("Interface Relationships - Update disconnect", () => {
             FOREACH(_ IN CASE this_disconnect_actedIn0_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actedIn0_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/update/update.test.ts
@@ -91,20 +91,20 @@ describe("Interface Relationships - Update update", () => {
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
             SET this_actedIn0.title = $this_update_actedIn0_title
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_title:$this_update_actedIn0_title})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
             SET this_actedIn0.title = $this_update_actedIn0_title
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_title:$this_update_actedIn0_title})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -176,13 +176,13 @@ describe("Interface Relationships - Update update", () => {
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
@@ -192,13 +192,13 @@ describe("Interface Relationships - Update update", () => {
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -280,22 +280,22 @@ describe("Interface Relationships - Update update", () => {
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_on_Movie_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors.args.update.actedIn[0].where.node.title
             CALL apoc.do.when(this_actedIn0 IS NOT NULL, \\"
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);
@@ -384,13 +384,13 @@ describe("Interface Relationships - Update update", () => {
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_on_Movie_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_on_Movie_actors0_name:$this_update_actedIn0_on_Movie_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             UNION
             WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
@@ -400,13 +400,13 @@ describe("Interface Relationships - Update update", () => {
             OPTIONAL MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
             CALL apoc.do.when(this_actedIn0_actors0 IS NOT NULL, \\\\\\"
             SET this_actedIn0_actors0.name = $this_update_actedIn0_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actedIn0:this_actedIn0, updateActors: $updateActors, this_actedIn0_actors0:this_actedIn0_actors0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateActors: $updateActors, this_actedIn0:this_actedIn0, auth:$auth,this_update_actedIn0_actors0_name:$this_update_actedIn0_actors0_name})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .name }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1115.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1115.test.ts
@@ -84,7 +84,7 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
             ON CREATE SET
                     this_connectOrCreate_children_this1.tcId = $this_connectOrCreate_children_param1
             MERGE (this_connectOrCreate_children_this1)-[this_connectOrCreate_children_this0:\`HAS\`]->(this)
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             	WITH this
             CALL {
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
             ON CREATE SET
                     this_connectOrCreate_children_this4.tcId = $this_connectOrCreate_children_param3
             MERGE (this_connectOrCreate_children_this4)-[this_connectOrCreate_children_this3:\`HAS\`]->(this)
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             RETURN 'Query cannot conclude with CALL'"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1131.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1131.test.ts
@@ -99,7 +99,7 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
                     this_isInPublication0_connectOrCreate_this2.uri = $this_isInPublication0_connectOrCreate_param1,
             this_isInPublication0_connectOrCreate_this2.prefLabel = $this_isInPublication0_connectOrCreate_param2
             MERGE (this)-[this_isInPublication0_connectOrCreate_this0:\`isInPublication\`]->(this_isInPublication0_connectOrCreate_this2)
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             	WITH this
             CALL {
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
                     this_isInPublication1_connectOrCreate_this2.uri = $this_isInPublication1_connectOrCreate_param1,
             this_isInPublication1_connectOrCreate_this2.prefLabel = $this_isInPublication1_connectOrCreate_param2
             MERGE (this)-[this_isInPublication1_connectOrCreate_this0:\`isInPublication\`]->(this_isInPublication1_connectOrCreate_this2)
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             RETURN collect(DISTINCT this { iri: this.uri, .prefLabel, isInPublication: [ (this)-[:isInPublication]->(this_isInPublication:\`Concept\`:\`Resource\`)  WHERE this_isInPublication.uri IN $this_isInPublication_iri_IN | this_isInPublication { iri: this_isInPublication.uri, .prefLabel } ] }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1132.test.ts
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             			MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -130,7 +130,7 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             FOREACH(_ IN CASE this_disconnect_targets0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_targets0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1182.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1182.test.ts
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             this0_actors_connectOrCreate_this1.homeAddress = $this0_actors_connectOrCreate_param2,
             this0_actors_connectOrCreate_this1.dob = $this0_actors_connectOrCreate_param3
             MERGE (this0_actors_connectOrCreate_this1)-[this0_actors_connectOrCreate_this0:\`ACTED_IN\`]->(this0)
-            	RETURN COUNT(*)
+            	RETURN COUNT(*) AS _
             }
             RETURN this0
             }

--- a/packages/graphql/tests/tck/tck-test-files/issues/324.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/324.test.ts
@@ -112,7 +112,7 @@ describe("#324", () => {
             			MERGE (this_car0_manufacturer0)-[:LOGO]->(this_car0_manufacturer0_logo0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this, this_car0, this_car0_manufacturer0
             CALL {
@@ -122,7 +122,7 @@ describe("#324", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDManufacturer.logo required', [0])
             	RETURN c AS this_car0_manufacturer0_logo_Logo_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_car0:this_car0, updatePeople: $updatePeople, this_car0_manufacturer0:this_car0_manufacturer0, auth:$auth,this_update_car0_manufacturer0_name:$this_update_car0_manufacturer0_name,this_car0_manufacturer0_logo0_connect0_node_identifier:$this_car0_manufacturer0_logo0_connect0_node_identifier})
             YIELD value AS _
             WITH this, this_car0
@@ -133,7 +133,7 @@ describe("#324", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDCar.manufacturer required', [0])
             	RETURN c AS this_car0_manufacturer_Manufacturer_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updatePeople: $updatePeople, this_car0:this_car0, auth:$auth,this_update_car0_manufacturer0_name:$this_update_car0_manufacturer0_name,this_car0_manufacturer0_logo0_connect0_node_identifier:$this_car0_manufacturer0_logo0_connect0_node_identifier})
             YIELD value AS _
             WITH this

--- a/packages/graphql/tests/tck/tck-test-files/issues/894.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/894.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             			MERGE (this)-[:ACTIVELY_MANAGING]->(this_connect_activeOrganization0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             FOREACH(_ IN CASE this_disconnect_activeOrganization0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_activeOrganization0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {

--- a/packages/graphql/tests/tck/tck-test-files/nested-unions.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/nested-unions.test.ts
@@ -125,9 +125,9 @@ describe("Nested Unions", () => {
             			MERGE (this_connect_actors_LeadActor0_node)-[:ACTED_IN]->(this_connect_actors_LeadActor0_node_actedIn_Series0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .title, actors:  [this_actors IN [(this)<-[:ACTED_IN]-(this_actors) WHERE (\\"LeadActor\\" IN labels(this_actors)) OR (\\"Extra\\" IN labels(this_actors)) | head( [ this_actors IN [this_actors] WHERE (\\"LeadActor\\" IN labels(this_actors)) | this_actors { __resolveType: \\"LeadActor\\",  .name, actedIn:  [this_actors_actedIn IN [(this_actors)-[:ACTED_IN]->(this_actors_actedIn) WHERE (\\"Movie\\" IN labels(this_actors_actedIn)) OR (\\"Series\\" IN labels(this_actors_actedIn)) | head( [ this_actors_actedIn IN [this_actors_actedIn] WHERE (\\"Movie\\" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: \\"Movie\\" }  ] + [ this_actors_actedIn IN [this_actors_actedIn] WHERE (\\"Series\\" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: \\"Series\\",  .name } ] ) ] WHERE this_actors_actedIn IS NOT NULL]  } ] + [ this_actors IN [this_actors] WHERE (\\"Extra\\" IN labels(this_actors)) | this_actors { __resolveType: \\"Extra\\" }  ] ) ] WHERE this_actors IS NOT NULL]  }) AS data"
         `);
@@ -197,9 +197,9 @@ describe("Nested Unions", () => {
             FOREACH(_ IN CASE this_disconnect_actors_LeadActor0_actedIn_Series0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actors_LeadActor0_actedIn_Series0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .title, actors:  [this_actors IN [(this)<-[:ACTED_IN]-(this_actors) WHERE (\\"LeadActor\\" IN labels(this_actors)) OR (\\"Extra\\" IN labels(this_actors)) | head( [ this_actors IN [this_actors] WHERE (\\"LeadActor\\" IN labels(this_actors)) | this_actors { __resolveType: \\"LeadActor\\",  .name, actedIn:  [this_actors_actedIn IN [(this_actors)-[:ACTED_IN]->(this_actors_actedIn) WHERE (\\"Movie\\" IN labels(this_actors_actedIn)) OR (\\"Series\\" IN labels(this_actors_actedIn)) | head( [ this_actors_actedIn IN [this_actors_actedIn] WHERE (\\"Movie\\" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: \\"Movie\\" }  ] + [ this_actors_actedIn IN [this_actors_actedIn] WHERE (\\"Series\\" IN labels(this_actors_actedIn)) | this_actors_actedIn { __resolveType: \\"Series\\",  .name } ] ) ] WHERE this_actors_actedIn IS NOT NULL]  } ] + [ this_actors IN [this_actors] WHERE (\\"Extra\\" IN labels(this_actors)) | this_actors { __resolveType: \\"Extra\\" }  ] ) ] WHERE this_actors IS NOT NULL]  }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/operations/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/connect.test.ts
@@ -163,11 +163,11 @@ describe("Cypher Connect", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
             	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this0
             CALL {
@@ -197,9 +197,9 @@ describe("Cypher Connect", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
             	RETURN c AS this0_photos_connect0_node_color_Color_unique_ignored
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this0
             CALL {
@@ -229,9 +229,9 @@ describe("Cypher Connect", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
             	RETURN c AS this0_photos_connect1_node_color_Color_unique_ignored
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }

--- a/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
@@ -283,7 +283,7 @@ describe("Cypher Create", () => {
             			MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -340,7 +340,7 @@ describe("Cypher Create", () => {
             			MERGE (this0)-[:ACTED_IN]->(this0_movies_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }

--- a/packages/graphql/tests/tck/tck-test-files/operations/disconnect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/disconnect.test.ts
@@ -138,11 +138,11 @@ describe("Cypher Disconnect", () => {
             FOREACH(_ IN CASE this_colors0_disconnect0_photos0_color0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_colors0_disconnect0_photos0_color0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -160,9 +160,9 @@ describe("Cypher Disconnect", () => {
             FOREACH(_ IN CASE this_photos0_disconnect0_color0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_photos0_disconnect0_color0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -180,9 +180,9 @@ describe("Cypher Disconnect", () => {
             FOREACH(_ IN CASE this_photos0_disconnect1_color0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_photos0_disconnect1_color0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/operations/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/update.test.ts
@@ -112,7 +112,7 @@ describe("Cypher Update", () => {
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
             SET this_actors0.name = $this_update_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
             YIELD value AS _
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -200,10 +200,10 @@ describe("Cypher Update", () => {
             WHERE this_actors0_movies0.id = $updateMovies.args.update.actors[0].update.node.movies[0].where.node.id
             CALL apoc.do.when(this_actors0_movies0 IS NOT NULL, \\\\\\"
             SET this_actors0_movies0.title = $this_update_actors0_movies0_title
-            RETURN count(*)
+            RETURN count(*) AS _
             \\\\\\", \\\\\\"\\\\\\", {this:this, this_actors0:this_actors0, updateMovies: $updateMovies, this_actors0_movies0:this_actors0_movies0, auth:$auth,this_update_actors0_movies0_title:$this_update_actors0_movies0_title})
             YIELD value AS _
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name,this_update_actors0_movies0_title:$this_update_actors0_movies0_title})
             YIELD value AS _
             RETURN collect(DISTINCT this { .id }) AS data"
@@ -286,7 +286,7 @@ describe("Cypher Update", () => {
             			MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -334,7 +334,7 @@ describe("Cypher Update", () => {
             			MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -346,7 +346,7 @@ describe("Cypher Update", () => {
             			MERGE (this)<-[this_connect_actors1_relationship:ACTED_IN]-(this_connect_actors1_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -388,7 +388,7 @@ describe("Cypher Update", () => {
             FOREACH(_ IN CASE this_disconnect_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -448,7 +448,7 @@ describe("Cypher Update", () => {
             FOREACH(_ IN CASE this_disconnect_actors0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actors0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this
             CALL {
@@ -458,7 +458,7 @@ describe("Cypher Update", () => {
             FOREACH(_ IN CASE this_disconnect_actors1 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_actors1_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -726,7 +726,7 @@ describe("Cypher Update", () => {
             WHERE this_actors0.name = $updateMovies.args.update.actors[0].where.node.name
             CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
             SET this_actors0.name = $this_update_actors0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
             YIELD value AS _
             WITH this

--- a/packages/graphql/tests/tck/tck-test-files/pringles.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/pringles.test.ts
@@ -172,7 +172,7 @@ describe("Cypher Create Pringles", () => {
             			MERGE (this0_photos1_node)-[:OF_COLOR]->(this0_photos1_node_color_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             MERGE (this0)-[:HAS_PHOTO]->(this0_photos1_node)
             WITH this0, this0_photos1_node
@@ -198,7 +198,7 @@ describe("Cypher Create Pringles", () => {
             			MERGE (this0_photos2_node)-[:OF_COLOR]->(this0_photos2_node_color_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             MERGE (this0)-[:HAS_PHOTO]->(this0_photos2_node)
             WITH this0, this0_photos2_node
@@ -293,7 +293,7 @@ describe("Cypher Create Pringles", () => {
             FOREACH(_ IN CASE this_photos0_color0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_photos0_color0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             WITH this, this_photos0
             CALL {
@@ -305,7 +305,7 @@ describe("Cypher Create Pringles", () => {
             			MERGE (this_photos0)-[:OF_COLOR]->(this_photos0_color0_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             WITH this, this_photos0
             CALL {
@@ -315,7 +315,7 @@ describe("Cypher Create Pringles", () => {
             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
             	RETURN c AS this_photos0_color_Color_unique_ignored
             }
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateProducts: $updateProducts, this_photos0:this_photos0, auth:$auth,this_update_photos0_description:$this_update_photos0_description,this_photos0_color0_connect0_node_name:$this_photos0_color0_connect0_node_name})
             YIELD value AS _
             RETURN collect(DISTINCT this { .id }) AS data"

--- a/packages/graphql/tests/tck/tck-test-files/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/rfcs/rfc-003.test.ts
@@ -449,7 +449,7 @@ describe("integration/rfs/003", () => {
                             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required', [0])
                             	RETURN c AS this_director0_address_Address_unique_ignored
                             }
-                            RETURN count(*)
+                            RETURN count(*) AS _
                             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_director0:this_director0, auth:$auth,this_update_director0_id:$this_update_director0_id})
                             YIELD value AS _
                             WITH this
@@ -543,7 +543,7 @@ describe("integration/rfs/003", () => {
                             	CALL apoc.util.validate(NOT(c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address must be less than or equal to one', [0])
                             	RETURN c AS this_director0_address_Address_unique_ignored
                             }
-                            RETURN count(*)
+                            RETURN count(*) AS _
                             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_director0:this_director0, auth:$auth,this_update_director0_id:$this_update_director0_id})
                             YIELD value AS _
                             WITH this
@@ -929,7 +929,7 @@ describe("integration/rfs/003", () => {
                         			MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
                         		)
                         	)
-                        	RETURN count(*)
+                        	RETURN count(*) AS _
                         }
                         WITH this0
                         CALL {
@@ -998,7 +998,7 @@ describe("integration/rfs/003", () => {
                         			MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
                         		)
                         	)
-                        	RETURN count(*)
+                        	RETURN count(*) AS _
                         }
                         WITH this0
                         CALL {
@@ -1103,9 +1103,9 @@ describe("integration/rfs/003", () => {
                             	CALL apoc.util.validate(NOT(c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required', [0])
                             	RETURN c AS this0_director_connect0_node_address_Address_unique_ignored
                             }
-                            	RETURN count(*)
+                            	RETURN count(*) AS _
                             }
-                            	RETURN count(*)
+                            	RETURN count(*) AS _
                             }
                             WITH this0
                             CALL {
@@ -1175,7 +1175,7 @@ describe("integration/rfs/003", () => {
                         FOREACH(_ IN CASE this_disconnect_director0 WHEN NULL THEN [] ELSE [1] END |
                         DELETE this_disconnect_director0_rel
                         )
-                        RETURN count(*)
+                        RETURN count(*) AS _
                         }
                         WITH this
                         CALL {
@@ -1267,7 +1267,7 @@ describe("integration/rfs/003", () => {
                         			MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
                         		)
                         	)
-                        	RETURN count(*)
+                        	RETURN count(*) AS _
                         }
                         WITH this
                         CALL {
@@ -1277,7 +1277,7 @@ describe("integration/rfs/003", () => {
                         FOREACH(_ IN CASE this_disconnect_director0 WHEN NULL THEN [] ELSE [1] END |
                         DELETE this_disconnect_director0_rel
                         )
-                        RETURN count(*)
+                        RETURN count(*) AS _
                         }
                         WITH this
                         CALL {
@@ -1368,7 +1368,7 @@ describe("integration/rfs/003", () => {
                         			MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
                         		)
                         	)
-                        	RETURN count(*)
+                        	RETURN count(*) AS _
                         }
                         WITH this
                         CALL {
@@ -1378,7 +1378,7 @@ describe("integration/rfs/003", () => {
                         FOREACH(_ IN CASE this_disconnect_director0 WHEN NULL THEN [] ELSE [1] END |
                         DELETE this_disconnect_director0_rel
                         )
-                        RETURN count(*)
+                        RETURN count(*) AS _
                         }
                         WITH this
                         CALL {

--- a/packages/graphql/tests/tck/tck-test-files/union.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/union.test.ts
@@ -206,7 +206,7 @@ describe("Cypher Union", () => {
             			MERGE (this0)-[:SEARCH]->(this0_search_Genre_connect0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN this0
             }
@@ -257,7 +257,7 @@ describe("Cypher Union", () => {
             WHERE this_search_Genre0.name = $updateMovies.args.update.search.Genre[0].where.node.name
             CALL apoc.do.when(this_search_Genre0 IS NOT NULL, \\"
             SET this_search_Genre0.name = $this_update_search_Genre0_name
-            RETURN count(*)
+            RETURN count(*) AS _
             \\", \\"\\", {this:this, updateMovies: $updateMovies, this_search_Genre0:this_search_Genre0, auth:$auth,this_update_search_Genre0_name:$this_update_search_Genre0_name})
             YIELD value AS _
             RETURN collect(DISTINCT this { .title }) AS data"
@@ -331,7 +331,7 @@ describe("Cypher Union", () => {
             FOREACH(_ IN CASE this_search_Genre0_disconnect0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_search_Genre0_disconnect0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .title }) AS data"
         `);
@@ -395,7 +395,7 @@ describe("Cypher Union", () => {
             FOREACH(_ IN CASE this_disconnect_search_Genre0 WHEN NULL THEN [] ELSE [1] END |
             DELETE this_disconnect_search_Genre0_rel
             )
-            RETURN count(*)
+            RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .title }) AS data"
         `);
@@ -457,7 +457,7 @@ describe("Cypher Union", () => {
             			MERGE (this)-[:SEARCH]->(this_connect_search_Genre0_node)
             		)
             	)
-            	RETURN count(*)
+            	RETURN count(*) AS _
             }
             RETURN collect(DISTINCT this { .title }) AS data"
         `);


### PR DESCRIPTION
# Description

Within subqueries, `RETURN` clauses used to be:

```
RETURN count(*)
```

Now they are:

```
RETURN count(*) AS _
```

This satisfies the requirements of 5.0