### PR TITLE
WIP Add concepts of PredicateExpressions and Expressions

### DIFF
--- a/packages/graphql/src/translate/cypher-builder/CypherBuilder.ts
+++ b/packages/graphql/src/translate/cypher-builder/CypherBuilder.ts
@@ -24,6 +24,24 @@ export { Apoc } from "./statements/Apoc";
 export { Call } from "./statements/Call";
 export { Match } from "./statements/Match";
 export { RawCypher, RawCypherWithCallback } from "./statements/RawCypher";
+export {
+    EqualityComparator,
+    StrComparator,
+    NumericalComparator,
+    ListComparator, 
+    Expression, 
+    Comparator,
+    TemporalComparatorAST,
+    NumbericalComparatorAST,
+    PointComparatorAST,
+    DurationComparatorAST,
+    StringComparatorAST,
+    BooleanComparatorAST,
+    LiteralExpression, 
+    PropertyExpression, 
+    ParamExpression 
+} from "./statements/PredicateExpresssionAST";
+
 
 export { Node, NamedNode } from "./references/Node";
 export { Param, RawParam, PointParam } from "./references/Param";

--- a/packages/graphql/src/translate/cypher-builder/statements/PredicateExpresssionAST.ts
+++ b/packages/graphql/src/translate/cypher-builder/statements/PredicateExpresssionAST.ts
@@ -1,0 +1,440 @@
+/*
+* Copyright (c) "Neo4j"
+* Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { CypherContext } from "../CypherContext";
+import { CypherParameter, CypherVariable } from "../references/References";
+import { Query } from "./Query";
+import { ScalarFunction } from "./scalar-functions";
+
+
+export type Expression  = PropertyExpression | ScalarFunction | LiteralExpression | ParamExpression;
+
+export class PropertyExpression {
+    property: any;
+    target: CypherVariable;
+    constructor(target: CypherVariable, property: any) {
+        this.property = property;
+        this.target = target;
+    }
+
+    getCypher(cypherContext: CypherContext): string {
+        const varId = cypherContext.getVariableId(this.target);
+        return `${varId}.${this.property}`;
+    }
+}
+
+export class LiteralExpression {
+    value: any;
+    constructor(value: any) {
+        this.value = value;
+    }
+
+    getCypher(cypherContext: CypherContext): string {
+        if (this.value === null) {
+            return `NULL`;
+        }
+        return `${this.value}`;
+    }
+}
+
+export class ParamExpression {
+    param: CypherParameter;
+    constructor(param: CypherParameter) {
+        this.param = param;
+    }
+
+    getCypher(cypherContext: CypherContext): string {
+        const paramId = cypherContext.getParamId(this.param);
+        return `$${paramId}`
+
+    }
+}
+
+export interface EqualityComparator {
+    eq: (left, right) => string;
+}
+
+export interface NumericalComparator extends EqualityComparator {
+    lt: (left, right) => string;
+    lte: (left, right) => string;
+    gt: (left, right) => string;
+    gte: (left, right) => string;
+}
+
+// Str just ot avoid a collision
+export interface StrComparator extends EqualityComparator {
+    contains: (left, right) => string;
+    startsWith: (left, right) => string;
+    endsWith: (left, right) => string;
+    matches: (left, right) => string;
+}
+
+export interface ListComparator {
+    in: (left, right) => string;
+    includes: (left, right) => string;
+}
+
+export abstract class Comparator extends Query {
+}
+
+export class PointComparatorAST extends Comparator implements NumericalComparator, ListComparator {
+    expression1: Expression;
+    expression2: Expression;
+    operation: any;
+    isArray: boolean;
+
+    constructor(
+        expression1: Expression, 
+        expression2: Expression, 
+        operation: keyof NumericalComparator | ListComparator,
+        isArray: boolean,
+        parent?: Query
+    ) {
+        super(parent);
+        this.expression1 = expression1;
+        this.expression2 = expression2;
+        this.operation = operation;
+        this.isArray = isArray;
+    }
+
+    cypher(context: CypherContext) {
+        const expression1Str = this.expression1.getCypher(context);
+        const expression2Str = this.expression2.getCypher(context);
+        if (expression2Str === "NULL") {
+            return `${expression1Str} IS ${expression2Str}`
+        }
+        return this[this.operation](expression1Str, expression2Str);
+    }
+
+    static distanceTemplate(property, param, comparator) {
+        return `distance(${property}, point(${param}.point)) ${comparator} ${param}.distance`;
+    }
+
+    static areaTemplate(point, points) {
+        return `${point} IN ${points}`;
+    }
+
+    static paramPoint(param) {
+        return `point(${param})`;
+    }
+
+    static paramPointArray(param) {
+        return `[p in ${param} | point(p)]`;
+    }
+
+    lt(left, right) {
+        return PointComparatorAST.distanceTemplate(left, right, "<");
+    }
+    
+    lte(left, right) {
+        return PointComparatorAST.distanceTemplate(left, right, "<=");
+    }
+
+    gt(left, right) {
+        return PointComparatorAST.distanceTemplate(left, right, ">")
+    }
+
+    gte(left, right) {
+        return PointComparatorAST.distanceTemplate(left, right, ">=")
+    }
+
+    in(left, right) {
+        return PointComparatorAST.areaTemplate(left, PointComparatorAST.paramPointArray(right));
+    }
+
+    includes(left, right) {
+        return PointComparatorAST.areaTemplate(PointComparatorAST.paramPoint(right), left);
+    }
+
+    eq(left, right) {
+        return `${left} = ${this.isArray ? PointComparatorAST.paramPointArray(right): PointComparatorAST.paramPoint(right)}`;
+    }
+}
+
+export class NumbericalComparatorAST extends Comparator implements NumericalComparator, ListComparator {
+    expression1: Expression;
+    expression2: Expression;
+    operation: any;
+
+    constructor(
+        expression1: Expression, 
+        expression2: Expression, 
+        operation: keyof NumericalComparator | ListComparator,
+        parent?: Query
+    ) {
+        super(parent);
+        this.expression1 = expression1;
+        this.expression2 = expression2;
+        this.operation = operation;
+    }
+
+    cypher(context: CypherContext) {
+        const expression1Str = this.expression1.getCypher(context);
+        const expression2Str = this.expression2.getCypher(context);
+        if (expression2Str === "NULL") {
+            return `${expression1Str} IS ${expression2Str}`;
+        }
+        return this[this.operation](expression1Str, expression2Str);
+    }
+
+    static numericalTemplate(left, right, operation) {
+        return `${left} ${operation} ${right}`;
+    }
+
+    lt(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(left, right, "<");
+    }
+    
+    lte(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(left, right, "<=");
+    }
+
+    gt(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(left, right, ">")
+    }
+
+    gte(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(left, right, ">=")
+    }
+
+    in(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(left, right, "IN");
+    }
+
+    includes(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(right, left, "IN");;
+    }
+
+    eq(left, right) {
+        return NumbericalComparatorAST.numericalTemplate(left, right, "=");
+    }
+}
+
+export class DurationComparatorAST extends Comparator implements NumericalComparator {
+    expression1: Expression;
+    expression2: Expression;
+    operation: any;
+
+    constructor(
+        expression1: Expression, 
+        expression2: Expression, 
+        operation: keyof NumericalComparator,
+        parent?: Query
+    ) {
+        super(parent);
+        this.expression1 = expression1;
+        this.expression2 = expression2;
+        this.operation = operation;
+    }
+
+    cypher(context: CypherContext) {
+        const expression1Str = this.expression1.getCypher(context);
+        const expression2Str = this.expression2.getCypher(context);
+        if (expression2Str === "NULL") {
+            return `${expression1Str} IS ${expression2Str}`;
+        }
+        return this[this.operation](expression1Str, expression2Str);
+    }
+
+    private static durationTemplate(left, right, operation) {
+        return `datetime() + ${left} ${operation} datetime() + ${right}`
+    }
+
+    lt(left, right) {
+        return DurationComparatorAST.durationTemplate(left, right, "<");
+    }
+    
+    lte(left, right) {
+        return DurationComparatorAST.durationTemplate(left, right, "<=");
+    }
+
+    gt(left, right) {
+        return DurationComparatorAST.durationTemplate(left, right, ">");
+    }
+
+    gte(left, right) {
+        return DurationComparatorAST.durationTemplate(left, right, ">=");
+    }
+
+    eq(left, right) {
+        return `${left} = ${right}`;
+    }
+}
+
+export class TemporalComparatorAST extends Comparator implements NumericalComparator, ListComparator {
+    expression1: Expression;
+    expression2: Expression;
+    operation: any;
+
+    constructor(
+        expression1: Expression, 
+        expression2: Expression, 
+        operation: keyof NumericalComparator | ListComparator,
+        parent?: Query
+    ) {
+        super(parent);
+        this.expression1 = expression1;
+        this.expression2 = expression2;
+        this.operation = operation;
+    }
+
+    cypher(context: CypherContext) {
+        const expression1Str = this.expression1.getCypher(context);
+        const expression2Str = this.expression2.getCypher(context);
+        if (expression2Str === "NULL") {
+            return `${expression1Str} IS ${expression2Str}`;
+        }
+        return this[this.operation](expression1Str, expression2Str);
+    }
+
+    private static temporalTemplate(left, right, operation) {
+        return `${left} ${operation} ${right}`
+    }
+
+    lt(left, right) {
+        return TemporalComparatorAST.temporalTemplate(left, right, "<");
+    }
+    
+    lte(left, right) {
+        return TemporalComparatorAST.temporalTemplate(left, right, "<=");
+    }
+
+    gt(left, right) {
+        return TemporalComparatorAST.temporalTemplate(left, right, ">");
+    }
+
+    gte(left, right) {
+        return TemporalComparatorAST.temporalTemplate(left, right, ">=");
+    }
+
+    in(left, right) {
+        return TemporalComparatorAST.temporalTemplate(left, right, "in");
+    }
+
+    includes(left, right) {
+        return TemporalComparatorAST.temporalTemplate(right, left, "in");
+    }
+
+    eq(left, right) {
+        return `${left} = ${right}`;
+    }
+}
+
+export class StringComparatorAST extends Comparator implements StrComparator, ListComparator {
+    expression1: Expression;
+    expression2: Expression;
+    operation: any;
+
+    constructor(
+        expression1: Expression, 
+        expression2: Expression, 
+        operation: keyof StrComparator | ListComparator,
+        parent?: Query
+    ) {
+        super(parent);
+        this.expression1 = expression1;
+        this.expression2 = expression2;
+        this.operation = operation;
+    }
+
+    cypher(context: CypherContext) {
+        const expression1Str = this.expression1.getCypher(context);
+        const expression2Str = this.expression2.getCypher(context);
+        if (expression2Str === "NULL") {
+            return `${expression1Str} IS ${expression2Str}`;
+        }
+        return this[this.operation](expression1Str, expression2Str);
+    }
+
+    private static stringTemplate(left, right, operation) {
+        return `${left} ${operation} ${right}`
+    }
+
+    startsWith(left, right) {
+        return StringComparatorAST.stringTemplate(left, right, "STARTS WITH");
+    }
+
+    endsWith(left, right) {
+        return StringComparatorAST.stringTemplate(left, right, "ENDS WITH");
+    }
+
+    contains(left, right) {
+        return StringComparatorAST.stringTemplate(left, right, "CONTAINS");
+    }
+
+    eq(left, right) {
+        return StringComparatorAST.stringTemplate(left, right, "=");
+    }
+
+    in(left, right) {
+        return StringComparatorAST.stringTemplate(left, right, "IN");
+    }
+
+    matches(left, right) {
+        return StringComparatorAST.stringTemplate(left, right, "=~");
+    }
+
+    includes(left, right) {
+        return StringComparatorAST.stringTemplate(right, left, "INCLUDES");
+    }
+}
+
+export class BooleanComparatorAST extends Comparator implements EqualityComparator, ListComparator {
+    expression1: Expression;
+    expression2: Expression;
+    operation: any;
+
+    constructor(
+        expression1: Expression, 
+        expression2: Expression, 
+        operation: keyof StrComparator | ListComparator,
+        parent?: Query
+    ) {
+        super(parent);
+        this.expression1 = expression1;
+        this.expression2 = expression2;
+        this.operation = operation;
+    }
+
+    cypher(context: CypherContext) {
+        const expression1Str = this.expression1.getCypher(context);
+        const expression2Str = this.expression2.getCypher(context);
+        if (expression2Str === "NULL") {
+            return `${expression1Str} IS ${expression2Str}`;
+        }
+        return this[this.operation](expression1Str, expression2Str);
+    }
+
+    private static booleanTemplate(left, right, operation) {
+        return `${left} ${operation} ${right}`
+    }
+
+    eq(left, right) {
+        return BooleanComparatorAST.booleanTemplate(left, right, "=");
+    }
+
+    in(left, right) {
+        return BooleanComparatorAST.booleanTemplate(left, right, "IN");
+    }
+
+    includes(left, right) {
+        return BooleanComparatorAST.booleanTemplate(right, left, "IN");
+    }
+}
+

--- a/packages/graphql/src/translate/cypher-builder/statements/Where.ts
+++ b/packages/graphql/src/translate/cypher-builder/statements/Where.ts
@@ -30,33 +30,6 @@ import { WhereOperator, and } from "./where-operators";
 
 type Params = Record<string, Param<any> | WhereClause>;
 
-// ASTNode
-//  -- Clause --- MATCH, RETURN
-//  -- SubClause --- WHERE, ORDER BY
-//      -- WHERE <BooleanOp | ComparisonOp>
-//  -- Function --- distance()
-//  -- RawCypher <- Weird hack
-
-// type Variable --- this, r
-// type Param --- param0
-// type PropertyRef=[Variable, PropertyPath] ---  this.potato, this.node.potato
-// type Operator --- +,=,, , AND, OR
-//   -- Boolean <Boolean | Comparison, OPERATOR, (Boolean | Comparison)?> --- AND, OR, NOT
-//   -- Comparison <Expression, Operator, Expression> --- IS NOT, =, <, IS NULL, STARTS WITH
-//   -- Math --- +,-,/
-//   -- List operators --- IN, [], .
-//   -- Aggregation operator DISTINCT
-//   -- Property operators --- =, +=, . (access) --- (propertyRef)
-
-// type List and type Map
-
-// type Expression --- PropertyRef | Variable | Function | Param | Operator | ¿CASE? | Literals
-
-// SET this.potato = distance(dsdas); // OK
-// SET this.potato = MATCH // X
-
-// type WhereInput=<Property, Expression>? --- this.potato = 5, "HELLO" IN this.potato
-
 export type WhereInput = Array<
     | [MatchableElement | Variable | ScalarFunction, Params]
     | WhereOperator

--- a/packages/graphql/src/translate/cypher-builder/statements/where-operators.ts
+++ b/packages/graphql/src/translate/cypher-builder/statements/where-operators.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { Exists, RawCypher, RawCypherWithCallback, Variable } from "../CypherBuilder";
+import { Exists, Comparator, RawCypher, RawCypherWithCallback, Variable } from "../CypherBuilder";
 import { CypherContext } from "../CypherContext";
 import { MatchableElement } from "../MatchPattern";
 import { Param } from "../references/Param";
@@ -43,7 +43,7 @@ export class WhereOperator {
         const nestedOperationsCypher = this.whereInput.map((input) => {
             if (input instanceof WhereOperator) return input.getCypher(context);
             if (input instanceof PredicateFunction) return input.getCypher(context);
-            if (input instanceof RawCypher || input instanceof RawCypherWithCallback || input instanceof Exists)
+            if (input instanceof RawCypher || input instanceof RawCypherWithCallback || input instanceof Exists || input instanceof Comparator)
                 return input.getCypher(context);
 
             return this.composeWhere(context, input as [MatchableElement | Variable, Params]);
@@ -131,7 +131,8 @@ class NotWhereOperator extends WhereOperator {
             inputOperator instanceof PredicateFunction ||
             inputOperator instanceof RawCypher ||
             inputOperator instanceof RawCypherWithCallback ||
-            inputOperator instanceof Exists
+            inputOperator instanceof Exists || 
+            inputOperator instanceof Comparator
         ) {
             const composedWhere = inputOperator.getCypher(context);
             return `\n${this.operation} ${composedWhere}`;

--- a/packages/graphql/src/translate/where/create-where-clause.ts
+++ b/packages/graphql/src/translate/where/create-where-clause.ts
@@ -62,11 +62,11 @@ export default function createWhereClause({
     // Comparison operations requires adding dates to durations
     // See https://neo4j.com/developer/cypher/dates-datetimes-durations/#comparing-filtering-values
     if (durationField && operator) {
-        return `datetime() + ${property} ${comparisonMap[operator]} datetime() + $${param}`;
+       return `datetime() + ${property} ${comparisonMap[operator]} datetime() + $${param}`;
     }
 
     const comparison = operator ? comparisonMap[operator] : "=";
-
+   
     switch (operator) {
         case "NOT_INCLUDES":
         case "INCLUDES":

--- a/packages/graphql/src/translate/where/utils.ts
+++ b/packages/graphql/src/translate/where/utils.ts
@@ -44,8 +44,9 @@ export const comparisonMap: Record<Exclude<WhereOperator, RelationshipWhereOpera
     INCLUDES: "IN",
 };
 
-export const whereRegEx =
-    /(?<prefix>\w*\.)?(?<fieldName>[_A-Za-z]\w*?)(?<isAggregate>Aggregate)?(?:_(?<operator>NOT|NOT_IN|IN|NOT_INCLUDES|INCLUDES|MATCHES|NOT_CONTAINS|CONTAINS|NOT_STARTS_WITH|STARTS_WITH|NOT_ENDS_WITH|ENDS_WITH|LT|LTE|GT|GTE|DISTANCE|ALL|NONE|SINGLE|SOME))?$/;
+export const whereRegEx = /(?<prefix>\w*\.)?(?<fieldName>[_A-Za-z]\w*?)(?<isAggregate>Aggregate)?(?:_(?<operator>NOT|NOT_IN|IN|NOT_INCLUDES|INCLUDES|MATCHES|NOT_CONTAINS|CONTAINS|NOT_STARTS_WITH|STARTS_WITH|NOT_ENDS_WITH|ENDS_WITH|LT|LTE|GT|GTE|DISTANCE|ALL|NONE|SINGLE|SOME))?$/;
+export const whereRegExWithoutNot =
+/(?<fieldName>(\w*\.)?[_A-Za-z]\w*?)(?<isAggregate>Aggregate)?(?:_(?<operator>IN|INCLUDES|INCLUDES|MATCHES|CONTAINS|CONTAINS|STARTS_WITH|ENDS_WITH|LT|LTE|GT|GTE|DISTANCE|ALL|NONE|SINGLE|SOME))?$/;
 // export const whereRegEx =
 //     /(?<fieldName>[_A-Za-z]\w*?)(?<isAggregate>Aggregate)?(?:_(?<operator>NOT|NOT_IN|IN|NOT_INCLUDES|INCLUDES|MATCHES|NOT_CONTAINS|CONTAINS|NOT_STARTS_WITH|STARTS_WITH|NOT_ENDS_WITH|ENDS_WITH|LT|LTE|GT|GTE|DISTANCE|ALL|NONE|SINGLE|SOME))?$/;
 export type WhereRegexGroups = {

--- a/packages/graphql/tests/tck/tck-test-files/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/advanced-filtering.test.ts
@@ -643,6 +643,7 @@ describe("Cypher Advanced Filtering", () => {
                 `;
                 return query;
             };
+
             test("ALL", async () => {
                 const query = generateQuery("ALL");
 


### PR DESCRIPTION
# Working in progress

Introduced the Concept of Expressions, Predicate Expressions, and Comparators.
All the tests are green, tck tests fail as they are not updated to understand better the changes of this PR, but the code is dirty and it needs some love before getting merged.

## TODO list:
- Move code from the PredicateExpressionAST to correct files and directories.
- Remove duplicates code from /translate/where/add-where-to-statement.ts. More details are below.
- The multiple switches over the operation are redundant.
- Duplicated code is used to identify the Comparator to use.
- Define an Expression interface.
- Move the not Cypher Comparators outside the CypherBuilder, for example, the PointComparator should not be part of the CypherBuilder IMO but instead should be an intermediate representation to use to build a NumericalComparator for Point fields.
- Common Comparator behaviors should be part of the Comparator abstract class rather than in the specialized classes.

