### PR TITLE
fixed: an EXISTS clause is used in a RETURN clause where it is not valid

### DIFF
--- a/.changeset/short-ants-return.md
+++ b/.changeset/short-ants-return.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+fixed: an EXISTS clause is used in a RETURN clause where it is not valid

--- a/packages/graphql/src/translate/where/create-where-and-params.ts
+++ b/packages/graphql/src/translate/where/create-where-and-params.ts
@@ -171,7 +171,7 @@ function createWhereAndParams({
             });
 
             if (recurse[0]) {
-                const clause = listPredicateToClause(listPredicate, matchPattern, recurse[0]);
+                const clause = listPredicateToSizeFunction(listPredicate, matchPattern, recurse[0]);
                 res.clauses.push(clause);
                 res.params = { ...res.params, ...recurse[1] };
             }

--- a/packages/graphql/tests/integration/issues/1779.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1779.int.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql, GraphQLSchema } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src";
+import { generateUniqueType } from "../../utils/graphql-types";
+import Neo4j from "../neo4j";
+
+describe("https://github.com/neo4j/graphql/issues/1779", () => {
+    const personType = generateUniqueType("Person");
+    const schoolType = generateUniqueType("School");
+
+    let schema: GraphQLSchema;
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        const typeDefs = `
+            type ${personType.name} {
+                name: String
+                age: Int
+                attends: [${schoolType.name}!]! @relationship(type: "ATTENDS", direction: OUT)
+            }
+
+            type ${schoolType.name} {
+                name: String
+                students: [${personType.name}!]! @relationship(type: "ATTENDS", direction: IN)
+            }
+        `;
+        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver });
+        schema = await neoGraphql.getSchema();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("Does not throw error 'The EXISTS subclause is not valid inside a WITH or RETURN clause. '", async () => {
+        const cypher = `
+        CREATE (personA:${personType.name} { name: "A", age: 24 })-[:ATTENDS]->(schoolOld:${schoolType.name} { name: "Old" })
+        CREATE (personB:${personType.name} { name: "B", age: 26 })-[:ATTENDS]->(schoolOld)
+        CREATE (personC:${personType.name} { name: "C", age: 23 })-[:ATTENDS]->(schoolYoung:${schoolType.name} { name: "Young" })
+        CREATE (personD:${personType.name} { name: "D", age: 25 })-[:ATTENDS]->(schoolYoung)
+    `;
+
+        const session = await neo4j.getSession();
+
+        try {
+            await session.run(cypher);
+        } finally {
+            await session.close();
+        }
+
+        const query = `
+            {
+                ${personType.plural} {
+                    name
+                    attends(where: { students_ALL: { age_GT: 23 } }) {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema,
+            source: query,
+            variableValues: {},
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(result.errors).toBeFalsy();
+        expect(result?.data?.[personType.plural]).toHaveLength(4);
+        expect(result?.data?.[personType.plural]).toEqual(
+            expect.arrayContaining([
+                {
+                    name: "A",
+                    attends: [
+                        {
+                            name: "Old",
+                        },
+                    ],
+                },
+                {
+                    name: "B",
+                    attends: [
+                        {
+                            name: "Old",
+                        },
+                    ],
+                },
+                {
+                    name: "C",
+                    attends: [],
+                },
+                {
+                    name: "D",
+                    attends: [],
+                },
+            ])
+        );
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/advanced-filtering.test.ts
@@ -593,7 +593,7 @@ describe("Cypher Advanced Filtering", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:Movie)
-                WHERE EXISTS { (this)-[:IN_GENRE]->(this_genres:Genre) WHERE this_genres.name = $this_genres_name }
+                WHERE size([(this)-[:IN_GENRE]->(this_genres:Genre) WHERE this_genres.name = $this_genres_name | 1]) > 0
                 RETURN this { .actorCount } as this"
             `);
 
@@ -620,7 +620,7 @@ describe("Cypher Advanced Filtering", () => {
 
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:Movie)
-                WHERE NOT EXISTS { (this)-[:IN_GENRE]->(this_genres_NOT:Genre) WHERE this_genres_NOT.name = $this_genres_NOT_name }
+                WHERE size([(this)-[:IN_GENRE]->(this_genres_NOT:Genre) WHERE this_genres_NOT.name = $this_genres_NOT_name | 1]) = 0
                 RETURN this { .actorCount } as this"
             `);
 
@@ -650,7 +650,7 @@ describe("Cypher Advanced Filtering", () => {
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:Movie)
-                    WHERE NOT EXISTS { (this)-[:IN_GENRE]->(this_genres_ALL:Genre) WHERE NOT this_genres_ALL.name = $this_genres_ALL_name }
+                    WHERE size([(this)-[:IN_GENRE]->(this_genres_ALL:Genre) WHERE NOT this_genres_ALL.name = $this_genres_ALL_name | 1]) = 0
                     RETURN this { .actorCount } as this"
                 `);
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -667,7 +667,7 @@ describe("Cypher Advanced Filtering", () => {
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:Movie)
-                    WHERE NOT EXISTS { (this)-[:IN_GENRE]->(this_genres_NONE:Genre) WHERE this_genres_NONE.name = $this_genres_NONE_name }
+                    WHERE size([(this)-[:IN_GENRE]->(this_genres_NONE:Genre) WHERE this_genres_NONE.name = $this_genres_NONE_name | 1]) = 0
                     RETURN this { .actorCount } as this"
                 `);
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -701,7 +701,7 @@ describe("Cypher Advanced Filtering", () => {
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:Movie)
-                    WHERE EXISTS { (this)-[:IN_GENRE]->(this_genres_SOME:Genre) WHERE this_genres_SOME.name = $this_genres_SOME_name }
+                    WHERE size([(this)-[:IN_GENRE]->(this_genres_SOME:Genre) WHERE this_genres_SOME.name = $this_genres_SOME_name | 1]) > 0
                     RETURN this { .actorCount } as this"
                 `);
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-label.test.ts
@@ -518,7 +518,7 @@ describe("Label in Node directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
-            WHERE EXISTS { (this)<-[:ACTED_IN]-(this_actors:\`Person\`) WHERE this_actors.name = $this_actors_name }
+            WHERE size([(this)<-[:ACTED_IN]-(this_actors:\`Person\`) WHERE this_actors.name = $this_actors_name | 1]) > 0
             DETACH DELETE this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/node/node-with-auth.test.ts
@@ -103,7 +103,7 @@ describe("Node Directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Comment\`)
-            WHERE EXISTS { (this)<-[:HAS_POST]-(this_creator:\`Person\`) WHERE this_creator.id = $this_creator_id }
+            WHERE size([(this)<-[:HAS_POST]-(this_creator:\`Person\`) WHERE this_creator.id = $this_creator_id | 1]) > 0
             WITH this
             CALL apoc.util.validate(NOT (any(r IN [\\"admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/tck-test-files/issues/1628.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1628.test.ts
@@ -62,7 +62,7 @@ describe("https://github.com/neo4j/graphql/issues/1628", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`frbr__Work\`:\`Resource\`)
-            WHERE EXISTS { (this)-[:dcterms__title]->(this_dcterms__title:\`dcterms_title\`:\`property\`) WHERE this_dcterms__title.value CONTAINS $this_dcterms__title_value_CONTAINS }
+            WHERE size([(this)-[:dcterms__title]->(this_dcterms__title:\`dcterms_title\`:\`property\`) WHERE this_dcterms__title.value CONTAINS $this_dcterms__title_value_CONTAINS | 1]) > 0
             RETURN this { iri: this.uri, dcterms__title: [ (this)-[:dcterms__title]->(this_dcterms__title:\`dcterms_title\`:\`property\`)  WHERE this_dcterms__title.value CONTAINS $this_dcterms__title_value_CONTAINS | this_dcterms__title { .value } ] } as this
             LIMIT $this_limit"
         `);

--- a/packages/graphql/tests/tck/tck-test-files/issues/1779.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1779.test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, formatParams, translateQuery } from "../../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/1779", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Person {
+                name: String
+                age: Int
+                attends: [School!]! @relationship(type: "attends", direction: OUT)
+            }
+
+            type School {
+                name: String
+                students: [Person!]! @relationship(type: "attends", direction: IN)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("EXISTS should not be within return clause", async () => {
+        const query = gql`
+            {
+                people {
+                    name
+                    attends(where: { students_ALL: { age_GT: 23 } }) {
+                        name
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Person)
+            RETURN this { .name, attends: [ (this)-[:attends]->(this_attends:School)  WHERE size([(this_attends)<-[:attends]-(this_attends_students_ALL:Person) WHERE NOT this_attends_students_ALL.age > $this_attends_students_ALL_age_GT | 1]) = 0 | this_attends { .name } ] } as this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this_attends_students_ALL_age_GT\\": {
+                    \\"low\\": 23,
+                    \\"high\\": 0
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/tck-test-files/issues/190.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/190.test.ts
@@ -69,7 +69,7 @@ describe("#190", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
-            WHERE EXISTS { (this)-[:HAS_DEMOGRAPHIC]->(this_demographics:UserDemographics) WHERE this_demographics.type = $this_demographics_type AND this_demographics.value = $this_demographics_value }
+            WHERE size([(this)-[:HAS_DEMOGRAPHIC]->(this_demographics:UserDemographics) WHERE this_demographics.type = $this_demographics_type AND this_demographics.value = $this_demographics_value | 1]) > 0
             RETURN this { .uid, demographics: [ (this)-[:HAS_DEMOGRAPHIC]->(this_demographics:UserDemographics)   | this_demographics { .type, .value } ] } as this"
         `);
 
@@ -105,7 +105,7 @@ describe("#190", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
-            WHERE EXISTS { (this)-[:HAS_DEMOGRAPHIC]->(this_demographics:UserDemographics) WHERE (this_demographics.type = $this_demographics_OR_type AND this_demographics.value = $this_demographics_OR_value OR this_demographics.type = $this_demographics_OR1_type OR this_demographics.type = $this_demographics_OR2_type) }
+            WHERE size([(this)-[:HAS_DEMOGRAPHIC]->(this_demographics:UserDemographics) WHERE (this_demographics.type = $this_demographics_OR_type AND this_demographics.value = $this_demographics_OR_value OR this_demographics.type = $this_demographics_OR1_type OR this_demographics.type = $this_demographics_OR2_type) | 1]) > 0
             RETURN this { .uid, demographics: [ (this)-[:HAS_DEMOGRAPHIC]->(this_demographics:UserDemographics)   | this_demographics { .type, .value } ] } as this"
         `);
 


### PR DESCRIPTION
# Description

Reported on Discord, `EXISTS` was being used in a `RETURN` clause where it is not valid.

This PR fixes this by switching to the `listPredicateToSizeFunction` to generate the clause. It's a shame, because we're now only using `EXISTS` in one place, which is the better solution. We need to switch from doing our projections of relationships in the `RETURN` clause itself to get around this.

# Issue

Closes #1779 
