### PR TITLE
Implement and/or filters on subscriptions

### DIFF
--- a/.changeset/proud-houses-love.md
+++ b/.changeset/proud-houses-love.md
@@ -2,4 +2,4 @@
 "@neo4j/graphql": minor
 ---
 
-Allows for combining filters with AND/OR when subscribing to events.
+Allows combining filters with AND/OR when subscribing to events.

--- a/.changeset/proud-houses-love.md
+++ b/.changeset/proud-houses-love.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Allows for combining filters with AND/OR when subscribing to events.

--- a/docs/modules/ROOT/pages/filtering.adoc
+++ b/docs/modules/ROOT/pages/filtering.adoc
@@ -96,6 +96,11 @@ Conversely, the following operators are available on array fields, and accept a 
 
 These four operators are available for all types apart from `Boolean`.
 
+=== AND, OR operators
+
+Complex combinations of operators are possible using the `AND`/ `OR` operators. 
+These are stand-alone operators - that is, they are used as such and not appended to field names, and they accept an array argument with items of the same format as the `where` argument. 
+
 == Usage
 
 Using the type definitions from xref::queries.adoc[Queries], below are some example of how filtering can be applied when querying for data.
@@ -109,6 +114,36 @@ By using the `where` argument on the Query field in question, you can return a U
 query {
     users(where: { id: "7CF1D9D6-E527-4ACD-9C2A-207AE0F5CB8C" }) {
         name
+    }
+}
+----
+
+=== Combining operators
+
+All above-mentioned operators can be combined using the `AND`/`OR` operators. 
+They accept an array argument with items of the same format as the `where` argument, which means they can also be nested to form complex combinations.
+As an example, the below query matches all actors by the name of either "Keanu" or belonging to the "Pantoliano" family, that played in "The Matrix" movie.
+
+[source, graphql, indent=0]
+----
+query {
+    actors(where: { 
+        AND: [
+            { 
+                OR: [
+                    { name_CONTAINS: "Keanu" },
+                    { name_ENDS_WITH: "Pantoliano" }
+                ]
+            },
+            {
+                movies_SOME: { title: "The Matrix" }
+            }
+        ]}
+    ) {
+        name
+        movies {
+            title
+        }
     }
 }
 ----

--- a/docs/modules/ROOT/pages/subscriptions/filtering.adoc
+++ b/docs/modules/ROOT/pages/subscriptions/filtering.adoc
@@ -50,6 +50,11 @@ Conversely, the following operators are available on array fields, and accept a 
 
 These four operators are available for all types apart from `Boolean`.
 
+=== AND, OR operators
+
+Complex combinations of operators are possible using the `AND`/ `OR` operators. 
+These are stand-alone operators - that is, they are used as such and not appended to field names, and they accept an array argument with items of the same format as the `where` argument. 
+
 == Usage
 
 Basic filtering of events can be done with the `where` parameter. This lets you filter on top-level properties of the created nodes.
@@ -144,3 +149,32 @@ movieDeleted(where: {genre_NOT: "Comedy"}) {
 This way, only deleted movies of all genres except for `"Comedy"` will trigger events to this subscription.
 
 NOTE: `Where` will only filter by existing properties right before deletion.
+
+=== Combining operators
+
+All above-mentioned operators can be combined using the `AND`/`OR` operators. 
+They accept an array argument with items of the same format as the `where` argument, which means they can also be nested to form complex combinations.
+
+Say we are picky fans of comedy movies and we only accept ratings below 7 for movies released before the 2000's. 
+As an exception we also like the movie "The Matrix". However, we do not like any of its sequels. 
+We could subscribe to any updates that we are interested in as follows:
+
+[source, graphql, indent=0]
+----
+movieUpdate(where: {
+    OR: [
+        {title_ENDS_WITH: "The Matrix"},
+        {AND: [
+            {genre: "comedy"},
+            {OR: [
+                {releasedIn_LTE: 2000},
+                {releasedIn_GT: 2000, averageRating_GT: 7}
+            ]}
+        ]}
+    ]
+}) {
+    updatedMovie {
+        title
+    }
+}
+----

--- a/packages/graphql/src/schema/resolvers/subscriptions/update-diff-filter.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/update-diff-filter.ts
@@ -19,16 +19,19 @@
 
 import type { SubscriptionsEvent } from "../../../types";
 import { compareProperties } from "./utils/compare-properties";
+import { haveSameLength } from "../../../utils/utils";
 
 export function updateDiffFilter(event: SubscriptionsEvent): boolean {
     if (event.event !== "update") {
         return true;
     }
-
-    const sameLength = Object.keys(event.properties.old).length === Object.keys(event.properties.new).length;
-    if (!sameLength) return true;
-    const sameProperties = compareProperties(event.properties.old, event.properties.new);
-    if (!sameProperties) return true;
+    if (!haveSameLength(event.properties.old, event.properties.new)) {
+        return true;
+    }
+    const haveSameProperties = compareProperties(event.properties.old, event.properties.new);
+    if (!haveSameProperties) {
+        return true;
+    }
 
     return false;
 }

--- a/packages/graphql/src/schema/resolvers/subscriptions/utils/compare-properties.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/utils/compare-properties.ts
@@ -22,17 +22,14 @@ import type Node from "../../../../classes/Node";
 import type { PrimitiveField } from "../../../../types";
 import { whereRegEx } from "../../../../translate/where/utils";
 import type { WhereRegexGroups } from "../../../../translate/where/utils";
-import { isSameType } from "../../../../utils/utils";
+import { isSameType, haveSameLength } from "../../../../utils/utils";
 
-function isDifferentNumberOfItems(o1: Record<string, any>, o2: Record<string, any>) {
-    return Object.keys(o1).length !== Object.keys(o2).length;
-}
 /**
  * Returns true if all properties in obj1 exists in obj2, false otherwise.
  * Properties can only be primitives or Array<primitive>
  */
 export function compareProperties(obj1: Record<string, any>, obj2: Record<string, any>): boolean {
-    if (!isSameType(obj1, obj2) || isDifferentNumberOfItems(obj1, obj2)) {
+    if (!isSameType(obj1, obj2) || !haveSameLength(obj1, obj2)) {
         return false;
     }
     for (const [k, value] of Object.entries(obj1)) {
@@ -154,19 +151,51 @@ function parseFilterProperty(key: string): { fieldName: string; operator: string
     return { fieldName, operator };
 }
 
+const multipleConditionsAggregationMap = {
+    AND: (results: boolean[]): boolean => {
+        for (const res of results) {
+            if (!res) {
+                return false;
+            }
+        }
+        return true;
+    },
+    OR: (results: boolean[]): boolean => {
+        for (const res of results) {
+            if (res) {
+                return true;
+            }
+        }
+        return false;
+    },
+};
+
 /** Returns true if receivedProperties comply with filters specified in whereProperties, false otherwise. */
 export function filterByProperties<T>(
     node: Node,
-    whereProperties: Record<string, T>,
+    whereProperties: Record<string, T | Array<Record<string, T>>>,
     receivedProperties: Record<string, T>
 ): boolean {
     for (const [k, v] of Object.entries(whereProperties)) {
-        const { fieldName, operator } = parseFilterProperty(k);
-        const receivedValue = receivedProperties[fieldName];
-        const fieldMeta = node.primitiveFields.find((f) => f.fieldName === fieldName);
-        const checkFilterPasses = getFilteringFn(operator);
-        if (!checkFilterPasses(receivedValue, v, fieldMeta)) {
-            return false;
+        if (Object.keys(multipleConditionsAggregationMap).includes(k)) {
+            const comparisonResultsAggregationFn = multipleConditionsAggregationMap[k];
+            if (!comparisonResultsAggregationFn) {
+                return false;
+            }
+            const comparisonResults = (v as Array<Record<string, T>>).map((whereCl) => {
+                return filterByProperties(node, whereCl, receivedProperties);
+            });
+            if (!comparisonResultsAggregationFn(comparisonResults)) {
+                return false;
+            }
+        } else {
+            const { fieldName, operator } = parseFilterProperty(k);
+            const receivedValue = receivedProperties[fieldName];
+            const fieldMeta = node.primitiveFields.find((f) => f.fieldName === fieldName);
+            const checkFilterPasses = getFilteringFn(operator);
+            if (!checkFilterPasses(receivedValue, v, fieldMeta)) {
+                return false;
+            }
         }
     }
     return true;

--- a/packages/graphql/src/schema/resolvers/subscriptions/utils/compare-properties.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/utils/compare-properties.ts
@@ -179,9 +179,6 @@ export function filterByProperties<T>(
     for (const [k, v] of Object.entries(whereProperties)) {
         if (Object.keys(multipleConditionsAggregationMap).includes(k)) {
             const comparisonResultsAggregationFn = multipleConditionsAggregationMap[k];
-            if (!comparisonResultsAggregationFn) {
-                return false;
-            }
             const comparisonResults = (v as Array<Record<string, T>>).map((whereCl) => {
                 return filterByProperties(node, whereCl, receivedProperties);
             });

--- a/packages/graphql/src/schema/subscriptions/generate-subscription-where-type.ts
+++ b/packages/graphql/src/schema/subscriptions/generate-subscription-where-type.ts
@@ -22,7 +22,8 @@ import type { Node } from "../../classes";
 import { objectFieldsToSubscriptionsWhereInputFields } from "../to-compose";
 
 export function generateSubscriptionWhereType(node: Node, schemaComposer: SchemaComposer): InputTypeComposer {
-    const whereFields = objectFieldsToSubscriptionsWhereInputFields([
+    const typeName = node.name;
+    const whereFields = objectFieldsToSubscriptionsWhereInputFields(typeName, [
         ...node.primitiveFields,
         ...node.enumFields,
         ...node.scalarFields,

--- a/packages/graphql/src/schema/to-compose.ts
+++ b/packages/graphql/src/schema/to-compose.ts
@@ -109,43 +109,47 @@ export function objectFieldsToCreateInputFields(fields: BaseField[]): Record<str
         }, {} as Record<string, InputField>);
 }
 
-export function objectFieldsToSubscriptionsWhereInputFields(fields: BaseField[]): Record<string, InputField> {
+export function objectFieldsToSubscriptionsWhereInputFields(
+    typeName: string,
+    fields: BaseField[]
+): Record<string, InputField> {
     return fields.reduce((res, f) => {
         const fieldType = f.typeMeta.input.update.pretty;
 
-        res[f.fieldName] = fieldType;
-        res[`${f.fieldName}_NOT`] = fieldType;
+        const ifArrayOfAnyTypeExceptBoolean = f.typeMeta.array && f.typeMeta.name !== "Boolean";
+        const ifAnyTypeExceptArrayAndBoolean = !f.typeMeta.array && f.typeMeta.name !== "Boolean";
+        const isOneOfNumberTypes = ["Int", "Float", "BigInt"].includes(f.typeMeta.name) && !f.typeMeta.array;
+        const isOneOfStringTypes = ["String", "ID"].includes(f.typeMeta.name) && !f.typeMeta.array;
 
-        if (f.typeMeta.array && f.typeMeta.name !== "Boolean") {
-            // expecting single value, not array
-            res[`${f.fieldName}_INCLUDES`] = f.typeMeta.name;
-            res[`${f.fieldName}_NOT_INCLUDES`] = f.typeMeta.name;
-            return res;
-        }
-
-        if (f.typeMeta.name !== "Boolean") {
-            // expecting array of values, not single
-            res[`${f.fieldName}_IN`] = `[${f.typeMeta.name}]`;
-            res[`${f.fieldName}_NOT_IN`] = `[${f.typeMeta.name}]`;
-        }
-
-        if (["Int", "Float", "BigInt"].includes(f.typeMeta.name)) {
-            res[`${f.fieldName}_LT`] = fieldType;
-            res[`${f.fieldName}_LTE`] = fieldType;
-            res[`${f.fieldName}_GT`] = fieldType;
-            res[`${f.fieldName}_GTE`] = fieldType;
-        }
-
-        if (["String", "ID"].includes(f.typeMeta.name)) {
-            res[`${f.fieldName}_STARTS_WITH`] = fieldType;
-            res[`${f.fieldName}_NOT_STARTS_WITH`] = fieldType;
-            res[`${f.fieldName}_ENDS_WITH`] = fieldType;
-            res[`${f.fieldName}_NOT_ENDS_WITH`] = fieldType;
-            res[`${f.fieldName}_CONTAINS`] = fieldType;
-            res[`${f.fieldName}_NOT_CONTAINS`] = fieldType;
-        }
-
-        return res;
+        return {
+            ...res,
+            AND: `[${typeName}SubscriptionWhere!]`,
+            OR: `[${typeName}SubscriptionWhere!]`,
+            [f.fieldName]: fieldType,
+            [`${f.fieldName}_NOT`]: fieldType,
+            ...(ifArrayOfAnyTypeExceptBoolean && {
+                [`${f.fieldName}_INCLUDES`]: f.typeMeta.name,
+                [`${f.fieldName}_NOT_INCLUDES`]: f.typeMeta.name,
+            }),
+            ...(ifAnyTypeExceptArrayAndBoolean && {
+                [`${f.fieldName}_IN`]: `[${f.typeMeta.name}]`,
+                [`${f.fieldName}_NOT_IN`]: `[${f.typeMeta.name}]`,
+            }),
+            ...(isOneOfNumberTypes && {
+                [`${f.fieldName}_LT`]: fieldType,
+                [`${f.fieldName}_LTE`]: fieldType,
+                [`${f.fieldName}_GT`]: fieldType,
+                [`${f.fieldName}_GTE`]: fieldType,
+            }),
+            ...(isOneOfStringTypes && {
+                [`${f.fieldName}_STARTS_WITH`]: fieldType,
+                [`${f.fieldName}_NOT_STARTS_WITH`]: fieldType,
+                [`${f.fieldName}_ENDS_WITH`]: fieldType,
+                [`${f.fieldName}_NOT_ENDS_WITH`]: fieldType,
+                [`${f.fieldName}_CONTAINS`]: fieldType,
+                [`${f.fieldName}_NOT_CONTAINS`]: fieldType,
+            }),
+        };
     }, {});
 }
 

--- a/packages/graphql/src/utils/utils.ts
+++ b/packages/graphql/src/utils/utils.ts
@@ -35,6 +35,11 @@ export function isSameType<T>(a: T, b: unknown): b is T {
     return typeof a === typeof b && isObject(a) === isObject(b) && Array.isArray(a) === Array.isArray(b);
 }
 
+/** Checks if two objects have the number of properties */
+export function haveSameLength(o1: Record<string, any>, o2: Record<string, any>) {
+    return Object.keys(o1).length === Object.keys(o2).length;
+}
+
 /** Checks if value is a Neo4j int object */
 export function isNeoInt(value: unknown): value is Integer {
     return isInt(value);

--- a/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { generateUniqueType } from "../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../utils/TestSubscriptionPlugin";
@@ -31,14 +31,14 @@ import Neo4j from "../setup/neo4j";
 describe("Create Subscription", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-    const typeActor = generateUniqueType("Actor");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
+    let typeActor: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
+        typeActor = generateUniqueType("Actor");
         const typeDefs = `
          type ${typeMovie} {
              title: String

--- a/packages/graphql/tests/e2e/subscriptions/delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { generateUniqueType } from "../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../utils/TestSubscriptionPlugin";
@@ -31,14 +31,14 @@ import Neo4j from "../setup/neo4j";
 describe("Delete Subscription", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-    const typeActor = generateUniqueType("Actor");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
+    let typeActor: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
+        typeActor = generateUniqueType("Actor");
         const typeDefs = `
         type ${typeMovie} {
             title: String

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-array-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-array-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Create Subscription with optional filters valid for all types", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-number-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-number-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Create Subscription with filters valid of number types (Int, Float, BigInt)", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-string-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-string-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Create Subscription with filters valid on string types (String, ID)", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Create Subscription with optional filters valid for all types", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete-array-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete-array-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Create Subscription with optional filters valid for all types", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete-number-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete-number-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Delete Subscription", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
         type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete-string-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete-string-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Delete Subscription", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
         type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Delete Subscription", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
         type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete.e2e.test.ts
@@ -155,6 +155,273 @@ describe("Delete Subscription", () => {
         expect(wsClient.events).toEqual([]);
     });
 
+    test("create subscription with where OR", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { OR: [{ title: "movie1"}, {title: "movie2"}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie1" },
+                },
+            },
+
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie2" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where AND match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { AND: [{ title: "movie2"}, {releasedIn: 2000}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie2" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where OR match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { OR: [{ title: "movie2", releasedIn: 2020}, {releasedIn: 2000}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie2" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where OR match 2", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { OR: [{ title: "movie2", releasedIn: 2000}, {title: "movie1", releasedIn: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie1" },
+                },
+            },
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie2" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { title: "movie3", OR: [{ releasedIn: 2001}, {title: "movie2", releasedIn: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+        await createMovie({ title: "movie3", releasedIn: 2001 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+        await deleteMovie("title", "movie3");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "movie3" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR match nothing", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { title: "movie2", OR: [{ releasedIn: 2001}, {title: "movie2", releasedIn: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+        await createMovie({ title: "movie3", releasedIn: 2001 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+        await deleteMovie("title", "movie3");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toEqual([]);
+    });
+    test("create subscription with where property + OR with filters match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { releasedIn_GTE: 2000, OR: [{ title_NOT_STARTS_WITH: "movie", releasedIn: 2001}, {title: "movie4", releasedIn: 1000}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2000 });
+        await createMovie({ title: "movie2", releasedIn: 2020 });
+        await createMovie({ title: "movie3", releasedIn: 2000 });
+        await createMovie({ title: "movie4", releasedIn: 1000 });
+        await createMovie({ title: "dummy-movie", releasedIn: 2001 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "movie2");
+        await deleteMovie("title", "movie3");
+        await deleteMovie("title", "movie4");
+        await deleteMovie("title", "dummy-movie");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "dummy-movie" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR with filters match 2", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { releasedIn_GTE: 2000, OR: [{ title_STARTS_WITH: "moviee", releasedIn: 2001}, {title: "amovie"}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2000 });
+        await createMovie({ title: "amovie", releasedIn: 2020 });
+        await createMovie({ title: "movie3", releasedIn: 2000 });
+        await createMovie({ title: "movie4", releasedIn: 1000 });
+        await createMovie({ title: "movie5", releasedIn: 2001 });
+        await createMovie({ title: "moviee1", releasedIn: 2001 });
+        await createMovie({ title: "moviee2", releasedIn: 2021 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "amovie");
+        await deleteMovie("title", "movie3");
+        await deleteMovie("title", "movie4");
+        await deleteMovie("title", "movie5");
+        await deleteMovie("title", "moviee1");
+        await deleteMovie("title", "moviee2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "moviee1" },
+                },
+            },
+            {
+                [typeMovie.operations.subscribe.deleted]: {
+                    [typeMovie.operations.subscribe.payload.deleted]: { title: "amovie" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR with filters match none", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.deleted}(where: { releasedIn_GTE: 2000, OR: [{ title_STARTS_WITH: "moviee", releasedIn: 2001}, {title: "amovie", releasedIn_GT: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.deleted} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2000 });
+        await createMovie({ title: "amovie", releasedIn: 2019 });
+        await createMovie({ title: "movie3", releasedIn: 2000 });
+        await createMovie({ title: "movie4", releasedIn: 1000 });
+        await createMovie({ title: "movie5", releasedIn: 2001 });
+        await createMovie({ title: "moviee2", releasedIn: 2021 });
+
+        await deleteMovie("title", "movie1");
+        await deleteMovie("title", "amovie");
+        await deleteMovie("title", "movie3");
+        await deleteMovie("title", "movie4");
+        await deleteMovie("title", "movie5");
+        await deleteMovie("title", "moviee2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([]);
+    });
+
     // all but boolean types
     test("subscription with IN on String", async () => {
         await wsClient.subscribe(`

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update-array-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update-array-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Create Subscription with optional filters valid for all types", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update-number-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update-number-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Update Subscriptions", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update-string-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update-string-filters.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,13 +31,12 @@ import Neo4j from "../../setup/neo4j";
 describe("Update Subscriptions", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
         const typeDefs = `
          type ${typeMovie} {
             id: ID

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { generateUniqueType } from "../../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
@@ -31,14 +31,14 @@ import Neo4j from "../../setup/neo4j";
 describe("Update Subscriptions", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-    const typeActor = generateUniqueType("Actor");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
+    let typeActor: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
+        typeActor = generateUniqueType("Actor");
         const typeDefs = `
          type ${typeMovie} {
             id: ID
@@ -675,7 +675,7 @@ describe("Update Subscriptions", () => {
     test("subscription with IN on Int", async () => {
         await wsClient.subscribe(`
             subscription {
-                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_IN: [2023, 2021] }) {
+                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_IN: [2020, 2021] }) {
                     ${typeMovie.operations.subscribe.payload.updated} {
                         releasedIn
                     }
@@ -683,11 +683,11 @@ describe("Update Subscriptions", () => {
             }
         `);
 
-        await createMovie({ releasedIn: 2023 });
+        await createMovie({ releasedIn: 2020 });
         await createMovie({ releasedIn: 2022 });
 
-        await updateMovie("releasedIn", 2023, 2022);
-        await updateMovie("releasedIn", 2022, 2023);
+        await updateMovie("releasedIn", 2020, 2022);
+        await updateMovie("releasedIn", 2022, 2020);
 
         expect(wsClient.errors).toEqual([]);
         expect(wsClient.events).toEqual([
@@ -840,10 +840,10 @@ describe("Update Subscriptions", () => {
             }
         `);
 
-        await createMovie({ releasedIn: 2033 });
+        await createMovie({ releasedIn: 2001 });
         await createMovie({ releasedIn: 2000 });
 
-        await updateMovie("releasedIn", 2033, 2000);
+        await updateMovie("releasedIn", 2001, 2000);
         await updateMovie("releasedIn", 2000, 2021);
 
         expect(wsClient.errors).toEqual([]);

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update.e2e.test.ts
@@ -154,6 +154,273 @@ describe("Update Subscriptions", () => {
         expect(wsClient.events).toEqual([]);
     });
 
+    test("create subscription with where OR", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { OR: [{ title: "movie1"}, {title: "movie2"}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await updateMovie("title", "movie1", "movie1.1");
+        await updateMovie("title", "movie2", "movie1.2");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie1.1" },
+                },
+            },
+
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie1.2" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where AND match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { AND: [{ title: "movie2"}, {releasedIn: 2000}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await updateMovie("title", "movie1", "movie1.3");
+        await updateMovie("title", "movie2", "movie1.4");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie1.4" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where OR match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { OR: [{ title: "movie2", releasedIn: 2020}, {releasedIn: 2000}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await updateMovie("title", "movie1", "movie1.5");
+        await updateMovie("title", "movie2", "movie1.6");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie1.6" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where OR match 2", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { OR: [{ title: "movie2", releasedIn: 2000}, {title: "movie1", releasedIn: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+
+        await updateMovie("title", "movie1", "movie1.7");
+        await updateMovie("title", "movie2", "movie1.8");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie1.7" },
+                },
+            },
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie1.8" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { title: "movie3", OR: [{ releasedIn: 2001}, {title: "movie2", releasedIn: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+        await createMovie({ title: "movie3", releasedIn: 2001 });
+
+        await updateMovie("title", "movie1", "movie4");
+        await updateMovie("title", "movie2", "movie5");
+        await updateMovie("title", "movie3", "movie6");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie6" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR match nothing", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { title: "movie2", OR: [{ releasedIn: 2001}, {title: "movie2", releasedIn: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2020 });
+        await createMovie({ title: "movie2", releasedIn: 2000 });
+        await createMovie({ title: "movie3", releasedIn: 2001 });
+
+        await updateMovie("title", "movie1", "movie4");
+        await updateMovie("title", "movie2", "movie5");
+        await updateMovie("title", "movie3", "movie6");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toEqual([]);
+    });
+    test("create subscription with where property + OR with filters match 1", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_GTE: 2000, OR: [{ title_NOT_STARTS_WITH: "movie", releasedIn: 2001}, {title: "movie4", releasedIn: 1000}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2000 });
+        await createMovie({ title: "movie2", releasedIn: 2020 });
+        await createMovie({ title: "movie3", releasedIn: 2000 });
+        await createMovie({ title: "movie4", releasedIn: 1000 });
+        await createMovie({ title: "dummy-movie", releasedIn: 2001 });
+
+        await updateMovie("title", "movie1", "movie5");
+        await updateMovie("title", "movie2", "movie6");
+        await updateMovie("title", "movie3", "movie7");
+        await updateMovie("title", "movie4", "movie8");
+        await updateMovie("title", "dummy-movie", "movie9");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie9" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR with filters match 2", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_GTE: 2000, OR: [{ title_STARTS_WITH: "moviee", releasedIn: 2001}, {title: "amovie"}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2000 });
+        await createMovie({ title: "amovie", releasedIn: 2020 });
+        await createMovie({ title: "movie3", releasedIn: 2000 });
+        await createMovie({ title: "movie4", releasedIn: 1000 });
+        await createMovie({ title: "movie5", releasedIn: 2001 });
+        await createMovie({ title: "moviee1", releasedIn: 2001 });
+        await createMovie({ title: "moviee2", releasedIn: 2021 });
+
+        await updateMovie("title", "movie1", "movie6");
+        await updateMovie("title", "amovie", "movie7");
+        await updateMovie("title", "movie3", "movie8");
+        await updateMovie("title", "movie4", "movie9");
+        await updateMovie("title", "movie5", "movie10");
+        await updateMovie("title", "moviee1", "movie11");
+        await updateMovie("title", "moviee2", "movie12");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie11" },
+                },
+            },
+            {
+                [typeMovie.operations.subscribe.updated]: {
+                    [typeMovie.operations.subscribe.payload.updated]: { title: "movie7" },
+                },
+            },
+        ]);
+    });
+    test("create subscription with where property + OR with filters match none", async () => {
+        await wsClient.subscribe(`
+            subscription {
+                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_GTE: 2000, OR: [{ title_STARTS_WITH: "moviee", releasedIn: 2001}, {title: "amovie", releasedIn_GT: 2020}] }) {
+                    ${typeMovie.operations.subscribe.payload.updated} {
+                        title
+                    }
+                }
+            }
+        `);
+
+        await createMovie({ title: "movie1", releasedIn: 2000 });
+        await createMovie({ title: "amovie", releasedIn: 2019 });
+        await createMovie({ title: "movie3", releasedIn: 2000 });
+        await createMovie({ title: "movie4", releasedIn: 1000 });
+        await createMovie({ title: "movie5", releasedIn: 2001 });
+        await createMovie({ title: "moviee2", releasedIn: 2021 });
+
+        await updateMovie("title", "movie1", "movie6");
+        await updateMovie("title", "amovie", "movie7");
+        await updateMovie("title", "movie3", "movie8");
+        await updateMovie("title", "movie4", "movie9");
+        await updateMovie("title", "movie5", "movie10");
+        await updateMovie("title", "moviee2", "movie11");
+
+        expect(wsClient.errors).toEqual([]);
+        expect(wsClient.events).toIncludeSameMembers([]);
+    });
+
     // all but boolean types
     test("subscription with IN on String", async () => {
         await wsClient.subscribe(`
@@ -241,7 +508,7 @@ describe("Update Subscriptions", () => {
     test("subscription with IN on Int", async () => {
         await wsClient.subscribe(`
             subscription {
-                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_IN: [2020, 2021] }) {
+                ${typeMovie.operations.subscribe.updated}(where: { releasedIn_IN: [2023, 2021] }) {
                     ${typeMovie.operations.subscribe.payload.updated} {
                         releasedIn
                     }
@@ -249,11 +516,11 @@ describe("Update Subscriptions", () => {
             }
         `);
 
-        await createMovie({ releasedIn: 2020 });
+        await createMovie({ releasedIn: 2023 });
         await createMovie({ releasedIn: 2022 });
 
-        await updateMovie("releasedIn", 2020, 2022);
-        await updateMovie("releasedIn", 2022, 2021);
+        await updateMovie("releasedIn", 2023, 2022);
+        await updateMovie("releasedIn", 2022, 2023);
 
         expect(wsClient.errors).toEqual([]);
         expect(wsClient.events).toEqual([
@@ -406,10 +673,10 @@ describe("Update Subscriptions", () => {
             }
         `);
 
-        await createMovie({ releasedIn: 2001 });
+        await createMovie({ releasedIn: 2033 });
         await createMovie({ releasedIn: 2000 });
 
-        await updateMovie("releasedIn", 2001, 2000);
+        await updateMovie("releasedIn", 2033, 2000);
         await updateMovie("releasedIn", 2000, 2021);
 
         expect(wsClient.errors).toEqual([]);

--- a/packages/graphql/tests/e2e/subscriptions/update.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/update.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { generateUniqueType } from "../../utils/graphql-types";
+import { generateUniqueType, UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
 import { TestSubscriptionsPlugin } from "../../utils/TestSubscriptionPlugin";
@@ -31,14 +31,14 @@ import Neo4j from "../setup/neo4j";
 describe("Update Subscriptions", () => {
     let neo4j: Neo4j;
     let driver: Driver;
-
-    const typeMovie = generateUniqueType("Movie");
-    const typeActor = generateUniqueType("Actor");
-
     let server: TestGraphQLServer;
     let wsClient: WebSocketTestClient;
+    let typeMovie: UniqueType;
+    let typeActor: UniqueType;
 
     beforeEach(async () => {
+        typeMovie = generateUniqueType("Movie");
+        typeActor = generateUniqueType("Actor");
         const typeDefs = `
          type ${typeMovie} {
             title: String

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -114,6 +114,8 @@ describe("Subscriptions", () => {
             }
 
             input ActorSubscriptionWhere {
+              AND: [ActorSubscriptionWhere!]
+              OR: [ActorSubscriptionWhere!]
               name: String
               name_CONTAINS: String
               name_ENDS_WITH: String
@@ -391,6 +393,8 @@ describe("Subscriptions", () => {
             }
 
             input MovieSubscriptionWhere {
+              AND: [MovieSubscriptionWhere!]
+              OR: [MovieSubscriptionWhere!]
               actorCount: Int
               actorCount_GT: Int
               actorCount_GTE: Int
@@ -1031,6 +1035,8 @@ describe("Subscriptions", () => {
             }
 
             input MovieSubscriptionWhere {
+              AND: [MovieSubscriptionWhere!]
+              OR: [MovieSubscriptionWhere!]
               actorCount: Int
               actorCount_GT: Int
               actorCount_GTE: Int
@@ -1284,6 +1290,8 @@ describe("Subscriptions", () => {
             }
 
             input ActorSubscriptionWhere {
+              AND: [ActorSubscriptionWhere!]
+              OR: [ActorSubscriptionWhere!]
               name: String
               name_CONTAINS: String
               name_ENDS_WITH: String


### PR DESCRIPTION
# Description

Allows for combining filters using AND/ OR for subscriptions.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
