### PR TITLE
fix: remove unsused script and stylesheets links in neo-push client

### DIFF
--- a/examples/neo-push/client/src/index.html
+++ b/examples/neo-push/client/src/index.html
@@ -7,9 +7,6 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css"
         integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous" />
 
-
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/2.1.0/pure-min.css" />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/github.min.css" />
     <title>Document</title>
 </head>
 
@@ -17,8 +14,6 @@
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <!-- React app root element -->
     <div id="root"></div>
-
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This popped up in the code scanning (low severity).

Info:
```
Including a resource from an untrusted source or using an untrusted channel may allow an attacker to include
arbitrary code in the response. When including an external resource (for example, a script element or an iframe element)
on a page, it is important to ensure that the received data is not malicious.
```

Can't find any trace that these stylesheets and the imported `highlight.js` library are still used.