### PR TITLE
Replace instances of `apoc.cypher.runFirstColumn` with `runFirstColumnSingle` and `runFirstColumnMany`

### DIFF
--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -24,7 +24,8 @@ export const AUTH_UNAUTHENTICATED_ERROR = "@neo4j/graphql/UNAUTHENTICATED";
 export const MIN_VERSIONS = [{ majorMinor: "4.3", neo4j: "4.3.2" }];
 export const REQUIRED_APOC_FUNCTIONS = [
     "apoc.util.validatePredicate",
-    "apoc.cypher.runFirstColumn",
+    "apoc.cypher.runFirstColumnSingle",
+    "apoc.cypher.runFirstColumnMany",
     "apoc.coll.sortMulti",
     "apoc.coll.flatten",
     "apoc.date.convertFormat",

--- a/packages/graphql/src/schema/resolvers/field/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/field/cypher.ts
@@ -169,18 +169,12 @@ export function cypherResolver({
         const expectMultipleValues = !field.isScalar && !field.isEnum && isArray;
         if (type === "Query") {
             if (expectMultipleValues) {
-                cypherStrs.push(`
-                WITH apoc.cypher.runFirstColumnMany("${statement}", ${apocParamsStr}) as x
-                UNWIND x as this
-                WITH this
-            `);
+                cypherStrs.push(`WITH apoc.cypher.runFirstColumnMany("${statement}", ${apocParamsStr}) as x`);
             } else {
-                cypherStrs.push(`
-                WITH apoc.cypher.runFirstColumnSingle("${statement}", ${apocParamsStr}) as x
-                UNWIND x as this
-                WITH this
-            `);
+                cypherStrs.push(`WITH apoc.cypher.runFirstColumnSingle("${statement}", ${apocParamsStr}) as x`);
             }
+
+            cypherStrs.push("UNWIND x as this\nWITH this");
         } else {
             cypherStrs.push(`
                 CALL apoc.cypher.doIt("${statement}", ${apocParamsStr}) YIELD value

--- a/packages/graphql/src/translate/create-aggregate-where-and-params.ts
+++ b/packages/graphql/src/translate/create-aggregate-where-and-params.ts
@@ -310,7 +310,7 @@ function createAggregateWhereAndParams({
     const labels = node.getLabelString(context);
     const matchStr = `MATCH (${varName})${inStr}${relTypeStr}${outStr}(${nodeVariable}${labels})`;
 
-    cyphers.push(`apoc.cypher.runFirstColumn(" ${matchStr}`);
+    cyphers.push(`apoc.cypher.runFirstColumnSingle(" ${matchStr}`);
 
     const { aggregations, params, withStrs } = createPredicate({
         aggregation,
@@ -338,7 +338,7 @@ function createAggregateWhereAndParams({
               .join(", ")}`
         : "";
 
-    cyphers.push(`", { ${varName}: ${varName}${apocParams} }, false )`);
+    cyphers.push(`", { ${varName}: ${varName}${apocParams} })`);
 
     return [cyphers.join("\n"), params];
 }

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -303,8 +303,7 @@ function createProjectionAndParams({
                 ...(context.cypherParams ? { cypherParams: context.cypherParams } : {}),
             };
 
-            const expectMultipleValues =
-                (referenceNode || referenceUnion) && cypherField.typeMeta.array ? "true" : "false";
+            const expectMultipleValues = (referenceNode || referenceUnion) && cypherField.typeMeta.array;
             const apocWhere = projectionAuthStrs.length
                 ? `WHERE apoc.util.validatePredicate(NOT (${projectionAuthStrs.join(
                       " AND "
@@ -319,9 +318,9 @@ function createProjectionAndParams({
 
             const apocStr = `${
                 !cypherField.isScalar && !cypherField.isEnum ? `${param} IN` : ""
-            } apoc.cypher.runFirstColumn("${cypherField.statement}", ${apocParamsStr}, ${expectMultipleValues})${
-                apocWhere ? ` ${apocWhere}` : ""
-            }${unionWhere ? ` ${unionWhere} ` : ""}${
+            } apoc.cypher.runFirstColumn${expectMultipleValues ? "Many" : "Single"}("${
+                cypherField.statement
+            }", ${apocParamsStr})${apocWhere ? ` ${apocWhere}` : ""}${unionWhere ? ` ${unionWhere} ` : ""}${
                 !isProjectionStrEmpty ? ` | ${!referenceUnion ? param : ""} ${projectionStr}` : ""
             }`;
 
@@ -612,9 +611,9 @@ function createProjectionAndParams({
             ];
 
             res.projection.push(
-                `${field.name}: apoc.cypher.runFirstColumn("${connection[0].replace(/("|')/g, "\\$1")} RETURN ${
+                `${field.name}: apoc.cypher.runFirstColumnSingle("${connection[0].replace(/("|')/g, "\\$1")} RETURN ${
                     field.name
-                }", { ${runFirstColumnParams.join(", ")} }, false)`
+                }", { ${runFirstColumnParams.join(", ")} })`
             );
             res.params = { ...res.params, ...connection[1] };
             return res;

--- a/packages/graphql/src/translate/cypher-builder/procedures/apoc/RunFirstColumn.test.ts
+++ b/packages/graphql/src/translate/cypher-builder/procedures/apoc/RunFirstColumn.test.ts
@@ -34,8 +34,8 @@ describe("RunFirstColumn", () => {
         const apocCall = new CypherBuilder.apoc.RunFirstColumn(subquery, [node]);
 
         expect(apocCall.getCypher(env)).toMatchInlineSnapshot(`
-            "apoc.cypher.runFirstColumn(\\"MATCH (this0:\`Movie\`)
-            RETURN this0\\", { this0: this0 }, true)"
+            "apoc.cypher.runFirstColumnMany(\\"MATCH (this0:\`Movie\`)
+            RETURN this0\\", { this0: this0 })"
         `);
     });
 
@@ -67,10 +67,10 @@ describe("RunFirstColumn", () => {
         expect(cypherResult.cypher).toMatchInlineSnapshot(`
             "MATCH (this0:\`Movie\`)
             WHERE this0.title = $param0
-            RETURN { result: apoc.cypher.runFirstColumn(\\"MATCH (this0)
+            RETURN { result: apoc.cypher.runFirstColumnMany(\\"MATCH (this0)
             SET
                 this0.released = $param1
-            RETURN this0\\", { this0: this0, param1: $param1 }, true) }"
+            RETURN this0\\", { this0: this0, param1: $param1 }) }"
         `);
         expect(cypherResult.params).toMatchInlineSnapshot(`
             Object {

--- a/packages/graphql/src/translate/projection/elements/create-point-element.test.ts
+++ b/packages/graphql/src/translate/projection/elements/create-point-element.test.ts
@@ -59,11 +59,11 @@ describe("createPointElement", () => {
         });
 
         expect(element).toMatchInlineSnapshot(`
-            "point: apoc.cypher.runFirstColumn('RETURN
+            "point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point, crs: this.point.crs }
             	ELSE NULL
-            END AS result',{ this: this },false)"
+            END AS result',{ this: this })"
         `);
     });
 
@@ -105,11 +105,11 @@ describe("createPointElement", () => {
         });
 
         expect(element).toMatchInlineSnapshot(`
-            "points: apoc.cypher.runFirstColumn('RETURN
+            "points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.points IS NOT NULL THEN [p in this.points | { point:p, crs: p.crs }]
             	ELSE NULL
-            END AS result',{ this: this },false)"
+            END AS result',{ this: this })"
         `);
     });
 });

--- a/packages/graphql/src/translate/projection/elements/create-point-element.ts
+++ b/packages/graphql/src/translate/projection/elements/create-point-element.ts
@@ -50,10 +50,9 @@ function createPointElement({
         : `{ ${fields.join(", ")} }`;
 
     const cypher = [
-        "apoc.cypher.runFirstColumn(",
+        "apoc.cypher.runFirstColumnSingle(",
         `'RETURN\nCASE\n\tWHEN ${variable}.${dbFieldName} IS NOT NULL THEN ${projection}\n\tELSE NULL\nEND AS result',`,
-        `{ ${variable}: ${variable} },`,
-        "false",
+        `{ ${variable}: ${variable} }`,
         ")",
     ];
 

--- a/packages/graphql/src/translate/projection/elements/create-relationship-property-element.test.ts
+++ b/packages/graphql/src/translate/projection/elements/create-relationship-property-element.test.ts
@@ -179,11 +179,11 @@ describe("createRelationshipPropertyElement", () => {
         const element = createRelationshipPropertyElement({ resolveTree, relationship, relationshipVariable: "this" });
 
         expect(element).toMatchInlineSnapshot(`
-            "point: apoc.cypher.runFirstColumn('RETURN
+            "point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point, crs: this.point.crs }
             	ELSE NULL
-            END AS result',{ this: this },false)"
+            END AS result',{ this: this })"
         `);
     });
 });

--- a/packages/graphql/src/translate/utils/apoc-run.test.ts
+++ b/packages/graphql/src/translate/utils/apoc-run.test.ts
@@ -23,11 +23,11 @@ describe("apoc translation utils", () => {
     describe("wrapInApocRunFirstColumn", () => {
         test("wraps and escapes a query inside runFirstColumn", () => {
             const result = wrapInApocRunFirstColumn(`MATCH(n) RETURN n, "Hello"`);
-            expect(result).toBe(`apoc.cypher.runFirstColumn("MATCH(n) RETURN n, \\"Hello\\"", {  })`);
+            expect(result).toBe(`apoc.cypher.runFirstColumnMany("MATCH(n) RETURN n, \\"Hello\\"", {  })`);
         });
         test("adds extra params", () => {
             const result = wrapInApocRunFirstColumn(`MATCH(n) RETURN n`, { auth: "auth" });
-            expect(result).toBe(`apoc.cypher.runFirstColumn("MATCH(n) RETURN n", { auth: auth })`);
+            expect(result).toBe(`apoc.cypher.runFirstColumnMany("MATCH(n) RETURN n", { auth: auth })`);
         });
         test("double wrap", () => {
             const firstWrap = wrapInApocRunFirstColumn(`MATCH(n) RETURN n, "Hello"`);
@@ -35,7 +35,7 @@ describe("apoc translation utils", () => {
             expect(result).toBe(
                 // no-useless-escape disabled due to how escaped strings work when comparing strings.
                 // eslint-disable-next-line no-useless-escape
-                `apoc.cypher.runFirstColumn(\"apoc.cypher.runFirstColumn(\\\"MATCH(n) RETURN n, \\\\\\\"Hello\\\\\\\"\\\", {  })\", {  })`
+                `apoc.cypher.runFirstColumnMany(\"apoc.cypher.runFirstColumnMany(\\\"MATCH(n) RETURN n, \\\\\\\"Hello\\\\\\\"\\\", {  })\", {  })`
             );
         });
     });

--- a/packages/graphql/src/translate/utils/apoc-run.ts
+++ b/packages/graphql/src/translate/utils/apoc-run.ts
@@ -28,9 +28,12 @@ export function wrapInApocRunFirstColumn(
 ): string {
     const serializedParams = stringifyObject(params);
     const escapedQuery = escapeQuery(query);
-    return `apoc.cypher.runFirstColumn("${escapedQuery}", ${serializedParams}${
-        expectMultipleValues === false ? ", false" : ""
-    })`;
+
+    if (expectMultipleValues === false) {
+        return `apoc.cypher.runFirstColumnSingle("${escapedQuery}", ${serializedParams})`;
+    }
+
+    return `apoc.cypher.runFirstColumnMany("${escapedQuery}", ${serializedParams})`;
 }
 
 export function serializeParamsForApocRun(params: Record<string, any>): Record<string, string> {

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -51,26 +51,26 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
                 productTitle: String!
                 releatsTo: [Product!]!
             }
-            
+
             type ${testSeries} implements Product {
                 productTitle: String!
                 releatsTo: [Product!]!  @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
-            
+
                 seasons: [${testSeason}!]!
             }
-            
+
             type ${testSeason} implements Product {
                 productTitle: String!
                 releatsTo: [Product!]!  @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
-            
+
                 seasonNumber: Int
                 episodes: [${testProgrammeItem}!]!
             }
-            
+
             type ${testProgrammeItem} implements Product {
                 productTitle: String!
                 releatsTo: [Product!]!  @relationship(type: "RELATES_TO", direction: OUT, queryDirection: DEFAULT_UNDIRECTED)
-            
+
                 episodeNumber: Int
             }
         `;
@@ -155,7 +155,7 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
         const queryResults = await graphqlQuery(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data as any).toEqual({
-            [testProgrammeItem.plural]: [
+            [testProgrammeItem.plural]: expect.toIncludeSameMembers([
                 {
                     productTitle: "TestEpisode2",
                     episodeNumber: 2,
@@ -181,7 +181,7 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
                         },
                     ],
                 },
-            ],
+            ]),
         });
     });
 });

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
@@ -73,7 +73,7 @@ describe("Field Level Aggregations Alias", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { actorsAggregate: { node: { myName: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
+            RETURN this { actorsAggregate: { node: { myName: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
                     WITH n as n
                     ORDER BY size(n.name) DESC
                     WITH collect(n.name) as list
@@ -105,7 +105,7 @@ describe("Field Level Aggregations Alias", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { actorsAggregate: { edge: { time: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
+            RETURN this { actorsAggregate: { edge: { time: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
                     RETURN {min: min(r.screentime), max: max(r.screentime), average: avg(r.screentime), sum: sum(r.screentime)}\\", { this: this })) } } } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
@@ -76,7 +76,7 @@ describe("Field Level Aggregations", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { actorsAggregate: { edge: { screentime: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
+            RETURN this { actorsAggregate: { edge: { screentime: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
                     RETURN {min: min(r.screentime), max: max(r.screentime), average: avg(r.screentime), sum: sum(r.screentime)}\\", { this: this })) } } } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
@@ -73,7 +73,7 @@ describe("Field Level Aggregations Alias", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
-            RETURN this { actorsAggregate: { node: { name: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:\`Person\`)
+            RETURN this { actorsAggregate: { node: { name: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:\`Person\`)
                     WITH n as n
                     ORDER BY size(n.name) DESC
                     WITH collect(n.name) as list

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -97,7 +97,7 @@ describe("Field Level Aggregations", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { actorsAggregate: { count: size([(this_actorsAggregate_this0:\`Actor\`)-[this_actorsAggregate_this1:ACTED_IN]->(this) | this_actorsAggregate_this0]), node: { name: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
+            RETURN this { actorsAggregate: { count: size([(this_actorsAggregate_this0:\`Actor\`)-[this_actorsAggregate_this1:ACTED_IN]->(this) | this_actorsAggregate_this0]), node: { name: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
                     WITH n as n
                     ORDER BY size(n.name) DESC
                     WITH collect(n.name) as list
@@ -132,7 +132,7 @@ describe("Field Level Aggregations", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { actorsAggregate: { node: { age: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
+            RETURN this { actorsAggregate: { node: { age: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
                     RETURN {min: min(n.age), max: max(n.age), average: avg(n.age), sum: sum(n.age)}\\", { this: this })) } } } as this"
         `);
 
@@ -163,7 +163,7 @@ describe("Field Level Aggregations", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { .title, actorsAggregate: { node: { name: head(apoc.cypher.runFirstColumn(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
+            RETURN this { .title, actorsAggregate: { node: { name: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)<-[r:ACTED_IN]-(n:Actor)
                     WITH n as n
                     ORDER BY size(n.name) DESC
                     WITH collect(n.name) as list
@@ -195,7 +195,7 @@ describe("Field Level Aggregations", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
-            RETURN this { moviesAggregate: { node: { released: head(apoc.cypher.runFirstColumn(\\"MATCH (this)-[r:ACTED_IN]->(n:Movie)
+            RETURN this { moviesAggregate: { node: { released: head(apoc.cypher.runFirstColumnMany(\\"MATCH (this)-[r:ACTED_IN]->(n:Movie)
                     RETURN { min: apoc.date.convertFormat(toString(min(n.released)), \\\\\\"iso_zoned_date_time\\\\\\", \\\\\\"iso_offset_date_time\\\\\\"), max: apoc.date.convertFormat(toString(max(n.released)), \\\\\\"iso_zoned_date_time\\\\\\", \\\\\\"iso_offset_date_time\\\\\\") }\\", { this: this })) } } } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/count.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/count.test.ts
@@ -61,9 +61,9 @@ describe("Cypher Aggregations where with count", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN count(aggr_node) = $aggr_count
-            \\", { this: this, aggr_count: $aggr_count }, false )
+            \\", { this: this, aggr_count: $aggr_count })
             RETURN this { .content } as this"
         `);
 
@@ -93,9 +93,9 @@ describe("Cypher Aggregations where with count", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN count(aggr_node) < $aggr_count_LT
-            \\", { this: this, aggr_count_LT: $aggr_count_LT }, false )
+            \\", { this: this, aggr_count_LT: $aggr_count_LT })
             RETURN this { .content } as this"
         `);
 
@@ -125,9 +125,9 @@ describe("Cypher Aggregations where with count", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN count(aggr_node) <= $aggr_count_LTE
-            \\", { this: this, aggr_count_LTE: $aggr_count_LTE }, false )
+            \\", { this: this, aggr_count_LTE: $aggr_count_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -157,9 +157,9 @@ describe("Cypher Aggregations where with count", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN count(aggr_node) > $aggr_count_GT
-            \\", { this: this, aggr_count_GT: $aggr_count_GT }, false )
+            \\", { this: this, aggr_count_GT: $aggr_count_GT })
             RETURN this { .content } as this"
         `);
 
@@ -189,9 +189,9 @@ describe("Cypher Aggregations where with count", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN count(aggr_node) >= $aggr_count_GTE
-            \\", { this: this, aggr_count_GTE: $aggr_count_GTE }, false )
+            \\", { this: this, aggr_count_GTE: $aggr_count_GTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/bigint.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/bigint.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someBigInt = $aggr_edge_someBigInt_EQUAL
-            \\", { this: this, aggr_edge_someBigInt_EQUAL: $aggr_edge_someBigInt_EQUAL }, false )
+            \\", { this: this, aggr_edge_someBigInt_EQUAL: $aggr_edge_someBigInt_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -98,9 +98,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someBigIntAlias = $aggr_edge_someBigIntAlias_EQUAL
-            \\", { this: this, aggr_edge_someBigIntAlias_EQUAL: $aggr_edge_someBigIntAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someBigIntAlias_EQUAL: $aggr_edge_someBigIntAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -130,9 +130,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someBigInt > $aggr_edge_someBigInt_GT
-            \\", { this: this, aggr_edge_someBigInt_GT: $aggr_edge_someBigInt_GT }, false )
+            \\", { this: this, aggr_edge_someBigInt_GT: $aggr_edge_someBigInt_GT })
             RETURN this { .content } as this"
         `);
 
@@ -162,9 +162,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someBigInt >= $aggr_edge_someBigInt_GTE
-            \\", { this: this, aggr_edge_someBigInt_GTE: $aggr_edge_someBigInt_GTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_GTE: $aggr_edge_someBigInt_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -194,9 +194,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someBigInt < $aggr_edge_someBigInt_LT
-            \\", { this: this, aggr_edge_someBigInt_LT: $aggr_edge_someBigInt_LT }, false )
+            \\", { this: this, aggr_edge_someBigInt_LT: $aggr_edge_someBigInt_LT })
             RETURN this { .content } as this"
         `);
 
@@ -226,9 +226,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someBigInt <= $aggr_edge_someBigInt_LTE
-            \\", { this: this, aggr_edge_someBigInt_LTE: $aggr_edge_someBigInt_LTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_LTE: $aggr_edge_someBigInt_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -258,9 +258,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someBigInt) = $aggr_edge_someBigInt_AVERAGE_EQUAL
-            \\", { this: this, aggr_edge_someBigInt_AVERAGE_EQUAL: $aggr_edge_someBigInt_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_edge_someBigInt_AVERAGE_EQUAL: $aggr_edge_someBigInt_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -290,9 +290,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someBigInt) > $aggr_edge_someBigInt_AVERAGE_GT
-            \\", { this: this, aggr_edge_someBigInt_AVERAGE_GT: $aggr_edge_someBigInt_AVERAGE_GT }, false )
+            \\", { this: this, aggr_edge_someBigInt_AVERAGE_GT: $aggr_edge_someBigInt_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -322,9 +322,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someBigInt) >= $aggr_edge_someBigInt_AVERAGE_GTE
-            \\", { this: this, aggr_edge_someBigInt_AVERAGE_GTE: $aggr_edge_someBigInt_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_AVERAGE_GTE: $aggr_edge_someBigInt_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -354,9 +354,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someBigInt) < $aggr_edge_someBigInt_AVERAGE_LT
-            \\", { this: this, aggr_edge_someBigInt_AVERAGE_LT: $aggr_edge_someBigInt_AVERAGE_LT }, false )
+            \\", { this: this, aggr_edge_someBigInt_AVERAGE_LT: $aggr_edge_someBigInt_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -386,9 +386,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someBigInt) <= $aggr_edge_someBigInt_AVERAGE_LTE
-            \\", { this: this, aggr_edge_someBigInt_AVERAGE_LTE: $aggr_edge_someBigInt_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_AVERAGE_LTE: $aggr_edge_someBigInt_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -418,10 +418,10 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someBigInt) AS aggr_edge_someBigInt_SUM_EQUAL_SUM
             RETURN aggr_edge_someBigInt_SUM_EQUAL_SUM = toFloat($aggr_edge_someBigInt_SUM_EQUAL)
-            \\", { this: this, aggr_edge_someBigInt_SUM_EQUAL: $aggr_edge_someBigInt_SUM_EQUAL }, false )
+            \\", { this: this, aggr_edge_someBigInt_SUM_EQUAL: $aggr_edge_someBigInt_SUM_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -451,10 +451,10 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someBigInt) AS aggr_edge_someBigInt_SUM_GT_SUM
             RETURN aggr_edge_someBigInt_SUM_GT_SUM > toFloat($aggr_edge_someBigInt_SUM_GT)
-            \\", { this: this, aggr_edge_someBigInt_SUM_GT: $aggr_edge_someBigInt_SUM_GT }, false )
+            \\", { this: this, aggr_edge_someBigInt_SUM_GT: $aggr_edge_someBigInt_SUM_GT })
             RETURN this { .content } as this"
         `);
 
@@ -484,10 +484,10 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someBigInt) AS aggr_edge_someBigInt_SUM_GTE_SUM
             RETURN aggr_edge_someBigInt_SUM_GTE_SUM >= toFloat($aggr_edge_someBigInt_SUM_GTE)
-            \\", { this: this, aggr_edge_someBigInt_SUM_GTE: $aggr_edge_someBigInt_SUM_GTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_SUM_GTE: $aggr_edge_someBigInt_SUM_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -517,10 +517,10 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someBigInt) AS aggr_edge_someBigInt_SUM_LT_SUM
             RETURN aggr_edge_someBigInt_SUM_LT_SUM < toFloat($aggr_edge_someBigInt_SUM_LT)
-            \\", { this: this, aggr_edge_someBigInt_SUM_LT: $aggr_edge_someBigInt_SUM_LT }, false )
+            \\", { this: this, aggr_edge_someBigInt_SUM_LT: $aggr_edge_someBigInt_SUM_LT })
             RETURN this { .content } as this"
         `);
 
@@ -550,10 +550,10 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someBigInt) AS aggr_edge_someBigInt_SUM_LTE_SUM
             RETURN aggr_edge_someBigInt_SUM_LTE_SUM <= toFloat($aggr_edge_someBigInt_SUM_LTE)
-            \\", { this: this, aggr_edge_someBigInt_SUM_LTE: $aggr_edge_someBigInt_SUM_LTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_SUM_LTE: $aggr_edge_someBigInt_SUM_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -583,9 +583,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someBigInt) = $aggr_edge_someBigInt_MIN_EQUAL
-            \\", { this: this, aggr_edge_someBigInt_MIN_EQUAL: $aggr_edge_someBigInt_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someBigInt_MIN_EQUAL: $aggr_edge_someBigInt_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -615,9 +615,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someBigInt) > $aggr_edge_someBigInt_MIN_GT
-            \\", { this: this, aggr_edge_someBigInt_MIN_GT: $aggr_edge_someBigInt_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someBigInt_MIN_GT: $aggr_edge_someBigInt_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -647,9 +647,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someBigInt) >= $aggr_edge_someBigInt_MIN_GTE
-            \\", { this: this, aggr_edge_someBigInt_MIN_GTE: $aggr_edge_someBigInt_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_MIN_GTE: $aggr_edge_someBigInt_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -679,9 +679,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someBigInt) < $aggr_edge_someBigInt_MIN_LT
-            \\", { this: this, aggr_edge_someBigInt_MIN_LT: $aggr_edge_someBigInt_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someBigInt_MIN_LT: $aggr_edge_someBigInt_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -711,9 +711,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someBigInt) <= $aggr_edge_someBigInt_MIN_LTE
-            \\", { this: this, aggr_edge_someBigInt_MIN_LTE: $aggr_edge_someBigInt_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_MIN_LTE: $aggr_edge_someBigInt_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -743,9 +743,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someBigInt) = $aggr_edge_someBigInt_MAX_EQUAL
-            \\", { this: this, aggr_edge_someBigInt_MAX_EQUAL: $aggr_edge_someBigInt_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someBigInt_MAX_EQUAL: $aggr_edge_someBigInt_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -775,9 +775,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someBigInt) > $aggr_edge_someBigInt_MAX_GT
-            \\", { this: this, aggr_edge_someBigInt_MAX_GT: $aggr_edge_someBigInt_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someBigInt_MAX_GT: $aggr_edge_someBigInt_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -807,9 +807,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someBigInt) >= $aggr_edge_someBigInt_MAX_GTE
-            \\", { this: this, aggr_edge_someBigInt_MAX_GTE: $aggr_edge_someBigInt_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_MAX_GTE: $aggr_edge_someBigInt_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -839,9 +839,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someBigInt) < $aggr_edge_someBigInt_MAX_LT
-            \\", { this: this, aggr_edge_someBigInt_MAX_LT: $aggr_edge_someBigInt_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someBigInt_MAX_LT: $aggr_edge_someBigInt_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -871,9 +871,9 @@ describe("Cypher Aggregations where edge with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someBigInt) <= $aggr_edge_someBigInt_MAX_LTE
-            \\", { this: this, aggr_edge_someBigInt_MAX_LTE: $aggr_edge_someBigInt_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someBigInt_MAX_LTE: $aggr_edge_someBigInt_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/datetime.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/datetime.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDateTime = $aggr_edge_someDateTime_EQUAL
-            \\", { this: this, aggr_edge_someDateTime_EQUAL: $aggr_edge_someDateTime_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDateTime_EQUAL: $aggr_edge_someDateTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -104,9 +104,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someDateTimeAlias = $aggr_edge_someDateTimeAlias_EQUAL
-            \\", { this: this, aggr_edge_someDateTimeAlias_EQUAL: $aggr_edge_someDateTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDateTimeAlias_EQUAL: $aggr_edge_someDateTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -142,9 +142,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDateTime > $aggr_edge_someDateTime_GT
-            \\", { this: this, aggr_edge_someDateTime_GT: $aggr_edge_someDateTime_GT }, false )
+            \\", { this: this, aggr_edge_someDateTime_GT: $aggr_edge_someDateTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -180,9 +180,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDateTime >= $aggr_edge_someDateTime_GTE
-            \\", { this: this, aggr_edge_someDateTime_GTE: $aggr_edge_someDateTime_GTE }, false )
+            \\", { this: this, aggr_edge_someDateTime_GTE: $aggr_edge_someDateTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -218,9 +218,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDateTime < $aggr_edge_someDateTime_LT
-            \\", { this: this, aggr_edge_someDateTime_LT: $aggr_edge_someDateTime_LT }, false )
+            \\", { this: this, aggr_edge_someDateTime_LT: $aggr_edge_someDateTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -256,9 +256,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDateTime <= $aggr_edge_someDateTime_LTE
-            \\", { this: this, aggr_edge_someDateTime_LTE: $aggr_edge_someDateTime_LTE }, false )
+            \\", { this: this, aggr_edge_someDateTime_LTE: $aggr_edge_someDateTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -294,9 +294,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDateTime) = $aggr_edge_someDateTime_MIN_EQUAL
-            \\", { this: this, aggr_edge_someDateTime_MIN_EQUAL: $aggr_edge_someDateTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDateTime_MIN_EQUAL: $aggr_edge_someDateTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -332,9 +332,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDateTime) > $aggr_edge_someDateTime_MIN_GT
-            \\", { this: this, aggr_edge_someDateTime_MIN_GT: $aggr_edge_someDateTime_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someDateTime_MIN_GT: $aggr_edge_someDateTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -370,9 +370,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDateTime) >= $aggr_edge_someDateTime_MIN_GTE
-            \\", { this: this, aggr_edge_someDateTime_MIN_GTE: $aggr_edge_someDateTime_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someDateTime_MIN_GTE: $aggr_edge_someDateTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -408,9 +408,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDateTime) < $aggr_edge_someDateTime_MIN_LT
-            \\", { this: this, aggr_edge_someDateTime_MIN_LT: $aggr_edge_someDateTime_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someDateTime_MIN_LT: $aggr_edge_someDateTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -446,9 +446,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDateTime) <= $aggr_edge_someDateTime_MIN_LTE
-            \\", { this: this, aggr_edge_someDateTime_MIN_LTE: $aggr_edge_someDateTime_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someDateTime_MIN_LTE: $aggr_edge_someDateTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -484,9 +484,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDateTime) = $aggr_edge_someDateTime_MAX_EQUAL
-            \\", { this: this, aggr_edge_someDateTime_MAX_EQUAL: $aggr_edge_someDateTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDateTime_MAX_EQUAL: $aggr_edge_someDateTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -522,9 +522,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDateTime) > $aggr_edge_someDateTime_MAX_GT
-            \\", { this: this, aggr_edge_someDateTime_MAX_GT: $aggr_edge_someDateTime_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someDateTime_MAX_GT: $aggr_edge_someDateTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -560,9 +560,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDateTime) >= $aggr_edge_someDateTime_MAX_GTE
-            \\", { this: this, aggr_edge_someDateTime_MAX_GTE: $aggr_edge_someDateTime_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someDateTime_MAX_GTE: $aggr_edge_someDateTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -598,9 +598,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDateTime) < $aggr_edge_someDateTime_MAX_LT
-            \\", { this: this, aggr_edge_someDateTime_MAX_LT: $aggr_edge_someDateTime_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someDateTime_MAX_LT: $aggr_edge_someDateTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -636,9 +636,9 @@ describe("Cypher Aggregations where edge with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDateTime) <= $aggr_edge_someDateTime_MAX_LTE
-            \\", { this: this, aggr_edge_someDateTime_MAX_LTE: $aggr_edge_someDateTime_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someDateTime_MAX_LTE: $aggr_edge_someDateTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/duration.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/duration.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDuration = $aggr_edge_someDuration_EQUAL
-            \\", { this: this, aggr_edge_someDuration_EQUAL: $aggr_edge_someDuration_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDuration_EQUAL: $aggr_edge_someDuration_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -106,9 +106,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someDurationAlias = $aggr_edge_someDurationAlias_EQUAL
-            \\", { this: this, aggr_edge_someDurationAlias_EQUAL: $aggr_edge_someDurationAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDurationAlias_EQUAL: $aggr_edge_someDurationAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -146,9 +146,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDuration > $aggr_edge_someDuration_GT
-            \\", { this: this, aggr_edge_someDuration_GT: $aggr_edge_someDuration_GT }, false )
+            \\", { this: this, aggr_edge_someDuration_GT: $aggr_edge_someDuration_GT })
             RETURN this { .content } as this"
         `);
 
@@ -186,9 +186,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDuration >= $aggr_edge_someDuration_GTE
-            \\", { this: this, aggr_edge_someDuration_GTE: $aggr_edge_someDuration_GTE }, false )
+            \\", { this: this, aggr_edge_someDuration_GTE: $aggr_edge_someDuration_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -226,9 +226,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDuration < $aggr_edge_someDuration_LT
-            \\", { this: this, aggr_edge_someDuration_LT: $aggr_edge_someDuration_LT }, false )
+            \\", { this: this, aggr_edge_someDuration_LT: $aggr_edge_someDuration_LT })
             RETURN this { .content } as this"
         `);
 
@@ -266,9 +266,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someDuration <= $aggr_edge_someDuration_LTE
-            \\", { this: this, aggr_edge_someDuration_LTE: $aggr_edge_someDuration_LTE }, false )
+            \\", { this: this, aggr_edge_someDuration_LTE: $aggr_edge_someDuration_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -306,9 +306,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someDuration) = $aggr_edge_someDuration_AVERAGE_EQUAL
-            \\", { this: this, aggr_edge_someDuration_AVERAGE_EQUAL: $aggr_edge_someDuration_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDuration_AVERAGE_EQUAL: $aggr_edge_someDuration_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -346,9 +346,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someDuration) > $aggr_edge_someDuration_AVERAGE_GT
-            \\", { this: this, aggr_edge_someDuration_AVERAGE_GT: $aggr_edge_someDuration_AVERAGE_GT }, false )
+            \\", { this: this, aggr_edge_someDuration_AVERAGE_GT: $aggr_edge_someDuration_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -386,9 +386,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someDuration) >= $aggr_edge_someDuration_AVERAGE_GTE
-            \\", { this: this, aggr_edge_someDuration_AVERAGE_GTE: $aggr_edge_someDuration_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_edge_someDuration_AVERAGE_GTE: $aggr_edge_someDuration_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -426,9 +426,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someDuration) < $aggr_edge_someDuration_AVERAGE_LT
-            \\", { this: this, aggr_edge_someDuration_AVERAGE_LT: $aggr_edge_someDuration_AVERAGE_LT }, false )
+            \\", { this: this, aggr_edge_someDuration_AVERAGE_LT: $aggr_edge_someDuration_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -466,9 +466,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someDuration) <= $aggr_edge_someDuration_AVERAGE_LTE
-            \\", { this: this, aggr_edge_someDuration_AVERAGE_LTE: $aggr_edge_someDuration_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_edge_someDuration_AVERAGE_LTE: $aggr_edge_someDuration_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -506,9 +506,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDuration) = $aggr_edge_someDuration_MIN_EQUAL
-            \\", { this: this, aggr_edge_someDuration_MIN_EQUAL: $aggr_edge_someDuration_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDuration_MIN_EQUAL: $aggr_edge_someDuration_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -546,9 +546,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDuration) > $aggr_edge_someDuration_MIN_GT
-            \\", { this: this, aggr_edge_someDuration_MIN_GT: $aggr_edge_someDuration_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someDuration_MIN_GT: $aggr_edge_someDuration_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -586,9 +586,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDuration) >= $aggr_edge_someDuration_MIN_GTE
-            \\", { this: this, aggr_edge_someDuration_MIN_GTE: $aggr_edge_someDuration_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someDuration_MIN_GTE: $aggr_edge_someDuration_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -626,9 +626,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDuration) < $aggr_edge_someDuration_MIN_LT
-            \\", { this: this, aggr_edge_someDuration_MIN_LT: $aggr_edge_someDuration_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someDuration_MIN_LT: $aggr_edge_someDuration_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -666,9 +666,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someDuration) <= $aggr_edge_someDuration_MIN_LTE
-            \\", { this: this, aggr_edge_someDuration_MIN_LTE: $aggr_edge_someDuration_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someDuration_MIN_LTE: $aggr_edge_someDuration_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -706,9 +706,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDuration) = $aggr_edge_someDuration_MAX_EQUAL
-            \\", { this: this, aggr_edge_someDuration_MAX_EQUAL: $aggr_edge_someDuration_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someDuration_MAX_EQUAL: $aggr_edge_someDuration_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -746,9 +746,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDuration) > $aggr_edge_someDuration_MAX_GT
-            \\", { this: this, aggr_edge_someDuration_MAX_GT: $aggr_edge_someDuration_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someDuration_MAX_GT: $aggr_edge_someDuration_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -786,9 +786,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDuration) >= $aggr_edge_someDuration_MAX_GTE
-            \\", { this: this, aggr_edge_someDuration_MAX_GTE: $aggr_edge_someDuration_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someDuration_MAX_GTE: $aggr_edge_someDuration_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -826,9 +826,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDuration) < $aggr_edge_someDuration_MAX_LT
-            \\", { this: this, aggr_edge_someDuration_MAX_LT: $aggr_edge_someDuration_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someDuration_MAX_LT: $aggr_edge_someDuration_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -866,9 +866,9 @@ describe("Cypher Aggregations where edge with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someDuration) <= $aggr_edge_someDuration_MAX_LTE
-            \\", { this: this, aggr_edge_someDuration_MAX_LTE: $aggr_edge_someDuration_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someDuration_MAX_LTE: $aggr_edge_someDuration_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/float.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/float.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someFloat = $aggr_edge_someFloat_EQUAL
-            \\", { this: this, aggr_edge_someFloat_EQUAL: $aggr_edge_someFloat_EQUAL }, false )
+            \\", { this: this, aggr_edge_someFloat_EQUAL: $aggr_edge_someFloat_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -95,9 +95,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someFloatAlias = $aggr_edge_someFloatAlias_EQUAL
-            \\", { this: this, aggr_edge_someFloatAlias_EQUAL: $aggr_edge_someFloatAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someFloatAlias_EQUAL: $aggr_edge_someFloatAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -124,9 +124,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someFloat > $aggr_edge_someFloat_GT
-            \\", { this: this, aggr_edge_someFloat_GT: $aggr_edge_someFloat_GT }, false )
+            \\", { this: this, aggr_edge_someFloat_GT: $aggr_edge_someFloat_GT })
             RETURN this { .content } as this"
         `);
 
@@ -153,9 +153,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someFloat >= $aggr_edge_someFloat_GTE
-            \\", { this: this, aggr_edge_someFloat_GTE: $aggr_edge_someFloat_GTE }, false )
+            \\", { this: this, aggr_edge_someFloat_GTE: $aggr_edge_someFloat_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -182,9 +182,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someFloat < $aggr_edge_someFloat_LT
-            \\", { this: this, aggr_edge_someFloat_LT: $aggr_edge_someFloat_LT }, false )
+            \\", { this: this, aggr_edge_someFloat_LT: $aggr_edge_someFloat_LT })
             RETURN this { .content } as this"
         `);
 
@@ -211,9 +211,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someFloat <= $aggr_edge_someFloat_LTE
-            \\", { this: this, aggr_edge_someFloat_LTE: $aggr_edge_someFloat_LTE }, false )
+            \\", { this: this, aggr_edge_someFloat_LTE: $aggr_edge_someFloat_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -240,9 +240,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someFloat) = $aggr_edge_someFloat_AVERAGE_EQUAL
-            \\", { this: this, aggr_edge_someFloat_AVERAGE_EQUAL: $aggr_edge_someFloat_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_edge_someFloat_AVERAGE_EQUAL: $aggr_edge_someFloat_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -269,9 +269,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someFloat) > $aggr_edge_someFloat_AVERAGE_GT
-            \\", { this: this, aggr_edge_someFloat_AVERAGE_GT: $aggr_edge_someFloat_AVERAGE_GT }, false )
+            \\", { this: this, aggr_edge_someFloat_AVERAGE_GT: $aggr_edge_someFloat_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -298,9 +298,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someFloat) >= $aggr_edge_someFloat_AVERAGE_GTE
-            \\", { this: this, aggr_edge_someFloat_AVERAGE_GTE: $aggr_edge_someFloat_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_edge_someFloat_AVERAGE_GTE: $aggr_edge_someFloat_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -327,9 +327,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someFloat) < $aggr_edge_someFloat_AVERAGE_LT
-            \\", { this: this, aggr_edge_someFloat_AVERAGE_LT: $aggr_edge_someFloat_AVERAGE_LT }, false )
+            \\", { this: this, aggr_edge_someFloat_AVERAGE_LT: $aggr_edge_someFloat_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -356,9 +356,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someFloat) <= $aggr_edge_someFloat_AVERAGE_LTE
-            \\", { this: this, aggr_edge_someFloat_AVERAGE_LTE: $aggr_edge_someFloat_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_edge_someFloat_AVERAGE_LTE: $aggr_edge_someFloat_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -385,10 +385,10 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someFloat) AS aggr_edge_someFloat_SUM_EQUAL_SUM
             RETURN aggr_edge_someFloat_SUM_EQUAL_SUM = toFloat($aggr_edge_someFloat_SUM_EQUAL)
-            \\", { this: this, aggr_edge_someFloat_SUM_EQUAL: $aggr_edge_someFloat_SUM_EQUAL }, false )
+            \\", { this: this, aggr_edge_someFloat_SUM_EQUAL: $aggr_edge_someFloat_SUM_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -415,10 +415,10 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someFloat) AS aggr_edge_someFloat_SUM_GT_SUM
             RETURN aggr_edge_someFloat_SUM_GT_SUM > toFloat($aggr_edge_someFloat_SUM_GT)
-            \\", { this: this, aggr_edge_someFloat_SUM_GT: $aggr_edge_someFloat_SUM_GT }, false )
+            \\", { this: this, aggr_edge_someFloat_SUM_GT: $aggr_edge_someFloat_SUM_GT })
             RETURN this { .content } as this"
         `);
 
@@ -445,10 +445,10 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someFloat) AS aggr_edge_someFloat_SUM_GTE_SUM
             RETURN aggr_edge_someFloat_SUM_GTE_SUM >= toFloat($aggr_edge_someFloat_SUM_GTE)
-            \\", { this: this, aggr_edge_someFloat_SUM_GTE: $aggr_edge_someFloat_SUM_GTE }, false )
+            \\", { this: this, aggr_edge_someFloat_SUM_GTE: $aggr_edge_someFloat_SUM_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -475,10 +475,10 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someFloat) AS aggr_edge_someFloat_SUM_LT_SUM
             RETURN aggr_edge_someFloat_SUM_LT_SUM < toFloat($aggr_edge_someFloat_SUM_LT)
-            \\", { this: this, aggr_edge_someFloat_SUM_LT: $aggr_edge_someFloat_SUM_LT }, false )
+            \\", { this: this, aggr_edge_someFloat_SUM_LT: $aggr_edge_someFloat_SUM_LT })
             RETURN this { .content } as this"
         `);
 
@@ -505,10 +505,10 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someFloat) AS aggr_edge_someFloat_SUM_LTE_SUM
             RETURN aggr_edge_someFloat_SUM_LTE_SUM <= toFloat($aggr_edge_someFloat_SUM_LTE)
-            \\", { this: this, aggr_edge_someFloat_SUM_LTE: $aggr_edge_someFloat_SUM_LTE }, false )
+            \\", { this: this, aggr_edge_someFloat_SUM_LTE: $aggr_edge_someFloat_SUM_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -535,9 +535,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someFloat) = $aggr_edge_someFloat_MIN_EQUAL
-            \\", { this: this, aggr_edge_someFloat_MIN_EQUAL: $aggr_edge_someFloat_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someFloat_MIN_EQUAL: $aggr_edge_someFloat_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -564,9 +564,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someFloat) > $aggr_edge_someFloat_MIN_GT
-            \\", { this: this, aggr_edge_someFloat_MIN_GT: $aggr_edge_someFloat_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someFloat_MIN_GT: $aggr_edge_someFloat_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -593,9 +593,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someFloat) >= $aggr_edge_someFloat_MIN_GTE
-            \\", { this: this, aggr_edge_someFloat_MIN_GTE: $aggr_edge_someFloat_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someFloat_MIN_GTE: $aggr_edge_someFloat_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -622,9 +622,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someFloat) < $aggr_edge_someFloat_MIN_LT
-            \\", { this: this, aggr_edge_someFloat_MIN_LT: $aggr_edge_someFloat_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someFloat_MIN_LT: $aggr_edge_someFloat_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -651,9 +651,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someFloat) <= $aggr_edge_someFloat_MIN_LTE
-            \\", { this: this, aggr_edge_someFloat_MIN_LTE: $aggr_edge_someFloat_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someFloat_MIN_LTE: $aggr_edge_someFloat_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -680,9 +680,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someFloat) = $aggr_edge_someFloat_MAX_EQUAL
-            \\", { this: this, aggr_edge_someFloat_MAX_EQUAL: $aggr_edge_someFloat_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someFloat_MAX_EQUAL: $aggr_edge_someFloat_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -709,9 +709,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someFloat) > $aggr_edge_someFloat_MAX_GT
-            \\", { this: this, aggr_edge_someFloat_MAX_GT: $aggr_edge_someFloat_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someFloat_MAX_GT: $aggr_edge_someFloat_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -738,9 +738,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someFloat) >= $aggr_edge_someFloat_MAX_GTE
-            \\", { this: this, aggr_edge_someFloat_MAX_GTE: $aggr_edge_someFloat_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someFloat_MAX_GTE: $aggr_edge_someFloat_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -767,9 +767,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someFloat) < $aggr_edge_someFloat_MAX_LT
-            \\", { this: this, aggr_edge_someFloat_MAX_LT: $aggr_edge_someFloat_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someFloat_MAX_LT: $aggr_edge_someFloat_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -796,9 +796,9 @@ describe("Cypher Aggregations where edge with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someFloat) <= $aggr_edge_someFloat_MAX_LTE
-            \\", { this: this, aggr_edge_someFloat_MAX_LTE: $aggr_edge_someFloat_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someFloat_MAX_LTE: $aggr_edge_someFloat_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/id.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/id.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with ID", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.id = $aggr_edge_id_EQUAL
-            \\", { this: this, aggr_edge_id_EQUAL: $aggr_edge_id_EQUAL }, false )
+            \\", { this: this, aggr_edge_id_EQUAL: $aggr_edge_id_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -95,9 +95,9 @@ describe("Cypher Aggregations where edge with ID", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someIdAlias = $aggr_edge_someIdAlias_EQUAL
-            \\", { this: this, aggr_edge_someIdAlias_EQUAL: $aggr_edge_someIdAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someIdAlias_EQUAL: $aggr_edge_someIdAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/int.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/int.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someInt = $aggr_edge_someInt_EQUAL
-            \\", { this: this, aggr_edge_someInt_EQUAL: $aggr_edge_someInt_EQUAL }, false )
+            \\", { this: this, aggr_edge_someInt_EQUAL: $aggr_edge_someInt_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -98,9 +98,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someIntAlias = $aggr_edge_someIntAlias_EQUAL
-            \\", { this: this, aggr_edge_someIntAlias_EQUAL: $aggr_edge_someIntAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someIntAlias_EQUAL: $aggr_edge_someIntAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -130,9 +130,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someInt > $aggr_edge_someInt_GT
-            \\", { this: this, aggr_edge_someInt_GT: $aggr_edge_someInt_GT }, false )
+            \\", { this: this, aggr_edge_someInt_GT: $aggr_edge_someInt_GT })
             RETURN this { .content } as this"
         `);
 
@@ -162,9 +162,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someInt >= $aggr_edge_someInt_GTE
-            \\", { this: this, aggr_edge_someInt_GTE: $aggr_edge_someInt_GTE }, false )
+            \\", { this: this, aggr_edge_someInt_GTE: $aggr_edge_someInt_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -194,9 +194,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someInt < $aggr_edge_someInt_LT
-            \\", { this: this, aggr_edge_someInt_LT: $aggr_edge_someInt_LT }, false )
+            \\", { this: this, aggr_edge_someInt_LT: $aggr_edge_someInt_LT })
             RETURN this { .content } as this"
         `);
 
@@ -226,9 +226,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someInt <= $aggr_edge_someInt_LTE
-            \\", { this: this, aggr_edge_someInt_LTE: $aggr_edge_someInt_LTE }, false )
+            \\", { this: this, aggr_edge_someInt_LTE: $aggr_edge_someInt_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -258,9 +258,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someInt) = $aggr_edge_someInt_AVERAGE_EQUAL
-            \\", { this: this, aggr_edge_someInt_AVERAGE_EQUAL: $aggr_edge_someInt_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_edge_someInt_AVERAGE_EQUAL: $aggr_edge_someInt_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -287,9 +287,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someInt) > $aggr_edge_someInt_AVERAGE_GT
-            \\", { this: this, aggr_edge_someInt_AVERAGE_GT: $aggr_edge_someInt_AVERAGE_GT }, false )
+            \\", { this: this, aggr_edge_someInt_AVERAGE_GT: $aggr_edge_someInt_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -316,9 +316,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someInt) >= $aggr_edge_someInt_AVERAGE_GTE
-            \\", { this: this, aggr_edge_someInt_AVERAGE_GTE: $aggr_edge_someInt_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_edge_someInt_AVERAGE_GTE: $aggr_edge_someInt_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -345,9 +345,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someInt) < $aggr_edge_someInt_AVERAGE_LT
-            \\", { this: this, aggr_edge_someInt_AVERAGE_LT: $aggr_edge_someInt_AVERAGE_LT }, false )
+            \\", { this: this, aggr_edge_someInt_AVERAGE_LT: $aggr_edge_someInt_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -374,9 +374,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_edge.someInt) <= $aggr_edge_someInt_AVERAGE_LTE
-            \\", { this: this, aggr_edge_someInt_AVERAGE_LTE: $aggr_edge_someInt_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_edge_someInt_AVERAGE_LTE: $aggr_edge_someInt_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -403,10 +403,10 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someInt) AS aggr_edge_someInt_SUM_EQUAL_SUM
             RETURN aggr_edge_someInt_SUM_EQUAL_SUM = toFloat($aggr_edge_someInt_SUM_EQUAL)
-            \\", { this: this, aggr_edge_someInt_SUM_EQUAL: $aggr_edge_someInt_SUM_EQUAL }, false )
+            \\", { this: this, aggr_edge_someInt_SUM_EQUAL: $aggr_edge_someInt_SUM_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -436,10 +436,10 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someInt) AS aggr_edge_someInt_SUM_GT_SUM
             RETURN aggr_edge_someInt_SUM_GT_SUM > toFloat($aggr_edge_someInt_SUM_GT)
-            \\", { this: this, aggr_edge_someInt_SUM_GT: $aggr_edge_someInt_SUM_GT }, false )
+            \\", { this: this, aggr_edge_someInt_SUM_GT: $aggr_edge_someInt_SUM_GT })
             RETURN this { .content } as this"
         `);
 
@@ -469,10 +469,10 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someInt) AS aggr_edge_someInt_SUM_GTE_SUM
             RETURN aggr_edge_someInt_SUM_GTE_SUM >= toFloat($aggr_edge_someInt_SUM_GTE)
-            \\", { this: this, aggr_edge_someInt_SUM_GTE: $aggr_edge_someInt_SUM_GTE }, false )
+            \\", { this: this, aggr_edge_someInt_SUM_GTE: $aggr_edge_someInt_SUM_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -502,10 +502,10 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someInt) AS aggr_edge_someInt_SUM_LT_SUM
             RETURN aggr_edge_someInt_SUM_LT_SUM < toFloat($aggr_edge_someInt_SUM_LT)
-            \\", { this: this, aggr_edge_someInt_SUM_LT: $aggr_edge_someInt_SUM_LT }, false )
+            \\", { this: this, aggr_edge_someInt_SUM_LT: $aggr_edge_someInt_SUM_LT })
             RETURN this { .content } as this"
         `);
 
@@ -535,10 +535,10 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_edge.someInt) AS aggr_edge_someInt_SUM_LTE_SUM
             RETURN aggr_edge_someInt_SUM_LTE_SUM <= toFloat($aggr_edge_someInt_SUM_LTE)
-            \\", { this: this, aggr_edge_someInt_SUM_LTE: $aggr_edge_someInt_SUM_LTE }, false )
+            \\", { this: this, aggr_edge_someInt_SUM_LTE: $aggr_edge_someInt_SUM_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -568,9 +568,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someInt) = $aggr_edge_someInt_MIN_EQUAL
-            \\", { this: this, aggr_edge_someInt_MIN_EQUAL: $aggr_edge_someInt_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someInt_MIN_EQUAL: $aggr_edge_someInt_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -600,9 +600,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someInt) > $aggr_edge_someInt_MIN_GT
-            \\", { this: this, aggr_edge_someInt_MIN_GT: $aggr_edge_someInt_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someInt_MIN_GT: $aggr_edge_someInt_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -632,9 +632,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someInt) >= $aggr_edge_someInt_MIN_GTE
-            \\", { this: this, aggr_edge_someInt_MIN_GTE: $aggr_edge_someInt_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someInt_MIN_GTE: $aggr_edge_someInt_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -664,9 +664,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someInt) < $aggr_edge_someInt_MIN_LT
-            \\", { this: this, aggr_edge_someInt_MIN_LT: $aggr_edge_someInt_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someInt_MIN_LT: $aggr_edge_someInt_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -696,9 +696,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someInt) <= $aggr_edge_someInt_MIN_LTE
-            \\", { this: this, aggr_edge_someInt_MIN_LTE: $aggr_edge_someInt_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someInt_MIN_LTE: $aggr_edge_someInt_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -728,9 +728,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someInt) = $aggr_edge_someInt_MAX_EQUAL
-            \\", { this: this, aggr_edge_someInt_MAX_EQUAL: $aggr_edge_someInt_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someInt_MAX_EQUAL: $aggr_edge_someInt_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -760,9 +760,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someInt) > $aggr_edge_someInt_MAX_GT
-            \\", { this: this, aggr_edge_someInt_MAX_GT: $aggr_edge_someInt_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someInt_MAX_GT: $aggr_edge_someInt_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -792,9 +792,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someInt) >= $aggr_edge_someInt_MAX_GTE
-            \\", { this: this, aggr_edge_someInt_MAX_GTE: $aggr_edge_someInt_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someInt_MAX_GTE: $aggr_edge_someInt_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -824,9 +824,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someInt) < $aggr_edge_someInt_MAX_LT
-            \\", { this: this, aggr_edge_someInt_MAX_LT: $aggr_edge_someInt_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someInt_MAX_LT: $aggr_edge_someInt_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -856,9 +856,9 @@ describe("Cypher Aggregations where edge with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someInt) <= $aggr_edge_someInt_MAX_LTE
-            \\", { this: this, aggr_edge_someInt_MAX_LTE: $aggr_edge_someInt_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someInt_MAX_LTE: $aggr_edge_someInt_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/localdatetime.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalDateTime = $aggr_edge_someLocalDateTime_EQUAL
-            \\", { this: this, aggr_edge_someLocalDateTime_EQUAL: $aggr_edge_someLocalDateTime_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_EQUAL: $aggr_edge_someLocalDateTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -103,9 +103,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someLocalDateTimeAlias = $aggr_edge_someLocalDateTimeAlias_EQUAL
-            \\", { this: this, aggr_edge_someLocalDateTimeAlias_EQUAL: $aggr_edge_someLocalDateTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalDateTimeAlias_EQUAL: $aggr_edge_someLocalDateTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -140,9 +140,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalDateTime > $aggr_edge_someLocalDateTime_GT
-            \\", { this: this, aggr_edge_someLocalDateTime_GT: $aggr_edge_someLocalDateTime_GT }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_GT: $aggr_edge_someLocalDateTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -177,9 +177,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalDateTime >= $aggr_edge_someLocalDateTime_GTE
-            \\", { this: this, aggr_edge_someLocalDateTime_GTE: $aggr_edge_someLocalDateTime_GTE }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_GTE: $aggr_edge_someLocalDateTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -214,9 +214,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalDateTime < $aggr_edge_someLocalDateTime_LT
-            \\", { this: this, aggr_edge_someLocalDateTime_LT: $aggr_edge_someLocalDateTime_LT }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_LT: $aggr_edge_someLocalDateTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -251,9 +251,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalDateTime <= $aggr_edge_someLocalDateTime_LTE
-            \\", { this: this, aggr_edge_someLocalDateTime_LTE: $aggr_edge_someLocalDateTime_LTE }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_LTE: $aggr_edge_someLocalDateTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -288,9 +288,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalDateTime) = $aggr_edge_someLocalDateTime_MIN_EQUAL
-            \\", { this: this, aggr_edge_someLocalDateTime_MIN_EQUAL: $aggr_edge_someLocalDateTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MIN_EQUAL: $aggr_edge_someLocalDateTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -325,9 +325,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalDateTime) > $aggr_edge_someLocalDateTime_MIN_GT
-            \\", { this: this, aggr_edge_someLocalDateTime_MIN_GT: $aggr_edge_someLocalDateTime_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MIN_GT: $aggr_edge_someLocalDateTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -362,9 +362,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalDateTime) >= $aggr_edge_someLocalDateTime_MIN_GTE
-            \\", { this: this, aggr_edge_someLocalDateTime_MIN_GTE: $aggr_edge_someLocalDateTime_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MIN_GTE: $aggr_edge_someLocalDateTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -399,9 +399,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalDateTime) < $aggr_edge_someLocalDateTime_MIN_LT
-            \\", { this: this, aggr_edge_someLocalDateTime_MIN_LT: $aggr_edge_someLocalDateTime_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MIN_LT: $aggr_edge_someLocalDateTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -436,9 +436,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalDateTime) <= $aggr_edge_someLocalDateTime_MIN_LTE
-            \\", { this: this, aggr_edge_someLocalDateTime_MIN_LTE: $aggr_edge_someLocalDateTime_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MIN_LTE: $aggr_edge_someLocalDateTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -473,9 +473,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalDateTime) = $aggr_edge_someLocalDateTime_MAX_EQUAL
-            \\", { this: this, aggr_edge_someLocalDateTime_MAX_EQUAL: $aggr_edge_someLocalDateTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MAX_EQUAL: $aggr_edge_someLocalDateTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -510,9 +510,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalDateTime) > $aggr_edge_someLocalDateTime_MAX_GT
-            \\", { this: this, aggr_edge_someLocalDateTime_MAX_GT: $aggr_edge_someLocalDateTime_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MAX_GT: $aggr_edge_someLocalDateTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -547,9 +547,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalDateTime) >= $aggr_edge_someLocalDateTime_MAX_GTE
-            \\", { this: this, aggr_edge_someLocalDateTime_MAX_GTE: $aggr_edge_someLocalDateTime_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MAX_GTE: $aggr_edge_someLocalDateTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -584,9 +584,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalDateTime) < $aggr_edge_someLocalDateTime_MAX_LT
-            \\", { this: this, aggr_edge_someLocalDateTime_MAX_LT: $aggr_edge_someLocalDateTime_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MAX_LT: $aggr_edge_someLocalDateTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -621,9 +621,9 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalDateTime) <= $aggr_edge_someLocalDateTime_MAX_LTE
-            \\", { this: this, aggr_edge_someLocalDateTime_MAX_LTE: $aggr_edge_someLocalDateTime_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someLocalDateTime_MAX_LTE: $aggr_edge_someLocalDateTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/localtime.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/localtime.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalTime = $aggr_edge_someLocalTime_EQUAL
-            \\", { this: this, aggr_edge_someLocalTime_EQUAL: $aggr_edge_someLocalTime_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalTime_EQUAL: $aggr_edge_someLocalTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -100,9 +100,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someLocalTimeAlias = $aggr_edge_someLocalTimeAlias_EQUAL
-            \\", { this: this, aggr_edge_someLocalTimeAlias_EQUAL: $aggr_edge_someLocalTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalTimeAlias_EQUAL: $aggr_edge_someLocalTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -134,9 +134,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalTime > $aggr_edge_someLocalTime_GT
-            \\", { this: this, aggr_edge_someLocalTime_GT: $aggr_edge_someLocalTime_GT }, false )
+            \\", { this: this, aggr_edge_someLocalTime_GT: $aggr_edge_someLocalTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -168,9 +168,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalTime >= $aggr_edge_someLocalTime_GTE
-            \\", { this: this, aggr_edge_someLocalTime_GTE: $aggr_edge_someLocalTime_GTE }, false )
+            \\", { this: this, aggr_edge_someLocalTime_GTE: $aggr_edge_someLocalTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -202,9 +202,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalTime < $aggr_edge_someLocalTime_LT
-            \\", { this: this, aggr_edge_someLocalTime_LT: $aggr_edge_someLocalTime_LT }, false )
+            \\", { this: this, aggr_edge_someLocalTime_LT: $aggr_edge_someLocalTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -236,9 +236,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someLocalTime <= $aggr_edge_someLocalTime_LTE
-            \\", { this: this, aggr_edge_someLocalTime_LTE: $aggr_edge_someLocalTime_LTE }, false )
+            \\", { this: this, aggr_edge_someLocalTime_LTE: $aggr_edge_someLocalTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -270,9 +270,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalTime) = $aggr_edge_someLocalTime_MIN_EQUAL
-            \\", { this: this, aggr_edge_someLocalTime_MIN_EQUAL: $aggr_edge_someLocalTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MIN_EQUAL: $aggr_edge_someLocalTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -304,9 +304,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalTime) > $aggr_edge_someLocalTime_MIN_GT
-            \\", { this: this, aggr_edge_someLocalTime_MIN_GT: $aggr_edge_someLocalTime_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MIN_GT: $aggr_edge_someLocalTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -338,9 +338,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalTime) >= $aggr_edge_someLocalTime_MIN_GTE
-            \\", { this: this, aggr_edge_someLocalTime_MIN_GTE: $aggr_edge_someLocalTime_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MIN_GTE: $aggr_edge_someLocalTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -372,9 +372,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalTime) < $aggr_edge_someLocalTime_MIN_LT
-            \\", { this: this, aggr_edge_someLocalTime_MIN_LT: $aggr_edge_someLocalTime_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MIN_LT: $aggr_edge_someLocalTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -406,9 +406,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someLocalTime) <= $aggr_edge_someLocalTime_MIN_LTE
-            \\", { this: this, aggr_edge_someLocalTime_MIN_LTE: $aggr_edge_someLocalTime_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MIN_LTE: $aggr_edge_someLocalTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -440,9 +440,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalTime) = $aggr_edge_someLocalTime_MAX_EQUAL
-            \\", { this: this, aggr_edge_someLocalTime_MAX_EQUAL: $aggr_edge_someLocalTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MAX_EQUAL: $aggr_edge_someLocalTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -474,9 +474,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalTime) > $aggr_edge_someLocalTime_MAX_GT
-            \\", { this: this, aggr_edge_someLocalTime_MAX_GT: $aggr_edge_someLocalTime_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MAX_GT: $aggr_edge_someLocalTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -508,9 +508,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalTime) >= $aggr_edge_someLocalTime_MAX_GTE
-            \\", { this: this, aggr_edge_someLocalTime_MAX_GTE: $aggr_edge_someLocalTime_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MAX_GTE: $aggr_edge_someLocalTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -542,9 +542,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalTime) < $aggr_edge_someLocalTime_MAX_LT
-            \\", { this: this, aggr_edge_someLocalTime_MAX_LT: $aggr_edge_someLocalTime_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MAX_LT: $aggr_edge_someLocalTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -576,9 +576,9 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someLocalTime) <= $aggr_edge_someLocalTime_MAX_LTE
-            \\", { this: this, aggr_edge_someLocalTime_MAX_LTE: $aggr_edge_someLocalTime_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someLocalTime_MAX_LTE: $aggr_edge_someLocalTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/logical.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/logical.test.ts
@@ -67,9 +67,9 @@ describe("Cypher Aggregations where edge with Logical AND + OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (aggr_edge.someFloat = $aggr_edge_AND_0_someFloat_EQUAL AND aggr_edge.someFloat = $aggr_edge_AND_1_someFloat_EQUAL)
-            \\", { this: this, aggr_edge_AND_0_someFloat_EQUAL: $aggr_edge_AND_0_someFloat_EQUAL, aggr_edge_AND_1_someFloat_EQUAL: $aggr_edge_AND_1_someFloat_EQUAL }, false )
+            \\", { this: this, aggr_edge_AND_0_someFloat_EQUAL: $aggr_edge_AND_0_someFloat_EQUAL, aggr_edge_AND_1_someFloat_EQUAL: $aggr_edge_AND_1_someFloat_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -97,9 +97,9 @@ describe("Cypher Aggregations where edge with Logical AND + OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (aggr_edge.someFloat = $aggr_edge_OR_0_someFloat_EQUAL OR aggr_edge.someFloat = $aggr_edge_OR_1_someFloat_EQUAL)
-            \\", { this: this, aggr_edge_OR_0_someFloat_EQUAL: $aggr_edge_OR_0_someFloat_EQUAL, aggr_edge_OR_1_someFloat_EQUAL: $aggr_edge_OR_1_someFloat_EQUAL }, false )
+            \\", { this: this, aggr_edge_OR_0_someFloat_EQUAL: $aggr_edge_OR_0_someFloat_EQUAL, aggr_edge_OR_1_someFloat_EQUAL: $aggr_edge_OR_1_someFloat_EQUAL })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/string.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/string.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someString = $aggr_edge_someString_EQUAL
-            \\", { this: this, aggr_edge_someString_EQUAL: $aggr_edge_someString_EQUAL }, false )
+            \\", { this: this, aggr_edge_someString_EQUAL: $aggr_edge_someString_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -95,9 +95,9 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someStringAlias = $aggr_edge_someStringAlias_EQUAL
-            \\", { this: this, aggr_edge_someStringAlias_EQUAL: $aggr_edge_someStringAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someStringAlias_EQUAL: $aggr_edge_someStringAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -124,9 +124,9 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_edge.someString) > $aggr_edge_someString_GT
-            \\", { this: this, aggr_edge_someString_GT: $aggr_edge_someString_GT }, false )
+            \\", { this: this, aggr_edge_someString_GT: $aggr_edge_someString_GT })
             RETURN this { .content } as this"
         `);
 
@@ -156,9 +156,9 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_edge.someString) >= $aggr_edge_someString_GTE
-            \\", { this: this, aggr_edge_someString_GTE: $aggr_edge_someString_GTE }, false )
+            \\", { this: this, aggr_edge_someString_GTE: $aggr_edge_someString_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -188,9 +188,9 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_edge.someString) < $aggr_edge_someString_LT
-            \\", { this: this, aggr_edge_someString_LT: $aggr_edge_someString_LT }, false )
+            \\", { this: this, aggr_edge_someString_LT: $aggr_edge_someString_LT })
             RETURN this { .content } as this"
         `);
 
@@ -220,9 +220,9 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_edge.someString) <= $aggr_edge_someString_LTE
-            \\", { this: this, aggr_edge_someString_LTE: $aggr_edge_someString_LTE }, false )
+            \\", { this: this, aggr_edge_someString_LTE: $aggr_edge_someString_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -252,10 +252,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_SHORTEST_EQUAL_SIZE
             RETURN min(aggr_edge_someString_SHORTEST_EQUAL_SIZE) = $aggr_edge_someString_SHORTEST_EQUAL
-            \\", { this: this, aggr_edge_someString_SHORTEST_EQUAL: $aggr_edge_someString_SHORTEST_EQUAL }, false )
+            \\", { this: this, aggr_edge_someString_SHORTEST_EQUAL: $aggr_edge_someString_SHORTEST_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -285,10 +285,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_SHORTEST_GT_SIZE
             RETURN min(aggr_edge_someString_SHORTEST_GT_SIZE) > $aggr_edge_someString_SHORTEST_GT
-            \\", { this: this, aggr_edge_someString_SHORTEST_GT: $aggr_edge_someString_SHORTEST_GT }, false )
+            \\", { this: this, aggr_edge_someString_SHORTEST_GT: $aggr_edge_someString_SHORTEST_GT })
             RETURN this { .content } as this"
         `);
 
@@ -318,10 +318,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_SHORTEST_GTE_SIZE
             RETURN min(aggr_edge_someString_SHORTEST_GTE_SIZE) >= $aggr_edge_someString_SHORTEST_GTE
-            \\", { this: this, aggr_edge_someString_SHORTEST_GTE: $aggr_edge_someString_SHORTEST_GTE }, false )
+            \\", { this: this, aggr_edge_someString_SHORTEST_GTE: $aggr_edge_someString_SHORTEST_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -351,10 +351,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_SHORTEST_LT_SIZE
             RETURN min(aggr_edge_someString_SHORTEST_LT_SIZE) < $aggr_edge_someString_SHORTEST_LT
-            \\", { this: this, aggr_edge_someString_SHORTEST_LT: $aggr_edge_someString_SHORTEST_LT }, false )
+            \\", { this: this, aggr_edge_someString_SHORTEST_LT: $aggr_edge_someString_SHORTEST_LT })
             RETURN this { .content } as this"
         `);
 
@@ -384,10 +384,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_SHORTEST_LTE_SIZE
             RETURN min(aggr_edge_someString_SHORTEST_LTE_SIZE) <= $aggr_edge_someString_SHORTEST_LTE
-            \\", { this: this, aggr_edge_someString_SHORTEST_LTE: $aggr_edge_someString_SHORTEST_LTE }, false )
+            \\", { this: this, aggr_edge_someString_SHORTEST_LTE: $aggr_edge_someString_SHORTEST_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -417,10 +417,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_LONGEST_EQUAL_SIZE
             RETURN max(aggr_edge_someString_LONGEST_EQUAL_SIZE) = $aggr_edge_someString_LONGEST_EQUAL
-            \\", { this: this, aggr_edge_someString_LONGEST_EQUAL: $aggr_edge_someString_LONGEST_EQUAL }, false )
+            \\", { this: this, aggr_edge_someString_LONGEST_EQUAL: $aggr_edge_someString_LONGEST_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -450,10 +450,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_LONGEST_GT_SIZE
             RETURN max(aggr_edge_someString_LONGEST_GT_SIZE) > $aggr_edge_someString_LONGEST_GT
-            \\", { this: this, aggr_edge_someString_LONGEST_GT: $aggr_edge_someString_LONGEST_GT }, false )
+            \\", { this: this, aggr_edge_someString_LONGEST_GT: $aggr_edge_someString_LONGEST_GT })
             RETURN this { .content } as this"
         `);
 
@@ -483,10 +483,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_LONGEST_GTE_SIZE
             RETURN max(aggr_edge_someString_LONGEST_GTE_SIZE) >= $aggr_edge_someString_LONGEST_GTE
-            \\", { this: this, aggr_edge_someString_LONGEST_GTE: $aggr_edge_someString_LONGEST_GTE }, false )
+            \\", { this: this, aggr_edge_someString_LONGEST_GTE: $aggr_edge_someString_LONGEST_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -516,10 +516,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_LONGEST_LT_SIZE
             RETURN max(aggr_edge_someString_LONGEST_LT_SIZE) < $aggr_edge_someString_LONGEST_LT
-            \\", { this: this, aggr_edge_someString_LONGEST_LT: $aggr_edge_someString_LONGEST_LT }, false )
+            \\", { this: this, aggr_edge_someString_LONGEST_LT: $aggr_edge_someString_LONGEST_LT })
             RETURN this { .content } as this"
         `);
 
@@ -549,10 +549,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_LONGEST_LTE_SIZE
             RETURN max(aggr_edge_someString_LONGEST_LTE_SIZE) <= $aggr_edge_someString_LONGEST_LTE
-            \\", { this: this, aggr_edge_someString_LONGEST_LTE: $aggr_edge_someString_LONGEST_LTE }, false )
+            \\", { this: this, aggr_edge_someString_LONGEST_LTE: $aggr_edge_someString_LONGEST_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -582,10 +582,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_AVERAGE_EQUAL_SIZE
             RETURN avg(aggr_edge_someString_AVERAGE_EQUAL_SIZE) = toFloat($aggr_edge_someString_AVERAGE_EQUAL)
-            \\", { this: this, aggr_edge_someString_AVERAGE_EQUAL: $aggr_edge_someString_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_edge_someString_AVERAGE_EQUAL: $aggr_edge_someString_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -612,10 +612,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_AVERAGE_GT_SIZE
             RETURN avg(aggr_edge_someString_AVERAGE_GT_SIZE) > toFloat($aggr_edge_someString_AVERAGE_GT)
-            \\", { this: this, aggr_edge_someString_AVERAGE_GT: $aggr_edge_someString_AVERAGE_GT }, false )
+            \\", { this: this, aggr_edge_someString_AVERAGE_GT: $aggr_edge_someString_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -642,10 +642,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_AVERAGE_GTE_SIZE
             RETURN avg(aggr_edge_someString_AVERAGE_GTE_SIZE) >= toFloat($aggr_edge_someString_AVERAGE_GTE)
-            \\", { this: this, aggr_edge_someString_AVERAGE_GTE: $aggr_edge_someString_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_edge_someString_AVERAGE_GTE: $aggr_edge_someString_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -672,10 +672,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_AVERAGE_LT_SIZE
             RETURN avg(aggr_edge_someString_AVERAGE_LT_SIZE) < toFloat($aggr_edge_someString_AVERAGE_LT)
-            \\", { this: this, aggr_edge_someString_AVERAGE_LT: $aggr_edge_someString_AVERAGE_LT }, false )
+            \\", { this: this, aggr_edge_someString_AVERAGE_LT: $aggr_edge_someString_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -702,10 +702,10 @@ describe("Cypher Aggregations where edge with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_edge.someString) AS aggr_edge_someString_AVERAGE_LTE_SIZE
             RETURN avg(aggr_edge_someString_AVERAGE_LTE_SIZE) <= toFloat($aggr_edge_someString_AVERAGE_LTE)
-            \\", { this: this, aggr_edge_someString_AVERAGE_LTE: $aggr_edge_someString_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_edge_someString_AVERAGE_LTE: $aggr_edge_someString_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/time.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/edge/time.test.ts
@@ -66,9 +66,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someTime = $aggr_edge_someTime_EQUAL
-            \\", { this: this, aggr_edge_someTime_EQUAL: $aggr_edge_someTime_EQUAL }, false )
+            \\", { this: this, aggr_edge_someTime_EQUAL: $aggr_edge_someTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -101,9 +101,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge._someTimeAlias = $aggr_edge_someTimeAlias_EQUAL
-            \\", { this: this, aggr_edge_someTimeAlias_EQUAL: $aggr_edge_someTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_edge_someTimeAlias_EQUAL: $aggr_edge_someTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -136,9 +136,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someTime > $aggr_edge_someTime_GT
-            \\", { this: this, aggr_edge_someTime_GT: $aggr_edge_someTime_GT }, false )
+            \\", { this: this, aggr_edge_someTime_GT: $aggr_edge_someTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -171,9 +171,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someTime >= $aggr_edge_someTime_GTE
-            \\", { this: this, aggr_edge_someTime_GTE: $aggr_edge_someTime_GTE }, false )
+            \\", { this: this, aggr_edge_someTime_GTE: $aggr_edge_someTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -206,9 +206,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someTime < $aggr_edge_someTime_LT
-            \\", { this: this, aggr_edge_someTime_LT: $aggr_edge_someTime_LT }, false )
+            \\", { this: this, aggr_edge_someTime_LT: $aggr_edge_someTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -241,9 +241,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_edge.someTime <= $aggr_edge_someTime_LTE
-            \\", { this: this, aggr_edge_someTime_LTE: $aggr_edge_someTime_LTE }, false )
+            \\", { this: this, aggr_edge_someTime_LTE: $aggr_edge_someTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -276,9 +276,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someTime) = $aggr_edge_someTime_MIN_EQUAL
-            \\", { this: this, aggr_edge_someTime_MIN_EQUAL: $aggr_edge_someTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_edge_someTime_MIN_EQUAL: $aggr_edge_someTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -311,9 +311,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someTime) > $aggr_edge_someTime_MIN_GT
-            \\", { this: this, aggr_edge_someTime_MIN_GT: $aggr_edge_someTime_MIN_GT }, false )
+            \\", { this: this, aggr_edge_someTime_MIN_GT: $aggr_edge_someTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -346,9 +346,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someTime) >= $aggr_edge_someTime_MIN_GTE
-            \\", { this: this, aggr_edge_someTime_MIN_GTE: $aggr_edge_someTime_MIN_GTE }, false )
+            \\", { this: this, aggr_edge_someTime_MIN_GTE: $aggr_edge_someTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -381,9 +381,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someTime) < $aggr_edge_someTime_MIN_LT
-            \\", { this: this, aggr_edge_someTime_MIN_LT: $aggr_edge_someTime_MIN_LT }, false )
+            \\", { this: this, aggr_edge_someTime_MIN_LT: $aggr_edge_someTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -416,9 +416,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_edge.someTime) <= $aggr_edge_someTime_MIN_LTE
-            \\", { this: this, aggr_edge_someTime_MIN_LTE: $aggr_edge_someTime_MIN_LTE }, false )
+            \\", { this: this, aggr_edge_someTime_MIN_LTE: $aggr_edge_someTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -451,9 +451,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someTime) = $aggr_edge_someTime_MAX_EQUAL
-            \\", { this: this, aggr_edge_someTime_MAX_EQUAL: $aggr_edge_someTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_edge_someTime_MAX_EQUAL: $aggr_edge_someTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -486,9 +486,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someTime) > $aggr_edge_someTime_MAX_GT
-            \\", { this: this, aggr_edge_someTime_MAX_GT: $aggr_edge_someTime_MAX_GT }, false )
+            \\", { this: this, aggr_edge_someTime_MAX_GT: $aggr_edge_someTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -521,9 +521,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someTime) >= $aggr_edge_someTime_MAX_GTE
-            \\", { this: this, aggr_edge_someTime_MAX_GTE: $aggr_edge_someTime_MAX_GTE }, false )
+            \\", { this: this, aggr_edge_someTime_MAX_GTE: $aggr_edge_someTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -556,9 +556,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someTime) < $aggr_edge_someTime_MAX_LT
-            \\", { this: this, aggr_edge_someTime_MAX_LT: $aggr_edge_someTime_MAX_LT }, false )
+            \\", { this: this, aggr_edge_someTime_MAX_LT: $aggr_edge_someTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -591,9 +591,9 @@ describe("Cypher Aggregations where edge with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_edge.someTime) <= $aggr_edge_someTime_MAX_LTE
-            \\", { this: this, aggr_edge_someTime_MAX_LTE: $aggr_edge_someTime_MAX_LTE }, false )
+            \\", { this: this, aggr_edge_someTime_MAX_LTE: $aggr_edge_someTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/logical.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/logical.test.ts
@@ -61,9 +61,9 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (count(aggr_node) > $aggr_AND_0_count_GT AND count(aggr_node) < $aggr_AND_1_count_LT)
-            \\", { this: this, aggr_AND_0_count_GT: $aggr_AND_0_count_GT, aggr_AND_1_count_LT: $aggr_AND_1_count_LT }, false )
+            \\", { this: this, aggr_AND_0_count_GT: $aggr_AND_0_count_GT, aggr_AND_1_count_LT: $aggr_AND_1_count_LT })
             RETURN this { .content } as this"
         `);
 
@@ -97,9 +97,9 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (count(aggr_node) > $aggr_OR_0_count_GT OR count(aggr_node) < $aggr_OR_1_count_LT)
-            \\", { this: this, aggr_OR_0_count_GT: $aggr_OR_0_count_GT, aggr_OR_1_count_LT: $aggr_OR_1_count_LT }, false )
+            \\", { this: this, aggr_OR_0_count_GT: $aggr_OR_0_count_GT, aggr_OR_1_count_LT: $aggr_OR_1_count_LT })
             RETURN this { .content } as this"
         `);
 
@@ -140,9 +140,9 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (count(aggr_node) > $aggr_AND_0_count_GT AND count(aggr_node) < $aggr_AND_1_count_LT) AND (count(aggr_node) > $aggr_OR_0_count_GT OR count(aggr_node) < $aggr_OR_1_count_LT)
-            \\", { this: this, aggr_AND_0_count_GT: $aggr_AND_0_count_GT, aggr_AND_1_count_LT: $aggr_AND_1_count_LT, aggr_OR_0_count_GT: $aggr_OR_0_count_GT, aggr_OR_1_count_LT: $aggr_OR_1_count_LT }, false )
+            \\", { this: this, aggr_AND_0_count_GT: $aggr_AND_0_count_GT, aggr_AND_1_count_LT: $aggr_AND_1_count_LT, aggr_OR_0_count_GT: $aggr_OR_0_count_GT, aggr_OR_1_count_LT: $aggr_OR_1_count_LT })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node.test.ts
@@ -61,9 +61,9 @@ describe("Cypher Where Aggregations with @node directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`_Post\`:\`additionalPost\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:\`_User\`:\`additionalUser\`)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:\`_User\`:\`additionalUser\`)
             RETURN size(aggr_node.someName) > $aggr_node_someName_GT
-            \\", { this: this, aggr_node_someName_GT: $aggr_node_someName_GT }, false )
+            \\", { this: this, aggr_node_someName_GT: $aggr_node_someName_GT })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/bigint.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/bigint.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someBigInt = $aggr_node_someBigInt_EQUAL
-            \\", { this: this, aggr_node_someBigInt_EQUAL: $aggr_node_someBigInt_EQUAL }, false )
+            \\", { this: this, aggr_node_someBigInt_EQUAL: $aggr_node_someBigInt_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -94,9 +94,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someBigIntAlias = $aggr_node_someBigIntAlias_EQUAL
-            \\", { this: this, aggr_node_someBigIntAlias_EQUAL: $aggr_node_someBigIntAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someBigIntAlias_EQUAL: $aggr_node_someBigIntAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -126,9 +126,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someBigInt > $aggr_node_someBigInt_GT
-            \\", { this: this, aggr_node_someBigInt_GT: $aggr_node_someBigInt_GT }, false )
+            \\", { this: this, aggr_node_someBigInt_GT: $aggr_node_someBigInt_GT })
             RETURN this { .content } as this"
         `);
 
@@ -158,9 +158,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someBigInt >= $aggr_node_someBigInt_GTE
-            \\", { this: this, aggr_node_someBigInt_GTE: $aggr_node_someBigInt_GTE }, false )
+            \\", { this: this, aggr_node_someBigInt_GTE: $aggr_node_someBigInt_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -190,9 +190,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someBigInt < $aggr_node_someBigInt_LT
-            \\", { this: this, aggr_node_someBigInt_LT: $aggr_node_someBigInt_LT }, false )
+            \\", { this: this, aggr_node_someBigInt_LT: $aggr_node_someBigInt_LT })
             RETURN this { .content } as this"
         `);
 
@@ -222,9 +222,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someBigInt <= $aggr_node_someBigInt_LTE
-            \\", { this: this, aggr_node_someBigInt_LTE: $aggr_node_someBigInt_LTE }, false )
+            \\", { this: this, aggr_node_someBigInt_LTE: $aggr_node_someBigInt_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -254,9 +254,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someBigInt) = $aggr_node_someBigInt_AVERAGE_EQUAL
-            \\", { this: this, aggr_node_someBigInt_AVERAGE_EQUAL: $aggr_node_someBigInt_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_node_someBigInt_AVERAGE_EQUAL: $aggr_node_someBigInt_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -286,9 +286,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someBigInt) > $aggr_node_someBigInt_AVERAGE_GT
-            \\", { this: this, aggr_node_someBigInt_AVERAGE_GT: $aggr_node_someBigInt_AVERAGE_GT }, false )
+            \\", { this: this, aggr_node_someBigInt_AVERAGE_GT: $aggr_node_someBigInt_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -318,9 +318,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someBigInt) >= $aggr_node_someBigInt_AVERAGE_GTE
-            \\", { this: this, aggr_node_someBigInt_AVERAGE_GTE: $aggr_node_someBigInt_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_node_someBigInt_AVERAGE_GTE: $aggr_node_someBigInt_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -350,9 +350,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someBigInt) < $aggr_node_someBigInt_AVERAGE_LT
-            \\", { this: this, aggr_node_someBigInt_AVERAGE_LT: $aggr_node_someBigInt_AVERAGE_LT }, false )
+            \\", { this: this, aggr_node_someBigInt_AVERAGE_LT: $aggr_node_someBigInt_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -382,9 +382,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someBigInt) <= $aggr_node_someBigInt_AVERAGE_LTE
-            \\", { this: this, aggr_node_someBigInt_AVERAGE_LTE: $aggr_node_someBigInt_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_node_someBigInt_AVERAGE_LTE: $aggr_node_someBigInt_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -414,10 +414,10 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someBigInt) AS aggr_node_someBigInt_SUM_EQUAL_SUM
             RETURN aggr_node_someBigInt_SUM_EQUAL_SUM = toFloat($aggr_node_someBigInt_SUM_EQUAL)
-            \\", { this: this, aggr_node_someBigInt_SUM_EQUAL: $aggr_node_someBigInt_SUM_EQUAL }, false )
+            \\", { this: this, aggr_node_someBigInt_SUM_EQUAL: $aggr_node_someBigInt_SUM_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -447,10 +447,10 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someBigInt) AS aggr_node_someBigInt_SUM_GT_SUM
             RETURN aggr_node_someBigInt_SUM_GT_SUM > toFloat($aggr_node_someBigInt_SUM_GT)
-            \\", { this: this, aggr_node_someBigInt_SUM_GT: $aggr_node_someBigInt_SUM_GT }, false )
+            \\", { this: this, aggr_node_someBigInt_SUM_GT: $aggr_node_someBigInt_SUM_GT })
             RETURN this { .content } as this"
         `);
 
@@ -480,10 +480,10 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someBigInt) AS aggr_node_someBigInt_SUM_GTE_SUM
             RETURN aggr_node_someBigInt_SUM_GTE_SUM >= toFloat($aggr_node_someBigInt_SUM_GTE)
-            \\", { this: this, aggr_node_someBigInt_SUM_GTE: $aggr_node_someBigInt_SUM_GTE }, false )
+            \\", { this: this, aggr_node_someBigInt_SUM_GTE: $aggr_node_someBigInt_SUM_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -513,10 +513,10 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someBigInt) AS aggr_node_someBigInt_SUM_LT_SUM
             RETURN aggr_node_someBigInt_SUM_LT_SUM < toFloat($aggr_node_someBigInt_SUM_LT)
-            \\", { this: this, aggr_node_someBigInt_SUM_LT: $aggr_node_someBigInt_SUM_LT }, false )
+            \\", { this: this, aggr_node_someBigInt_SUM_LT: $aggr_node_someBigInt_SUM_LT })
             RETURN this { .content } as this"
         `);
 
@@ -546,10 +546,10 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someBigInt) AS aggr_node_someBigInt_SUM_LTE_SUM
             RETURN aggr_node_someBigInt_SUM_LTE_SUM <= toFloat($aggr_node_someBigInt_SUM_LTE)
-            \\", { this: this, aggr_node_someBigInt_SUM_LTE: $aggr_node_someBigInt_SUM_LTE }, false )
+            \\", { this: this, aggr_node_someBigInt_SUM_LTE: $aggr_node_someBigInt_SUM_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -579,9 +579,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someBigInt) = $aggr_node_someBigInt_MIN_EQUAL
-            \\", { this: this, aggr_node_someBigInt_MIN_EQUAL: $aggr_node_someBigInt_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someBigInt_MIN_EQUAL: $aggr_node_someBigInt_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -611,9 +611,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someBigInt) > $aggr_node_someBigInt_MIN_GT
-            \\", { this: this, aggr_node_someBigInt_MIN_GT: $aggr_node_someBigInt_MIN_GT }, false )
+            \\", { this: this, aggr_node_someBigInt_MIN_GT: $aggr_node_someBigInt_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -643,9 +643,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someBigInt) >= $aggr_node_someBigInt_MIN_GTE
-            \\", { this: this, aggr_node_someBigInt_MIN_GTE: $aggr_node_someBigInt_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someBigInt_MIN_GTE: $aggr_node_someBigInt_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -675,9 +675,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someBigInt) < $aggr_node_someBigInt_MIN_LT
-            \\", { this: this, aggr_node_someBigInt_MIN_LT: $aggr_node_someBigInt_MIN_LT }, false )
+            \\", { this: this, aggr_node_someBigInt_MIN_LT: $aggr_node_someBigInt_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -707,9 +707,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someBigInt) <= $aggr_node_someBigInt_MIN_LTE
-            \\", { this: this, aggr_node_someBigInt_MIN_LTE: $aggr_node_someBigInt_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someBigInt_MIN_LTE: $aggr_node_someBigInt_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -739,9 +739,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someBigInt) = $aggr_node_someBigInt_MAX_EQUAL
-            \\", { this: this, aggr_node_someBigInt_MAX_EQUAL: $aggr_node_someBigInt_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someBigInt_MAX_EQUAL: $aggr_node_someBigInt_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -771,9 +771,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someBigInt) > $aggr_node_someBigInt_MAX_GT
-            \\", { this: this, aggr_node_someBigInt_MAX_GT: $aggr_node_someBigInt_MAX_GT }, false )
+            \\", { this: this, aggr_node_someBigInt_MAX_GT: $aggr_node_someBigInt_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -803,9 +803,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someBigInt) >= $aggr_node_someBigInt_MAX_GTE
-            \\", { this: this, aggr_node_someBigInt_MAX_GTE: $aggr_node_someBigInt_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someBigInt_MAX_GTE: $aggr_node_someBigInt_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -835,9 +835,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someBigInt) < $aggr_node_someBigInt_MAX_LT
-            \\", { this: this, aggr_node_someBigInt_MAX_LT: $aggr_node_someBigInt_MAX_LT }, false )
+            \\", { this: this, aggr_node_someBigInt_MAX_LT: $aggr_node_someBigInt_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -867,9 +867,9 @@ describe("Cypher Aggregations where node with BigInt", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someBigInt) <= $aggr_node_someBigInt_MAX_LTE
-            \\", { this: this, aggr_node_someBigInt_MAX_LTE: $aggr_node_someBigInt_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someBigInt_MAX_LTE: $aggr_node_someBigInt_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/datetime.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/datetime.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDateTime = $aggr_node_someDateTime_EQUAL
-            \\", { this: this, aggr_node_someDateTime_EQUAL: $aggr_node_someDateTime_EQUAL }, false )
+            \\", { this: this, aggr_node_someDateTime_EQUAL: $aggr_node_someDateTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -100,9 +100,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someDateTimeAlias = $aggr_node_someDateTimeAlias_EQUAL
-            \\", { this: this, aggr_node_someDateTimeAlias_EQUAL: $aggr_node_someDateTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someDateTimeAlias_EQUAL: $aggr_node_someDateTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -138,9 +138,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDateTime > $aggr_node_someDateTime_GT
-            \\", { this: this, aggr_node_someDateTime_GT: $aggr_node_someDateTime_GT }, false )
+            \\", { this: this, aggr_node_someDateTime_GT: $aggr_node_someDateTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -176,9 +176,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDateTime >= $aggr_node_someDateTime_GTE
-            \\", { this: this, aggr_node_someDateTime_GTE: $aggr_node_someDateTime_GTE }, false )
+            \\", { this: this, aggr_node_someDateTime_GTE: $aggr_node_someDateTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -214,9 +214,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDateTime < $aggr_node_someDateTime_LT
-            \\", { this: this, aggr_node_someDateTime_LT: $aggr_node_someDateTime_LT }, false )
+            \\", { this: this, aggr_node_someDateTime_LT: $aggr_node_someDateTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -252,9 +252,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDateTime <= $aggr_node_someDateTime_LTE
-            \\", { this: this, aggr_node_someDateTime_LTE: $aggr_node_someDateTime_LTE }, false )
+            \\", { this: this, aggr_node_someDateTime_LTE: $aggr_node_someDateTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -290,9 +290,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDateTime) = $aggr_node_someDateTime_MIN_EQUAL
-            \\", { this: this, aggr_node_someDateTime_MIN_EQUAL: $aggr_node_someDateTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someDateTime_MIN_EQUAL: $aggr_node_someDateTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -328,9 +328,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDateTime) > $aggr_node_someDateTime_MIN_GT
-            \\", { this: this, aggr_node_someDateTime_MIN_GT: $aggr_node_someDateTime_MIN_GT }, false )
+            \\", { this: this, aggr_node_someDateTime_MIN_GT: $aggr_node_someDateTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -366,9 +366,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDateTime) >= $aggr_node_someDateTime_MIN_GTE
-            \\", { this: this, aggr_node_someDateTime_MIN_GTE: $aggr_node_someDateTime_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someDateTime_MIN_GTE: $aggr_node_someDateTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -404,9 +404,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDateTime) < $aggr_node_someDateTime_MIN_LT
-            \\", { this: this, aggr_node_someDateTime_MIN_LT: $aggr_node_someDateTime_MIN_LT }, false )
+            \\", { this: this, aggr_node_someDateTime_MIN_LT: $aggr_node_someDateTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -442,9 +442,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDateTime) <= $aggr_node_someDateTime_MIN_LTE
-            \\", { this: this, aggr_node_someDateTime_MIN_LTE: $aggr_node_someDateTime_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someDateTime_MIN_LTE: $aggr_node_someDateTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -480,9 +480,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDateTime) = $aggr_node_someDateTime_MAX_EQUAL
-            \\", { this: this, aggr_node_someDateTime_MAX_EQUAL: $aggr_node_someDateTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someDateTime_MAX_EQUAL: $aggr_node_someDateTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -518,9 +518,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDateTime) > $aggr_node_someDateTime_MAX_GT
-            \\", { this: this, aggr_node_someDateTime_MAX_GT: $aggr_node_someDateTime_MAX_GT }, false )
+            \\", { this: this, aggr_node_someDateTime_MAX_GT: $aggr_node_someDateTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -556,9 +556,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDateTime) >= $aggr_node_someDateTime_MAX_GTE
-            \\", { this: this, aggr_node_someDateTime_MAX_GTE: $aggr_node_someDateTime_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someDateTime_MAX_GTE: $aggr_node_someDateTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -594,9 +594,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDateTime) < $aggr_node_someDateTime_MAX_LT
-            \\", { this: this, aggr_node_someDateTime_MAX_LT: $aggr_node_someDateTime_MAX_LT }, false )
+            \\", { this: this, aggr_node_someDateTime_MAX_LT: $aggr_node_someDateTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -632,9 +632,9 @@ describe("Cypher Aggregations where node with DateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDateTime) <= $aggr_node_someDateTime_MAX_LTE
-            \\", { this: this, aggr_node_someDateTime_MAX_LTE: $aggr_node_someDateTime_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someDateTime_MAX_LTE: $aggr_node_someDateTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/duration.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/duration.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDuration = $aggr_node_someDuration_EQUAL
-            \\", { this: this, aggr_node_someDuration_EQUAL: $aggr_node_someDuration_EQUAL }, false )
+            \\", { this: this, aggr_node_someDuration_EQUAL: $aggr_node_someDuration_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -102,9 +102,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someDurationAlias = $aggr_node_someDurationAlias_EQUAL
-            \\", { this: this, aggr_node_someDurationAlias_EQUAL: $aggr_node_someDurationAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someDurationAlias_EQUAL: $aggr_node_someDurationAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -142,9 +142,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDuration > $aggr_node_someDuration_GT
-            \\", { this: this, aggr_node_someDuration_GT: $aggr_node_someDuration_GT }, false )
+            \\", { this: this, aggr_node_someDuration_GT: $aggr_node_someDuration_GT })
             RETURN this { .content } as this"
         `);
 
@@ -182,9 +182,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDuration >= $aggr_node_someDuration_GTE
-            \\", { this: this, aggr_node_someDuration_GTE: $aggr_node_someDuration_GTE }, false )
+            \\", { this: this, aggr_node_someDuration_GTE: $aggr_node_someDuration_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -222,9 +222,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDuration < $aggr_node_someDuration_LT
-            \\", { this: this, aggr_node_someDuration_LT: $aggr_node_someDuration_LT }, false )
+            \\", { this: this, aggr_node_someDuration_LT: $aggr_node_someDuration_LT })
             RETURN this { .content } as this"
         `);
 
@@ -262,9 +262,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someDuration <= $aggr_node_someDuration_LTE
-            \\", { this: this, aggr_node_someDuration_LTE: $aggr_node_someDuration_LTE }, false )
+            \\", { this: this, aggr_node_someDuration_LTE: $aggr_node_someDuration_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -302,9 +302,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someDuration) = $aggr_node_someDuration_AVERAGE_EQUAL
-            \\", { this: this, aggr_node_someDuration_AVERAGE_EQUAL: $aggr_node_someDuration_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_node_someDuration_AVERAGE_EQUAL: $aggr_node_someDuration_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -342,9 +342,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someDuration) > $aggr_node_someDuration_AVERAGE_GT
-            \\", { this: this, aggr_node_someDuration_AVERAGE_GT: $aggr_node_someDuration_AVERAGE_GT }, false )
+            \\", { this: this, aggr_node_someDuration_AVERAGE_GT: $aggr_node_someDuration_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -382,9 +382,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someDuration) >= $aggr_node_someDuration_AVERAGE_GTE
-            \\", { this: this, aggr_node_someDuration_AVERAGE_GTE: $aggr_node_someDuration_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_node_someDuration_AVERAGE_GTE: $aggr_node_someDuration_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -422,9 +422,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someDuration) < $aggr_node_someDuration_AVERAGE_LT
-            \\", { this: this, aggr_node_someDuration_AVERAGE_LT: $aggr_node_someDuration_AVERAGE_LT }, false )
+            \\", { this: this, aggr_node_someDuration_AVERAGE_LT: $aggr_node_someDuration_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -462,9 +462,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someDuration) <= $aggr_node_someDuration_AVERAGE_LTE
-            \\", { this: this, aggr_node_someDuration_AVERAGE_LTE: $aggr_node_someDuration_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_node_someDuration_AVERAGE_LTE: $aggr_node_someDuration_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -502,9 +502,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDuration) = $aggr_node_someDuration_MIN_EQUAL
-            \\", { this: this, aggr_node_someDuration_MIN_EQUAL: $aggr_node_someDuration_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someDuration_MIN_EQUAL: $aggr_node_someDuration_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -542,9 +542,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDuration) > $aggr_node_someDuration_MIN_GT
-            \\", { this: this, aggr_node_someDuration_MIN_GT: $aggr_node_someDuration_MIN_GT }, false )
+            \\", { this: this, aggr_node_someDuration_MIN_GT: $aggr_node_someDuration_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -582,9 +582,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDuration) >= $aggr_node_someDuration_MIN_GTE
-            \\", { this: this, aggr_node_someDuration_MIN_GTE: $aggr_node_someDuration_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someDuration_MIN_GTE: $aggr_node_someDuration_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -622,9 +622,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDuration) < $aggr_node_someDuration_MIN_LT
-            \\", { this: this, aggr_node_someDuration_MIN_LT: $aggr_node_someDuration_MIN_LT }, false )
+            \\", { this: this, aggr_node_someDuration_MIN_LT: $aggr_node_someDuration_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -662,9 +662,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someDuration) <= $aggr_node_someDuration_MIN_LTE
-            \\", { this: this, aggr_node_someDuration_MIN_LTE: $aggr_node_someDuration_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someDuration_MIN_LTE: $aggr_node_someDuration_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -702,9 +702,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDuration) = $aggr_node_someDuration_MAX_EQUAL
-            \\", { this: this, aggr_node_someDuration_MAX_EQUAL: $aggr_node_someDuration_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someDuration_MAX_EQUAL: $aggr_node_someDuration_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -742,9 +742,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDuration) > $aggr_node_someDuration_MAX_GT
-            \\", { this: this, aggr_node_someDuration_MAX_GT: $aggr_node_someDuration_MAX_GT }, false )
+            \\", { this: this, aggr_node_someDuration_MAX_GT: $aggr_node_someDuration_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -782,9 +782,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDuration) >= $aggr_node_someDuration_MAX_GTE
-            \\", { this: this, aggr_node_someDuration_MAX_GTE: $aggr_node_someDuration_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someDuration_MAX_GTE: $aggr_node_someDuration_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -822,9 +822,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDuration) < $aggr_node_someDuration_MAX_LT
-            \\", { this: this, aggr_node_someDuration_MAX_LT: $aggr_node_someDuration_MAX_LT }, false )
+            \\", { this: this, aggr_node_someDuration_MAX_LT: $aggr_node_someDuration_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -862,9 +862,9 @@ describe("Cypher Aggregations where node with Duration", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someDuration) <= $aggr_node_someDuration_MAX_LTE
-            \\", { this: this, aggr_node_someDuration_MAX_LTE: $aggr_node_someDuration_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someDuration_MAX_LTE: $aggr_node_someDuration_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/float.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/float.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someFloat = $aggr_node_someFloat_EQUAL
-            \\", { this: this, aggr_node_someFloat_EQUAL: $aggr_node_someFloat_EQUAL }, false )
+            \\", { this: this, aggr_node_someFloat_EQUAL: $aggr_node_someFloat_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -91,9 +91,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someFloatAlias = $aggr_node_someFloatAlias_EQUAL
-            \\", { this: this, aggr_node_someFloatAlias_EQUAL: $aggr_node_someFloatAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someFloatAlias_EQUAL: $aggr_node_someFloatAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -120,9 +120,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someFloat > $aggr_node_someFloat_GT
-            \\", { this: this, aggr_node_someFloat_GT: $aggr_node_someFloat_GT }, false )
+            \\", { this: this, aggr_node_someFloat_GT: $aggr_node_someFloat_GT })
             RETURN this { .content } as this"
         `);
 
@@ -149,9 +149,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someFloat >= $aggr_node_someFloat_GTE
-            \\", { this: this, aggr_node_someFloat_GTE: $aggr_node_someFloat_GTE }, false )
+            \\", { this: this, aggr_node_someFloat_GTE: $aggr_node_someFloat_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -178,9 +178,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someFloat < $aggr_node_someFloat_LT
-            \\", { this: this, aggr_node_someFloat_LT: $aggr_node_someFloat_LT }, false )
+            \\", { this: this, aggr_node_someFloat_LT: $aggr_node_someFloat_LT })
             RETURN this { .content } as this"
         `);
 
@@ -207,9 +207,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someFloat <= $aggr_node_someFloat_LTE
-            \\", { this: this, aggr_node_someFloat_LTE: $aggr_node_someFloat_LTE }, false )
+            \\", { this: this, aggr_node_someFloat_LTE: $aggr_node_someFloat_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -236,9 +236,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someFloat) = $aggr_node_someFloat_AVERAGE_EQUAL
-            \\", { this: this, aggr_node_someFloat_AVERAGE_EQUAL: $aggr_node_someFloat_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_node_someFloat_AVERAGE_EQUAL: $aggr_node_someFloat_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -265,9 +265,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someFloat) > $aggr_node_someFloat_AVERAGE_GT
-            \\", { this: this, aggr_node_someFloat_AVERAGE_GT: $aggr_node_someFloat_AVERAGE_GT }, false )
+            \\", { this: this, aggr_node_someFloat_AVERAGE_GT: $aggr_node_someFloat_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -294,9 +294,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someFloat) >= $aggr_node_someFloat_AVERAGE_GTE
-            \\", { this: this, aggr_node_someFloat_AVERAGE_GTE: $aggr_node_someFloat_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_node_someFloat_AVERAGE_GTE: $aggr_node_someFloat_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -323,9 +323,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someFloat) < $aggr_node_someFloat_AVERAGE_LT
-            \\", { this: this, aggr_node_someFloat_AVERAGE_LT: $aggr_node_someFloat_AVERAGE_LT }, false )
+            \\", { this: this, aggr_node_someFloat_AVERAGE_LT: $aggr_node_someFloat_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -352,9 +352,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someFloat) <= $aggr_node_someFloat_AVERAGE_LTE
-            \\", { this: this, aggr_node_someFloat_AVERAGE_LTE: $aggr_node_someFloat_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_node_someFloat_AVERAGE_LTE: $aggr_node_someFloat_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -381,10 +381,10 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someFloat) AS aggr_node_someFloat_SUM_EQUAL_SUM
             RETURN aggr_node_someFloat_SUM_EQUAL_SUM = toFloat($aggr_node_someFloat_SUM_EQUAL)
-            \\", { this: this, aggr_node_someFloat_SUM_EQUAL: $aggr_node_someFloat_SUM_EQUAL }, false )
+            \\", { this: this, aggr_node_someFloat_SUM_EQUAL: $aggr_node_someFloat_SUM_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -411,10 +411,10 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someFloat) AS aggr_node_someFloat_SUM_GT_SUM
             RETURN aggr_node_someFloat_SUM_GT_SUM > toFloat($aggr_node_someFloat_SUM_GT)
-            \\", { this: this, aggr_node_someFloat_SUM_GT: $aggr_node_someFloat_SUM_GT }, false )
+            \\", { this: this, aggr_node_someFloat_SUM_GT: $aggr_node_someFloat_SUM_GT })
             RETURN this { .content } as this"
         `);
 
@@ -441,10 +441,10 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someFloat) AS aggr_node_someFloat_SUM_GTE_SUM
             RETURN aggr_node_someFloat_SUM_GTE_SUM >= toFloat($aggr_node_someFloat_SUM_GTE)
-            \\", { this: this, aggr_node_someFloat_SUM_GTE: $aggr_node_someFloat_SUM_GTE }, false )
+            \\", { this: this, aggr_node_someFloat_SUM_GTE: $aggr_node_someFloat_SUM_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -471,10 +471,10 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someFloat) AS aggr_node_someFloat_SUM_LT_SUM
             RETURN aggr_node_someFloat_SUM_LT_SUM < toFloat($aggr_node_someFloat_SUM_LT)
-            \\", { this: this, aggr_node_someFloat_SUM_LT: $aggr_node_someFloat_SUM_LT }, false )
+            \\", { this: this, aggr_node_someFloat_SUM_LT: $aggr_node_someFloat_SUM_LT })
             RETURN this { .content } as this"
         `);
 
@@ -501,10 +501,10 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someFloat) AS aggr_node_someFloat_SUM_LTE_SUM
             RETURN aggr_node_someFloat_SUM_LTE_SUM <= toFloat($aggr_node_someFloat_SUM_LTE)
-            \\", { this: this, aggr_node_someFloat_SUM_LTE: $aggr_node_someFloat_SUM_LTE }, false )
+            \\", { this: this, aggr_node_someFloat_SUM_LTE: $aggr_node_someFloat_SUM_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -531,9 +531,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someFloat) = $aggr_node_someFloat_MIN_EQUAL
-            \\", { this: this, aggr_node_someFloat_MIN_EQUAL: $aggr_node_someFloat_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someFloat_MIN_EQUAL: $aggr_node_someFloat_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -560,9 +560,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someFloat) > $aggr_node_someFloat_MIN_GT
-            \\", { this: this, aggr_node_someFloat_MIN_GT: $aggr_node_someFloat_MIN_GT }, false )
+            \\", { this: this, aggr_node_someFloat_MIN_GT: $aggr_node_someFloat_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -589,9 +589,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someFloat) >= $aggr_node_someFloat_MIN_GTE
-            \\", { this: this, aggr_node_someFloat_MIN_GTE: $aggr_node_someFloat_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someFloat_MIN_GTE: $aggr_node_someFloat_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -618,9 +618,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someFloat) < $aggr_node_someFloat_MIN_LT
-            \\", { this: this, aggr_node_someFloat_MIN_LT: $aggr_node_someFloat_MIN_LT }, false )
+            \\", { this: this, aggr_node_someFloat_MIN_LT: $aggr_node_someFloat_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -647,9 +647,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someFloat) <= $aggr_node_someFloat_MIN_LTE
-            \\", { this: this, aggr_node_someFloat_MIN_LTE: $aggr_node_someFloat_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someFloat_MIN_LTE: $aggr_node_someFloat_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -676,9 +676,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someFloat) = $aggr_node_someFloat_MAX_EQUAL
-            \\", { this: this, aggr_node_someFloat_MAX_EQUAL: $aggr_node_someFloat_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someFloat_MAX_EQUAL: $aggr_node_someFloat_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -705,9 +705,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someFloat) > $aggr_node_someFloat_MAX_GT
-            \\", { this: this, aggr_node_someFloat_MAX_GT: $aggr_node_someFloat_MAX_GT }, false )
+            \\", { this: this, aggr_node_someFloat_MAX_GT: $aggr_node_someFloat_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -734,9 +734,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someFloat) >= $aggr_node_someFloat_MAX_GTE
-            \\", { this: this, aggr_node_someFloat_MAX_GTE: $aggr_node_someFloat_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someFloat_MAX_GTE: $aggr_node_someFloat_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -763,9 +763,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someFloat) < $aggr_node_someFloat_MAX_LT
-            \\", { this: this, aggr_node_someFloat_MAX_LT: $aggr_node_someFloat_MAX_LT }, false )
+            \\", { this: this, aggr_node_someFloat_MAX_LT: $aggr_node_someFloat_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -792,9 +792,9 @@ describe("Cypher Aggregations where node with Float", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someFloat) <= $aggr_node_someFloat_MAX_LTE
-            \\", { this: this, aggr_node_someFloat_MAX_LTE: $aggr_node_someFloat_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someFloat_MAX_LTE: $aggr_node_someFloat_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/id.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/id.test.ts
@@ -63,9 +63,9 @@ describe("Cypher Aggregations where node with ID", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.id = $aggr_node_id_EQUAL
-            \\", { this: this, aggr_node_id_EQUAL: $aggr_node_id_EQUAL }, false )
+            \\", { this: this, aggr_node_id_EQUAL: $aggr_node_id_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -92,9 +92,9 @@ describe("Cypher Aggregations where node with ID", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someIdAlias = $aggr_node_someIdAlias_EQUAL
-            \\", { this: this, aggr_node_someIdAlias_EQUAL: $aggr_node_someIdAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someIdAlias_EQUAL: $aggr_node_someIdAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/int.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/int.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someInt = $aggr_node_someInt_EQUAL
-            \\", { this: this, aggr_node_someInt_EQUAL: $aggr_node_someInt_EQUAL }, false )
+            \\", { this: this, aggr_node_someInt_EQUAL: $aggr_node_someInt_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -94,9 +94,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someIntAlias = $aggr_node_someIntAlias_EQUAL
-            \\", { this: this, aggr_node_someIntAlias_EQUAL: $aggr_node_someIntAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someIntAlias_EQUAL: $aggr_node_someIntAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -126,9 +126,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someInt > $aggr_node_someInt_GT
-            \\", { this: this, aggr_node_someInt_GT: $aggr_node_someInt_GT }, false )
+            \\", { this: this, aggr_node_someInt_GT: $aggr_node_someInt_GT })
             RETURN this { .content } as this"
         `);
 
@@ -158,9 +158,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someInt >= $aggr_node_someInt_GTE
-            \\", { this: this, aggr_node_someInt_GTE: $aggr_node_someInt_GTE }, false )
+            \\", { this: this, aggr_node_someInt_GTE: $aggr_node_someInt_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -190,9 +190,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someInt < $aggr_node_someInt_LT
-            \\", { this: this, aggr_node_someInt_LT: $aggr_node_someInt_LT }, false )
+            \\", { this: this, aggr_node_someInt_LT: $aggr_node_someInt_LT })
             RETURN this { .content } as this"
         `);
 
@@ -222,9 +222,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someInt <= $aggr_node_someInt_LTE
-            \\", { this: this, aggr_node_someInt_LTE: $aggr_node_someInt_LTE }, false )
+            \\", { this: this, aggr_node_someInt_LTE: $aggr_node_someInt_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -254,9 +254,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someInt) = $aggr_node_someInt_AVERAGE_EQUAL
-            \\", { this: this, aggr_node_someInt_AVERAGE_EQUAL: $aggr_node_someInt_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_node_someInt_AVERAGE_EQUAL: $aggr_node_someInt_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -283,9 +283,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someInt) > $aggr_node_someInt_AVERAGE_GT
-            \\", { this: this, aggr_node_someInt_AVERAGE_GT: $aggr_node_someInt_AVERAGE_GT }, false )
+            \\", { this: this, aggr_node_someInt_AVERAGE_GT: $aggr_node_someInt_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -312,9 +312,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someInt) >= $aggr_node_someInt_AVERAGE_GTE
-            \\", { this: this, aggr_node_someInt_AVERAGE_GTE: $aggr_node_someInt_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_node_someInt_AVERAGE_GTE: $aggr_node_someInt_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -341,9 +341,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someInt) < $aggr_node_someInt_AVERAGE_LT
-            \\", { this: this, aggr_node_someInt_AVERAGE_LT: $aggr_node_someInt_AVERAGE_LT }, false )
+            \\", { this: this, aggr_node_someInt_AVERAGE_LT: $aggr_node_someInt_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -370,9 +370,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN avg(aggr_node.someInt) <= $aggr_node_someInt_AVERAGE_LTE
-            \\", { this: this, aggr_node_someInt_AVERAGE_LTE: $aggr_node_someInt_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_node_someInt_AVERAGE_LTE: $aggr_node_someInt_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -399,10 +399,10 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someInt) AS aggr_node_someInt_SUM_EQUAL_SUM
             RETURN aggr_node_someInt_SUM_EQUAL_SUM = toFloat($aggr_node_someInt_SUM_EQUAL)
-            \\", { this: this, aggr_node_someInt_SUM_EQUAL: $aggr_node_someInt_SUM_EQUAL }, false )
+            \\", { this: this, aggr_node_someInt_SUM_EQUAL: $aggr_node_someInt_SUM_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -432,10 +432,10 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someInt) AS aggr_node_someInt_SUM_GT_SUM
             RETURN aggr_node_someInt_SUM_GT_SUM > toFloat($aggr_node_someInt_SUM_GT)
-            \\", { this: this, aggr_node_someInt_SUM_GT: $aggr_node_someInt_SUM_GT }, false )
+            \\", { this: this, aggr_node_someInt_SUM_GT: $aggr_node_someInt_SUM_GT })
             RETURN this { .content } as this"
         `);
 
@@ -465,10 +465,10 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someInt) AS aggr_node_someInt_SUM_GTE_SUM
             RETURN aggr_node_someInt_SUM_GTE_SUM >= toFloat($aggr_node_someInt_SUM_GTE)
-            \\", { this: this, aggr_node_someInt_SUM_GTE: $aggr_node_someInt_SUM_GTE }, false )
+            \\", { this: this, aggr_node_someInt_SUM_GTE: $aggr_node_someInt_SUM_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -498,10 +498,10 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someInt) AS aggr_node_someInt_SUM_LT_SUM
             RETURN aggr_node_someInt_SUM_LT_SUM < toFloat($aggr_node_someInt_SUM_LT)
-            \\", { this: this, aggr_node_someInt_SUM_LT: $aggr_node_someInt_SUM_LT }, false )
+            \\", { this: this, aggr_node_someInt_SUM_LT: $aggr_node_someInt_SUM_LT })
             RETURN this { .content } as this"
         `);
 
@@ -531,10 +531,10 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, sum(aggr_node.someInt) AS aggr_node_someInt_SUM_LTE_SUM
             RETURN aggr_node_someInt_SUM_LTE_SUM <= toFloat($aggr_node_someInt_SUM_LTE)
-            \\", { this: this, aggr_node_someInt_SUM_LTE: $aggr_node_someInt_SUM_LTE }, false )
+            \\", { this: this, aggr_node_someInt_SUM_LTE: $aggr_node_someInt_SUM_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -564,9 +564,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someInt) = $aggr_node_someInt_MIN_EQUAL
-            \\", { this: this, aggr_node_someInt_MIN_EQUAL: $aggr_node_someInt_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someInt_MIN_EQUAL: $aggr_node_someInt_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -596,9 +596,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someInt) > $aggr_node_someInt_MIN_GT
-            \\", { this: this, aggr_node_someInt_MIN_GT: $aggr_node_someInt_MIN_GT }, false )
+            \\", { this: this, aggr_node_someInt_MIN_GT: $aggr_node_someInt_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -628,9 +628,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someInt) >= $aggr_node_someInt_MIN_GTE
-            \\", { this: this, aggr_node_someInt_MIN_GTE: $aggr_node_someInt_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someInt_MIN_GTE: $aggr_node_someInt_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -660,9 +660,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someInt) < $aggr_node_someInt_MIN_LT
-            \\", { this: this, aggr_node_someInt_MIN_LT: $aggr_node_someInt_MIN_LT }, false )
+            \\", { this: this, aggr_node_someInt_MIN_LT: $aggr_node_someInt_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -692,9 +692,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someInt) <= $aggr_node_someInt_MIN_LTE
-            \\", { this: this, aggr_node_someInt_MIN_LTE: $aggr_node_someInt_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someInt_MIN_LTE: $aggr_node_someInt_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -724,9 +724,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someInt) = $aggr_node_someInt_MAX_EQUAL
-            \\", { this: this, aggr_node_someInt_MAX_EQUAL: $aggr_node_someInt_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someInt_MAX_EQUAL: $aggr_node_someInt_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -756,9 +756,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someInt) > $aggr_node_someInt_MAX_GT
-            \\", { this: this, aggr_node_someInt_MAX_GT: $aggr_node_someInt_MAX_GT }, false )
+            \\", { this: this, aggr_node_someInt_MAX_GT: $aggr_node_someInt_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -788,9 +788,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someInt) >= $aggr_node_someInt_MAX_GTE
-            \\", { this: this, aggr_node_someInt_MAX_GTE: $aggr_node_someInt_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someInt_MAX_GTE: $aggr_node_someInt_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -820,9 +820,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someInt) < $aggr_node_someInt_MAX_LT
-            \\", { this: this, aggr_node_someInt_MAX_LT: $aggr_node_someInt_MAX_LT }, false )
+            \\", { this: this, aggr_node_someInt_MAX_LT: $aggr_node_someInt_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -852,9 +852,9 @@ describe("Cypher Aggregations where node with Int", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someInt) <= $aggr_node_someInt_MAX_LTE
-            \\", { this: this, aggr_node_someInt_MAX_LTE: $aggr_node_someInt_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someInt_MAX_LTE: $aggr_node_someInt_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/localdatetime.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalDateTime = $aggr_node_someLocalDateTime_EQUAL
-            \\", { this: this, aggr_node_someLocalDateTime_EQUAL: $aggr_node_someLocalDateTime_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_EQUAL: $aggr_node_someLocalDateTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -99,9 +99,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someLocalDateTimeAlias = $aggr_node_someLocalDateTimeAlias_EQUAL
-            \\", { this: this, aggr_node_someLocalDateTimeAlias_EQUAL: $aggr_node_someLocalDateTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalDateTimeAlias_EQUAL: $aggr_node_someLocalDateTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -136,9 +136,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalDateTime > $aggr_node_someLocalDateTime_GT
-            \\", { this: this, aggr_node_someLocalDateTime_GT: $aggr_node_someLocalDateTime_GT }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_GT: $aggr_node_someLocalDateTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -173,9 +173,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalDateTime >= $aggr_node_someLocalDateTime_GTE
-            \\", { this: this, aggr_node_someLocalDateTime_GTE: $aggr_node_someLocalDateTime_GTE }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_GTE: $aggr_node_someLocalDateTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -210,9 +210,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalDateTime < $aggr_node_someLocalDateTime_LT
-            \\", { this: this, aggr_node_someLocalDateTime_LT: $aggr_node_someLocalDateTime_LT }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_LT: $aggr_node_someLocalDateTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -247,9 +247,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalDateTime <= $aggr_node_someLocalDateTime_LTE
-            \\", { this: this, aggr_node_someLocalDateTime_LTE: $aggr_node_someLocalDateTime_LTE }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_LTE: $aggr_node_someLocalDateTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -284,9 +284,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalDateTime) = $aggr_node_someLocalDateTime_MIN_EQUAL
-            \\", { this: this, aggr_node_someLocalDateTime_MIN_EQUAL: $aggr_node_someLocalDateTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MIN_EQUAL: $aggr_node_someLocalDateTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -321,9 +321,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalDateTime) > $aggr_node_someLocalDateTime_MIN_GT
-            \\", { this: this, aggr_node_someLocalDateTime_MIN_GT: $aggr_node_someLocalDateTime_MIN_GT }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MIN_GT: $aggr_node_someLocalDateTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -358,9 +358,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalDateTime) >= $aggr_node_someLocalDateTime_MIN_GTE
-            \\", { this: this, aggr_node_someLocalDateTime_MIN_GTE: $aggr_node_someLocalDateTime_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MIN_GTE: $aggr_node_someLocalDateTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -395,9 +395,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalDateTime) < $aggr_node_someLocalDateTime_MIN_LT
-            \\", { this: this, aggr_node_someLocalDateTime_MIN_LT: $aggr_node_someLocalDateTime_MIN_LT }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MIN_LT: $aggr_node_someLocalDateTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -432,9 +432,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalDateTime) <= $aggr_node_someLocalDateTime_MIN_LTE
-            \\", { this: this, aggr_node_someLocalDateTime_MIN_LTE: $aggr_node_someLocalDateTime_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MIN_LTE: $aggr_node_someLocalDateTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -469,9 +469,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalDateTime) = $aggr_node_someLocalDateTime_MAX_EQUAL
-            \\", { this: this, aggr_node_someLocalDateTime_MAX_EQUAL: $aggr_node_someLocalDateTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MAX_EQUAL: $aggr_node_someLocalDateTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -506,9 +506,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalDateTime) > $aggr_node_someLocalDateTime_MAX_GT
-            \\", { this: this, aggr_node_someLocalDateTime_MAX_GT: $aggr_node_someLocalDateTime_MAX_GT }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MAX_GT: $aggr_node_someLocalDateTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -543,9 +543,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalDateTime) >= $aggr_node_someLocalDateTime_MAX_GTE
-            \\", { this: this, aggr_node_someLocalDateTime_MAX_GTE: $aggr_node_someLocalDateTime_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MAX_GTE: $aggr_node_someLocalDateTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -580,9 +580,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalDateTime) < $aggr_node_someLocalDateTime_MAX_LT
-            \\", { this: this, aggr_node_someLocalDateTime_MAX_LT: $aggr_node_someLocalDateTime_MAX_LT }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MAX_LT: $aggr_node_someLocalDateTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -617,9 +617,9 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalDateTime) <= $aggr_node_someLocalDateTime_MAX_LTE
-            \\", { this: this, aggr_node_someLocalDateTime_MAX_LTE: $aggr_node_someLocalDateTime_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someLocalDateTime_MAX_LTE: $aggr_node_someLocalDateTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/localtime.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/localtime.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalTime = $aggr_node_someLocalTime_EQUAL
-            \\", { this: this, aggr_node_someLocalTime_EQUAL: $aggr_node_someLocalTime_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalTime_EQUAL: $aggr_node_someLocalTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -96,9 +96,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someLocalTimeAlias = $aggr_node_someLocalTimeAlias_EQUAL
-            \\", { this: this, aggr_node_someLocalTimeAlias_EQUAL: $aggr_node_someLocalTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalTimeAlias_EQUAL: $aggr_node_someLocalTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -130,9 +130,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalTime > $aggr_node_someLocalTime_GT
-            \\", { this: this, aggr_node_someLocalTime_GT: $aggr_node_someLocalTime_GT }, false )
+            \\", { this: this, aggr_node_someLocalTime_GT: $aggr_node_someLocalTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -164,9 +164,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalTime >= $aggr_node_someLocalTime_GTE
-            \\", { this: this, aggr_node_someLocalTime_GTE: $aggr_node_someLocalTime_GTE }, false )
+            \\", { this: this, aggr_node_someLocalTime_GTE: $aggr_node_someLocalTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -198,9 +198,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalTime < $aggr_node_someLocalTime_LT
-            \\", { this: this, aggr_node_someLocalTime_LT: $aggr_node_someLocalTime_LT }, false )
+            \\", { this: this, aggr_node_someLocalTime_LT: $aggr_node_someLocalTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -232,9 +232,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someLocalTime <= $aggr_node_someLocalTime_LTE
-            \\", { this: this, aggr_node_someLocalTime_LTE: $aggr_node_someLocalTime_LTE }, false )
+            \\", { this: this, aggr_node_someLocalTime_LTE: $aggr_node_someLocalTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -266,9 +266,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalTime) = $aggr_node_someLocalTime_MIN_EQUAL
-            \\", { this: this, aggr_node_someLocalTime_MIN_EQUAL: $aggr_node_someLocalTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalTime_MIN_EQUAL: $aggr_node_someLocalTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -300,9 +300,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalTime) > $aggr_node_someLocalTime_MIN_GT
-            \\", { this: this, aggr_node_someLocalTime_MIN_GT: $aggr_node_someLocalTime_MIN_GT }, false )
+            \\", { this: this, aggr_node_someLocalTime_MIN_GT: $aggr_node_someLocalTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -334,9 +334,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalTime) >= $aggr_node_someLocalTime_MIN_GTE
-            \\", { this: this, aggr_node_someLocalTime_MIN_GTE: $aggr_node_someLocalTime_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someLocalTime_MIN_GTE: $aggr_node_someLocalTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -368,9 +368,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalTime) < $aggr_node_someLocalTime_MIN_LT
-            \\", { this: this, aggr_node_someLocalTime_MIN_LT: $aggr_node_someLocalTime_MIN_LT }, false )
+            \\", { this: this, aggr_node_someLocalTime_MIN_LT: $aggr_node_someLocalTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -402,9 +402,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someLocalTime) <= $aggr_node_someLocalTime_MIN_LTE
-            \\", { this: this, aggr_node_someLocalTime_MIN_LTE: $aggr_node_someLocalTime_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someLocalTime_MIN_LTE: $aggr_node_someLocalTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -436,9 +436,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalTime) = $aggr_node_someLocalTime_MAX_EQUAL
-            \\", { this: this, aggr_node_someLocalTime_MAX_EQUAL: $aggr_node_someLocalTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someLocalTime_MAX_EQUAL: $aggr_node_someLocalTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -470,9 +470,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalTime) > $aggr_node_someLocalTime_MAX_GT
-            \\", { this: this, aggr_node_someLocalTime_MAX_GT: $aggr_node_someLocalTime_MAX_GT }, false )
+            \\", { this: this, aggr_node_someLocalTime_MAX_GT: $aggr_node_someLocalTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -504,9 +504,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalTime) >= $aggr_node_someLocalTime_MAX_GTE
-            \\", { this: this, aggr_node_someLocalTime_MAX_GTE: $aggr_node_someLocalTime_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someLocalTime_MAX_GTE: $aggr_node_someLocalTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -538,9 +538,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalTime) < $aggr_node_someLocalTime_MAX_LT
-            \\", { this: this, aggr_node_someLocalTime_MAX_LT: $aggr_node_someLocalTime_MAX_LT }, false )
+            \\", { this: this, aggr_node_someLocalTime_MAX_LT: $aggr_node_someLocalTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -572,9 +572,9 @@ describe("Cypher Aggregations where node with LocalTime", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someLocalTime) <= $aggr_node_someLocalTime_MAX_LTE
-            \\", { this: this, aggr_node_someLocalTime_MAX_LTE: $aggr_node_someLocalTime_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someLocalTime_MAX_LTE: $aggr_node_someLocalTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/logical.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/logical.test.ts
@@ -63,9 +63,9 @@ describe("Cypher Aggregations where node with Logical AND + OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (aggr_node.someFloat = $aggr_node_AND_0_someFloat_EQUAL AND aggr_node.someFloat = $aggr_node_AND_1_someFloat_EQUAL)
-            \\", { this: this, aggr_node_AND_0_someFloat_EQUAL: $aggr_node_AND_0_someFloat_EQUAL, aggr_node_AND_1_someFloat_EQUAL: $aggr_node_AND_1_someFloat_EQUAL }, false )
+            \\", { this: this, aggr_node_AND_0_someFloat_EQUAL: $aggr_node_AND_0_someFloat_EQUAL, aggr_node_AND_1_someFloat_EQUAL: $aggr_node_AND_1_someFloat_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -93,9 +93,9 @@ describe("Cypher Aggregations where node with Logical AND + OR", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN (aggr_node.someFloat = $aggr_node_OR_0_someFloat_EQUAL OR aggr_node.someFloat = $aggr_node_OR_1_someFloat_EQUAL)
-            \\", { this: this, aggr_node_OR_0_someFloat_EQUAL: $aggr_node_OR_0_someFloat_EQUAL, aggr_node_OR_1_someFloat_EQUAL: $aggr_node_OR_1_someFloat_EQUAL }, false )
+            \\", { this: this, aggr_node_OR_0_someFloat_EQUAL: $aggr_node_OR_0_someFloat_EQUAL, aggr_node_OR_1_someFloat_EQUAL: $aggr_node_OR_1_someFloat_EQUAL })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/string.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/string.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.name = $aggr_node_name_EQUAL
-            \\", { this: this, aggr_node_name_EQUAL: $aggr_node_name_EQUAL }, false )
+            \\", { this: this, aggr_node_name_EQUAL: $aggr_node_name_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -91,9 +91,9 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someStringAlias = $aggr_node_someStringAlias_EQUAL
-            \\", { this: this, aggr_node_someStringAlias_EQUAL: $aggr_node_someStringAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someStringAlias_EQUAL: $aggr_node_someStringAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -120,9 +120,9 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_node.name) > $aggr_node_name_GT
-            \\", { this: this, aggr_node_name_GT: $aggr_node_name_GT }, false )
+            \\", { this: this, aggr_node_name_GT: $aggr_node_name_GT })
             RETURN this { .content } as this"
         `);
 
@@ -152,9 +152,9 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_node.name) >= $aggr_node_name_GTE
-            \\", { this: this, aggr_node_name_GTE: $aggr_node_name_GTE }, false )
+            \\", { this: this, aggr_node_name_GTE: $aggr_node_name_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -184,9 +184,9 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_node.name) < $aggr_node_name_LT
-            \\", { this: this, aggr_node_name_LT: $aggr_node_name_LT }, false )
+            \\", { this: this, aggr_node_name_LT: $aggr_node_name_LT })
             RETURN this { .content } as this"
         `);
 
@@ -216,9 +216,9 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN size(aggr_node.name) <= $aggr_node_name_LTE
-            \\", { this: this, aggr_node_name_LTE: $aggr_node_name_LTE }, false )
+            \\", { this: this, aggr_node_name_LTE: $aggr_node_name_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -248,10 +248,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_SHORTEST_EQUAL_SIZE
             RETURN min(aggr_node_name_SHORTEST_EQUAL_SIZE) = $aggr_node_name_SHORTEST_EQUAL
-            \\", { this: this, aggr_node_name_SHORTEST_EQUAL: $aggr_node_name_SHORTEST_EQUAL }, false )
+            \\", { this: this, aggr_node_name_SHORTEST_EQUAL: $aggr_node_name_SHORTEST_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -281,10 +281,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_SHORTEST_GT_SIZE
             RETURN min(aggr_node_name_SHORTEST_GT_SIZE) > $aggr_node_name_SHORTEST_GT
-            \\", { this: this, aggr_node_name_SHORTEST_GT: $aggr_node_name_SHORTEST_GT }, false )
+            \\", { this: this, aggr_node_name_SHORTEST_GT: $aggr_node_name_SHORTEST_GT })
             RETURN this { .content } as this"
         `);
 
@@ -314,10 +314,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_SHORTEST_GTE_SIZE
             RETURN min(aggr_node_name_SHORTEST_GTE_SIZE) >= $aggr_node_name_SHORTEST_GTE
-            \\", { this: this, aggr_node_name_SHORTEST_GTE: $aggr_node_name_SHORTEST_GTE }, false )
+            \\", { this: this, aggr_node_name_SHORTEST_GTE: $aggr_node_name_SHORTEST_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -347,10 +347,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_SHORTEST_LT_SIZE
             RETURN min(aggr_node_name_SHORTEST_LT_SIZE) < $aggr_node_name_SHORTEST_LT
-            \\", { this: this, aggr_node_name_SHORTEST_LT: $aggr_node_name_SHORTEST_LT }, false )
+            \\", { this: this, aggr_node_name_SHORTEST_LT: $aggr_node_name_SHORTEST_LT })
             RETURN this { .content } as this"
         `);
 
@@ -380,10 +380,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_SHORTEST_LTE_SIZE
             RETURN min(aggr_node_name_SHORTEST_LTE_SIZE) <= $aggr_node_name_SHORTEST_LTE
-            \\", { this: this, aggr_node_name_SHORTEST_LTE: $aggr_node_name_SHORTEST_LTE }, false )
+            \\", { this: this, aggr_node_name_SHORTEST_LTE: $aggr_node_name_SHORTEST_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -413,10 +413,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_LONGEST_EQUAL_SIZE
             RETURN max(aggr_node_name_LONGEST_EQUAL_SIZE) = $aggr_node_name_LONGEST_EQUAL
-            \\", { this: this, aggr_node_name_LONGEST_EQUAL: $aggr_node_name_LONGEST_EQUAL }, false )
+            \\", { this: this, aggr_node_name_LONGEST_EQUAL: $aggr_node_name_LONGEST_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -446,10 +446,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_LONGEST_GT_SIZE
             RETURN max(aggr_node_name_LONGEST_GT_SIZE) > $aggr_node_name_LONGEST_GT
-            \\", { this: this, aggr_node_name_LONGEST_GT: $aggr_node_name_LONGEST_GT }, false )
+            \\", { this: this, aggr_node_name_LONGEST_GT: $aggr_node_name_LONGEST_GT })
             RETURN this { .content } as this"
         `);
 
@@ -479,10 +479,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_LONGEST_GTE_SIZE
             RETURN max(aggr_node_name_LONGEST_GTE_SIZE) >= $aggr_node_name_LONGEST_GTE
-            \\", { this: this, aggr_node_name_LONGEST_GTE: $aggr_node_name_LONGEST_GTE }, false )
+            \\", { this: this, aggr_node_name_LONGEST_GTE: $aggr_node_name_LONGEST_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -512,10 +512,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_LONGEST_LT_SIZE
             RETURN max(aggr_node_name_LONGEST_LT_SIZE) < $aggr_node_name_LONGEST_LT
-            \\", { this: this, aggr_node_name_LONGEST_LT: $aggr_node_name_LONGEST_LT }, false )
+            \\", { this: this, aggr_node_name_LONGEST_LT: $aggr_node_name_LONGEST_LT })
             RETURN this { .content } as this"
         `);
 
@@ -545,10 +545,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_LONGEST_LTE_SIZE
             RETURN max(aggr_node_name_LONGEST_LTE_SIZE) <= $aggr_node_name_LONGEST_LTE
-            \\", { this: this, aggr_node_name_LONGEST_LTE: $aggr_node_name_LONGEST_LTE }, false )
+            \\", { this: this, aggr_node_name_LONGEST_LTE: $aggr_node_name_LONGEST_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -578,10 +578,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_AVERAGE_EQUAL_SIZE
             RETURN avg(aggr_node_name_AVERAGE_EQUAL_SIZE) = toFloat($aggr_node_name_AVERAGE_EQUAL)
-            \\", { this: this, aggr_node_name_AVERAGE_EQUAL: $aggr_node_name_AVERAGE_EQUAL }, false )
+            \\", { this: this, aggr_node_name_AVERAGE_EQUAL: $aggr_node_name_AVERAGE_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -608,10 +608,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_AVERAGE_GT_SIZE
             RETURN avg(aggr_node_name_AVERAGE_GT_SIZE) > toFloat($aggr_node_name_AVERAGE_GT)
-            \\", { this: this, aggr_node_name_AVERAGE_GT: $aggr_node_name_AVERAGE_GT }, false )
+            \\", { this: this, aggr_node_name_AVERAGE_GT: $aggr_node_name_AVERAGE_GT })
             RETURN this { .content } as this"
         `);
 
@@ -638,10 +638,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_AVERAGE_GTE_SIZE
             RETURN avg(aggr_node_name_AVERAGE_GTE_SIZE) >= toFloat($aggr_node_name_AVERAGE_GTE)
-            \\", { this: this, aggr_node_name_AVERAGE_GTE: $aggr_node_name_AVERAGE_GTE }, false )
+            \\", { this: this, aggr_node_name_AVERAGE_GTE: $aggr_node_name_AVERAGE_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -668,10 +668,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_AVERAGE_LT_SIZE
             RETURN avg(aggr_node_name_AVERAGE_LT_SIZE) < toFloat($aggr_node_name_AVERAGE_LT)
-            \\", { this: this, aggr_node_name_AVERAGE_LT: $aggr_node_name_AVERAGE_LT }, false )
+            \\", { this: this, aggr_node_name_AVERAGE_LT: $aggr_node_name_AVERAGE_LT })
             RETURN this { .content } as this"
         `);
 
@@ -698,10 +698,10 @@ describe("Cypher Aggregations where node with String", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             WITH aggr_node, aggr_edge, size(aggr_node.name) AS aggr_node_name_AVERAGE_LTE_SIZE
             RETURN avg(aggr_node_name_AVERAGE_LTE_SIZE) <= toFloat($aggr_node_name_AVERAGE_LTE)
-            \\", { this: this, aggr_node_name_AVERAGE_LTE: $aggr_node_name_AVERAGE_LTE }, false )
+            \\", { this: this, aggr_node_name_AVERAGE_LTE: $aggr_node_name_AVERAGE_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/time.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/aggregations/where/node/time.test.ts
@@ -62,9 +62,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someTime = $aggr_node_someTime_EQUAL
-            \\", { this: this, aggr_node_someTime_EQUAL: $aggr_node_someTime_EQUAL }, false )
+            \\", { this: this, aggr_node_someTime_EQUAL: $aggr_node_someTime_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -97,9 +97,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node._someTimeAlias = $aggr_node_someTimeAlias_EQUAL
-            \\", { this: this, aggr_node_someTimeAlias_EQUAL: $aggr_node_someTimeAlias_EQUAL }, false )
+            \\", { this: this, aggr_node_someTimeAlias_EQUAL: $aggr_node_someTimeAlias_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -132,9 +132,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someTime > $aggr_node_someTime_GT
-            \\", { this: this, aggr_node_someTime_GT: $aggr_node_someTime_GT }, false )
+            \\", { this: this, aggr_node_someTime_GT: $aggr_node_someTime_GT })
             RETURN this { .content } as this"
         `);
 
@@ -167,9 +167,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someTime >= $aggr_node_someTime_GTE
-            \\", { this: this, aggr_node_someTime_GTE: $aggr_node_someTime_GTE }, false )
+            \\", { this: this, aggr_node_someTime_GTE: $aggr_node_someTime_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -202,9 +202,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someTime < $aggr_node_someTime_LT
-            \\", { this: this, aggr_node_someTime_LT: $aggr_node_someTime_LT }, false )
+            \\", { this: this, aggr_node_someTime_LT: $aggr_node_someTime_LT })
             RETURN this { .content } as this"
         `);
 
@@ -237,9 +237,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN aggr_node.someTime <= $aggr_node_someTime_LTE
-            \\", { this: this, aggr_node_someTime_LTE: $aggr_node_someTime_LTE }, false )
+            \\", { this: this, aggr_node_someTime_LTE: $aggr_node_someTime_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -272,9 +272,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someTime) = $aggr_node_someTime_MIN_EQUAL
-            \\", { this: this, aggr_node_someTime_MIN_EQUAL: $aggr_node_someTime_MIN_EQUAL }, false )
+            \\", { this: this, aggr_node_someTime_MIN_EQUAL: $aggr_node_someTime_MIN_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -307,9 +307,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someTime) > $aggr_node_someTime_MIN_GT
-            \\", { this: this, aggr_node_someTime_MIN_GT: $aggr_node_someTime_MIN_GT }, false )
+            \\", { this: this, aggr_node_someTime_MIN_GT: $aggr_node_someTime_MIN_GT })
             RETURN this { .content } as this"
         `);
 
@@ -342,9 +342,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someTime) >= $aggr_node_someTime_MIN_GTE
-            \\", { this: this, aggr_node_someTime_MIN_GTE: $aggr_node_someTime_MIN_GTE }, false )
+            \\", { this: this, aggr_node_someTime_MIN_GTE: $aggr_node_someTime_MIN_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -377,9 +377,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someTime) < $aggr_node_someTime_MIN_LT
-            \\", { this: this, aggr_node_someTime_MIN_LT: $aggr_node_someTime_MIN_LT }, false )
+            \\", { this: this, aggr_node_someTime_MIN_LT: $aggr_node_someTime_MIN_LT })
             RETURN this { .content } as this"
         `);
 
@@ -412,9 +412,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  min(aggr_node.someTime) <= $aggr_node_someTime_MIN_LTE
-            \\", { this: this, aggr_node_someTime_MIN_LTE: $aggr_node_someTime_MIN_LTE }, false )
+            \\", { this: this, aggr_node_someTime_MIN_LTE: $aggr_node_someTime_MIN_LTE })
             RETURN this { .content } as this"
         `);
 
@@ -447,9 +447,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someTime) = $aggr_node_someTime_MAX_EQUAL
-            \\", { this: this, aggr_node_someTime_MAX_EQUAL: $aggr_node_someTime_MAX_EQUAL }, false )
+            \\", { this: this, aggr_node_someTime_MAX_EQUAL: $aggr_node_someTime_MAX_EQUAL })
             RETURN this { .content } as this"
         `);
 
@@ -482,9 +482,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someTime) > $aggr_node_someTime_MAX_GT
-            \\", { this: this, aggr_node_someTime_MAX_GT: $aggr_node_someTime_MAX_GT }, false )
+            \\", { this: this, aggr_node_someTime_MAX_GT: $aggr_node_someTime_MAX_GT })
             RETURN this { .content } as this"
         `);
 
@@ -517,9 +517,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someTime) >= $aggr_node_someTime_MAX_GTE
-            \\", { this: this, aggr_node_someTime_MAX_GTE: $aggr_node_someTime_MAX_GTE }, false )
+            \\", { this: this, aggr_node_someTime_MAX_GTE: $aggr_node_someTime_MAX_GTE })
             RETURN this { .content } as this"
         `);
 
@@ -552,9 +552,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someTime) < $aggr_node_someTime_MAX_LT
-            \\", { this: this, aggr_node_someTime_MAX_LT: $aggr_node_someTime_MAX_LT }, false )
+            \\", { this: this, aggr_node_someTime_MAX_LT: $aggr_node_someTime_MAX_LT })
             RETURN this { .content } as this"
         `);
 
@@ -587,9 +587,9 @@ describe("Cypher Aggregations where node with Time", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.cypher.runFirstColumn(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
+            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this)<-[aggr_edge:LIKES]-(aggr_node:User)
             RETURN  max(aggr_node.someTime) <= $aggr_node_someTime_MAX_LTE
-            \\", { this: this, aggr_node_someTime_MAX_LTE: $aggr_node_someTime_MAX_LTE }, false )
+            \\", { this: this, aggr_node_someTime_MAX_LTE: $aggr_node_someTime_MAX_LTE })
             RETURN this { .content } as this"
         `);
 

--- a/packages/graphql/tests/tck/tck-test-files/alias.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/alias.test.ts
@@ -82,8 +82,8 @@ describe("Cypher Alias", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { movieId: this.id, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor)   | this_actors { aliasActorsName: this_actors.name } ], custom: [this_custom IN apoc.cypher.runFirstColumn(\\"MATCH (m:Movie)
-            RETURN m\\", {this: this, auth: $auth}, true) | this_custom { aliasCustomId: this_custom.id }] } as this"
+            RETURN this { movieId: this.id, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor)   | this_actors { aliasActorsName: this_actors.name } ], custom: [this_custom IN apoc.cypher.runFirstColumnMany(\\"MATCH (m:Movie)
+            RETURN m\\", {this: this, auth: $auth}) | this_custom { aliasCustomId: this_custom.id }] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/array-methods.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/array-methods.test.ts
@@ -181,11 +181,11 @@ describe("Arrays Methods", () => {
             "MATCH (this:\`Movie\`)
             CALL apoc.util.validate(this.filmingLocations IS NULL, \\"Property %s cannot be NULL\\", ['filmingLocations'])
             SET this.filmingLocations = this.filmingLocations + [p in $this_update_filmingLocations_PUSH | point(p)]
-            RETURN collect(DISTINCT this { .title, filmingLocations: apoc.cypher.runFirstColumn('RETURN
+            RETURN collect(DISTINCT this { .title, filmingLocations: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.filmingLocations IS NOT NULL THEN [p in this.filmingLocations | { point:p }]
             	ELSE NULL
-            END AS result',{ this: this },false) }) AS data"
+            END AS result',{ this: this }) }) AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/node/points.test.ts
@@ -96,11 +96,11 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WHERE distance(this_actor.currentLocation, point($this_actorsConnection.args.where.node.currentLocation_DISTANCE.point)) = $this_actorsConnection.args.where.node.currentLocation_DISTANCE.distance
-            WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, currentLocation: apoc.cypher.runFirstColumn('RETURN
+            WITH collect({ screenTime: this_acted_in_relationship.screenTime, node: { name: this_actor.name, currentLocation: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this_actor.currentLocation IS NOT NULL THEN { point: this_actor.currentLocation }
             	ELSE NULL
-            END AS result',{ this_actor: this_actor },false) } }) AS edges
+            END AS result',{ this_actor: this_actor }) } }) AS edges
             UNWIND edges as edge
             WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
             RETURN { edges: edges, totalCount: totalCount } AS actorsConnection

--- a/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/filtering/relationship/points.test.ts
@@ -94,11 +94,11 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
             WITH this
             MATCH (this)<-[this_acted_in_relationship:ACTED_IN]-(this_actor:Actor)
             WHERE distance(this_acted_in_relationship.location, point($this_actorsConnection.args.where.edge.location_DISTANCE.point)) = $this_actorsConnection.args.where.edge.location_DISTANCE.distance
-            WITH collect({ screenTime: this_acted_in_relationship.screenTime, location: apoc.cypher.runFirstColumn('RETURN
+            WITH collect({ screenTime: this_acted_in_relationship.screenTime, location: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this_acted_in_relationship.location IS NOT NULL THEN { point: this_acted_in_relationship.location }
             	ELSE NULL
-            END AS result',{ this_acted_in_relationship: this_acted_in_relationship },false), node: { name: this_actor.name } }) AS edges
+            END AS result',{ this_acted_in_relationship: this_acted_in_relationship }), node: { name: this_actor.name } }) AS edges
             UNWIND edges as edge
             WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
             RETURN { edges: edges, totalCount: totalCount } AS actorsConnection

--- a/packages/graphql/tests/tck/tck-test-files/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/connections/mixed-nesting.test.ts
@@ -221,7 +221,7 @@ describe("Mixed nesting", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
             WHERE this.title = $param0
-            RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor)  WHERE this_actors.name = $this_actors_param0 | this_actors { .name, moviesConnection: apoc.cypher.runFirstColumn(\\"CALL {
+            RETURN this { .title, actors: [ (this)<-[:ACTED_IN]-(this_actors:Actor)  WHERE this_actors.name = $this_actors_param0 | this_actors { .name, moviesConnection: apoc.cypher.runFirstColumnSingle(\\"CALL {
             WITH this_actors
             MATCH (this_actors)-[this_actors_acted_in_relationship:ACTED_IN]->(this_actors_movie:Movie)
             WHERE (NOT this_actors_movie.title = $this_actors_moviesConnection.args.where.node.title_NOT)
@@ -229,7 +229,7 @@ describe("Mixed nesting", () => {
             UNWIND edges as edge
             WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
             RETURN { edges: edges, totalCount: totalCount } AS moviesConnection
-            } RETURN moviesConnection\\", { this_actors: this_actors, this_actors_moviesConnection: $this_actors_moviesConnection, auth: $auth }, false) } ] } as this"
+            } RETURN moviesConnection\\", { this_actors: this_actors, this_actors_moviesConnection: $this_actors_moviesConnection, auth: $auth }) } ] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
@@ -178,7 +178,7 @@ describe("Cypher Auth isAuthenticated", () => {
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN this { history: [this_history IN apoc.cypher.runFirstColumn(\\"MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h\\", {this: this, auth: $auth}, true) WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_history { .url }] } as this"
+            RETURN this { history: [this_history IN apoc.cypher.runFirstColumnMany(\\"MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h\\", {this: this, auth: $auth}) WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_history { .url }] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/auth/arguments/roles/roles.test.ts
@@ -184,7 +184,7 @@ describe("Cypher Auth Roles", () => {
             CALL apoc.util.validate(NOT (any(r IN [\\"admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL apoc.util.validate(NOT (any(r IN [\\"super-admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN this { history: [this_history IN apoc.cypher.runFirstColumn(\\"MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h\\", {this: this, auth: $auth}, true) WHERE apoc.util.validatePredicate(NOT (any(r IN [\\"super-admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_history { .url }] } as this"
+            RETURN this { history: [this_history IN apoc.cypher.runFirstColumnMany(\\"MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h\\", {this: this, auth: $auth}) WHERE apoc.util.validatePredicate(NOT (any(r IN [\\"super-admin\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_history { .url }] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/directives/cypher.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/directives/cypher.test.ts
@@ -131,8 +131,8 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this, auth: $auth}, false) | this_topActor { .name }]) } as this"
+            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this, auth: $auth}) | this_topActor { .name }]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -161,7 +161,7 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
-            RETURN this { randomNumber:  apoc.cypher.runFirstColumn(\\"RETURN rand()\\", {this: this, auth: $auth}, false) } as this"
+            RETURN this { randomNumber:  apoc.cypher.runFirstColumnSingle(\\"RETURN rand()\\", {this: this, auth: $auth}) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -192,7 +192,7 @@ describe("Cypher directive", () => {
             "MATCH (this:\`Actor\`)
             WITH this
             LIMIT $this_limit
-            RETURN this { randomNumber:  apoc.cypher.runFirstColumn(\\"RETURN rand()\\", {this: this, auth: $auth}, false) } as this"
+            RETURN this { randomNumber:  apoc.cypher.runFirstColumnSingle(\\"RETURN rand()\\", {this: this, auth: $auth}) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -225,7 +225,7 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
-            WITH this,  apoc.cypher.runFirstColumn(\\"RETURN rand()\\", {this: this, auth: $auth}, false) AS randomNumber
+            WITH this,  apoc.cypher.runFirstColumnSingle(\\"RETURN rand()\\", {this: this, auth: $auth}) AS randomNumber
             ORDER BY randomNumber ASC
             LIMIT $this_limit
             RETURN this { randomNumber: randomNumber } as this"
@@ -267,9 +267,9 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this, auth: $auth}, false) | this_topActor { .name, movies: [this_topActor_movies IN apoc.cypher.runFirstColumn(\\"MATCH (m:Movie {title: $title})
-            RETURN m\\", {this: this_topActor, auth: $auth, title: $this_topActor_movies_title}, true) | this_topActor_movies { .title }] }]) } as this"
+            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this, auth: $auth}) | this_topActor { .name, movies: [this_topActor_movies IN apoc.cypher.runFirstColumnMany(\\"MATCH (m:Movie {title: $title})
+            RETURN m\\", {this: this_topActor, auth: $auth, title: $this_topActor_movies_title}) | this_topActor_movies { .title }] }]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -311,11 +311,11 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this, auth: $auth}, false) | this_topActor { .name, movies: [this_topActor_movies IN apoc.cypher.runFirstColumn(\\"MATCH (m:Movie {title: $title})
-            RETURN m\\", {this: this_topActor, auth: $auth, title: $this_topActor_movies_title}, true) | this_topActor_movies { .title, topActor: head([this_topActor_movies_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this_topActor_movies, auth: $auth}, false) | this_topActor_movies_topActor { .name, movies: [this_topActor_movies_topActor_movies IN apoc.cypher.runFirstColumn(\\"MATCH (m:Movie {title: $title})
-            RETURN m\\", {this: this_topActor_movies_topActor, auth: $auth, title: $this_topActor_movies_topActor_movies_title}, true) | this_topActor_movies_topActor_movies { .title }] }]) }] }]) } as this"
+            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this, auth: $auth}) | this_topActor { .name, movies: [this_topActor_movies IN apoc.cypher.runFirstColumnMany(\\"MATCH (m:Movie {title: $title})
+            RETURN m\\", {this: this_topActor, auth: $auth, title: $this_topActor_movies_title}) | this_topActor_movies { .title, topActor: head([this_topActor_movies_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this_topActor_movies, auth: $auth}) | this_topActor_movies_topActor { .name, movies: [this_topActor_movies_topActor_movies IN apoc.cypher.runFirstColumnMany(\\"MATCH (m:Movie {title: $title})
+            RETURN m\\", {this: this_topActor_movies_topActor, auth: $auth, title: $this_topActor_movies_topActor_movies_title}) | this_topActor_movies_topActor_movies { .title }] }]) }] }]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -352,9 +352,9 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this, auth: $auth}, false) | this_topActor { .name, movies: [this_topActor_movies IN apoc.cypher.runFirstColumn(\\"MATCH (m:Movie {title: $title})
-            RETURN m\\", {this: this_topActor, auth: $auth, title: $this_topActor_movies_title}, true) | this_topActor_movies { .title }] }]) } as this"
+            RETURN this { .title, topActor: head([this_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this, auth: $auth}) | this_topActor { .name, movies: [this_topActor_movies IN apoc.cypher.runFirstColumnMany(\\"MATCH (m:Movie {title: $title})
+            RETURN m\\", {this: this_topActor, auth: $auth, title: $this_topActor_movies_title}) | this_topActor_movies { .title }] }]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -399,11 +399,11 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
-            RETURN this { movieOrTVShow: apoc.coll.flatten([this_movieOrTVShow IN apoc.cypher.runFirstColumn(\\"MATCH (n)
+            RETURN this { movieOrTVShow: apoc.coll.flatten([this_movieOrTVShow IN apoc.cypher.runFirstColumnMany(\\"MATCH (n)
             WHERE (n:TVShow OR n:Movie) AND ($title IS NULL OR n.title = $title)
-            RETURN n\\", {this: this, auth: $auth, title: $this_movieOrTVShow_title}, true) WHERE (this_movieOrTVShow:\`Movie\`) OR (this_movieOrTVShow:\`TVShow\`)  |   [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`Movie\`) | this_movieOrTVShow { __resolveType: \\"Movie\\",  .id, .title, topActor: head([this_movieOrTVShow_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this_movieOrTVShow, auth: $auth}, false) | this_movieOrTVShow_topActor { .name }]) } ] + [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`TVShow\`) | this_movieOrTVShow { __resolveType: \\"TVShow\\",  .id, .title, topActor: head([this_movieOrTVShow_topActor IN apoc.cypher.runFirstColumn(\\"MATCH (a:Actor)
-            RETURN a\\", {this: this_movieOrTVShow, auth: $auth}, false) | this_movieOrTVShow_topActor { .name }]) } ] ]) } as this"
+            RETURN n\\", {this: this, auth: $auth, title: $this_movieOrTVShow_title}) WHERE (this_movieOrTVShow:\`Movie\`) OR (this_movieOrTVShow:\`TVShow\`)  |   [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`Movie\`) | this_movieOrTVShow { __resolveType: \\"Movie\\",  .id, .title, topActor: head([this_movieOrTVShow_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this_movieOrTVShow, auth: $auth}) | this_movieOrTVShow_topActor { .name }]) } ] + [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`TVShow\`) | this_movieOrTVShow { __resolveType: \\"TVShow\\",  .id, .title, topActor: head([this_movieOrTVShow_topActor IN apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
+            RETURN a\\", {this: this_movieOrTVShow, auth: $auth}) | this_movieOrTVShow_topActor { .name }]) } ] ]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -435,9 +435,9 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
-            RETURN this { movieOrTVShow: apoc.coll.flatten([this_movieOrTVShow IN apoc.cypher.runFirstColumn(\\"MATCH (n)
+            RETURN this { movieOrTVShow: apoc.coll.flatten([this_movieOrTVShow IN apoc.cypher.runFirstColumnMany(\\"MATCH (n)
             WHERE (n:TVShow OR n:Movie) AND ($title IS NULL OR n.title = $title)
-            RETURN n\\", {this: this, auth: $auth, title: $this_movieOrTVShow_title}, true) WHERE (this_movieOrTVShow:\`Movie\`) OR (this_movieOrTVShow:\`TVShow\`)  |  head( [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`Movie\`) | this_movieOrTVShow { __resolveType: \\"Movie\\" }  ] + [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`TVShow\`) | this_movieOrTVShow { __resolveType: \\"TVShow\\" }  ] )]) } as this"
+            RETURN n\\", {this: this, auth: $auth, title: $this_movieOrTVShow_title}) WHERE (this_movieOrTVShow:\`Movie\`) OR (this_movieOrTVShow:\`TVShow\`)  |  head( [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`Movie\`) | this_movieOrTVShow { __resolveType: \\"Movie\\" }  ] + [ this_movieOrTVShow IN [this_movieOrTVShow] WHERE (this_movieOrTVShow:\`TVShow\`) | this_movieOrTVShow { __resolveType: \\"TVShow\\" }  ] )]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/issues/1139.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1139.test.ts
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/1139", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WHERE this.id = $param0
-            RETURN this { updates: apoc.coll.flatten([this_updates IN apoc.cypher.runFirstColumn(\\"MATCH (this)-[a:WROTE]->(wrote:Post)
+            RETURN this { updates: apoc.coll.flatten([this_updates IN apoc.cypher.runFirstColumnMany(\\"MATCH (this)-[a:WROTE]->(wrote:Post)
             WHERE a.date_added IS NOT NULL
             WITH COLLECT(wrote{ .*, date_added: a.date_added, typename: 'WROTE' }) as updates1, this
             MATCH (this)-[a:FOLLOWS]->(umb)
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/1139", () => {
             UNWIND allUpdates as update
             RETURN update
             ORDER BY update.date_added DESC
-            LIMIT 5\\", {this: this, auth: $auth}, true) WHERE (this_updates:\`Post\`) OR (this_updates:\`Movie\`) OR (this_updates:\`User\`)  |  head( [ this_updates IN [this_updates] WHERE (this_updates:\`Post\`) | this_updates { __resolveType: \\"Post\\" }  ] + [ this_updates IN [this_updates] WHERE (this_updates:\`Movie\`) | this_updates { __resolveType: \\"Movie\\" }  ] + [ this_updates IN [this_updates] WHERE (this_updates:\`User\`) | this_updates { __resolveType: \\"User\\" }  ] )]) } as this"
+            LIMIT 5\\", {this: this, auth: $auth}) WHERE (this_updates:\`Post\`) OR (this_updates:\`Movie\`) OR (this_updates:\`User\`)  |  head( [ this_updates IN [this_updates] WHERE (this_updates:\`Post\`) | this_updates { __resolveType: \\"Post\\" }  ] + [ this_updates IN [this_updates] WHERE (this_updates:\`Movie\`) | this_updates { __resolveType: \\"Movie\\" }  ] + [ this_updates IN [this_updates] WHERE (this_updates:\`User\`) | this_updates { __resolveType: \\"User\\" }  ] )]) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/issues/1364.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1364.test.ts
@@ -109,8 +109,8 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             RETURN this, totalCount, edges
             ORDER BY this.title ASC
             }
-            WITH COLLECT({ node: this { .title, totalGenres:  apoc.cypher.runFirstColumn(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth}, false) } }) as edges, totalCount
+            WITH COLLECT({ node: this { .title, totalGenres:  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth}) } }) as edges, totalCount
             RETURN { edges: edges, totalCount: totalCount } as this"
         `);
     });
@@ -138,8 +138,8 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             WITH COLLECT(this) as edges
             WITH edges, size(edges) as totalCount
             UNWIND edges as this
-            WITH this, totalCount, { totalGenres:  apoc.cypher.runFirstColumn(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth}, false)} as edges
+            WITH this, totalCount, { totalGenres:  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth})} as edges
             RETURN this, totalCount, edges
             ORDER BY edges.totalGenres ASC
             }
@@ -172,13 +172,13 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             WITH COLLECT(this) as edges
             WITH edges, size(edges) as totalCount
             UNWIND edges as this
-            WITH this, totalCount, { totalGenres:  apoc.cypher.runFirstColumn(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth}, false)} as edges
+            WITH this, totalCount, { totalGenres:  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth})} as edges
             RETURN this, totalCount, edges
             ORDER BY edges.totalGenres ASC
             }
-            WITH COLLECT({ node: this { .title, totalGenres: edges.totalGenres, totalActors:  apoc.cypher.runFirstColumn(\\"MATCH (this)<-[:ACTED_IN]-(actor:Actor)
-            RETURN count(DISTINCT actor)\\", {this: this, auth: $auth}, false) } }) as edges, totalCount
+            WITH COLLECT({ node: this { .title, totalGenres: edges.totalGenres, totalActors:  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:ACTED_IN]-(actor:Actor)
+            RETURN count(DISTINCT actor)\\", {this: this, auth: $auth}) } }) as edges, totalCount
             RETURN { edges: edges, totalCount: totalCount } as this"
         `);
     });

--- a/packages/graphql/tests/tck/tck-test-files/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1528.test.ts
@@ -82,8 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             MATCH (this)<-[this_is_genre_relationship:IS_GENRE]-(this_movie:Movie)
             WITH this_is_genre_relationship, this_movie
             ORDER BY this_movie.actorsCount DESC
-            WITH collect({ node: { title: this_movie.title, actorsCount:  apoc.cypher.runFirstColumn(\\"MATCH (this)<-[:ACTED_IN]-(ac:Person)
-            RETURN count(ac)\\", {this: this_movie, auth: $auth}, false) } }) AS edges
+            WITH collect({ node: { title: this_movie.title, actorsCount:  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:ACTED_IN]-(ac:Person)
+            RETURN count(ac)\\", {this: this_movie, auth: $auth}) } }) AS edges
             UNWIND edges as edge
             WITH edges, edge
             ORDER BY edge.node.actorsCount DESC

--- a/packages/graphql/tests/tck/tck-test-files/issues/1566.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1566.test.ts
@@ -82,8 +82,8 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Community\`)
             WHERE this.id = $param0
-            RETURN this { .id, hasFeedItems: apoc.coll.flatten([this_hasFeedItems IN apoc.cypher.runFirstColumn(\\"Match(this)-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES|:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]-(pag)
-               return pag SKIP ($limit * $pageIndex) LIMIT $limit\\", {this: this, auth: $auth, limit: $this_hasFeedItems_limit, page: $this_hasFeedItems_page}, true) WHERE (this_hasFeedItems:\`Content\`) OR (this_hasFeedItems:\`Project\`)  |   [ this_hasFeedItems IN [this_hasFeedItems] WHERE (this_hasFeedItems:\`Content\`) | this_hasFeedItems { __resolveType: \\"Content\\",  .name } ] + [ this_hasFeedItems IN [this_hasFeedItems] WHERE (this_hasFeedItems:\`Project\`) | this_hasFeedItems { __resolveType: \\"Project\\",  .name } ] ]) } as this"
+            RETURN this { .id, hasFeedItems: apoc.coll.flatten([this_hasFeedItems IN apoc.cypher.runFirstColumnMany(\\"Match(this)-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES|:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]-(pag)
+               return pag SKIP ($limit * $pageIndex) LIMIT $limit\\", {this: this, auth: $auth, limit: $this_hasFeedItems_limit, page: $this_hasFeedItems_page}) WHERE (this_hasFeedItems:\`Content\`) OR (this_hasFeedItems:\`Project\`)  |   [ this_hasFeedItems IN [this_hasFeedItems] WHERE (this_hasFeedItems:\`Content\`) | this_hasFeedItems { __resolveType: \\"Content\\",  .name } ] + [ this_hasFeedItems IN [this_hasFeedItems] WHERE (this_hasFeedItems:\`Project\`) | this_hasFeedItems { __resolveType: \\"Project\\",  .name } ] ]) } as this"
         `);
     });
 });

--- a/packages/graphql/tests/tck/tck-test-files/issues/1685.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1685.test.ts
@@ -74,10 +74,10 @@ describe("https://github.com/neo4j/graphql/issues/1685", () => {
             CALL {
             WITH this
             MATCH (this)<-[this_has_genre_relationship:HAS_GENRE]-(this_Movie:Movie)
-            WHERE apoc.cypher.runFirstColumn(\\"RETURN exists((this_Movie)-[:HAS_GENRE]->(:Genre))
+            WHERE apoc.cypher.runFirstColumnSingle(\\"RETURN exists((this_Movie)-[:HAS_GENRE]->(:Genre))
             AND any(this_Movie_Genre_map IN [(this_Movie)-[this_Movie_Genre_MovieGenresRelationship:HAS_GENRE]->(this_Movie_Genre:Genre) | { node: this_Movie_Genre, relationship: this_Movie_Genre_MovieGenresRelationship } ] WHERE
             this_Movie_Genre_map.node.name = $this_moviesConnection.args.where.node._on.Movie.genresConnection_SOME.node.name
-            )\\", { this_Movie: this_Movie, this_moviesConnection: $this_moviesConnection }, false)
+            )\\", { this_Movie: this_Movie, this_moviesConnection: $this_moviesConnection })
             WITH { node: { __resolveType: \\"Movie\\" } } AS edge
             RETURN edge
             }

--- a/packages/graphql/tests/tck/tck-test-files/issues/1760.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/1760.test.ts
@@ -125,7 +125,7 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`ApplicationVariant\`)
             WHERE this.current = $param0
-            WITH this,  apoc.cypher.runFirstColumn(\\"MATCH (this)<-[:HAS_BASE]-(n:BaseObject) RETURN n.id\\", {this: this, auth: $auth}, false) AS relatedId
+            WITH this,  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:HAS_BASE]-(n:BaseObject) RETURN n.id\\", {this: this, auth: $auth}) AS relatedId
             ORDER BY relatedId ASC
             SKIP $this_offset
             LIMIT $this_limit

--- a/packages/graphql/tests/tck/tck-test-files/issues/387.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/387.test.ts
@@ -85,7 +85,7 @@ describe("#387", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Place\`)
-            RETURN this { url_works:  apoc.cypher.runFirstColumn(\\"return '' + ''\\", {this: this, auth: $auth}, false), url_fails:  apoc.cypher.runFirstColumn(\\"return '' + ''\\", {this: this, auth: $auth}, false), url_array_works:  apoc.cypher.runFirstColumn(\\"return ['' + '']\\", {this: this, auth: $auth}, false), url_array_fails:  apoc.cypher.runFirstColumn(\\"return ['' + '']\\", {this: this, auth: $auth}, false) } as this"
+            RETURN this { url_works:  apoc.cypher.runFirstColumnSingle(\\"return '' + ''\\", {this: this, auth: $auth}), url_fails:  apoc.cypher.runFirstColumnSingle(\\"return '' + ''\\", {this: this, auth: $auth}), url_array_works:  apoc.cypher.runFirstColumnSingle(\\"return ['' + '']\\", {this: this, auth: $auth}), url_array_fails:  apoc.cypher.runFirstColumnSingle(\\"return ['' + '']\\", {this: this, auth: $auth}) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/issues/601.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/601.test.ts
@@ -92,7 +92,7 @@ describe("#601", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Stakeholder\`)
             CALL apoc.util.validate(NOT (any(r IN [\\"view\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN this { documents: [ (this)-[:REQUIRES]->(this_documents:Document)  WHERE apoc.util.validatePredicate(NOT (any(r IN [\\"view\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_documents { customerContactConnection: apoc.cypher.runFirstColumn(\\"CALL {
+            RETURN this { documents: [ (this)-[:REQUIRES]->(this_documents:Document)  WHERE apoc.util.validatePredicate(NOT (any(r IN [\\"view\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) | this_documents { customerContactConnection: apoc.cypher.runFirstColumnSingle(\\"CALL {
             WITH this_documents
             MATCH (this_documents)<-[this_documents_uploaded_relationship:UPLOADED]-(this_documents_customercontact:CustomerContact)
             CALL apoc.util.validate(NOT (any(r IN [\\\\\\"view\\\\\\"] WHERE any(rr IN $auth.roles WHERE r = rr))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
@@ -100,7 +100,7 @@ describe("#601", () => {
             UNWIND edges as edge
             WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
             RETURN { edges: edges, totalCount: totalCount } AS customerContactConnection
-            } RETURN customerContactConnection\\", { this_documents: this_documents, auth: $auth }, false) } ] } as this"
+            } RETURN customerContactConnection\\", { this_documents: this_documents, auth: $auth }) } ] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/issues/630.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/issues/630.test.ts
@@ -73,14 +73,14 @@ describe("Cypher directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
-            RETURN this { movies: [this_movies IN apoc.cypher.runFirstColumn(\\"MATCH (m:Movie {title: $title})
-            RETURN m\\", {this: this, auth: $auth, title: $this_movies_title}, true) | this_movies { actorsConnection: apoc.cypher.runFirstColumn(\\"CALL {
+            RETURN this { movies: [this_movies IN apoc.cypher.runFirstColumnMany(\\"MATCH (m:Movie {title: $title})
+            RETURN m\\", {this: this, auth: $auth, title: $this_movies_title}) | this_movies { actorsConnection: apoc.cypher.runFirstColumnSingle(\\"CALL {
             WITH this_movies
             MATCH (this_movies)<-[this_movies_acted_in_relationship:ACTED_IN]-(this_movies_actor:Actor)
             WITH collect({  }) AS edges
             WITH size(edges) AS totalCount
             RETURN { totalCount: totalCount } AS actorsConnection
-            } RETURN actorsConnection\\", { this_movies: this_movies, auth: $auth }, false) }] } as this"
+            } RETURN actorsConnection\\", { this_movies: this_movies, auth: $auth }) }] } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/operations/create.test.ts
@@ -345,7 +345,7 @@ describe("Cypher Create", () => {
             RETURN this0
             }
             RETURN [
-            this0 { .name, movies: [ (this0)-[:ACTED_IN]->(this0_movies:Movie)   | this0_movies { actorsConnection: apoc.cypher.runFirstColumn(\\"CALL {
+            this0 { .name, movies: [ (this0)-[:ACTED_IN]->(this0_movies:Movie)   | this0_movies { actorsConnection: apoc.cypher.runFirstColumnSingle(\\"CALL {
             WITH this0_movies
             MATCH (this0_movies)<-[this0_movies_acted_in_relationship:ACTED_IN]-(this0_movies_actor:Actor)
             WHERE this0_movies_actor.name = $projection_movies_actorsConnection.args.where.node.name
@@ -353,7 +353,7 @@ describe("Cypher Create", () => {
             UNWIND edges as edge
             WITH collect(edge) AS edges, size(collect(edge)) AS totalCount
             RETURN { edges: edges, totalCount: totalCount } AS actorsConnection
-            } RETURN actorsConnection\\", { this0_movies: this0_movies, projection_movies_actorsConnection: $projection_movies_actorsConnection, auth: $auth }, false) } ] }] AS data"
+            } RETURN actorsConnection\\", { this0_movies: this0_movies, projection_movies_actorsConnection: $projection_movies_actorsConnection, auth: $auth }) } ] }] AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/projection.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/projection.test.ts
@@ -111,16 +111,16 @@ describe("Cypher Projection", () => {
             RETURN this1
             }
             RETURN [
-            this0 { .id, photos: [ (this0)-[:HAS_PHOTO]->(this0_photos:Photo)  WHERE this0_photos.url = $projection_photos_param0 | this0_photos { .url, location: apoc.cypher.runFirstColumn('RETURN
+            this0 { .id, photos: [ (this0)-[:HAS_PHOTO]->(this0_photos:Photo)  WHERE this0_photos.url = $projection_photos_param0 | this0_photos { .url, location: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this0_photos.location IS NOT NULL THEN { point: this0_photos.location }
             	ELSE NULL
-            END AS result',{ this0_photos: this0_photos },false) } ], colors: [ (this0)-[:HAS_COLOR]->(this0_colors:Color)  WHERE this0_colors.id = $projection_colors_param0 | this0_colors { .id } ], sizes: [ (this0)-[:HAS_SIZE]->(this0_sizes:Size)  WHERE this0_sizes.name = $projection_sizes_param0 | this0_sizes { .name } ] },
-            this1 { .id, photos: [ (this1)-[:HAS_PHOTO]->(this1_photos:Photo)  WHERE this1_photos.url = $projection_photos_param0 | this1_photos { .url, location: apoc.cypher.runFirstColumn('RETURN
+            END AS result',{ this0_photos: this0_photos }) } ], colors: [ (this0)-[:HAS_COLOR]->(this0_colors:Color)  WHERE this0_colors.id = $projection_colors_param0 | this0_colors { .id } ], sizes: [ (this0)-[:HAS_SIZE]->(this0_sizes:Size)  WHERE this0_sizes.name = $projection_sizes_param0 | this0_sizes { .name } ] },
+            this1 { .id, photos: [ (this1)-[:HAS_PHOTO]->(this1_photos:Photo)  WHERE this1_photos.url = $projection_photos_param0 | this1_photos { .url, location: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this1_photos.location IS NOT NULL THEN { point: this1_photos.location }
             	ELSE NULL
-            END AS result',{ this1_photos: this1_photos },false) } ], colors: [ (this1)-[:HAS_COLOR]->(this1_colors:Color)  WHERE this1_colors.id = $projection_colors_param0 | this1_colors { .id } ], sizes: [ (this1)-[:HAS_SIZE]->(this1_sizes:Size)  WHERE this1_sizes.name = $projection_sizes_param0 | this1_sizes { .name } ] }] AS data"
+            END AS result',{ this1_photos: this1_photos }) } ], colors: [ (this1)-[:HAS_COLOR]->(this1_colors:Color)  WHERE this1_colors.id = $projection_colors_param0 | this1_colors { .id } ], sizes: [ (this1)-[:HAS_SIZE]->(this1_sizes:Size)  WHERE this1_sizes.name = $projection_sizes_param0 | this1_sizes { .name } ] }] AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/sort.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/sort.test.ts
@@ -160,8 +160,8 @@ describe("Cypher sort tests", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            WITH this,  apoc.cypher.runFirstColumn(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
-            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth}, false) AS totalGenres
+            WITH this,  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
+            RETURN count(DISTINCT genre)\\", {this: this, auth: $auth}) AS totalGenres
             ORDER BY totalGenres DESC
             RETURN this { totalGenres: totalGenres } as this"
         `);
@@ -315,8 +315,8 @@ describe("Cypher sort tests", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN this { genres: apoc.coll.sortMulti([ (this)-[:HAS_GENRE]->(this_genres:Genre)   | this_genres { .name, totalMovies:  apoc.cypher.runFirstColumn(\\"MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
-            RETURN count(DISTINCT movie)\\", {this: this_genres, auth: $auth}, false) } ], ['^totalMovies']) } as this"
+            RETURN this { genres: apoc.coll.sortMulti([ (this)-[:HAS_GENRE]->(this_genres:Genre)   | this_genres { .name, totalMovies:  apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
+            RETURN count(DISTINCT movie)\\", {this: this_genres, auth: $auth}) } ], ['^totalMovies']) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/types/point.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/types/point.test.ts
@@ -62,11 +62,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE this.point = point($param0)
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point, crs: this.point.crs }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -99,11 +99,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE NOT this.point = point($param0)
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -137,11 +137,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE this.point IN [var0 IN $param0 | point(var0)]
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point, crs: this.point.crs }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -177,11 +177,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE NOT this.point IN [var0 IN $param0 | point(var0)]
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point, crs: this.point.crs }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -216,11 +216,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE distance(this.point, point($param0.point)) < $param0.distance
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -256,11 +256,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE distance(this.point, point($param0.point)) <= $param0.distance
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -296,11 +296,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE distance(this.point, point($param0.point)) > $param0.distance
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -336,11 +336,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE distance(this.point, point($param0.point)) >= $param0.distance
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -378,11 +378,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE distance(this.point, point($param0.point)) = $param0.distance
-            RETURN this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point }
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -425,11 +425,11 @@ describe("Cypher Points", () => {
             RETURN this0
             }
             RETURN [
-            this0 { point: apoc.cypher.runFirstColumn('RETURN
+            this0 { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this0.point IS NOT NULL THEN { point: this0.point, crs: this0.point.crs }
             	ELSE NULL
-            END AS result',{ this0: this0 },false) }] AS data"
+            END AS result',{ this0: this0 }) }] AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -467,11 +467,11 @@ describe("Cypher Points", () => {
             "MATCH (this:\`PointContainer\`)
             WHERE this.id = $param0
             SET this.point = point($this_update_point)
-            RETURN collect(DISTINCT this { point: apoc.cypher.runFirstColumn('RETURN
+            RETURN collect(DISTINCT this { point: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.point IS NOT NULL THEN { point: this.point, crs: this.point.crs }
             	ELSE NULL
-            END AS result',{ this: this },false) }) AS data"
+            END AS result',{ this: this }) }) AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/tck-test-files/types/points.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/types/points.test.ts
@@ -62,11 +62,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE this.points = [var0 IN $param0 | point(var0)]
-            RETURN this { points: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.points IS NOT NULL THEN [p in this.points | { point:p, crs: p.crs }]
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -101,11 +101,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE NOT this.points = [var0 IN $param0 | point(var0)]
-            RETURN this { points: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.points IS NOT NULL THEN [p in this.points | { point:p }]
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -141,11 +141,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE point($param0) IN this.points
-            RETURN this { points: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.points IS NOT NULL THEN [p in this.points | { point:p, crs: p.crs }]
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -179,11 +179,11 @@ describe("Cypher Points", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`PointContainer\`)
             WHERE NOT point($param0) IN this.points
-            RETURN this { points: apoc.cypher.runFirstColumn('RETURN
+            RETURN this { points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.points IS NOT NULL THEN [p in this.points | { point:p, crs: p.crs }]
             	ELSE NULL
-            END AS result',{ this: this },false) } as this"
+            END AS result',{ this: this }) } as this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -223,11 +223,11 @@ describe("Cypher Points", () => {
             RETURN this0
             }
             RETURN [
-            this0 { points: apoc.cypher.runFirstColumn('RETURN
+            this0 { points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this0.points IS NOT NULL THEN [p in this0.points | { point:p, crs: p.crs }]
             	ELSE NULL
-            END AS result',{ this0: this0 },false) }] AS data"
+            END AS result',{ this0: this0 }) }] AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -267,11 +267,11 @@ describe("Cypher Points", () => {
             "MATCH (this:\`PointContainer\`)
             WHERE this.id = $param0
             SET this.points = [p in $this_update_points | point(p)]
-            RETURN collect(DISTINCT this { points: apoc.cypher.runFirstColumn('RETURN
+            RETURN collect(DISTINCT this { points: apoc.cypher.runFirstColumnSingle('RETURN
             CASE
             	WHEN this.points IS NOT NULL THEN [p in this.points | { point:p, crs: p.crs }]
             	ELSE NULL
-            END AS result',{ this: this },false) }) AS data"
+            END AS result',{ this: this }) }) AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`


### PR DESCRIPTION
# Description

Yet another deprecation in the upcoming 5.0 release!