### PR TITLE
Performance improvement on _SINGLE operation

### DIFF
--- a/.changeset/nice-parrots-kick.md
+++ b/.changeset/nice-parrots-kick.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Performance improvement on \_SINGLE operations

--- a/packages/graphql/src/translate/cypher-builder/CypherBuilder.ts
+++ b/packages/graphql/src/translate/cypher-builder/CypherBuilder.ts
@@ -87,7 +87,7 @@ export {
     sum,
 } from "./functions/CypherFunction";
 export * from "./functions/ListFunctions";
-export { any, all, exists } from "./functions/PredicateFunctions";
+export { any, all, exists, single } from "./functions/PredicateFunctions";
 
 // Types
 export type { CypherResult } from "./types";

--- a/packages/graphql/src/translate/cypher-builder/functions/PredicateFunctions.ts
+++ b/packages/graphql/src/translate/cypher-builder/functions/PredicateFunctions.ts
@@ -60,6 +60,10 @@ export function all(variable: Variable, listExpr: Expr, whereFilter?: Predicate)
     return new ListPredicateFunction("all", variable, listExpr, whereFilter);
 }
 
+export function single(variable: Variable, listExpr: Expr, whereFilter: Predicate): PredicateFunction {
+    return new ListPredicateFunction("single", variable, listExpr, whereFilter);
+}
+
 class ExistsFunction extends PredicateFunction {
     private pattern: Pattern;
 

--- a/packages/graphql/src/translate/where/property-operations/create-where-property-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-where-property-operation.ts
@@ -24,6 +24,8 @@ import { whereRegEx, WhereRegexGroups } from "../utils";
 import mapToDbProperty from "../../../utils/map-to-db-property";
 import { createGlobalNodeOperation } from "./create-global-node-operation";
 import { createAggregateOperation } from "./create-aggregate-operation";
+// Recursive function
+// eslint-disable-next-line import/no-cycle
 import { createConnectionOperation } from "./create-connection-operation";
 import { createComparisonOperation } from "./create-comparison-operation";
 // Recursive function
@@ -43,7 +45,7 @@ export function createWherePropertyOperation({
     element: GraphElement;
     targetElement: CypherBuilder.Variable;
     context: Context;
-}): CypherBuilder.ComparisonOp | CypherBuilder.BooleanOp | CypherBuilder.RawCypher | CypherBuilder.Exists | undefined {
+}): CypherBuilder.Predicate | undefined {
     const match = whereRegEx.exec(key);
     if (!match) {
         throw new Error(`Failed to match key in filter: ${key}`);

--- a/packages/graphql/tests/performance/graphql/query.graphql
+++ b/packages/graphql/tests/performance/graphql/query.graphql
@@ -145,3 +145,23 @@ query DeeplyNestedWithRelationshipFilters {
         name
     }
 }
+
+query DeeplyNestedWithRelationshipSingleFilters {
+    people(
+        where: {
+            name_STARTS_WITH: "T"
+            movies_SINGLE: {
+                title_CONTAINS: "i"
+                actors_SINGLE: {
+                    name_CONTAINS: "i"
+                    movies_SINGLE: {
+                        title_NOT: "non-existant"
+                        actors_SINGLE: { name_CONTAINS: "i", movies_SINGLE: { title: "The Matrix" } }
+                    }
+                }
+            }
+        }
+    ) {
+        name
+    }
+}

--- a/packages/graphql/tests/tck/tck-test-files/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/tck-test-files/advanced-filtering.test.ts
@@ -814,7 +814,7 @@ describe("Cypher Advanced Filtering", () => {
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
-                    WHERE size([(this)-[:IN_GENRE]->(this0:\`Genre\`) WHERE this0.name = $param0 | 1]) = 1
+                    WHERE single(this0 IN [(this)-[:IN_GENRE]->(this0:\`Genre\`) | this0] WHERE this0.name = $param0)
                     RETURN this { .actorCount } as this"
                 `);
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`


### PR DESCRIPTION
# Description

After some performance test, it is clear that using `single()` instead of `size() = 1` improves performance on `_SINGLE` operations for the cases reported in #1937 

 