### PR TITLE
Release tweaks following first hotfix

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -2,7 +2,7 @@
     "$schema": "https://unpkg.com/@changesets/config@2.0.0/schema.json",
     "changelog": ["@changesets/changelog-github", { "repo": "neo4j/graphql" }],
     "commit": false,
-    "fixed": [["@neo4j/graphql", "@neo4j/graphql-ogm"]],
+    "fixed": [["@neo4j/graphql", "@neo4j/graphql-ogm", "@neo4j/graphql-toolbox"]],
     "linked": [],
     "access": "public",
     "baseBranch": "dev",

--- a/.github/workflows/changesets-master.yml
+++ b/.github/workflows/changesets-master.yml
@@ -62,10 +62,18 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
+      - name: Create release branch for merging into dev
+        uses: peterjgrainger/action-create-branch@c2800a3a9edbba2218da6861fa46496cf8f3195a # renovate: tag=v2.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}
+        with:
+          branch: "release/${{ github.sha }}"
+
       - name: pull-request
         if: steps.changesets.outputs.published == 'true'
         uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde # renovate: tag=v2.6.2
         with:
+          source_branch: "release/${{ github.sha }}"
           destination_branch: "dev"
           pr_title: "Merge ${{ github.ref }} into dev"
           github_token: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
# Description

A couple of changes which came out of the woodwork as part of the hotfix release:

- The GraphQL Toolbox should be bumped whenever we bump the library - this will lead onto more reliable releases
- A branch should be created from `master` before creating a PR into `dev` following a hotfix release - this will avoid corrupting the commit history of `master`.
