### PR TITLE
2189 cypher directive seems to force query to omit results with missing fields

### DIFF
--- a/.changeset/smooth-panthers-nail.md
+++ b/.changeset/smooth-panthers-nail.md
@@ -2,4 +2,4 @@
 "@neo4j/graphql": patch
 ---
 
-Fix #2189: @cypher directive forcefuly omits empty fields
+Fix #2189: `@cypher` directive forcefuly omits empty fields

--- a/.changeset/smooth-panthers-nail.md
+++ b/.changeset/smooth-panthers-nail.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix #2189: @cypher directive forcefuly omits empty fields

--- a/packages/graphql/src/translate/projection/subquery/translate-cypher-directive-projection.ts
+++ b/packages/graphql/src/translate/projection/subquery/translate-cypher-directive-projection.ts
@@ -243,8 +243,9 @@ function createReturnClause({
     projectionExpr: CypherBuilder.Expr | undefined;
 }): CypherBuilder.Return {
     let returnData: CypherBuilder.Expr = projectionExpr || returnVariable;
-    if (isArray) {
-        returnData = CypherBuilder.collect(returnData);
+    returnData = CypherBuilder.collect(returnData);
+    if (!isArray) {
+        returnData = CypherBuilder.head(returnData);
     }
     return new CypherBuilder.Return([returnData, returnVariable]);
 }

--- a/packages/graphql/tests/integration/issues/2189.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2189.int.test.ts
@@ -1,0 +1,339 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { generateUniqueType, UniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/2189", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neoSchema: Neo4jGraphQL;
+
+    let Test_Item: UniqueType;
+    let Test_Feedback: UniqueType;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(() => {
+        Test_Item = generateUniqueType("Test_Item");
+        Test_Feedback = generateUniqueType("Test_Feedback");
+
+        const typeDefs = `
+            type ${Test_Item} {
+                uuid: ID! @id
+                int: Int
+                str: String
+                bool: Boolean
+
+                feedback: ${Test_Feedback} @relationship(type: "TEST_RELATIONSHIP", direction: IN)
+                feedbackCypher: ${Test_Feedback}
+                    @cypher(
+                        statement: """
+                        OPTIONAL MATCH (this)<-[:TEST_RELATIONSHIP]-(t:${Test_Feedback})
+                        RETURN t
+                        LIMIT 1
+                        """
+                    )
+            }
+            type ${Test_Feedback} {
+                uuid: ID! @id
+                int: Int
+                str: String
+                bool: Boolean
+
+                item: ${Test_Item} @relationship(type: "TEST_RELATIONSHIP", direction: OUT)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+        });
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("Mutation followed by query with Cypher field should return 2 nodes", async () => {
+        const session = await neo4j.getSession();
+
+        const mutation = `
+            mutation {
+                ${Test_Item.operations.create}(
+                    input: [
+                        { feedback: { create: { node: { str: "hi there" } } }, int: 1, str: "one", bool: false }
+                        { int: 2, str: "two", bool: true }
+                    ]
+                ) {
+                    info {
+                        relationshipsCreated
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const query = `
+            query FeedbackCypher {
+                ${Test_Item.plural} {
+                    bool
+                    int
+                    str
+                    uuid
+                    feedbackCypher {
+                        bool
+                        str
+                        int
+                        uuid
+                    }
+                    feedback {
+                        uuid
+                        int
+                        str
+                        bool
+                    }
+                }
+            }
+        `;
+
+        try {
+            const mutationResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: mutation,
+                contextValue: neo4j.getContextValues(),
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+            expect((mutationResult?.data as any)[Test_Item.operations.create].info).toEqual({
+                relationshipsCreated: 1,
+                nodesCreated: 3,
+            });
+
+            const queryResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues(),
+            });
+
+            expect(queryResult.errors).toBeFalsy();
+            expect((queryResult?.data as any)[Test_Item.plural]).toHaveLength(2);
+            expect(
+                (queryResult?.data as any)[Test_Item.plural].filter((t) => t.str === "one")[0].feedbackCypher.str
+            ).toBe("hi there");
+            expect(
+                (queryResult?.data as any)[Test_Item.plural].filter((t) => t.str == "two")[0].feedbackCypher
+            ).toBeNull();
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("Mutation followed by query without Cypher field should return 2 nodes", async () => {
+        const session = await neo4j.getSession();
+
+        const mutation = `
+            mutation {
+                ${Test_Item.operations.create}(
+                    input: [
+                        { feedback: { create: { node: { str: "hi there" } } }, int: 1, str: "one", bool: false }
+                        { int: 2, str: "two", bool: true }
+                    ]
+                ) {
+                    info {
+                        relationshipsCreated
+                        nodesCreated
+                    }
+                }
+            }
+        `;
+
+        const query = `
+            query FeedbackCypher {
+                ${Test_Item.plural} {
+                    bool
+                    int
+                    str
+                    uuid
+                    feedback {
+                        uuid
+                        int
+                        str
+                        bool
+                    }
+                }
+            }
+        `;
+
+        try {
+            const mutationResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: mutation,
+                contextValue: neo4j.getContextValues(),
+            });
+
+            expect(mutationResult.errors).toBeFalsy();
+            expect((mutationResult?.data as any)[Test_Item.operations.create].info).toEqual({
+                relationshipsCreated: 1,
+                nodesCreated: 3,
+            });
+
+            const queryResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues(),
+            });
+
+            expect(queryResult.errors).toBeFalsy();
+            expect((queryResult?.data as any)[Test_Item.plural]).toHaveLength(2);
+            expect((queryResult?.data as any)[Test_Item.plural].filter((t) => t.str === "one")[0].feedback.str).toBe(
+                "hi there"
+            );
+            expect((queryResult?.data as any)[Test_Item.plural].filter((t) => t.str == "two")[0].feedback).toBeNull();
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("Mutation with Cypher relationship in projection should return 2 nodes", async () => {
+        const session = await neo4j.getSession();
+
+        const query = `
+            mutation {
+                ${Test_Item.operations.create}(
+                    input: [
+                        { feedback: { create: { node: { str: "hi there" } } }, int: 1, str: "one", bool: false }
+                        { int: 2, str: "two", bool: true }
+                    ]
+                ) {
+                    info {
+                        relationshipsCreated
+                        nodesCreated
+                    }
+                    ${Test_Item.plural} {
+                        bool
+                        int
+                        str
+                        uuid
+                        feedbackCypher {
+                            bool
+                            str
+                            int
+                            uuid
+                        }
+                        feedback {
+                            uuid
+                            int
+                            str
+                            bool
+                        }
+                    }
+                }
+            }
+        `;
+
+        try {
+            const result = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues(),
+            });
+
+            expect(result.errors).toBeFalsy();
+            expect((result?.data as any)[Test_Item.operations.create].info).toEqual({
+                relationshipsCreated: 1,
+                nodesCreated: 3,
+            });
+            expect((result?.data as any)[Test_Item.operations.create][Test_Item.plural]).toHaveLength(2);
+            expect(
+                (result?.data as any)[Test_Item.operations.create][Test_Item.plural].filter((t) => t.str === "one")[0]
+                    .feedbackCypher.str
+            ).toBe("hi there");
+            expect(
+                (result?.data as any)[Test_Item.operations.create][Test_Item.plural].filter((t) => t.str == "two")[0]
+                    .feedbackCypher
+            ).toBeNull();
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("Mutation without Cypher relationship in projection should return 2 nodes", async () => {
+        const session = await neo4j.getSession();
+
+        const query = `
+            mutation {
+                ${Test_Item.operations.create}(
+                    input: [
+                        { feedback: { create: { node: { str: "hi there" } } }, int: 1, str: "one", bool: false }
+                        { int: 2, str: "two", bool: true }
+                    ]
+                ) {
+                    info {
+                        relationshipsCreated
+                        nodesCreated
+                    }
+                    ${Test_Item.plural} {
+                        bool
+                        int
+                        str
+                        uuid
+                        feedback {
+                            uuid
+                            int
+                            str
+                            bool
+                        }
+                    }
+                }
+            }
+        `;
+
+        try {
+            const result = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues(),
+            });
+
+            expect(result.errors).toBeFalsy();
+            expect((result?.data as any)[Test_Item.operations.create].info).toEqual({
+                relationshipsCreated: 1,
+                nodesCreated: 3,
+            });
+            expect((result?.data as any)[Test_Item.operations.create][Test_Item.plural]).toHaveLength(2);
+            expect(
+                (result?.data as any)[Test_Item.operations.create][Test_Item.plural].filter((t) => t.str === "one")[0]
+                    .feedback.str
+            ).toBe("hi there");
+            expect(
+                (result?.data as any)[Test_Item.operations.create][Test_Item.plural].filter((t) => t.str == "two")[0]
+                    .feedback
+            ).toBeNull();
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/tck/directives/cypher.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher.test.ts
@@ -136,7 +136,7 @@ describe("Cypher directive", () => {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
                 RETURN a\\", { this: this, auth: $auth }) AS this_topActor
-                RETURN this_topActor { .name } AS this_topActor
+                RETURN head(collect(this_topActor { .name })) AS this_topActor
             }
             RETURN this { .title, topActor: this_topActor } as this"
         `);
@@ -170,7 +170,7 @@ describe("Cypher directive", () => {
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"RETURN rand()\\", { this: this, auth: $auth }) AS this_randomNumber
-                RETURN this_randomNumber AS this_randomNumber
+                RETURN head(collect(this_randomNumber)) AS this_randomNumber
             }
             RETURN this { randomNumber: this_randomNumber } as this"
         `);
@@ -206,7 +206,7 @@ describe("Cypher directive", () => {
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"RETURN rand()\\", { this: this, auth: $auth }) AS this_randomNumber
-                RETURN this_randomNumber AS this_randomNumber
+                RETURN head(collect(this_randomNumber)) AS this_randomNumber
             }
             RETURN this { randomNumber: this_randomNumber } as this"
         `);
@@ -244,7 +244,7 @@ describe("Cypher directive", () => {
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"RETURN rand()\\", { this: this, auth: $auth }) AS this_randomNumber
-                RETURN this_randomNumber AS this_randomNumber
+                RETURN head(collect(this_randomNumber)) AS this_randomNumber
             }
             WITH *
             ORDER BY this_randomNumber ASC
@@ -298,7 +298,7 @@ describe("Cypher directive", () => {
                     RETURN m\\", { title: $thisparam1, this: this_topActor, auth: $auth }) AS this_topActor_movies
                     RETURN collect(this_topActor_movies { .title }) AS this_topActor_movies
                 }
-                RETURN this_topActor { .name, movies: this_topActor_movies } AS this_topActor
+                RETURN head(collect(this_topActor { .name, movies: this_topActor_movies })) AS this_topActor
             }
             RETURN this { .title, topActor: this_topActor } as this"
         `);
@@ -360,11 +360,11 @@ describe("Cypher directive", () => {
                             RETURN m\\", { title: $thisparam4, this: this_topActor_movies_topActor, auth: $auth }) AS this_topActor_movies_topActor_movies
                             RETURN collect(this_topActor_movies_topActor_movies { .title }) AS this_topActor_movies_topActor_movies
                         }
-                        RETURN this_topActor_movies_topActor { .name, movies: this_topActor_movies_topActor_movies } AS this_topActor_movies_topActor
+                        RETURN head(collect(this_topActor_movies_topActor { .name, movies: this_topActor_movies_topActor_movies })) AS this_topActor_movies_topActor
                     }
                     RETURN collect(this_topActor_movies { .title, topActor: this_topActor_movies_topActor }) AS this_topActor_movies
                 }
-                RETURN this_topActor { .name, movies: this_topActor_movies } AS this_topActor
+                RETURN head(collect(this_topActor { .name, movies: this_topActor_movies })) AS this_topActor
             }
             RETURN this { .title, topActor: this_topActor } as this"
         `);
@@ -413,7 +413,7 @@ describe("Cypher directive", () => {
                     RETURN m\\", { title: $thisparam1, this: this_topActor, auth: $auth }) AS this_topActor_movies
                     RETURN collect(this_topActor_movies { .title }) AS this_topActor_movies
                 }
-                RETURN this_topActor { .name, movies: this_topActor_movies } AS this_topActor
+                RETURN head(collect(this_topActor { .name, movies: this_topActor_movies })) AS this_topActor
             }
             RETURN this { .title, topActor: this_topActor } as this"
         `);
@@ -476,7 +476,7 @@ describe("Cypher directive", () => {
                     WITH this_movieOrTVShow_0
                     UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
                     RETURN a\\", { this: this_movieOrTVShow_0, auth: $auth }) AS this_movieOrTVShow_0_topActor
-                    RETURN this_movieOrTVShow_0_topActor { .name, .year } AS this_movieOrTVShow_0_topActor
+                    RETURN head(collect(this_movieOrTVShow_0_topActor { .name, .year })) AS this_movieOrTVShow_0_topActor
                 }
                 CALL {
                     WITH this_movieOrTVShow_0
@@ -489,7 +489,7 @@ describe("Cypher directive", () => {
                     WITH this_movieOrTVShow_1
                     UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (a:Actor)
                     RETURN a\\", { this: this_movieOrTVShow_1, auth: $auth }) AS this_movieOrTVShow_1_topActor
-                    RETURN this_movieOrTVShow_1_topActor { .name } AS this_movieOrTVShow_1_topActor
+                    RETURN head(collect(this_movieOrTVShow_1_topActor { .name })) AS this_movieOrTVShow_1_topActor
                 }
                 RETURN collect(CASE
                     WHEN this_movieOrTVShow:\`Movie\` THEN this_movieOrTVShow { __resolveType: \\"Movie\\",  .id, .title, topActor: this_movieOrTVShow_0_topActor, actors: this_movieOrTVShow_0_actors }

--- a/packages/graphql/tests/tck/issues/1364.test.ts
+++ b/packages/graphql/tests/tck/issues/1364.test.ts
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
                 RETURN count(DISTINCT genre)\\", { this: this, auth: $auth }) AS this_totalGenres
-                RETURN this_totalGenres AS this_totalGenres
+                RETURN head(collect(this_totalGenres)) AS this_totalGenres
             }
             WITH { node: this { .title, totalGenres: this_totalGenres } } as edge, totalCount, this
             ORDER BY this.title ASC
@@ -145,7 +145,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
                 RETURN count(DISTINCT genre)\\", { this: this, auth: $auth }) AS this_totalGenres
-                RETURN this_totalGenres AS this_totalGenres
+                RETURN head(collect(this_totalGenres)) AS this_totalGenres
             }
             WITH { node: this { .title, totalGenres: this_totalGenres } } as edge, totalCount, this
             ORDER BY edge.node.totalGenres ASC
@@ -182,13 +182,13 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
                 RETURN count(DISTINCT genre)\\", { this: this, auth: $auth }) AS this_totalGenres
-                RETURN this_totalGenres AS this_totalGenres
+                RETURN head(collect(this_totalGenres)) AS this_totalGenres
             }
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:ACTED_IN]-(actor:Actor)
                 RETURN count(DISTINCT actor)\\", { this: this, auth: $auth }) AS this_totalActors
-                RETURN this_totalActors AS this_totalActors
+                RETURN head(collect(this_totalActors)) AS this_totalActors
             }
             WITH { node: this { .title, totalGenres: this_totalGenres, totalActors: this_totalActors } } as edge, totalCount, this
             ORDER BY edge.node.totalGenres ASC

--- a/packages/graphql/tests/tck/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/issues/1528.test.ts
@@ -86,7 +86,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
                     WITH this_Movie
                     UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:ACTED_IN]-(ac:Person)
                     RETURN count(ac)\\", { this: this_Movie, auth: $auth }) AS this_Movie_actorsCount
-                    RETURN this_Movie_actorsCount AS this_Movie_actorsCount
+                    RETURN head(collect(this_Movie_actorsCount)) AS this_Movie_actorsCount
                 }
                 WITH { node: { title: this_Movie.title, actorsCount: this_Movie_actorsCount } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/1760.test.ts
+++ b/packages/graphql/tests/tck/issues/1760.test.ts
@@ -128,7 +128,7 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:HAS_BASE]-(n:BaseObject) RETURN n.id\\", { this: this, auth: $auth }) AS this_relatedId
-                RETURN this_relatedId AS this_relatedId
+                RETURN head(collect(this_relatedId)) AS this_relatedId
             }
             WITH *
             ORDER BY this_relatedId ASC

--- a/packages/graphql/tests/tck/issues/2100.test.ts
+++ b/packages/graphql/tests/tck/issues/2100.test.ts
@@ -123,7 +123,7 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
                     WITH this_bussing
                     UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:PRESENT_AT_SERVICE|ABSENT_FROM_SERVICE]-(member:Member)
                     RETURN COUNT(member) > 0 AS markedAttendance\\", { this: this_bussing, auth: $auth }) AS this_bussing_markedAttendance
-                    RETURN this_bussing_markedAttendance AS this_bussing_markedAttendance
+                    RETURN head(collect(this_bussing_markedAttendance)) AS this_bussing_markedAttendance
                 }
                 CALL {
                     WITH this_bussing

--- a/packages/graphql/tests/tck/issues/387.test.ts
+++ b/packages/graphql/tests/tck/issues/387.test.ts
@@ -88,12 +88,12 @@ describe("#387", () => {
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"return '' + ''\\", { this: this, auth: $auth }) AS this_url_works
-                RETURN this_url_works AS this_url_works
+                RETURN head(collect(this_url_works)) AS this_url_works
             }
             CALL {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"return '' + ''\\", { this: this, auth: $auth }) AS this_url_fails
-                RETURN this_url_fails AS this_url_fails
+                RETURN head(collect(this_url_fails)) AS this_url_fails
             }
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/sort.test.ts
+++ b/packages/graphql/tests/tck/sort.test.ts
@@ -164,7 +164,7 @@ describe("Cypher sort tests", () => {
                 WITH this
                 UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)-[:HAS_GENRE]->(genre:Genre)
                 RETURN count(DISTINCT genre)\\", { this: this, auth: $auth }) AS this_totalGenres
-                RETURN this_totalGenres AS this_totalGenres
+                RETURN head(collect(this_totalGenres)) AS this_totalGenres
             }
             WITH *
             ORDER BY this_totalGenres DESC
@@ -341,7 +341,7 @@ describe("Cypher sort tests", () => {
                     WITH this_genres
                     UNWIND apoc.cypher.runFirstColumnSingle(\\"MATCH (this)<-[:HAS_GENRE]-(movie:Movie)
                     RETURN count(DISTINCT movie)\\", { this: this_genres, auth: $auth }) AS this_genres_totalMovies
-                    RETURN this_genres_totalMovies AS this_genres_totalMovies
+                    RETURN head(collect(this_genres_totalMovies)) AS this_genres_totalMovies
                 }
                 WITH this_genres { .name, totalMovies: this_genres_totalMovies } AS this_genres
                 ORDER BY this_genres.totalMovies ASC


### PR DESCRIPTION
# Description
This PR fixes #2189 , introduced in 3.9.0 in which the nodes with empty `@cypher` fields are filtered out.