### PR TITLE
Refactor Aura tests in GHA, add tests for 5.0 against `dev`

### DIFF
--- a/.github/workflows/changesets-release.yml
+++ b/.github/workflows/changesets-release.yml
@@ -40,11 +40,21 @@ jobs:
     if: github.event.pull_request.merged == true
     uses: ./.github/workflows/reusable-toolbox-tests.yml
 
-  aura-tests:
+  aura-free-tests:
     if: github.event.pull_request.merged == true
     uses: ./.github/workflows/reusable-aura-tests.yml
-    secrets: inherit
-    concurrency: aura
+    secrets:
+      URI: ${{ secrets.AURA_FREE_URI }}
+      PASSWORD: ${{ secrets.AURA_FREE_PASSWORD }}
+    concurrency: aura-free
+
+  aura-professional-tests:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/reusable-aura-tests.yml
+    secrets:
+      URI: ${{ secrets.AURA_PROFESSIONAL_URI }}
+      PASSWORD: ${{ secrets.AURA_PROFESSIONAL_PASSWORD }}
+    concurrency: aura-professional
 
   # slack-release-notification:
   #   needs:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -37,7 +37,26 @@ jobs:
   toolbox-tests:
     uses: ./.github/workflows/reusable-toolbox-tests.yml
 
-  aura-tests:
+  aura-free-tests:
+    if: github.event.pull_request.merged == true
     uses: ./.github/workflows/reusable-aura-tests.yml
-    secrets: inherit
-    concurrency: aura
+    secrets:
+      URI: ${{ secrets.AURA_FREE_URI }}
+      PASSWORD: ${{ secrets.AURA_FREE_PASSWORD }}
+    concurrency: aura-free
+
+  aura-professional-tests:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/reusable-aura-tests.yml
+    secrets:
+      URI: ${{ secrets.AURA_PROFESSIONAL_URI }}
+      PASSWORD: ${{ secrets.AURA_PROFESSIONAL_PASSWORD }}
+    concurrency: aura-professional
+
+  aura-5-tests:
+    if: github.event.pull_request.merged == true
+    uses: ./.github/workflows/reusable-aura-tests.yml
+    secrets:
+      URI: ${{ secrets.AURA_5_URI }}
+      PASSWORD: ${{ secrets.AURA_5_PASSWORD }}
+    concurrency: aura-5

--- a/.github/workflows/reusable-aura-tests.yml
+++ b/.github/workflows/reusable-aura-tests.yml
@@ -3,27 +3,15 @@ name: "Aura tests"
 on:
   workflow_call:
     secrets:
-      AURA_FREE_URI:
+      URI:
         required: true
-        description: "URI locating the AuraDB Free instance to test against"
-      AURA_FREE_PASSWORD:
+        description: "The URI locating the AuraDB instance to be tested against"
+      PASSWORD:
         required: true
-        description: "Password of the AuraDB Free instance to test against"
-      AURA_PROFESSIONAL_URI:
-        required: true
-        description: "URI locating the AuraDB Professional instance to test against"
-      AURA_PROFESSIONAL_PASSWORD:
-        required: true
-        description: "Password of the AuraDB Professional instance to test against"
+        description: "The password needed to access the AuraDB instance"
 
 jobs:
-  aura-teardown:
-    strategy:
-      matrix:
-        aura-instance:
-          - free
-          - professional
-
+  teardown:
     runs-on: ubuntu-latest
 
     steps:
@@ -37,18 +25,13 @@ jobs:
         run: yarn --immutable
       - name: Install ts-node and typescript
         run: npm install -g ts-node typescript
-      - name: Uppercase instance name
-        run: |
-          lowercase_instance=${{ matrix.aura-instance }}
-          echo "AURA_URI_SECRET=AURA_${lowercase_instance^^}_URI" >>"${GITHUB_ENV}"
-          echo "AURA_PASSWORD_SECRET=AURA_${lowercase_instance^^}_PASSWORD" >>"${GITHUB_ENV}"
       - name: Delete all data in instance
         run: ts-node tests/integration/teardown.ts
         working-directory: packages/graphql
         env:
           NEO_USER: neo4j
-          NEO_PASSWORD: ${{ secrets[env.AURA_PASSWORD_SECRET] }}
-          NEO_URL: ${{ secrets[env.AURA_URI_SECRET] }}
+          NEO_PASSWORD: ${{ secrets.PASSWORD }}
+          NEO_URL: ${{ secrets.URI }}
 
   integration-tests-aura:
     needs:
@@ -63,9 +46,6 @@ jobs:
           - graphql
           - introspector
           - ogm
-        aura-instance:
-          - free
-          - professional
 
     runs-on: ubuntu-latest
 
@@ -78,17 +58,11 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable
-      - name: Uppercase instance name
-        run: |
-          lowercase_instance=${{ matrix.aura-instance }}
-          echo "AURA_URI_SECRET=AURA_${lowercase_instance^^}_URI" >>"${GITHUB_ENV}"
-          echo "AURA_PASSWORD_SECRET=AURA_${lowercase_instance^^}_PASSWORD" >>"${GITHUB_ENV}"
       - name: Run @neo4j/graphql integration tests
         run: |
-          yarn test:int --coverage
-          mv coverage coverage-aura-${{ matrix.aura-instance }}
+          yarn test:int
         working-directory: packages/${{ matrix.package }}
         env:
           NEO_USER: neo4j
-          NEO_PASSWORD: ${{ secrets[env.AURA_PASSWORD_SECRET] }}
-          NEO_URL: ${{ secrets[env.AURA_URI_SECRET] }}
+          NEO_PASSWORD: ${{ secrets.PASSWORD }}
+          NEO_URL: ${{ secrets.URI }}


### PR DESCRIPTION
# Description

Instead of having specific instance details in the reusable workflow for testing Aura, this expects the URI and password to passed in as secrets, so you call the workflow as many times as you require for testing against Aura. This is helpful because for instance, failing against 5.0 shouldn't be a release blocker. 