### PR TITLE
Compatibility checks which are compatible with 5.0

### DIFF
--- a/packages/graphql/src/classes/utils/verify-database.test.ts
+++ b/packages/graphql/src/classes/utils/verify-database.test.ts
@@ -162,41 +162,6 @@ describe("checkNeo4jCompat", () => {
         await expect(checkNeo4jCompat({ driver: fakeDriver })).resolves.not.toThrow();
     });
 
-    test("should throw expected APOC version", async () => {
-        const invalidApocVersion = "2.3.1";
-
-        // @ts-ignore
-        const fakeSession: Session = {
-            // @ts-ignore
-            run: () => ({
-                records: [
-                    {
-                        toObject: () => ({
-                            version: MIN_VERSIONS[0].neo4j,
-                            apocVersion: invalidApocVersion,
-                            functions: REQUIRED_APOC_FUNCTIONS,
-                            procedures: REQUIRED_APOC_PROCEDURES,
-                        }),
-                    },
-                ],
-            }),
-            // @ts-ignore
-            close: () => undefined,
-        };
-
-        // @ts-ignore
-        const fakeDriver: Driver = {
-            // @ts-ignore
-            session: () => fakeSession,
-            // @ts-ignore
-            verifyConnectivity: () => undefined,
-        };
-
-        await expect(checkNeo4jCompat({ driver: fakeDriver })).rejects.toThrow(
-            `Encountered the following DBMS compatiblility issues:\nAPOC version does not match Neo4j version '4.2', received: '${invalidApocVersion}'`
-        );
-    });
-
     test("should throw missing APOC functions", async () => {
         const minVersion = MIN_VERSIONS[0];
 

--- a/packages/graphql/src/classes/utils/verify-database.ts
+++ b/packages/graphql/src/classes/utils/verify-database.ts
@@ -18,16 +18,10 @@
  */
 
 import { Driver } from "neo4j-driver";
-import semver from "semver";
-import { REQUIRED_APOC_FUNCTIONS, REQUIRED_APOC_PROCEDURES, MIN_VERSIONS } from "../../constants";
 import { DriverConfig } from "../../types";
-
-interface DBInfo {
-    version: string;
-    apocVersion: string;
-    functions: string[];
-    procedures: string[];
-}
+import { verifyFunctions } from "./verify-functions";
+import { verifyProcedures } from "./verify-procedures";
+import { verifyVersion } from "./verify-version";
 
 async function checkNeo4jCompat({ driver, driverConfig }: { driver: Driver; driverConfig?: DriverConfig }) {
     await driver.verifyConnectivity();
@@ -47,73 +41,24 @@ async function checkNeo4jCompat({ driver, driverConfig }: { driver: Driver; driv
         }
     }
 
-    const session = driver.session(sessionParams);
-    const cypher = `
-        CALL dbms.components() yield versions
-        WITH head(versions) AS version
-        CALL dbms.functions() yield name AS functions
-        WITH version, COLLECT(functions) AS functions
-        CALL dbms.procedures() yield name AS procedures
-        RETURN
-            version,
-            functions,
-            COLLECT(procedures) AS procedures,
-            CASE "apoc.version" IN functions
-                WHEN true THEN apoc.version()
-                ELSE false
-            END AS apocVersion
-    `;
+    const sessionFactory = () => driver.session(sessionParams);
 
-    try {
-        const result = await session.run(cypher);
-        const info = result.records[0].toObject() as DBInfo;
-        const errors: string[] = [];
+    const errors: string[] = [];
 
-        if (!info.version.includes("aura")) {
-            const minimumVersions = MIN_VERSIONS.find(({ majorMinor }) => info.version.startsWith(majorMinor));
-            const coercedNeo4jVersion = semver.coerce(info.version);
+    const verificationResults = await Promise.allSettled([
+        verifyVersion(sessionFactory),
+        verifyFunctions(sessionFactory),
+        verifyProcedures(sessionFactory),
+    ]);
 
-            if (coercedNeo4jVersion) {
-                if (!minimumVersions) {
-                    // If new major/minor version comes out, this will stop error being thrown
-                    if (semver.lt(coercedNeo4jVersion, MIN_VERSIONS[0].neo4j)) {
-                        errors.push(
-                            `Expected Neo4j version '${MIN_VERSIONS[0].majorMinor}' or greater, received: '${info.version}'`
-                        );
-                    }
-                } else {
-                    if (semver.lt(coercedNeo4jVersion, minimumVersions.neo4j)) {
-                        errors.push(
-                            `Expected minimum Neo4j version: '${minimumVersions.neo4j}' received: '${info.version}'`
-                        );
-                    }
-
-                    if (!info.apocVersion.startsWith(minimumVersions.majorMinor)) {
-                        errors.push(
-                            `APOC version does not match Neo4j version '${minimumVersions.majorMinor}', received: '${info.apocVersion}'`
-                        );
-                    }
-                }
-            } else {
-                errors.push(`Unable to coerce version '${info.version}'`);
-            }
+    verificationResults.forEach((v) => {
+        if (v.status === "rejected") {
+            errors.push((v.reason as Error).message);
         }
+    });
 
-        const missingFunctions = REQUIRED_APOC_FUNCTIONS.filter((f) => !info.functions.includes(f));
-        if (missingFunctions.length) {
-            errors.push(`Missing APOC functions: [ ${missingFunctions.join(", ")} ]`);
-        }
-
-        const missingProcedures = REQUIRED_APOC_PROCEDURES.filter((p) => !info.procedures.includes(p));
-        if (missingProcedures.length) {
-            errors.push(`Missing APOC procedures: [ ${missingProcedures.join(", ")} ]`);
-        }
-
-        if (errors.length) {
-            throw new Error(`Encountered the following DBMS compatiblility issues:\n${errors.join("\n")}`);
-        }
-    } finally {
-        await session.close();
+    if (errors.length) {
+        throw new Error(`Encountered the following DBMS compatiblility issues:\n${errors.join("\n")}`);
     }
 }
 

--- a/packages/graphql/src/classes/utils/verify-functions.ts
+++ b/packages/graphql/src/classes/utils/verify-functions.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Session } from "neo4j-driver";
+import { REQUIRED_APOC_FUNCTIONS } from "../../constants";
+
+export async function verifyFunctions(sessionFactory: () => Session): Promise<void> {
+    const session = sessionFactory();
+
+    const cypher = `
+        SHOW FUNCTIONS
+        YIELD name
+        WHERE name IN ["${REQUIRED_APOC_FUNCTIONS.join('", "')}"]
+        RETURN collect(name) as functions
+    `;
+
+    try {
+        const result = await session.run(cypher);
+        const record = result.records[0].toObject() as { functions: string[] };
+
+        const missingFunctions = REQUIRED_APOC_FUNCTIONS.filter((f) => !record.functions.includes(f));
+        if (missingFunctions.length) {
+            throw new Error(`Missing APOC functions: [ ${missingFunctions.join(", ")} ]`);
+        }
+    } finally {
+        await session.close();
+    }
+}

--- a/packages/graphql/src/classes/utils/verify-procedures.ts
+++ b/packages/graphql/src/classes/utils/verify-procedures.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Session } from "neo4j-driver";
+import { REQUIRED_APOC_PROCEDURES } from "../../constants";
+
+export async function verifyProcedures(sessionFactory: () => Session): Promise<void> {
+    const session = sessionFactory();
+
+    const cypher = `
+        SHOW PROCEDURES
+        YIELD name
+        WHERE name IN ["${REQUIRED_APOC_PROCEDURES.join('", "')}"]
+        RETURN collect(name) as procedures
+    `;
+
+    try {
+        const result = await session.run(cypher);
+        const record = result.records[0].toObject() as { procedures: string[] };
+
+        const missingProcedures = REQUIRED_APOC_PROCEDURES.filter((f) => !record.procedures.includes(f));
+        if (missingProcedures.length) {
+            throw new Error(`Missing APOC procedures: [ ${missingProcedures.join(", ")} ]`);
+        }
+    } finally {
+        await session.close();
+    }
+}

--- a/packages/graphql/src/classes/utils/verify-version.ts
+++ b/packages/graphql/src/classes/utils/verify-version.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Session } from "neo4j-driver";
+import semver from "semver";
+import { MIN_VERSIONS } from "../../constants";
+
+export async function verifyVersion(sessionFactory: () => Session): Promise<void> {
+    const session = sessionFactory();
+
+    const cypher = `
+        CALL dbms.components() YIELD versions
+        RETURN head(versions) AS version
+    `;
+
+    try {
+        const result = await session.run(cypher);
+        const record = result.records[0].toObject() as { version: string };
+        const version = record.version;
+
+        if (!version.includes("aura")) {
+            const minimumVersions = MIN_VERSIONS.find(({ majorMinor }) => version.startsWith(majorMinor));
+            const coercedNeo4jVersion = semver.coerce(version);
+
+            if (coercedNeo4jVersion) {
+                if (!minimumVersions) {
+                    // If new major/minor version comes out, this will stop error being thrown
+                    if (semver.lt(coercedNeo4jVersion, MIN_VERSIONS[0].neo4j)) {
+                        throw new Error(
+                            `Expected Neo4j version '${MIN_VERSIONS[0].majorMinor}' or greater, received: '${version}'`
+                        );
+                    }
+                } else if (semver.lt(coercedNeo4jVersion, minimumVersions.neo4j)) {
+                    throw new Error(
+                        `Expected minimum Neo4j version: '${minimumVersions.neo4j}' received: '${version}'`
+                    );
+                }
+            } else {
+                throw new Error(`Unable to coerce version '${version}'`);
+            }
+        }
+    } finally {
+        await session.close();
+    }
+}


### PR DESCRIPTION
# Description

Removes the usage of `dbms.functions()` and `dbms.procedures()` - note, this is dependent on #1583!

Broken out into three separate calls to the database - `SHOW FUNCTIONS` and `SHOW PROCEDURES` can not be combined into Cypher queries like their predecessors. However, this is done with 3 parallel calls.