### PR TITLE
Fix: UI and doc publish

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           yarn
           yarn build
-          echo $PULL_REQUEST_NUMBER > ./build/prnumber
+          echo "$PULL_REQUEST_NUMBER" > ./build/prnumber
         working-directory: docs/
       - name: Archive documentation
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -20,10 +20,12 @@ jobs:
         with:
           node-version: lts/*
       - name: Build documentation
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           yarn
           yarn build
-          echo ${{ github.event.number }} > ./build/prnumber
+          echo $PULL_REQUEST_NUMBER > ./build/prnumber
         working-directory: docs/
       - name: Archive documentation
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -37,6 +37,7 @@ jobs:
       - id: get-pr-number
         run: |
           number=$(<prnumber)
+          case "$number" in ''|*[!0-9]*) echo "Provided PR number is not an integer"; exit 1 ;; esac
           echo "::set-output name=pr-number::$number"
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/ui-stage-build.yml
+++ b/.github/workflows/ui-stage-build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           yarn
           yarn build
-          echo $PULL_REQUEST_NUMBER > ./dist/prnumber
+          echo "$PULL_REQUEST_NUMBER" > ./dist/prnumber
         working-directory: packages/graphql-toolbox
       - name: Archive UI
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ui-stage-build.yml
+++ b/.github/workflows/ui-stage-build.yml
@@ -19,10 +19,12 @@ jobs:
         with:
           node-version: lts/*
       - name: UI build
+        env:
+          PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           yarn
           yarn build
-          echo ${{ github.event.number }} > ./dist/prnumber
+          echo $PULL_REQUEST_NUMBER > ./dist/prnumber
         working-directory: packages/graphql-toolbox
       - name: Archive UI
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ui-stage-publish.yml
+++ b/.github/workflows/ui-stage-publish.yml
@@ -37,6 +37,7 @@ jobs:
       - id: get-pr-number
         run: |
           number=$(<prnumber)
+          case "$number" in ''|*[!0-9]*) echo "Provided PR number is not an integer"; exit 1 ;; esac
           echo "::set-output name=pr-number::$number"
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# Description

Note: This PR is against `master`.

Using the same changes as in https://github.com/neo4j/graphql/pull/1610.
Cleanup PR number usage in docs and UI workflows to follow the commonly used `github.event.pull_request.number`.
