### PR TITLE
Fix: remove redundant check against non-existent parameter when querying interface connection

### DIFF
--- a/.changeset/tall-windows-relax.md
+++ b/.changeset/tall-windows-relax.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+fixed: redundant check against non-existent parameter when querying interface connection using `_on`

--- a/packages/graphql/src/translate/where/create-connection-where-and-params.ts
+++ b/packages/graphql/src/translate/where/create-connection-where-and-params.ts
@@ -120,19 +120,7 @@ function createConnectionWhereAndParams({
 
                 if (v?._on?.[node.name]) {
                     const onTypeNodeWhere = createElementWhereAndParams({
-                        whereInput: {
-                            ...Object.entries(v).reduce((args, [key, value]) => {
-                                if (key !== "_on") {
-                                    return { ...args, [key]: value };
-                                }
-
-                                if (Object.prototype.hasOwnProperty.call(value, node.name)) {
-                                    return { ...args, ...(value as any)[node.name] };
-                                }
-
-                                return args;
-                            }, {}),
-                        },
+                        whereInput: v._on[node.name],
                         element: node,
                         varName: nodeVariable,
                         context,

--- a/packages/graphql/tests/tck/tck-test-files/issues/1263.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1263.test.ts
@@ -85,13 +85,13 @@ describe("https://github.com/neo4j/graphql/issues/1263", () => {
             CALL {
             WITH this
             MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Movie:Movie)
-            WHERE this_Movie.title = $this_actedInConnection.args.where.node.title AND this_Movie.title = $this_actedInConnection.args.where.node._on.Movie.title AND this_Movie.runtime > $this_actedInConnection.args.where.node._on.Movie.runtime_GT
+            WHERE this_Movie.title = $this_actedInConnection.args.where.node.title AND this_Movie.runtime > $this_actedInConnection.args.where.node._on.Movie.runtime_GT
             WITH { node: { __resolveType: \\"Movie\\", title: this_Movie.title } } AS edge
             RETURN edge
             UNION
             WITH this
             MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Series:Series)
-            WHERE this_Series.title = $this_actedInConnection.args.where.node.title AND this_Series.title = $this_actedInConnection.args.where.node._on.Series.title AND this_Series.episodes > $this_actedInConnection.args.where.node._on.Series.episodes_GT
+            WHERE this_Series.title = $this_actedInConnection.args.where.node.title AND this_Series.episodes > $this_actedInConnection.args.where.node._on.Series.episodes_GT
             WITH { node: { __resolveType: \\"Series\\", title: this_Series.title } } AS edge
             RETURN edge
             }

--- a/packages/graphql/tests/tck/tck-test-files/issues/1263.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1263.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/1263", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Production {
+                title: String!
+            }
+
+            type Movie implements Production {
+                title: String!
+                runtime: Int!
+            }
+
+            type Series implements Production {
+                title: String!
+                episodes: Int!
+            }
+
+            interface ActedIn @relationshipProperties {
+                screenTime: Int!
+            }
+
+            type Actor {
+                name: String!
+                actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("doesn't have redundant check of non-existent parameter", async () => {
+        const query = gql`
+            query {
+                actors {
+                    name
+                    actedInConnection(
+                        where: {
+                            node: { title: "foo", _on: { Movie: { runtime_GT: 90 }, Series: { episodes_GT: 50 } } }
+                        }
+                    ) {
+                        edges {
+                            node {
+                                title
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Actor)
+            CALL {
+            WITH this
+            CALL {
+            WITH this
+            MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Movie:Movie)
+            WHERE this_Movie.title = $this_actedInConnection.args.where.node.title AND this_Movie.title = $this_actedInConnection.args.where.node._on.Movie.title AND this_Movie.runtime > $this_actedInConnection.args.where.node._on.Movie.runtime_GT
+            WITH { node: { __resolveType: \\"Movie\\", title: this_Movie.title } } AS edge
+            RETURN edge
+            UNION
+            WITH this
+            MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_Series:Series)
+            WHERE this_Series.title = $this_actedInConnection.args.where.node.title AND this_Series.title = $this_actedInConnection.args.where.node._on.Series.title AND this_Series.episodes > $this_actedInConnection.args.where.node._on.Series.episodes_GT
+            WITH { node: { __resolveType: \\"Series\\", title: this_Series.title } } AS edge
+            RETURN edge
+            }
+            WITH collect(edge) as edges
+            RETURN { edges: edges, totalCount: size(edges) } AS actedInConnection
+            }
+            RETURN this { .name, actedInConnection } as this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this_actedInConnection\\": {
+                    \\"args\\": {
+                        \\"where\\": {
+                            \\"node\\": {
+                                \\"title\\": \\"foo\\",
+                                \\"_on\\": {
+                                    \\"Movie\\": {
+                                        \\"runtime_GT\\": {
+                                            \\"low\\": 90,
+                                            \\"high\\": 0
+                                        }
+                                    },
+                                    \\"Series\\": {
+                                        \\"episodes_GT\\": {
+                                            \\"low\\": 50,
+                                            \\"high\\": 0
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

There was some overly complex code generating the where clause for the `_on` argument - this has been removed which fixed the Cypher issue.

# Issue

Closes #1263

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
