### PR TITLE
feat: add rel noreferrer to link

### DIFF
--- a/packages/graphql-toolbox/src/modules/HelpDrawer/Resources.tsx
+++ b/packages/graphql-toolbox/src/modules/HelpDrawer/Resources.tsx
@@ -81,7 +81,12 @@ const ResourceLinksBlock = ({ listBlockTitle, links }: ResourceLinksBlockProps):
                 {links.map((link) => {
                     return (
                         <li key={link.href} className="mt-6 cursor-pointer">
-                            <a className="flex justify-start items-center" href={link.href} target="_blank">
+                            <a
+                                className="flex justify-start items-center"
+                                href={link.href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                            >
                                 {/* @ts-ignore - iconName is a string */}
                                 <HeroIcon className="h-6 w-6 mr-2 stroke-1" type="outline" iconName={link.iconName} />
                                 <p className="p-0 m-0">{link.label}</p>

--- a/packages/graphql-toolbox/src/modules/HelpDrawer/Resources.tsx
+++ b/packages/graphql-toolbox/src/modules/HelpDrawer/Resources.tsx
@@ -85,7 +85,7 @@ const ResourceLinksBlock = ({ listBlockTitle, links }: ResourceLinksBlockProps):
                                 className="flex justify-start items-center"
                                 href={link.href}
                                 target="_blank"
-                                rel="noopener noreferrer"
+                                rel="noreferrer"
                             >
                                 {/* @ts-ignore - iconName is a string */}
                                 <HeroIcon className="h-6 w-6 mr-2 stroke-1" type="outline" iconName={link.iconName} />


### PR DESCRIPTION
This popped up during the code scanning.

Info:
```
HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using
window.opener unless link type noopener or noreferrer is specified.
```

It's low severity yet easy to fix.