### PR TITLE
Add boilerplate needed to use toIncludeSameMembers from jest-extended

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -50,7 +50,7 @@ jobs:
           list-files: shell
           filters: |
             typescript:
-              - added|modified: 'packages/**/*.ts'
+              - added|modified: 'packages/*/src/**/*.ts'
 
   license-header-check:
     needs: typescript-changes

--- a/jest.config.base.js
+++ b/jest.config.base.js
@@ -19,7 +19,8 @@ module.exports = {
         "@neo4j/introspector(.*)$": "<rootDir>/packages/introspector/src/$1",
         "@neo4j/graphql-ogm(.*)$": "<rootDir>/packages/ogm/src/$1",
         "@neo4j/graphql-plugin-auth(.*)$": "<rootDir>/packages/plugins/graphql-plugin-auth/src/$1",
-        "@neo4j/graphql-plugin-subscriptions-amqp(.*)$": "<rootDir>/packages/plugins/graphql-plugin-subscriptions-amqp/src/$1",
+        "@neo4j/graphql-plugin-subscriptions-amqp(.*)$":
+            "<rootDir>/packages/plugins/graphql-plugin-subscriptions-amqp/src/$1",
         "@neo4j/graphql(.*)$": "<rootDir>/packages/graphql/src/$1",
     },
 };

--- a/packages/graphql/global.d.ts
+++ b/packages/graphql/global.d.ts
@@ -1,0 +1,1 @@
+import "jest-extended";

--- a/packages/graphql/global.d.ts
+++ b/packages/graphql/global.d.ts
@@ -1,1 +1,2 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
 import "jest-extended";

--- a/packages/graphql/jest.config.js
+++ b/packages/graphql/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
     ...globalConf,
     displayName: "@neo4j/graphql",
     globalSetup: path.join(__dirname, "jest.global-setup.js"),
+    setupFilesAfterEnv: [path.join(__dirname, "jest.test-setup.js")],
     globalTeardown: path.join(__dirname, "jest.global-teardown.js"),
     roots: ["<rootDir>/packages/graphql/src/", "<rootDir>/packages/graphql/tests/"],
     coverageDirectory: "<rootDir>/packages/graphql/coverage/",

--- a/packages/graphql/jest.test-setup.js
+++ b/packages/graphql/jest.test-setup.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { toIncludeSameMembers } = require("jest-extended");
+
+expect.extend({ toIncludeSameMembers });

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -67,6 +67,7 @@
         "graphql-ws": "5.9.1",
         "is-uuid": "1.0.2",
         "jest": "28.1.3",
+        "jest-extended": "^3.0.1",
         "koa": "2.13.4",
         "koa-jwt": "4.0.3",
         "koa-router": "12.0.0",

--- a/packages/graphql/tsconfig.json
+++ b/packages/graphql/tsconfig.json
@@ -8,6 +8,6 @@
             "@neo4j/graphql-plugin-auth": ["../plugins/graphql-plugin-auth/src"]
         }
     },
-    "include": ["package.json", "src/**/*", "tests/**/*"],
+    "include": ["global.d.ts", "package.json", "src/**/*", "tests/**/*"],
     "references": [{ "path": "../plugins/graphql-plugin-auth/tsconfig.json" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2629,6 +2629,7 @@ __metadata:
     graphql-ws: 5.9.1
     is-uuid: 1.0.2
     jest: 28.1.3
+    jest-extended: ^3.0.1
     koa: 2.13.4
     koa-jwt: 4.0.3
     koa-router: 12.0.0
@@ -11402,6 +11403,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jest-diff@npm:^28.0.0, jest-diff@npm:^28.1.3":
+  version: 28.1.3
+  resolution: "jest-diff@npm:28.1.3"
+  dependencies:
+    chalk: ^4.0.0
+    diff-sequences: ^28.1.1
+    jest-get-type: ^28.0.2
+    pretty-format: ^28.1.3
+  checksum: fa8583e0ccbe775714ce850b009be1b0f6b17a4b6759f33ff47adef27942ebc610dbbcc8a5f7cfb7f12b3b3b05afc9fb41d5f766674616025032ff1e4f9866e0
+  languageName: node
+  linkType: hard
+
 "jest-diff@npm:^28.1.1":
   version: 28.1.1
   resolution: "jest-diff@npm:28.1.1"
@@ -11411,18 +11424,6 @@ __metadata:
     jest-get-type: ^28.0.2
     pretty-format: ^28.1.1
   checksum: d9e0355880bee8728f7615ac0f03c66dcd4e93113935cca056a5f5a2f20ac2c7812aca6ad68e79bd1b11f2428748bd9123e6b1c7e51c93b4da3dfa5a875339f7
-  languageName: node
-  linkType: hard
-
-"jest-diff@npm:^28.1.3":
-  version: 28.1.3
-  resolution: "jest-diff@npm:28.1.3"
-  dependencies:
-    chalk: ^4.0.0
-    diff-sequences: ^28.1.1
-    jest-get-type: ^28.0.2
-    pretty-format: ^28.1.3
-  checksum: fa8583e0ccbe775714ce850b009be1b0f6b17a4b6759f33ff47adef27942ebc610dbbcc8a5f7cfb7f12b3b3b05afc9fb41d5f766674616025032ff1e4f9866e0
   languageName: node
   linkType: hard
 
@@ -11478,7 +11479,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jest-get-type@npm:^28.0.2":
+"jest-extended@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "jest-extended@npm:3.0.1"
+  dependencies:
+    jest-diff: ^28.0.0
+    jest-get-type: ^28.0.0
+  peerDependencies:
+    jest: ">=27.2.5"
+  checksum: 42b64a3e7aba1040b8847012d059644782ee7dd86b5cc280ec0e1b9e0f679396d5136191e9d1abf3bc52ae41507ce94aa3ea29d12f000c34b16e986596942652
+  languageName: node
+  linkType: hard
+
+"jest-get-type@npm:^28.0.0, jest-get-type@npm:^28.0.2":
   version: 28.0.2
   resolution: "jest-get-type@npm:28.0.2"
   checksum: 5281d7c89bc8156605f6d15784f45074f4548501195c26e9b188742768f72d40948252d13230ea905b5349038865a1a8eeff0e614cc530ff289dfc41fe843abd


### PR DESCRIPTION
# Description

When asserting the values of arrays, what is currently:

```js
const array = [1, 2, 3]; // assume that we don't know the order here

expect(array).toHaveLength(3);
expect(array).toBe(expect.arrayContaining([3, 2, 1]);
```

Can now become:

```js
const array = [1, 2, 3]; // assume that we don't know the order here

expect(array).toIncludeSameMembers([3, 2, 1]);
```

This also works for nested items, for instance:

```js
expect(o).toEqual({
  nestedArray: expect.toIncludeSameMembers([3, 2, 1]),
});
```

This should become our de facto standard for asserting the values of arrays unless we're _100% sure_ of the order, to avoid test flakiness. We should refactor all existing tests.