### PR TITLE
feat: add rate-limiting to neo-push server

### DIFF
--- a/examples/neo-push/server/package.json
+++ b/examples/neo-push/server/package.json
@@ -5,7 +5,7 @@
     "description": "",
     "main": "./dist/src/index.js",
     "scripts": {
-        "start": "nodemon --watch './src/**/*.ts' --exec ./node_modules/.bin/ts-node -r tsconfig-paths/register --project ./src/tsconfig.json ./src/index.ts",
+        "start": "nodemon --watch './src/**/*.ts' --exec ../../../node_modules/.bin/ts-node -r tsconfig-paths/register --project ./src/tsconfig.json ./src/index.ts",
         "build": "tsc  --project src/",
         "seed": "ts-node -r tsconfig-paths/register --project ./src/tsconfig.json ./src/seeder.ts",
         "test": "jest"
@@ -21,6 +21,7 @@
         "debug": "4.3.4",
         "dotenv": "^16.0.1",
         "express": "4.17.1",
+        "express-rate-limit": "^6.5.2",
         "graphql": "16.6.0",
         "jsonwebtoken": "8.5.1",
         "neo4j-driver": "4.4.7"

--- a/examples/neo-push/server/src/server.ts
+++ b/examples/neo-push/server/src/server.ts
@@ -1,4 +1,5 @@
 import express from "express";
+import rateLimit from "express-rate-limit";
 import * as path from "path";
 import * as config from "./config";
 import createDebug from "./debugger";
@@ -7,10 +8,19 @@ import { getServer } from "./gql";
 export async function start(): Promise<void> {
     const app = express();
 
+    const limiter = rateLimit({
+        windowMs: 1 * 60 * 1000, // 1 minute
+        max: 20, // Limit each IP to 20 requests per `window` (here, per 1 minute)
+        standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
+    });
+
     const debug = createDebug("HTTP");
 
     if (config.NODE_ENV === "production") {
         debug("Production serving statics");
+
+        // Apply the rate limiting middleware to all requests
+        app.use(limiter);
 
         app.use("/", express.static(path.join(__dirname, "../../dist")));
 

--- a/examples/neo-push/server/src/types.ts
+++ b/examples/neo-push/server/src/types.ts
@@ -1,5 +1,5 @@
-import { Driver } from "neo4j-driver";
-import { OGM } from "@neo4j/graphql-ogm";
+import type { Driver } from "neo4j-driver";
+import type { OGM } from "@neo4j/graphql-ogm";
 
 export type Context = {
     ogm: OGM;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8272,6 +8272,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"express-rate-limit@npm:^6.5.2":
+  version: 6.5.2
+  resolution: "express-rate-limit@npm:6.5.2"
+  peerDependencies:
+    express: ^4 || ^5
+  checksum: 20ce3cc0d58b9fcab5a427c100315c8e4467e0a43877fe4341bfefae8df627949efe1c98c16ee9b7d6ed4f19f0d06df8485f52bb81b490ffb534d1cbc3cd21f7
+  languageName: node
+  linkType: hard
+
 "express@npm:4.17.1":
   version: 4.17.1
   resolution: "express@npm:4.17.1"
@@ -13159,6 +13168,7 @@ __metadata:
     debug: 4.3.4
     dotenv: ^16.0.1
     express: 4.17.1
+    express-rate-limit: ^6.5.2
     graphql: 16.6.0
     jest: 29.0.1
     jsonwebtoken: 8.5.1


### PR DESCRIPTION
This popped up during the code scanning.

Info:
```
HTTP request handlers should not perform expensive operations such as accessing the file system, executing an operating
system command or interacting with a database without limiting the rate at which requests are accepted. Otherwise, the 
application becomes vulnerable to denial-of-service attacks where an attacker can cause the application to crash or become 
unresponsive by issuing a large number of requests at the same time.
```

Since neo-push is an example project it's not critical to address this yet it's good practice to follow the guidance even for an example project.