### PR TITLE
Docs: remove unnecessary requirement from Toolbox page

### DIFF
--- a/docs/modules/ROOT/pages/toolbox.adoc
+++ b/docs/modules/ROOT/pages/toolbox.adoc
@@ -24,4 +24,4 @@ Access the Toolbox here: https://graphql-toolbox.neo4j.io/
 == Requirements
 
 1. https://neo4j.com/docs/desktop-manual/current/[Neo4j Desktop] or https://neo4j.com/cloud/[Neo4j AuraDB]
-2. Make sure the database fulfills the requirements stated xref::introduction.adoc#introduction-requirements[here], including the necessary plugins. You must not have `Node.js` installed to use this Toolbox.
+2. Make sure the database fulfills the requirements stated xref::introduction.adoc#introduction-requirements[here], including the necessary plugins.


### PR DESCRIPTION
# Description

There was a typo in the sentence around Node.js on the Toolbox page, but I don't think it is necessary at all.