### PR TITLE
Remove Neo4jError prefix when checking for multi DB error

### DIFF
--- a/packages/graphql/tests/utils/is-multi-db-unsupported-error.ts
+++ b/packages/graphql/tests/utils/is-multi-db-unsupported-error.ts
@@ -20,8 +20,8 @@
 export function isMultiDbUnsupportedError(e: Error) {
     if (
         e.message.includes("This is an administration command and it should be executed against the system database") ||
-        e.message.includes("Neo4jError: Unsupported administration command") ||
-        e.message.includes("Neo4jError: Unable to route write operation to leader for database 'system'")
+        e.message.includes("Unsupported administration command") ||
+        e.message.includes("Unable to route write operation to leader for database 'system'")
     ) {
         return true;
     }


### PR DESCRIPTION
# Description

Continued 5.0 compatibility effort following failure of `supportsMultiDb`.