### PR TITLE
Fix update in subscriptions with multiple fields update

### DIFF
--- a/docs/modules/ROOT/pages/subscriptions/getting-started.adoc
+++ b/docs/modules/ROOT/pages/subscriptions/getting-started.adoc
@@ -118,3 +118,6 @@ mutation {
     }
 }
 ```
+
+NOTE: This example uses the link:https://www.npmjs.com/package/graphql-ws[graphql-ws] implementation, if you are using Apollo Studio, make sure
+to select "graphql-ws" implementation in connection settings.

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -36,6 +36,7 @@ import { filterMetaVariable } from "./subscriptions/filter-meta-variable";
 import { escapeQuery } from "./utils/escape-query";
 import { CallbackBucket } from "../classes/CallbackBucket";
 import { addCallbackAndSetParam } from "./utils/callback-utils";
+import { indentBlock } from "./utils/indent-block";
 
 interface Res {
     strs: string[];
@@ -48,7 +49,7 @@ interface UpdateMeta {
     postAuthStrs: string[];
 }
 
-function createUpdateAndParams({
+export default function createUpdateAndParams({
     updateInput,
     varName,
     node,
@@ -364,7 +365,6 @@ function createUpdateAndParams({
                         if (withVars) {
                             subquery.push(`WITH ${withVars.join(", ")}`);
                         }
-
                         const creates = relationField.typeMeta.array ? update.create : [update.create];
                         creates.forEach((create, i) => {
                             const baseName = `${_varName}_create${i}`;
@@ -436,11 +436,6 @@ function createUpdateAndParams({
             return res;
         }
 
-        if (context.subscriptionsEnabled) {
-            const oldProps = `WITH ${varName} { .* } AS ${META_OLD_PROPS_CYPHER_VARIABLE}, ${withVars.join(", ")}`;
-            res.strs.push(oldProps);
-        }
-
         if (!hasAppliedTimeStamps) {
             const timestampedFields = node.temporalFields.filter(
                 (temporalField) =>
@@ -474,11 +469,6 @@ function createUpdateAndParams({
             }
 
             res.params[param] = value;
-        }
-
-        if (context.subscriptionsEnabled) {
-            const eventMeta = createEventMeta({ event: "update", nodeVariable: varName, typename: node.name });
-            res.strs.push(`WITH ${filterMetaVariable(withVars).join(", ")}, ${eventMeta}`);
         }
 
         if (authableField) {
@@ -575,10 +565,20 @@ function createUpdateAndParams({
         const apocStr = `CALL apoc.util.validate(NOT(${postAuthStrs.join(" AND ")}), ${forbiddenString}, [0])`;
         postAuthStr = `${withStr}\n${apocStr}`;
     }
+
+    let statements = strs;
+    if (context.subscriptionsEnabled) {
+        statements = wrapInSubscriptionsMetaCall({
+            withVars,
+            nodeVariable: varName,
+            typename: node.name,
+            statements: strs,
+        });
+    }
     return [
         [
             preAuthStr,
-            ...strs,
+            ...statements,
             postAuthStr,
             ...(relationshipValidationStr ? [withStr, relationshipValidationStr] : []),
         ].join("\n"),
@@ -586,4 +586,25 @@ function createUpdateAndParams({
     ];
 }
 
-export default createUpdateAndParams;
+function wrapInSubscriptionsMetaCall({
+    statements,
+    nodeVariable,
+    typename,
+    withVars,
+}: {
+    statements: string[];
+    nodeVariable: string;
+    typename: string;
+    withVars: string[];
+}): string[] {
+    const updateMetaVariable = "update_meta";
+    const preCallWith = `WITH ${nodeVariable} { .* } AS ${META_OLD_PROPS_CYPHER_VARIABLE}, ${withVars.join(", ")}`;
+
+    const callBlock = ["WITH *", ...statements, `RETURN ${META_CYPHER_VARIABLE} as ${updateMetaVariable}`];
+    const postCallWith = `WITH *, ${updateMetaVariable} as ${META_CYPHER_VARIABLE}`;
+
+    const eventMeta = createEventMeta({ event: "update", nodeVariable, typename });
+    const eventMetaWith = `WITH ${filterMetaVariable(withVars).join(", ")}, ${eventMeta}`;
+
+    return [preCallWith, "CALL {", ...indentBlock(callBlock), "}", postCallWith, eventMetaWith];
+}

--- a/packages/graphql/src/translate/utils/indent-block.ts
+++ b/packages/graphql/src/translate/utils/indent-block.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function indentBlock(query: string): string;
+export function indentBlock(query: string[]): string[];
+export function indentBlock(query: string | string[]): string | string[] {
+    if (typeof query === "string") {
+        const statements = query.split("\n");
+        return indentStatements(statements).join("\n");
+    } else {
+        return indentStatements(query);
+    }
+}
+
+function indentStatements(statements: string[]): string[] {
+    return statements.map((s) => `\t${s}`);
+}

--- a/packages/graphql/src/translate/utils/indent-block.ts
+++ b/packages/graphql/src/translate/utils/indent-block.ts
@@ -23,9 +23,8 @@ export function indentBlock(query: string | string[]): string | string[] {
     if (typeof query === "string") {
         const statements = query.split("\n");
         return indentStatements(statements).join("\n");
-    } else {
-        return indentStatements(query);
     }
+    return indentStatements(query);
 }
 
 function indentStatements(statements: string[]): string[] {

--- a/packages/graphql/tests/tck/tck-test-files/subscriptions/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/subscriptions/update.test.ts
@@ -73,7 +73,12 @@ describe("Subscriptions metadata on update", () => {
             MATCH (this:Movie)
             WHERE this.id = $this_id
             WITH this { .* } AS oldProps, this, meta
-            SET this.id = $this_update_id
+            CALL {
+            	WITH *
+            	SET this.id = $this_update_id
+            	RETURN meta as update_meta
+            }
+            WITH *, update_meta as meta
             WITH this, meta + { event: \\"update\\", id: id(this), properties: { old: oldProps, new: this { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
             WITH this, meta
             UNWIND meta AS m


### PR DESCRIPTION
# Description
This fix removes all references to `meta` in the updates query itself. If subscriptions are set, it will wrap the whole block in a call statement, with the pre and post assignments of the meta variables 