### PR TITLE
Feat: Toolbox - remove the beta tag

### DIFF
--- a/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
+++ b/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
@@ -47,7 +47,6 @@ export const TopBar = () => {
                 <div className="flex items-center justify-space">
                     <img src={Neo4jLogoIcon} alt="Neo4j logo Icon" className="ml-8 w-24" />
                     <p className="ml-6 text-base">GraphQL Toolbox</p>
-                    <div className="px-2 py-1 ml-3 rounded n-bg-danger-20 n-text-danger-60 text-sm">beta</div>
                 </div>
             </div>
             <div className="flex-1 flex justify-center">


### PR DESCRIPTION
# Description

Removing the `beta` tag in the GraphQL Toolbox.
