### PR TITLE
Fix incorrect WITH in CALL statements

### DIFF
--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -433,16 +433,16 @@ export default function createUpdateAndParams({
                     subqueries.push(subquery.join("\n"));
                 }
             });
-
             if (relationField.interface) {
                 res.strs.push(`WITH ${withVars.join(", ")}`);
                 res.strs.push("CALL {");
-                res.strs.push(subqueries.join("\n}\nCALL {\n\t"));
+                res.strs.push(subqueries.join(`\n}\nCALL {\n\t WITH ${withVars.join(", ")}\n\t`));
                 res.strs.push("}");
             } else {
                 res.strs.push(subqueries.join("\n"));
             }
 
+            console.log(res.strs);
             return res;
         }
 
@@ -582,7 +582,6 @@ export default function createUpdateAndParams({
         strs: [],
         params: {},
     });
-
     const { strs, meta = { preArrayMethodValidationStrs: [], preAuthStrs: [], postAuthStrs: [] } } = reducedUpdate;
     let params = reducedUpdate.params;
 

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -232,6 +232,7 @@ describe("@auth allow on specific interface implementation", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             CALL apoc.do.when(this_content0 IS NOT NULL, \\"

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -251,6 +251,7 @@ describe("@auth allow with interface relationships", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             CALL apoc.do.when(this_content0 IS NOT NULL, \\"

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -289,6 +289,7 @@ describe("Cypher Auth Allow", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             WHERE this_content0.id = $updateUsers_args_update_content0_where_Postparam0

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
@@ -206,6 +206,7 @@ describe("Cypher Auth Allow", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             WHERE this_content0.id = $updateUsers_args_update_content0_where_Postparam0

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -422,6 +422,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
@@ -746,6 +747,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this
@@ -812,6 +814,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this
@@ -990,6 +993,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this
@@ -1052,6 +1056,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -428,6 +428,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
@@ -756,6 +757,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this
@@ -822,6 +824,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this
@@ -1002,6 +1005,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this
@@ -1064,6 +1068,7 @@ describe("Cypher Auth Where", () => {
             RETURN count(*) AS update_this_Comment
             }
             CALL {
+            	 WITH this
             	WITH this
             WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
             WITH this

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
@@ -97,6 +97,7 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*) AS update_this_Movie
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_Seriesparam0
@@ -188,6 +189,7 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*) AS update_this_Movie
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_Seriesparam0
@@ -295,6 +297,7 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*) AS update_this_Movie
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_Seriesparam0
@@ -402,6 +405,7 @@ describe("Interface Relationships - Update update", () => {
             RETURN count(*) AS update_this_Movie
             }
             CALL {
+            	 WITH this
             	WITH this
             OPTIONAL MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
             WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_Seriesparam0


### PR DESCRIPTION
# Description
This PR add an extra `WITH` inside update `CALL` subqueries, to avoid errors related incompatible import with and normal `WITH`