### PR TITLE
Revert "Switch multi DB checks to `driver.supportsMultiDb()` to avoid our own parsing of errors"

### DIFF
--- a/packages/graphql/tests/integration/directives/fulltext.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext.int.test.ts
@@ -25,28 +25,37 @@ import neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { generateUniqueType } from "../../utils/graphql-types";
 import { delay } from "../../../src/utils/utils";
+import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
 
 describe("@fulltext directive", () => {
     let driver: Driver;
     let databaseName: string;
-    let MULTIDB_SUPPORT: boolean;
+    let MULTIDB_SUPPORT = true;
 
     beforeAll(async () => {
         driver = await neo4j();
 
-        MULTIDB_SUPPORT = await driver.supportsMultiDb();
+        databaseName = generate({ readable: true, charset: "alphabetic" });
 
-        if (MULTIDB_SUPPORT) {
-            databaseName = generate({ readable: true, charset: "alphabetic" });
+        const cypher = `CREATE DATABASE ${databaseName}`;
+        const session = driver.session();
 
-            const cypher = `CREATE DATABASE ${databaseName}`;
-            const session = driver.session();
-
+        try {
             await session.run(cypher);
+        } catch (e) {
+            if (e instanceof Error) {
+                if (isMultiDbUnsupportedError(e)) {
+                    // No multi-db support, so we skip tests
+                    MULTIDB_SUPPORT = false;
+                } else {
+                    throw e;
+                }
+            }
+        } finally {
             await session.close();
-
-            await delay(5000);
         }
+
+        await delay(5000);
     });
 
     afterAll(async () => {

--- a/packages/graphql/tests/integration/directives/unique.int.test.ts
+++ b/packages/graphql/tests/integration/directives/unique.int.test.ts
@@ -24,28 +24,36 @@ import { gql } from "apollo-server";
 import neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { generateUniqueType } from "../../utils/graphql-types";
-import { delay } from "../../../src/utils/utils";
+import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
 
 describe("assertIndexesAndConstraints/unique", () => {
     let driver: Driver;
     let databaseName: string;
-    let MULTIDB_SUPPORT: boolean;
+    let MULTIDB_SUPPORT = true;
 
     beforeAll(async () => {
         driver = await neo4j();
 
-        MULTIDB_SUPPORT = await driver.supportsMultiDb();
+        databaseName = generate({ readable: true, charset: "alphabetic" });
 
-        if (MULTIDB_SUPPORT) {
-            databaseName = generate({ readable: true, charset: "alphabetic" });
-
-            const cypher = `CREATE DATABASE ${databaseName}`;
-            const session = driver.session();
+        const cypher = `CREATE DATABASE ${databaseName}`;
+        const session = driver.session();
+        try {
             await session.run(cypher);
+        } catch (e) {
+            if (e instanceof Error) {
+                if (isMultiDbUnsupportedError(e)) {
+                    // No multi-db support, so we skip tests
+                    MULTIDB_SUPPORT = false;
+                } else {
+                    throw e;
+                }
+            }
+        } finally {
             await session.close();
-
-            await delay(5000);
         }
+        // eslint-disable-next-line no-promise-executor-return
+        await new Promise((x) => setTimeout(x, 5000));
     });
 
     afterAll(async () => {

--- a/packages/graphql/tests/utils/is-multi-db-unsupported-error.ts
+++ b/packages/graphql/tests/utils/is-multi-db-unsupported-error.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export function isMultiDbUnsupportedError(e: Error) {
+    if (
+        e.message.includes("This is an administration command and it should be executed against the system database") ||
+        e.message.includes("Neo4jError: Unsupported administration command") ||
+        e.message.includes("Neo4jError: Unable to route write operation to leader for database 'system'")
+    ) {
+        return true;
+    }
+
+    return false;
+}

--- a/packages/introspector/tests/integration/graphql/graphs.test.ts
+++ b/packages/introspector/tests/integration/graphql/graphs.test.ts
@@ -25,27 +25,38 @@ import createDriver from "../neo4j";
 describe("GraphQL - Infer Schema on graphs", () => {
     const dbName = "introspectToNeo4jGrahqlTypeDefsGraphITDb";
     let driver: neo4j.Driver;
-    let MULTIDB_SUPPORT: boolean;
+    let MULTIDB_SUPPORT = true;
 
     const sessionFactory = (bm: string[]) => () =>
         driver.session({ defaultAccessMode: neo4j.session.READ, bookmarks: bm, database: dbName });
 
     beforeAll(async () => {
         driver = await createDriver();
-
-        MULTIDB_SUPPORT = await driver.supportsMultiDb();
-
-        if (MULTIDB_SUPPORT) {
-            const cSession = driver.session({ defaultAccessMode: neo4j.session.WRITE });
+        const cSession = driver.session({ defaultAccessMode: neo4j.session.WRITE });
+        try {
             await cSession.writeTransaction((tx) => tx.run(`CREATE DATABASE ${dbName}`));
-            const waitSession = driver.session({
-                defaultAccessMode: neo4j.session.READ,
-                database: dbName,
-                bookmarks: cSession.lastBookmark(),
-            });
-            await cSession.close();
-            await waitSession.close();
+        } catch (e) {
+            if (e instanceof Error) {
+                if (
+                    e.message.includes("should be executed against the system database") ||
+                    e.message.includes("Unsupported administration command")
+                ) {
+                    // No multi-db support, so we skip tests
+                    MULTIDB_SUPPORT = false;
+                } else {
+                    throw e;
+                }
+            } else {
+                throw e;
+            }
         }
+        const waitSession = driver.session({
+            defaultAccessMode: neo4j.session.READ,
+            database: dbName,
+            bookmarks: cSession.lastBookmark(),
+        });
+        await cSession.close();
+        await waitSession.close();
     });
     afterEach(async () => {
         if (MULTIDB_SUPPORT) {


### PR DESCRIPTION
Reverts neo4j/graphql#1603

Reason: This is sadly breaking all the Aura tests because `driver.supportsMultiDb()` is resulting in `true` when calling an Aura instance, free as well as professional. However, one is not allowed to create another database on Aura which breaks the tests.
We did not catch this because for pull requests we do not run any integration tests against Aura.

Example: https://github.com/neo4j/graphql/runs/7108025134?check_suite_focus=true#step:6:897 

