### PR TITLE
fix: always specify a default database

### DIFF
--- a/.changeset/eight-doors-own.md
+++ b/.changeset/eight-doors-own.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+fix: always specify a default database to avoid round-trip requests for routing table

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -165,7 +165,8 @@ export class Executor {
     }
 
     private getSessionParam(defaultAccessMode: SessionMode): SessionParam {
-        const sessionParam: SessionParam = { defaultAccessMode };
+        // Always specify a default database to avoid requests for routing table
+        const sessionParam: SessionParam = { defaultAccessMode, database: "neo4j" };
 
         if (this.database) {
             sessionParam.database = this.database;


### PR DESCRIPTION
# Description

If a default database is not always specified, this will result in a round-trip request to the database for the routing table, which can then lead on to other issues. This PR always specifies "neo4j" as the default database unless overridden.
