### PR TITLE
fix: test checks the average of integers for the edge aggregate

### DIFF
--- a/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
@@ -462,7 +462,7 @@ describe("aggregations-where-edge-int", () => {
 
                 const query = `
                     {
-                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_GT: ${avgGT} } } }) {
+                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_AVERAGE_GT: ${avgGT} } } }) {
                             testString
                             likes {
                                 testString
@@ -512,7 +512,7 @@ describe("aggregations-where-edge-int", () => {
 
                 const query = `
                     {
-                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_GTE: ${avg} } } }) {
+                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_AVERAGE_GTE: ${avg} } } }) {
                             testString
                             likes {
                                 testString
@@ -553,16 +553,16 @@ describe("aggregations-where-edge-int", () => {
                 await session.run(
                     `
                         CREATE (p:Post {testString: "${testString}"})
-                        CREATE (p)<-[:LIKES { someInt: ${someInt3} }]-(:User {testString: "${testString}"})
-                        CREATE (p)<-[:LIKES { someInt: ${someInt2} }]-(:User {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:User {testString: "${testString}"})
+                        CREATE (p)<-[:LIKES { someInt: ${someInt2} }]-(:User {testString: "${testString}"})
+                        CREATE (p)<-[:LIKES { someInt: ${someInt3} }]-(:User {testString: "${testString}"})
                         CREATE (:Post {testString: "${testString}"})
                     `
                 );
 
                 const query = `
                     {
-                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_LT: ${avgLT} } } }) {
+                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_AVERAGE_LT: ${avgLT} } } }) {
                             testString
                             likes {
                                 testString
@@ -612,7 +612,7 @@ describe("aggregations-where-edge-int", () => {
 
                 const query = `
                     {
-                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_LTE: ${avg} } } }) {
+                        posts(where: { testString: "${testString}", likesAggregate: { edge: { someInt_AVERAGE_LTE: ${avg} } } }) {
                             testString
                             likes {
                                 testString


### PR DESCRIPTION
This test file was quite flaky when executing the integration tests locally.

The fix is to do what the test subscription indicates: `should return posts where the average of an edge like Int's is LTE than`, note the word `average`.

In a related file for testing the aggregates on nodes this is done correctly, with the `AVERAGE_` string before the operator: https://github.com/neo4j/graphql/blob/dev/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts#L451

