### PR TITLE
fixed: Aggregation column contains implicit grouping expressions

### DIFF
--- a/.changeset/breezy-peaches-draw.md
+++ b/.changeset/breezy-peaches-draw.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+fixed: Aggregation column contains implicit grouping expressions

--- a/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.test.ts
@@ -116,7 +116,8 @@ describe("createConnectionAndParams", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }"
         `);
     });
@@ -223,7 +224,8 @@ describe("createConnectionAndParams", () => {
             UNWIND edges as edge
             WITH edges, edge
             ORDER BY edge.screenTime DESC, edge.node.name ASC
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }"
         `);
     });

--- a/packages/graphql/tests/tck/tck-test-files/connections/alias.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/alias.test.ts
@@ -72,7 +72,8 @@ describe("Connections Alias", () => {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS actors
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS actors
             }
             RETURN this { actors } as this"
         `);
@@ -119,7 +120,8 @@ describe("Connections Alias", () => {
             WHERE this_actor.name = $this_hanks.args.where.node.name
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS hanks
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS hanks
             }
             CALL {
             WITH this
@@ -127,7 +129,8 @@ describe("Connections Alias", () => {
             WHERE this_actor.name = $this_jenny.args.where.node.name
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS jenny
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS jenny
             }
             RETURN this { .title, hanks, jenny } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/composite.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/composite.test.ts
@@ -95,7 +95,8 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             WHERE ((this_acted_in_relationship.screenTime > $this_actorsConnection.args.where.edge.AND[0].screenTime_GT) AND (this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.AND[1].screenTime_LT)) AND ((this_actor.firstName = $this_actorsConnection.args.where.node.AND[0].firstName) AND (this_actor.lastName = $this_actorsConnection.args.where.node.AND[1].lastName))
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/and.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/and.test.ts
@@ -89,7 +89,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
             WHERE ((this_actor.firstName = $this_actorsConnection.args.where.node.AND[0].firstName) AND (this_actor.lastName = $this_actorsConnection.args.where.node.AND[1].lastName))
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/arrays.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/arrays.test.ts
@@ -88,7 +88,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             WHERE this_actor.name IN $this_actorsConnection.args.where.node.name_IN
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -141,7 +142,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             WHERE (NOT this_actor.name IN $this_actorsConnection.args.where.node.name_NOT_IN)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -195,7 +197,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             WHERE $this_actorsConnection.args.where.node.favouriteColours_INCLUDES IN this_actor.favouriteColours
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, favouriteColours: this_actor.favouriteColours } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -246,7 +249,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             WHERE (NOT $this_actorsConnection.args.where.node.favouriteColours_NOT_INCLUDES IN this_actor.favouriteColours)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, favouriteColours: this_actor.favouriteColours } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/equality.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/equality.test.ts
@@ -87,7 +87,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
             WHERE this_actor.name = $this_actorsConnection.args.where.node.name
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -137,7 +138,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
             WHERE (NOT this_actor.name = $this_actorsConnection.args.where.node.name_NOT)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/numerical.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/numerical.test.ts
@@ -89,7 +89,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             WHERE this_actor.age < $this_actorsConnection.args.where.node.age_LT
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -143,7 +144,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             WHERE this_actor.age <= $this_actorsConnection.args.where.node.age_LTE
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -197,7 +199,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             WHERE this_actor.age > $this_actorsConnection.args.where.node.age_GT
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -251,7 +254,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             WHERE this_actor.age >= $this_actorsConnection.args.where.node.age_GTE
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, age: this_actor.age } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/or.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/or.test.ts
@@ -89,7 +89,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
             WHERE ((this_actor.firstName = $this_actorsConnection.args.where.node.OR[0].firstName) OR (this_actor.lastName = $this_actorsConnection.args.where.node.OR[1].lastName))
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { firstName: this_actor.firstName, lastName: this_actor.lastName } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/points.test.ts
@@ -102,7 +102,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
             	ELSE NULL
             END AS result',{ this_actor: this_actor },false) } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/relationship.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/relationship.test.ts
@@ -82,7 +82,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> Relationship", () => {
             WHERE EXISTS { (this_actor)-[:ACTED_IN]->(this_actor_movies:Movie) WHERE this_actor_movies.title = $this_actorsConnection.args.where.node.movies.title }
             WITH collect({ node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/string.test.ts
@@ -97,7 +97,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE this_actor.name CONTAINS $this_actorsConnection.args.where.node.name_CONTAINS
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -147,7 +148,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE (NOT this_actor.name CONTAINS $this_actorsConnection.args.where.node.name_NOT_CONTAINS)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -197,7 +199,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE this_actor.name STARTS WITH $this_actorsConnection.args.where.node.name_STARTS_WITH
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -247,7 +250,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE (NOT this_actor.name STARTS WITH $this_actorsConnection.args.where.node.name_NOT_STARTS_WITH)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -297,7 +301,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE this_actor.name ENDS WITH $this_actorsConnection.args.where.node.name_ENDS_WITH
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -347,7 +352,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE (NOT this_actor.name ENDS WITH $this_actorsConnection.args.where.node.name_NOT_ENDS_WITH)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -397,7 +403,8 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             WHERE this_actor.name =~ $this_actorsConnection.args.where.node.name_MATCHES
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/and.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/and.test.ts
@@ -89,7 +89,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
             WHERE ((this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.AND[0].role_ENDS_WITH) AND (this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.AND[1].screenTime_LT))
             WITH collect({ role: this_acted_in_relationship.role, screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/arrays.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/arrays.test.ts
@@ -88,7 +88,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             WHERE this_acted_in_relationship.screenTime IN $this_actorsConnection.args.where.edge.screenTime_IN
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -147,7 +148,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             WHERE (NOT this_acted_in_relationship.screenTime IN $this_actorsConnection.args.where.edge.screenTime_NOT_IN)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -206,7 +208,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             WHERE $this_actorsConnection.args.where.edge.quotes_INCLUDES IN this_acted_in_relationship.quotes
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -256,7 +259,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             WHERE (NOT $this_actorsConnection.args.where.edge.quotes_NOT_INCLUDES IN this_acted_in_relationship.quotes)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/equality.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/equality.test.ts
@@ -87,7 +87,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
             WHERE this_acted_in_relationship.screenTime = $this_actorsConnection.args.where.edge.screenTime
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -140,7 +141,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
             WHERE (NOT this_acted_in_relationship.screenTime = $this_actorsConnection.args.where.edge.screenTime_NOT)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/numerical.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/numerical.test.ts
@@ -87,7 +87,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             WHERE this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.screenTime_LT
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -140,7 +141,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             WHERE this_acted_in_relationship.screenTime <= $this_actorsConnection.args.where.edge.screenTime_LTE
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -193,7 +195,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             WHERE this_acted_in_relationship.screenTime > $this_actorsConnection.args.where.edge.screenTime_GT
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -246,7 +249,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             WHERE this_acted_in_relationship.screenTime >= $this_actorsConnection.args.where.edge.screenTime_GTE
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/or.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/or.test.ts
@@ -89,7 +89,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
             WHERE ((this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.OR[0].role_ENDS_WITH) OR (this_acted_in_relationship.screenTime < $this_actorsConnection.args.where.edge.OR[1].screenTime_LT))
             WITH collect({ role: this_acted_in_relationship.role, screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/points.test.ts
@@ -100,7 +100,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
             	ELSE NULL
             END AS result',{ this_acted_in_relationship: this_acted_in_relationship },false), node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/string.test.ts
@@ -98,7 +98,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE this_acted_in_relationship.role CONTAINS $this_actorsConnection.args.where.edge.role_CONTAINS
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -148,7 +149,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE (NOT this_acted_in_relationship.role CONTAINS $this_actorsConnection.args.where.edge.role_NOT_CONTAINS)
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -198,7 +200,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE this_acted_in_relationship.role STARTS WITH $this_actorsConnection.args.where.edge.role_STARTS_WITH
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -248,7 +251,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE (NOT this_acted_in_relationship.role STARTS WITH $this_actorsConnection.args.where.edge.role_NOT_STARTS_WITH)
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -298,7 +302,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.role_ENDS_WITH
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -348,7 +353,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE (NOT this_acted_in_relationship.role ENDS WITH $this_actorsConnection.args.where.edge.role_NOT_ENDS_WITH)
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -398,7 +404,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             WHERE this_acted_in_relationship.role =~ $this_actorsConnection.args.where.edge.role_MATCHES
             WITH collect({ role: this_acted_in_relationship.role, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/temporal.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/temporal.test.ts
@@ -91,7 +91,8 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
             WHERE this_acted_in_relationship.startDate > $this_actorsConnection.args.where.edge.startDate_GT AND this_acted_in_relationship.endDateTime < $this_actorsConnection.args.where.edge.endDateTime_LT
             WITH collect({ startDate: this_acted_in_relationship.startDate, endDateTime: apoc.date.convertFormat(toString(this_acted_in_relationship.endDateTime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/interfaces.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/interfaces.test.ts
@@ -104,7 +104,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { .name, actedInConnection } as this"
         `);
@@ -159,7 +160,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { .name, actedInConnection } as this"
         `);
@@ -228,7 +230,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { .name, actedInConnection } as this"
         `);
@@ -308,7 +311,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { .name, actedInConnection } as this"
         `);
@@ -381,7 +385,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     UNWIND edges as edge
                     WITH edges, edge
                     ORDER BY edge.screenTime ASC
-                    RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+                    WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+                    RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
                     }
                     RETURN this { .name, actedInConnection } as this"
                 `);
@@ -437,7 +442,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     UNWIND edges as edge
                     WITH edges, edge
                     ORDER BY edge.node.title ASC
-                    RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+                    WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+                    RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
                     }
                     RETURN this { .name, actedInConnection } as this"
                 `);
@@ -494,7 +500,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     UNWIND edges as edge
                     WITH edges, edge
                     ORDER BY edge.screenTime ASC
-                    RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+                    WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+                    RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
                     }
                     RETURN this { .name, actedInConnection } as this"
                 `);
@@ -549,7 +556,8 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     UNWIND edges as edge
                     WITH edges, edge
                     ORDER BY edge.node.title ASC
-                    RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+                    WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+                    RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
                     }
                     RETURN this { .name, actedInConnection } as this"
                 `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/mixed-nesting.test.ts
@@ -84,7 +84,8 @@ describe("Mixed nesting", () => {
             WHERE this_actor.name = $this_actorsConnection.args.where.node.name
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, movies: [ (this_actor)-[:ACTED_IN]->(this_actor_movies:Movie)  WHERE (NOT this_actor_movies.title = $this_actor_movies_title_NOT) | this_actor_movies { .title } ] } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -151,11 +152,13 @@ describe("Mixed nesting", () => {
             WHERE (NOT this_actor_movie.title = $this_actorsConnection.edges.node.moviesConnection.args.where.node.title_NOT)
             WITH collect({ node: { title: this_actor_movie.title, actors: [ (this_actor_movie)<-[:ACTED_IN]-(this_actor_movie_actors:Actor)  WHERE (NOT this_actor_movie_actors.name = $this_actor_movie_actors_name_NOT) | this_actor_movie_actors { .name } ] } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS moviesConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
             }
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -224,7 +227,8 @@ describe("Mixed nesting", () => {
             WHERE (NOT this_actors_movie.title = $this_actors_moviesConnection.args.where.node.title_NOT)
             WITH collect({ screenTime: this_actors_acted_in_relationship.screenTime, node: { title: this_actors_movie.title } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS moviesConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
             } RETURN moviesConnection\\", { this_actors: this_actors, this_actors_moviesConnection: $this_actors_moviesConnection, auth: $auth }, false) } ] } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/projections/create.test.ts
@@ -92,7 +92,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
             WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN [
             this0 { .title, actorsConnection }] AS data"
@@ -146,14 +147,16 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
             WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             CALL {
             WITH this1
             MATCH (this1)<-[this1_acted_in_relationship:ACTED_IN]-(this1_actor:Actor)
             WITH collect({ screenTime: this1_acted_in_relationship.screenTime, node: { name: this1_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN [
             this0 { .title, actorsConnection },
@@ -210,7 +213,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             WHERE this0_actor.name = $this0_actorsConnection.args.where.node.name
             WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             CALL {
             WITH this1
@@ -218,7 +222,8 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             WHERE this1_actor.name = $this1_actorsConnection.args.where.node.name
             WITH collect({ screenTime: this1_acted_in_relationship.screenTime, node: { name: this1_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN [
             this0 { .title, actorsConnection },

--- a/packages/graphql/tests/tck/tck-test-files/connections/projections/projections.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/projections/projections.test.ts
@@ -84,7 +84,8 @@ describe("Relay Cursor Connection projections", () => {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS actorsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -125,7 +126,8 @@ describe("Relay Cursor Connection projections", () => {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({  }) AS edges
-            RETURN { edges: edges, totalCount: size(edges) } AS actorsConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -208,7 +210,8 @@ describe("Relay Cursor Connection projections", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { totalCount: size(edges) } AS productionsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS productionsConnection
             }
             RETURN this { .name, productionsConnection } as this"
         `);
@@ -259,7 +262,8 @@ describe("Relay Cursor Connection projections", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS productionsConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS productionsConnection
             }
             RETURN this { .name, productionsConnection } as this"
         `);
@@ -301,7 +305,8 @@ describe("Relay Cursor Connection projections", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/projections/update.test.ts
@@ -90,7 +90,8 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN collect(DISTINCT this { .title, actorsConnection }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship-properties.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship-properties.test.ts
@@ -80,7 +80,8 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -123,7 +124,8 @@ describe("Relationship Properties Cypher", () => {
             WHERE this_actor.name = $this_actorsConnection.args.where.node.name
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -178,7 +180,8 @@ describe("Relationship Properties Cypher", () => {
             UNWIND edges as edge
             WITH edges, edge
             ORDER BY edge.screenTime DESC
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -231,11 +234,13 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this_actor)-[this_actor_acted_in_relationship:ACTED_IN]->(this_actor_movie:Movie)
             WITH collect({ screenTime: this_actor_acted_in_relationship.screenTime, node: { title: this_actor_movie.title } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS moviesConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
             }
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);
@@ -299,15 +304,18 @@ describe("Relationship Properties Cypher", () => {
             MATCH (this_actor_movie)<-[this_actor_movie_acted_in_relationship:ACTED_IN]-(this_actor_movie_actor:Actor)
             WITH collect({ screenTime: this_actor_movie_acted_in_relationship.screenTime, node: { name: this_actor_movie_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             WITH collect({ screenTime: this_actor_acted_in_relationship.screenTime, node: { title: this_actor_movie.title, actorsConnection: actorsConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS moviesConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
             }
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, moviesConnection: moviesConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/connect.test.ts
@@ -104,7 +104,8 @@ describe("Relationship Properties Connect Cypher", () => {
             MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
             WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN [
             this0 { .title, actorsConnection }] AS data"
@@ -177,7 +178,8 @@ describe("Relationship Properties Connect Cypher", () => {
             MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
             WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN [
             this0 { .title, actorsConnection }] AS data"
@@ -241,7 +243,8 @@ describe("Relationship Properties Connect Cypher", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN collect(DISTINCT this { .title, actorsConnection }) AS data"
         `);
@@ -307,7 +310,8 @@ describe("Relationship Properties Connect Cypher", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN collect(DISTINCT this { .title, actorsConnection }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/relationship_properties/create.test.ts
@@ -104,7 +104,8 @@ describe("Relationship Properties Create Cypher", () => {
             MATCH (this0)<-[this0_acted_in_relationship:ACTED_IN]-(this0_actor:Actor)
             WITH collect({ screenTime: this0_acted_in_relationship.screenTime, node: { name: this0_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN [
             this0 { .title, actorsConnection }] AS data"

--- a/packages/graphql/tests/tck/tck-test-files/connections/unions.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/unions.test.ts
@@ -101,7 +101,8 @@ describe("Cypher -> Connections -> Unions", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS publicationsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
             }
             RETURN this { .name, publicationsConnection } as this"
         `);
@@ -160,7 +161,8 @@ describe("Cypher -> Connections -> Unions", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS publicationsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
             }
             RETURN this { .name, publicationsConnection } as this"
         `);
@@ -235,7 +237,8 @@ describe("Cypher -> Connections -> Unions", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS publicationsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
             }
             RETURN this { .name, publicationsConnection } as this"
         `);
@@ -319,7 +322,8 @@ describe("Cypher -> Connections -> Unions", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS publicationsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
             }
             RETURN this { .name, publicationsConnection } as this"
         `);
@@ -405,7 +409,8 @@ describe("Cypher -> Connections -> Unions", () => {
             UNWIND edges as edge
             WITH edges, edge
             ORDER BY edge.words ASC
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS publicationsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS publicationsConnection
             }
             RETURN this { .name, publicationsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/alias.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/alias.test.ts
@@ -111,7 +111,8 @@ describe("Cypher alias directive", () => {
             MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_movie:Movie)
             WITH collect({ character: this_acted_in_relationship.characterPropInDb, screenTime: this_acted_in_relationship.screenTime, node: { title: this_movie.title, rating: this_movie.ratingPropInDb } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { .name, city: this.cityPropInDb, actedInConnection } as this"
         `);
@@ -182,7 +183,8 @@ describe("Cypher alias directive", () => {
             MATCH (this0)-[this0_acted_in_relationship:ACTED_IN]->(this0_movie:Movie)
             WITH collect({ character: this0_acted_in_relationship.characterPropInDb, screenTime: this0_acted_in_relationship.screenTime, node: { title: this0_movie.title, rating: this0_movie.ratingPropInDb } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN [
             this0 { .name, city: this0.cityPropInDb, actedIn: [ (this0)-[:ACTED_IN]->(this0_actedIn:Movie)   | this0_actedIn { .title, rating: this0_actedIn.ratingPropInDb } ], actedInConnection }] AS data"

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles-where.test.ts
@@ -247,7 +247,8 @@ describe("Cypher Auth Where with Roles", () => {
             CALL apoc.util.validate(NOT (((any(r IN [\\"user\\"] WHERE any(rr IN $auth.roles WHERE r = rr))) OR (any(r IN [\\"admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { content: this_post.content } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .id, postsConnection } as this"
         `);
@@ -304,7 +305,8 @@ describe("Cypher Auth Where with Roles", () => {
             CALL apoc.util.validate(NOT (((any(r IN [\\"user\\"] WHERE any(rr IN $auth.roles WHERE r = rr))) OR (any(r IN [\\"admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { content: this_post.content } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .id, postsConnection } as this"
         `);
@@ -467,7 +469,8 @@ describe("Cypher Auth Where with Roles", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);
@@ -530,7 +533,8 @@ describe("Cypher Auth Where with Roles", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -230,7 +230,8 @@ describe("Cypher Auth Where", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);
@@ -285,7 +286,8 @@ describe("Cypher Auth Where", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -233,7 +233,8 @@ describe("Cypher Auth Where", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);
@@ -289,7 +290,8 @@ describe("Cypher Auth Where", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/where/where.test.ts
@@ -195,7 +195,8 @@ describe("Cypher Auth Where", () => {
             WHERE exists((this_post)<-[:HAS_POST]-(:User)) AND all(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_where0_creator_id)
             WITH collect({ node: { content: this_post.content } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .id, postsConnection } as this"
         `);
@@ -238,7 +239,8 @@ describe("Cypher Auth Where", () => {
             WHERE this_post.id = $this_postsConnection.args.where.node.id AND exists((this_post)<-[:HAS_POST]-(:User)) AND all(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_where0_creator_id)
             WITH collect({ node: { content: this_post.content } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .id, postsConnection } as this"
         `);
@@ -361,7 +363,8 @@ describe("Cypher Auth Where", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);
@@ -410,7 +413,8 @@ describe("Cypher Auth Where", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { .id, contentConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/projection-connection-union.test.ts
@@ -103,13 +103,15 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
             CALL apoc.util.validate(NOT (this_Post_user.id IS NOT NULL AND this_Post_user.id = $this_Post_user_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { name: this_Post_user.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS creatorConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS creatorConnection
             }
             WITH { node: { __resolveType: \\"Post\\", content: this_Post.content, creatorConnection: creatorConnection } } AS edge
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS contentConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS contentConnection
             }
             RETURN this { contentConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/projection-connection.test.ts
@@ -87,7 +87,8 @@ describe("Cypher Auth Projection On Connections", () => {
             CALL apoc.util.validate(NOT (exists((this_post)<-[:HAS_POST]-(:User)) AND any(creator IN [(this_post)<-[:HAS_POST]-(creator:User) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { content: this_post.content } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .name, postsConnection } as this"
         `);
@@ -141,11 +142,13 @@ describe("Cypher Auth Projection On Connections", () => {
             CALL apoc.util.validate(NOT (this_post_user.id IS NOT NULL AND this_post_user.id = $this_post_user_auth_allow0_id), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { name: this_post_user.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS creatorConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS creatorConnection
             }
             WITH collect({ node: { content: this_post.content, creatorConnection: creatorConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .name, postsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/coalesce.test.ts
@@ -223,7 +223,8 @@ describe("Cypher coalesce()", () => {
             WHERE coalesce(this_movie.status, \\"ACTIVE\\") = $this_moviesConnection.args.where.node.status
             WITH collect({ node: { id: this_movie.id, status: this_movie.status } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS moviesConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
             }
             RETURN this { moviesConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
@@ -129,7 +129,8 @@ describe("Label in Node directive", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:\`Person\`)
             WITH collect({ node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth-projection.test.ts
@@ -87,7 +87,8 @@ describe("Cypher Auth Projection On Connections", () => {
             CALL apoc.util.validate(NOT (exists((this_post)<-[:HAS_POST]-(:\`Person\`)) AND any(creator IN [(this_post)<-[:HAS_POST]-(creator:\`Person\`) | creator] WHERE creator.id IS NOT NULL AND creator.id = $this_post_auth_allow0_creator_id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH collect({ node: { content: this_post.content } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS postsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS postsConnection
             }
             RETURN this { .name, postsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/interface-relationships/read.test.ts
@@ -345,7 +345,8 @@ describe("Interface Relationships", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { actedInConnection } as this"
         `);
@@ -399,7 +400,8 @@ describe("Interface Relationships", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { actedInConnection } as this"
         `);
@@ -464,7 +466,8 @@ describe("Interface Relationships", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { actedInConnection } as this"
         `);
@@ -545,7 +548,8 @@ describe("Interface Relationships", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { actedInConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1150.test.ts
@@ -133,11 +133,13 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
             }
             WITH collect(edge) as edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS driveComponentConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS driveComponentConnection
             }
             WITH collect({ node: { driveComponentConnection: driveComponentConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS driveCompositionsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS driveCompositionsConnection
             }
             RETURN this { .current, driveCompositionsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1221.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1221.test.ts
@@ -100,11 +100,13 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             WHERE this_masterdata_has_name_relationship.current = $this_architectureConnection.edges.node.nameDetailsConnection.args.where.edge.current
             WITH collect({ node: { fullName: this_masterdata_namedetails.fullName } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS nameDetailsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS nameDetailsConnection
             }
             WITH collect({ node: { nameDetailsConnection: nameDetailsConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS architectureConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS architectureConnection
             }
             RETURN this { .id, architectureConnection } as this"
         `);
@@ -248,15 +250,18 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             WHERE this_series_masterdata_has_name_relationship.current = $this_mainConnection.edges.node.architectureConnection.edges.node.nameDetailsConnection.args.where.edge.current
             WITH collect({ node: { fullName: this_series_masterdata_namedetails.fullName } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS nameDetailsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS nameDetailsConnection
             }
             WITH collect({ node: { nameDetailsConnection: nameDetailsConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS architectureConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS architectureConnection
             }
             WITH collect({ node: { architectureConnection: architectureConnection } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS mainConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS mainConnection
             }
             RETURN this { .id, mainConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1263.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1263.test.ts
@@ -96,7 +96,8 @@ describe("https://github.com/neo4j/graphql/issues/1263", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS actedInConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN this { .name, actedInConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1348.test.ts
@@ -154,7 +154,8 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
             RETURN edge
             }
             WITH collect(edge) as edges
-            RETURN { edges: edges, totalCount: size(edges) } AS releatsToConnection
+            WITH edges, size(edges) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS releatsToConnection
             }
             RETURN this { .productTitle, .episodeNumber, releatsToConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1528.test.ts
@@ -87,7 +87,8 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             UNWIND edges as edge
             WITH edges, edge
             ORDER BY edge.node.actorsCount DESC
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS moviesConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
             }
             RETURN this { moviesConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/433.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/433.test.ts
@@ -74,7 +74,8 @@ describe("#413", () => {
             MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_person:Person)
             WITH collect({ node: { name: this_person.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             RETURN this { .title, actorsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/601.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/601.test.ts
@@ -98,7 +98,8 @@ describe("#601", () => {
             CALL apoc.util.validate(NOT (any(r IN [\\\\\\"view\\\\\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
             WITH collect({ fileId: this_documents_uploaded_relationship.fileId, uploadedAt: apoc.date.convertFormat(toString(this_documents_uploaded_relationship.uploadedAt), \\\\\\"iso_zoned_date_time\\\\\\", \\\\\\"iso_offset_date_time\\\\\\") }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS customerContactConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS customerContactConnection
             } RETURN customerContactConnection\\", { this_documents: this_documents, auth: $auth }, false) } ] } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/issues/630.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/630.test.ts
@@ -78,7 +78,8 @@ describe("Cypher directive", () => {
             WITH this_movies
             MATCH (this_movies)<-[this_movies_acted_in_relationship:ACTED_IN]-(this_movies_actor:Actor)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS actorsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS actorsConnection
             } RETURN actorsConnection\\", { this_movies: this_movies, auth: $auth }, false) }] } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/issues/988.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/988.test.ts
@@ -142,14 +142,16 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
             MATCH (this)-[this_manufacturer_relationship:MANUFACTURER]->(this_manufacturer:Manufacturer)
             WITH collect({ current: this_manufacturer_relationship.current, node: { name: this_manufacturer.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS manufacturerConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS manufacturerConnection
             }
             CALL {
             WITH this
             MATCH (this)-[this_brand_relationship:BRAND]->(this_brand:Brand)
             WITH collect({ current: this_brand_relationship.current, node: { name: this_brand.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS brandConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS brandConnection
             }
             RETURN this { .name, .current, manufacturerConnection, brandConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/math.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/math.test.ts
@@ -260,7 +260,8 @@ describe("Math operators", () => {
             MATCH (this)-[this_acted_in_relationship:ACTED_IN]->(this_movie:Movie)
             WITH collect({ pay: this_acted_in_relationship.pay }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actedInConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actedInConnection
             }
             RETURN collect(DISTINCT this { .name, actedIn: [ (this)-[:ACTED_IN]->(this_actedIn:Movie)   | this_actedIn { .title } ], actedInConnection }) AS data"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
@@ -351,7 +351,8 @@ describe("Cypher Create", () => {
             WHERE this0_movies_actor.name = $projection_movies_actorsConnection.args.where.node.name
             WITH collect({ node: { name: this0_movies_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             } RETURN actorsConnection\\", { this0_movies: this0_movies, projection_movies_actorsConnection: $projection_movies_actorsConnection, auth: $auth }, false) } ] }] AS data"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/root-connection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/root-connection.test.ts
@@ -203,7 +203,8 @@ describe("Root Connection Query tests", () => {
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WITH collect({ node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
-            RETURN { edges: collect(edge), totalCount: size(collect(edge)) } AS actorsConnection
+            WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
+            RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
             }
             WITH COLLECT({ node: this { .title, actorsConnection } }) as edges, totalCount
             RETURN { edges: edges, totalCount: totalCount } as this"

--- a/packages/graphql/tests/tck/tck-test-files/undirected-relationships/query-direction-connection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/undirected-relationships/query-direction-connection.test.ts
@@ -67,7 +67,8 @@ describe("QueryDirection in relationships connection", () => {
             WITH this
             MATCH (this)-[this_friends_with_relationship:FRIENDS_WITH]-(this_user:User)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS friendsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS friendsConnection
             }
             RETURN this { friendsConnection } as this"
         `);
@@ -112,7 +113,8 @@ describe("QueryDirection in relationships connection", () => {
             WITH this
             MATCH (this)-[this_friends_with_relationship:FRIENDS_WITH]->(this_user:User)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS friendsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS friendsConnection
             }
             RETURN this { friendsConnection } as this"
         `);
@@ -156,7 +158,8 @@ describe("QueryDirection in relationships connection", () => {
             WITH this
             MATCH (this)-[this_friends_with_relationship:FRIENDS_WITH]-(this_user:User)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS friendsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS friendsConnection
             }
             RETURN this { friendsConnection } as this"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/undirected-relationships/undirected-connection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/undirected-relationships/undirected-connection.test.ts
@@ -66,7 +66,8 @@ describe("Undirected connections", () => {
             WITH this
             MATCH (this)-[this_friends_with_relationship:FRIENDS_WITH]-(this_user:User)
             WITH collect({  }) AS edges
-            RETURN { totalCount: size(edges) } AS friendsConnection
+            WITH size(edges) AS totalCount
+            RETURN { totalCount: totalCount } AS friendsConnection
             }
             RETURN this { friendsConnection } as this"
         `);


### PR DESCRIPTION
# Description

Continued work on 5.0 compatibility, addressing the following error:

```
Aggregation column contains implicit grouping expressions. For example, in 'RETURN n.a, n.a + n.b + count(*)' the aggregation expression 'n.a + n.b + count(*)' includes the implicit grouping key 'n.b'. It may be possible to rewrite the query by extracting these grouping/aggregation expressions into a preceding WITH clause.
```