### PR TITLE
refactor createProjectionAndParam result

### DIFF
--- a/packages/graphql/src/schema/resolvers/field/cypher.ts
+++ b/packages/graphql/src/schema/resolvers/field/cypher.ts
@@ -71,7 +71,8 @@ export function cypherResolver({
                 context,
                 varName: `this`,
             });
-            const [str, p, meta] = recurse;
+
+            const { projection: str, params: p, meta } = recurse;
             projectionStr = str;
             params = { ...params, ...p };
 
@@ -114,7 +115,11 @@ export function cypherResolver({
                     const innerHeadStr: string[] = [`[ this IN [this] WHERE (${labelsStatements.join(" AND ")})`];
 
                     if (resolveTree.fieldsByTypeName[node.name]) {
-                        const [str, p, meta] = createProjectionAndParams({
+                        const {
+                            projection: str,
+                            params: p,
+                            meta,
+                        } = createProjectionAndParams({
                             resolveTree,
                             node,
                             context,

--- a/packages/graphql/src/translate/connection/create-connection-and-params.ts
+++ b/packages/graphql/src/translate/connection/create-connection-and-params.ts
@@ -163,15 +163,15 @@ function createConnectionAndParams({
                         literalElements: true,
                         resolveType: true,
                     });
-                    const [nodeProjection, nodeProjectionParams] = nodeProjectionAndParams;
+                    const { projection: nodeProjection, params: nodeProjectionParams } = nodeProjectionAndParams;
                     subqueryElementsToCollect.push(`node: ${nodeProjection}`);
                     globalParams = {
                         ...globalParams,
                         ...nodeProjectionParams,
                     };
 
-                    if (nodeProjectionAndParams[2]?.connectionFields?.length) {
-                        nodeProjectionAndParams[2].connectionFields.forEach((connectionResolveTree) => {
+                    if (nodeProjectionAndParams.meta?.connectionFields?.length) {
+                        nodeProjectionAndParams.meta.connectionFields.forEach((connectionResolveTree) => {
                             const connectionField = n.connectionFields.find(
                                 (x) => x.fieldName === connectionResolveTree.name
                             ) as ConnectionField;
@@ -374,14 +374,17 @@ function createConnectionAndParams({
         const nestedSubqueries: string[] = [];
 
         if (node) {
-            const nodeProjectionAndParams = createProjectionAndParams({
+            const {
+                projection: nodeProjection,
+                params: nodeProjectionParams,
+                meta: projectionMeta,
+            } = createProjectionAndParams({
                 resolveTree: node,
                 node: relatedNode,
                 context,
                 varName: relatedNodeVariable,
                 literalElements: true,
             });
-            const [nodeProjection, nodeProjectionParams, projectionMeta] = nodeProjectionAndParams;
             elementsToCollect.push(`node: ${nodeProjection}`);
             globalParams = { ...globalParams, ...nodeProjectionParams };
 

--- a/packages/graphql/src/translate/create-projection-and-params.test.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.test.ts
@@ -77,8 +77,8 @@ describe("createProjectionAndParams", () => {
 
         const result = createProjectionAndParams({ resolveTree, node, context, varName: "this" });
 
-        expect(result[0]).toBe(`{ .title }`);
-        expect(result[1]).toMatchObject({});
+        expect(result.projection).toBe(`{ .title }`);
+        expect(result.params).toMatchObject({});
     });
     test("should return the correct projection when querying for a global with id in the selection set", () => {
         const resolveTree: ResolveTree = {
@@ -132,6 +132,6 @@ describe("createProjectionAndParams", () => {
         }).instance();
 
         const result = createProjectionAndParams({ resolveTree, node, context, varName: "this" });
-        expect(result[0]).toBe(`{ .title }`);
+        expect(result.projection).toBe(`{ .title }`);
     });
 });

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -110,20 +110,20 @@ export default async function translateCreate({
             resolveTree: nodeProjection,
             varName: "REPLACE_ME",
         });
-        if (projection[2]?.authValidateStrs?.length) {
-            projAuth = `CALL apoc.util.validate(NOT (${projection[2].authValidateStrs.join(
+        if (projection.meta?.authValidateStrs?.length) {
+            projAuth = `CALL apoc.util.validate(NOT (${projection.meta.authValidateStrs.join(
                 " AND "
             )}), "${AUTH_FORBIDDEN_ERROR}", [0])`;
         }
 
-        replacedProjectionParams = Object.entries(projection[1]).reduce((res, [key, value]) => {
+        replacedProjectionParams = Object.entries(projection.params).reduce((res, [key, value]) => {
             return { ...res, [key.replace("REPLACE_ME", "projection")]: value };
         }, {});
 
         projectionStr = createStrs
             .map(
                 (_, i) =>
-                    `\nthis${i} ${projection[0]
+                    `\nthis${i} ${projection.projection
                         // First look to see if projection param is being reassigned
                         // e.g. in an apoc.cypher.runFirstColumn function call used in createProjection->connectionField
                         .replace(/REPLACE_ME(?=\w+: \$REPLACE_ME)/g, "projection")
@@ -137,8 +137,8 @@ export default async function translateCreate({
             .join("\n");
 
         const withVars = context.subscriptionsEnabled ? [META_CYPHER_VARIABLE] : [];
-        if (projection[2]?.connectionFields?.length) {
-            projection[2].connectionFields.forEach((connectionResolveTree) => {
+        if (projection.meta?.connectionFields?.length) {
+            projection.meta.connectionFields.forEach((connectionResolveTree) => {
                 const connectionField = node.connectionFields.find(
                     (x) => x.fieldName === connectionResolveTree.name
                 ) as ConnectionField;
@@ -155,9 +155,9 @@ export default async function translateCreate({
             });
         }
 
-        if (projection[2]?.interfaceFields?.length) {
+        if (projection.meta?.interfaceFields?.length) {
             const prevRelationshipFields: string[] = [];
-            projection[2].interfaceFields.forEach((interfaceResolveTree) => {
+            projection.meta.interfaceFields.forEach((interfaceResolveTree) => {
                 const relationshipField = node.relationFields.find(
                     (x) => x.fieldName === interfaceResolveTree.name
                 ) as RelationField;
@@ -235,7 +235,7 @@ export default async function translateCreate({
     let resolvedCallbacks = {};
 
     ({ cypher, params: resolvedCallbacks } = await callbackBucket.resolveCallbacksAndFilterCypher({ cypher }));
- 
+
     const createQuery = new CypherBuilder.RawCypher(() => {
         return [
             cypher,

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -21,7 +21,7 @@ import type { Integer } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { cursorToOffset } from "graphql-relay";
 import type { Node } from "../classes";
-import createProjectionAndParams, { ProjectionMeta } from "./create-projection-and-params";
+import createProjectionAndParams, { ProjectionMeta, ProjectionResult } from "./create-projection-and-params";
 import type { GraphQLOptionsArg, GraphQLSortArg, Context, ConnectionField, RelationField } from "../types";
 import createAuthAndParams from "./create-auth-and-params";
 import { AUTH_FORBIDDEN_ERROR } from "../constants";
@@ -66,16 +66,17 @@ export function translateRead({
         varName,
         isRootConnectionField,
     });
-    cypherParams = { ...cypherParams, ...projection[1] };
 
-    if (projection[2]?.authValidateStrs?.length) {
-        projAuth = `CALL apoc.util.validate(NOT (${projection[2].authValidateStrs.join(
+    cypherParams = { ...cypherParams, ...projection.params };
+
+    if (projection.meta?.authValidateStrs?.length) {
+        projAuth = `CALL apoc.util.validate(NOT (${projection.meta.authValidateStrs.join(
             " AND "
         )}), "${AUTH_FORBIDDEN_ERROR}", [0])`;
     }
 
-    if (projection[2]?.connectionFields?.length) {
-        projection[2].connectionFields.forEach((connectionResolveTree) => {
+    if (projection.meta?.connectionFields?.length) {
+        projection.meta.connectionFields.forEach((connectionResolveTree) => {
             const connectionField = node.connectionFields.find(
                 (x) => x.fieldName === connectionResolveTree.name
             ) as ConnectionField;
@@ -90,9 +91,9 @@ export function translateRead({
         });
     }
 
-    if (projection[2]?.interfaceFields?.length) {
+    if (projection.meta?.interfaceFields?.length) {
         const prevRelationshipFields: string[] = [];
-        projection[2].interfaceFields.forEach((interfaceResolveTree) => {
+        projection.meta.interfaceFields.forEach((interfaceResolveTree) => {
             const relationshipField = node.relationFields.find(
                 (x) => x.fieldName === interfaceResolveTree.name
             ) as RelationField;
@@ -170,7 +171,7 @@ function translateRootField({
     node: Node;
     context: Context;
     varName: string;
-    projection: [string, Record<string, any>, ProjectionMeta | undefined];
+    projection: ProjectionResult;
     subStr: {
         matchAndWhereStr: string;
         authStr: string;
@@ -192,7 +193,7 @@ function translateRootField({
     const params = {} as Record<string, any>;
     const hasOffset = Boolean(optionsInput.offset) || optionsInput.offset === 0;
 
-    const sortCypherFields = projection[2]?.cypherSortFields ?? [];
+    const sortCypherFields = projection.meta?.cypherSortFields ?? [];
     const sortCypherProj = sortCypherFields.map(({ alias, apocStr }) => `${apocStr} AS ${alias}`);
     const sortOffsetLimit: string[] = [[`WITH ${varName}`, ...sortCypherProj].join(", ")];
 
@@ -224,7 +225,7 @@ function translateRootField({
 
     const withStrs = subStr.projAuth ? [`WITH ${varName}`, subStr.projAuth] : [];
 
-    const returnStrs = [`RETURN ${varName} ${projection[0]} as ${varName}`];
+    const returnStrs = [`RETURN ${varName} ${projection.projection} as ${varName}`];
 
     const cypher: string[] = [
         subStr.matchAndWhereStr,
@@ -247,7 +248,7 @@ function translateRootConnectionField({
 }: {
     context: Context;
     varName: string;
-    projection: [string, Record<string, any>, ProjectionMeta | undefined];
+    projection: ProjectionResult;
     subStr: {
         matchAndWhereStr: string;
         authStr: string;
@@ -268,7 +269,7 @@ function translateRootConnectionField({
     const hasFirst = Boolean(firstInput);
     const hasSort = Boolean(sortInput && sortInput.length);
 
-    const sortCypherFields = projection[2]?.cypherSortFields ?? [];
+    const sortCypherFields = projection.meta?.cypherSortFields ?? [];
     const sortCypherProj = sortCypherFields.map(({ alias, apocStr }) => `${alias}: ${apocStr}`);
 
     let sortStr = "";
@@ -303,7 +304,7 @@ function translateRootConnectionField({
     }
 
     const returnStrs: string[] = [
-        `WITH COLLECT({ node: ${varName} ${projection[0]} }) as edges, totalCount`,
+        `WITH COLLECT({ node: ${varName} ${projection.projection} }) as edges, totalCount`,
         `RETURN { edges: edges, totalCount: totalCount } as ${varName}`,
     ];
 

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -21,7 +21,7 @@ import type { Integer } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { cursorToOffset } from "graphql-relay";
 import type { Node } from "../classes";
-import createProjectionAndParams, { ProjectionMeta, ProjectionResult } from "./create-projection-and-params";
+import createProjectionAndParams, { ProjectionResult } from "./create-projection-and-params";
 import type { GraphQLOptionsArg, GraphQLSortArg, Context, ConnectionField, RelationField } from "../types";
 import createAuthAndParams from "./create-auth-and-params";
 import { AUTH_FORBIDDEN_ERROR } from "../constants";

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -363,7 +363,7 @@ export default async function translateUpdate({
                     refNode,
                     context,
                     withVars,
-                    callbackBucket
+                    callbackBucket,
                 });
                 connectStrs.push(cypher);
                 cypherParams = { ...cypherParams, ...params };
@@ -378,16 +378,16 @@ export default async function translateUpdate({
             resolveTree: nodeProjection,
             varName,
         });
-        [projStr] = projection;
-        cypherParams = { ...cypherParams, ...projection[1] };
-        if (projection[2]?.authValidateStrs?.length) {
-            projAuth = `CALL apoc.util.validate(NOT (${projection[2].authValidateStrs.join(
+        projStr = projection.projection;
+        cypherParams = { ...cypherParams, ...projection.params };
+        if (projection.meta?.authValidateStrs?.length) {
+            projAuth = `CALL apoc.util.validate(NOT (${projection.meta.authValidateStrs.join(
                 " AND "
             )}), "${AUTH_FORBIDDEN_ERROR}", [0])`;
         }
 
-        if (projection[2]?.connectionFields?.length) {
-            projection[2].connectionFields.forEach((connectionResolveTree) => {
+        if (projection.meta?.connectionFields?.length) {
+            projection.meta.connectionFields.forEach((connectionResolveTree) => {
                 const connectionField = node.connectionFields.find(
                     (x) => x.fieldName === connectionResolveTree.name
                 ) as ConnectionField;
@@ -403,9 +403,9 @@ export default async function translateUpdate({
             });
         }
 
-        if (projection[2]?.interfaceFields?.length) {
+        if (projection.meta?.interfaceFields?.length) {
             const prevRelationshipFields: string[] = [];
-            projection[2].interfaceFields.forEach((interfaceResolveTree) => {
+            projection.meta.interfaceFields.forEach((interfaceResolveTree) => {
                 const relationshipField = node.relationFields.find(
                     (x) => x.fieldName === interfaceResolveTree.name
                 ) as RelationField;


### PR DESCRIPTION
# Description
This PR simply moves the `createProjectionAndParams` from an array to an object, to accommodate the extra fields required for subquery projections.
No tests or behaviour modified.