### PR TITLE
Fix count without alias in subqueries

### DIFF
--- a/packages/graphql/src/translate/create-connect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.test.ts
@@ -92,37 +92,37 @@ describe("createConnectAndParams", () => {
         });
 
         expect(result[0]).toMatchInlineSnapshot(`
-            "WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this0_node:Movie)
-            	WHERE this0_node.title = $this0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this0_node
-            		MERGE (this)-[:SIMILAR]->(this0_node)
-            		RETURN count(*)
-            	}
-            WITH this, this0_node
-            CALL {
-            	WITH this, this0_node
-            	OPTIONAL MATCH (this0_node_similarMovies0_node:Movie)
-            	WHERE this0_node_similarMovies0_node.title = $this0_node_similarMovies0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this0_node_similarMovies0_node) as connectedNodes, collect(this0_node) as parentNodes
-            		UNWIND parentNodes as this0_node
-            		UNWIND connectedNodes as this0_node_similarMovies0_node
-            		MERGE (this0_node)-[:SIMILAR]->(this0_node_similarMovies0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_node_similarMovies_Movie
-            }
-            	RETURN count(*) AS connect_this_Movie
-            }"
-        `);
+"WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this0_node:Movie)
+	WHERE this0_node.title = $this0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this0_node
+		MERGE (this)-[:SIMILAR]->(this0_node)
+		RETURN count(*) AS _
+	}
+WITH this, this0_node
+CALL {
+	WITH this, this0_node
+	OPTIONAL MATCH (this0_node_similarMovies0_node:Movie)
+	WHERE this0_node_similarMovies0_node.title = $this0_node_similarMovies0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this0_node_similarMovies0_node) as connectedNodes, collect(this0_node) as parentNodes
+		UNWIND parentNodes as this0_node
+		UNWIND connectedNodes as this0_node_similarMovies0_node
+		MERGE (this0_node)-[:SIMILAR]->(this0_node_similarMovies0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_node_similarMovies_Movie
+}
+	RETURN count(*) AS connect_this_Movie
+}"
+`);
 
         expect(result[1]).toMatchObject({
             this0_node_param0: "abc",

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -234,7 +234,7 @@ function createConnectAndParams({
             subquery.push(setA[0]);
             params = { ...params, ...setA[1] };
         }
-        subquery.push(`\t\tRETURN count(*)`);
+        subquery.push(`\t\tRETURN count(*) AS _`);
         subquery.push("\t}");
 
         if (includeRelationshipValidation) {

--- a/packages/graphql/src/translate/create-delete-and-params.ts
+++ b/packages/graphql/src/translate/create-delete-and-params.ts
@@ -234,7 +234,7 @@ function createDeleteAndParams({
                     res.strs.push(`\tWITH ${variableName}_to_delete`);
                     res.strs.push(`\tUNWIND ${variableName}_to_delete AS x`);
                     res.strs.push(`\tDETACH DELETE x`);
-                    res.strs.push("\tRETURN count(*)"); // Avoids CANNOT END WITH DETACH DELETE ERROR
+                    res.strs.push("\tRETURN count(*) AS _"); // Avoids CANNOT END WITH DETACH DELETE ERROR
                     res.strs.push("}");
                     // TODO - relationship validation
                 });

--- a/packages/graphql/src/translate/create-disconnect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.test.ts
@@ -104,35 +104,35 @@ describe("createDisconnectAndParams", () => {
         });
 
         expect(result[0]).toMatchInlineSnapshot(`
-            "WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this0_rel:SIMILAR]->(this0:Movie)
-            WHERE this0.title = $this0_where_Movieparam0
-            CALL {
-            	WITH this0, this0_rel
-            	WITH collect(this0) as this0, this0_rel
-            	UNWIND this0 as x
-            	DELETE this0_rel
-            	RETURN count(*)
-            }
-            WITH this, this0
-            CALL {
-            WITH this, this0
-            OPTIONAL MATCH (this0)-[this0_similarMovies0_rel:SIMILAR]->(this0_similarMovies0:Movie)
-            WHERE this0_similarMovies0.title = $this0_disconnect_similarMovies0_where_Movieparam0
-            CALL {
-            	WITH this0_similarMovies0, this0_similarMovies0_rel
-            	WITH collect(this0_similarMovies0) as this0_similarMovies0, this0_similarMovies0_rel
-            	UNWIND this0_similarMovies0 as x
-            	DELETE this0_similarMovies0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this0_similarMovies_Movie
-            }
-            RETURN count(*) AS disconnect_this_Movie
-            }"
-        `);
+"WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this0_rel:SIMILAR]->(this0:Movie)
+WHERE this0.title = $this0_where_Movieparam0
+CALL {
+	WITH this0, this0_rel
+	WITH collect(this0) as this0, this0_rel
+	UNWIND this0 as x
+	DELETE this0_rel
+	RETURN count(*) AS _
+}
+WITH this, this0
+CALL {
+WITH this, this0
+OPTIONAL MATCH (this0)-[this0_similarMovies0_rel:SIMILAR]->(this0_similarMovies0:Movie)
+WHERE this0_similarMovies0.title = $this0_disconnect_similarMovies0_where_Movieparam0
+CALL {
+	WITH this0_similarMovies0, this0_similarMovies0_rel
+	WITH collect(this0_similarMovies0) as this0_similarMovies0, this0_similarMovies0_rel
+	UNWIND this0_similarMovies0 as x
+	DELETE this0_similarMovies0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this0_similarMovies_Movie
+}
+RETURN count(*) AS disconnect_this_Movie
+}"
+`);
 
         expect(result[1]).toMatchObject({});
     });

--- a/packages/graphql/src/translate/create-disconnect-and-params.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.ts
@@ -163,8 +163,8 @@ function createDisconnectAndParams({
         subquery.push(`\tWITH collect(${variableName}) as ${variableName}, ${variableName}_rel`);
         subquery.push(`\tUNWIND ${variableName} as x`);
         subquery.push(`\tDELETE ${variableName}_rel`);
-        subquery.push(`\tRETURN count(*)`); // Avoids CANNOT END WITH DETACH DELETE ERROR
-        subquery.push(`}`); // close FOREACH
+        subquery.push(`\tRETURN count(*) AS _`); // Avoids CANNOT END WITH DETACH DELETE ERROR
+        subquery.push(`}`);
 
         // TODO - relationship validation - Blocking, if this were to be enforced it would stop someone from 'reconnecting'
 

--- a/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
@@ -82,37 +82,37 @@ describe("Relationship Properties Connect Cypher", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Movie)
-            SET this0.title = $this0_title
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_actors_connect0_node:Actor)
-            	CALL {
-            		WITH *
-            		WITH collect(this0_actors_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_actors_connect0_node
-            		MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
-            SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_actors_connect_Actor
-            }
-            RETURN this0
-            }
-            CALL {
-                WITH this0
-                MATCH (this0)<-[this0_connection_actorsConnectionthis0:ACTED_IN]-(this0_Actor:\`Actor\`)
-                WITH { screenTime: this0_connection_actorsConnectionthis0.screenTime, node: { name: this0_Actor.name } } AS edge
-                WITH collect(edge) AS edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS this0_actorsConnection
-            }
-            RETURN [
-            this0 { .title, actorsConnection: this0_actorsConnection }] AS data"
-        `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.title = $this0_title
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_actors_connect0_node:Actor)
+	CALL {
+		WITH *
+		WITH collect(this0_actors_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_actors_connect0_node
+		MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
+SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_actors_connect_Actor
+}
+RETURN this0
+}
+CALL {
+    WITH this0
+    MATCH (this0)<-[this0_connection_actorsConnectionthis0:ACTED_IN]-(this0_Actor:\`Actor\`)
+    WITH { screenTime: this0_connection_actorsConnectionthis0.screenTime, node: { name: this0_Actor.name } } AS edge
+    WITH collect(edge) AS edges
+    WITH edges, size(edges) AS totalCount
+    RETURN { edges: edges, totalCount: totalCount } AS this0_actorsConnection
+}
+RETURN [
+this0 { .title, actorsConnection: this0_actorsConnection }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -158,38 +158,38 @@ describe("Relationship Properties Connect Cypher", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Movie)
-            SET this0.title = $this0_title
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_actors_connect0_node:Actor)
-            	WHERE this0_actors_connect0_node.name = $this0_actors_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_actors_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_actors_connect0_node
-            		MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
-            SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_actors_connect_Actor
-            }
-            RETURN this0
-            }
-            CALL {
-                WITH this0
-                MATCH (this0)<-[this0_connection_actorsConnectionthis0:ACTED_IN]-(this0_Actor:\`Actor\`)
-                WITH { screenTime: this0_connection_actorsConnectionthis0.screenTime, node: { name: this0_Actor.name } } AS edge
-                WITH collect(edge) AS edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS this0_actorsConnection
-            }
-            RETURN [
-            this0 { .title, actorsConnection: this0_actorsConnection }] AS data"
-        `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.title = $this0_title
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_actors_connect0_node:Actor)
+	WHERE this0_actors_connect0_node.name = $this0_actors_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_actors_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_actors_connect0_node
+		MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
+SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_actors_connect_Actor
+}
+RETURN this0
+}
+CALL {
+    WITH this0
+    MATCH (this0)<-[this0_connection_actorsConnectionthis0:ACTED_IN]-(this0_Actor:\`Actor\`)
+    WITH { screenTime: this0_connection_actorsConnectionthis0.screenTime, node: { name: this0_Actor.name } } AS edge
+    WITH collect(edge) AS edges
+    WITH edges, size(edges) AS totalCount
+    RETURN { edges: edges, totalCount: totalCount } AS this0_actorsConnection
+}
+RETURN [
+this0 { .title, actorsConnection: this0_actorsConnection }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -229,34 +229,34 @@ describe("Relationship Properties Connect Cypher", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors0_node:Actor)
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors0_node
-            		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
-            SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_Actor
-            }
-            WITH *
-            CALL {
-                WITH this
-                MATCH (this)<-[this_connection_actorsConnectionthis0:ACTED_IN]-(this_Actor:\`Actor\`)
-                WITH { screenTime: this_connection_actorsConnectionthis0.screenTime, node: { name: this_Actor.name } } AS edge
-                WITH collect(edge) AS edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS this_actorsConnection
-            }
-            RETURN collect(DISTINCT this { .title, actorsConnection: this_actorsConnection }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors0_node:Actor)
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors0_node
+		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_Actor
+}
+WITH *
+CALL {
+    WITH this
+    MATCH (this)<-[this_connection_actorsConnectionthis0:ACTED_IN]-(this_Actor:\`Actor\`)
+    WITH { screenTime: this_connection_actorsConnectionthis0.screenTime, node: { name: this_Actor.name } } AS edge
+    WITH collect(edge) AS edges
+    WITH edges, size(edges) AS totalCount
+    RETURN { edges: edges, totalCount: totalCount } AS this_actorsConnection
+}
+RETURN collect(DISTINCT this { .title, actorsConnection: this_actorsConnection }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -298,35 +298,35 @@ describe("Relationship Properties Connect Cypher", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors0_node:Actor)
-            	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors0_node
-            		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
-            SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_Actor
-            }
-            WITH *
-            CALL {
-                WITH this
-                MATCH (this)<-[this_connection_actorsConnectionthis0:ACTED_IN]-(this_Actor:\`Actor\`)
-                WITH { screenTime: this_connection_actorsConnectionthis0.screenTime, node: { name: this_Actor.name } } AS edge
-                WITH collect(edge) AS edges
-                WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS this_actorsConnection
-            }
-            RETURN collect(DISTINCT this { .title, actorsConnection: this_actorsConnection }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors0_node:Actor)
+	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors0_node
+		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_Actor
+}
+WITH *
+CALL {
+    WITH this
+    MATCH (this)<-[this_connection_actorsConnectionthis0:ACTED_IN]-(this_Actor:\`Actor\`)
+    WITH { screenTime: this_connection_actorsConnectionthis0.screenTime, node: { name: this_Actor.name } } AS edge
+    WITH collect(edge) AS edges
+    WITH edges, size(edges) AS totalCount
+    RETURN { edges: edges, totalCount: totalCount } AS this_actorsConnection
+}
+RETURN collect(DISTINCT this { .title, actorsConnection: this_actorsConnection }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/allow.test.ts
@@ -545,24 +545,24 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_Postparam0
-            WITH this, this_posts0
-            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
-            CALL {
-            	WITH this_posts0_to_delete
-            	UNWIND this_posts0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_Postparam0
+WITH this, this_posts0
+CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
+CALL {
+	WITH this_posts0_to_delete
+	UNWIND this_posts0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -606,27 +606,27 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0
-            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0
+WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -676,58 +676,58 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Comment\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
-            WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_post0_disconnect0, this_post0_disconnect0_rel
-            	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel
-            	UNWIND this_post0_disconnect0 as x
-            	DELETE this_post0_disconnect0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_post0_disconnect0
-            CALL {
-            WITH this, this_post0_disconnect0
-            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
-            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_Userparam0
-            WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            	UNWIND this_post0_disconnect0_creator0 as x
-            	DELETE this_post0_disconnect0_creator0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_post0_disconnect0_creator_User
-            }
-            RETURN count(*) AS disconnect_this_post0_disconnect_Post
-            }
-            WITH this
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
-            	WITH count(this_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
-            	RETURN c AS this_creator_User_unique_ignored
-            }
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
-            	WITH count(this_post_Post_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
-            	RETURN c AS this_post_Post_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Comment\`)
+WHERE this.id = $param0
+WITH this
+CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
+WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
+CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_post0_disconnect0, this_post0_disconnect0_rel
+	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel
+	UNWIND this_post0_disconnect0 as x
+	DELETE this_post0_disconnect0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_post0_disconnect0
+CALL {
+WITH this, this_post0_disconnect0
+OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
+WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_Userparam0
+WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+	UNWIND this_post0_disconnect0_creator0 as x
+	DELETE this_post0_disconnect0_creator0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_post0_disconnect0_creator_User
+}
+RETURN count(*) AS disconnect_this_post0_disconnect_Post
+}
+WITH this
+CALL {
+	WITH this
+	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
+	WITH count(this_creator_User_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
+	RETURN c AS this_creator_User_unique_ignored
+}
+CALL {
+	WITH this
+	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+	WITH count(this_post_Post_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
+	RETURN c AS this_post_Post_unique_ignored
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -777,28 +777,28 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/inherited.test.ts
@@ -538,24 +538,24 @@ describe("@auth allow when inherited from interface", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_Postparam0
-            WITH this, this_posts0
-            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
-            CALL {
-            	WITH this_posts0_to_delete
-            	UNWIND this_posts0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_Postparam0
+WITH this, this_posts0
+CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
+CALL {
+	WITH this_posts0_to_delete
+	UNWIND this_posts0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -599,27 +599,27 @@ describe("@auth allow when inherited from interface", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0
-            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0
+WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -669,58 +669,58 @@ describe("@auth allow when inherited from interface", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Comment\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
-            WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_post0_disconnect0, this_post0_disconnect0_rel
-            	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel
-            	UNWIND this_post0_disconnect0 as x
-            	DELETE this_post0_disconnect0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_post0_disconnect0
-            CALL {
-            WITH this, this_post0_disconnect0
-            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
-            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_Userparam0
-            WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            	UNWIND this_post0_disconnect0_creator0 as x
-            	DELETE this_post0_disconnect0_creator0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_post0_disconnect0_creator_User
-            }
-            RETURN count(*) AS disconnect_this_post0_disconnect_Post
-            }
-            WITH this
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
-            	WITH count(this_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
-            	RETURN c AS this_creator_User_unique_ignored
-            }
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
-            	WITH count(this_post_Post_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
-            	RETURN c AS this_post_Post_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Comment\`)
+WHERE this.id = $param0
+WITH this
+CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
+WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
+CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_post0_disconnect0, this_post0_disconnect0_rel
+	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel
+	UNWIND this_post0_disconnect0 as x
+	DELETE this_post0_disconnect0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_post0_disconnect0
+CALL {
+WITH this, this_post0_disconnect0
+OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
+WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_Userparam0
+WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+	UNWIND this_post0_disconnect0_creator0 as x
+	DELETE this_post0_disconnect0_creator0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_post0_disconnect0_creator_User
+}
+RETURN count(*) AS disconnect_this_post0_disconnect_Post
+}
+WITH this
+CALL {
+	WITH this
+	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
+	WITH count(this_creator_User_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required', [0])
+	RETURN c AS this_creator_User_unique_ignored
+}
+CALL {
+	WITH this
+	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+	WITH count(this_post_Post_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
+	RETURN c AS this_post_Post_unique_ignored
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -770,28 +770,28 @@ describe("@auth allow when inherited from interface", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -325,32 +325,32 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_Commentparam0
-            WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
-            CALL {
-            	WITH this_content_Comment0_to_delete
-            	UNWIND this_content_Comment0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_Postparam0
-            WITH this, this_content_Post0
-            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
-            CALL {
-            	WITH this_content_Post0_to_delete
-            	UNWIND this_content_Post0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_Commentparam0
+WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
+CALL {
+	WITH this_content_Comment0_to_delete
+	UNWIND this_content_Comment0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_Postparam0
+WITH this, this_content_Post0
+CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
+CALL {
+	WITH this_content_Post0_to_delete
+	UNWIND this_content_Post0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -394,40 +394,40 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -480,56 +480,56 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_content0
-            CALL {
-            WITH this, this_disconnect_content0
-            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
-            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Commentparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            	UNWIND this_disconnect_content0_comments0 as x
-            	DELETE this_disconnect_content0_comments0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content0_comments_Comment
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_content0
+CALL {
+WITH this, this_disconnect_content0
+OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
+WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Commentparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+	UNWIND this_disconnect_content0_comments0 as x
+	DELETE this_disconnect_content0_comments0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content0_comments_Comment
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -592,42 +592,42 @@ describe("@auth allow on specific interface implementation", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -426,36 +426,36 @@ describe("@auth allow with interface relationships", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_Commentparam0
-            WITH this, this_content_Comment0
-            CALL apoc.util.validate(NOT ((exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
-            CALL {
-            	WITH this_content_Comment0_to_delete
-            	UNWIND this_content_Comment0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_Postparam0
-            WITH this, this_content_Post0
-            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
-            CALL {
-            	WITH this_content_Post0_to_delete
-            	UNWIND this_content_Post0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_Commentparam0
+WITH this, this_content_Comment0
+CALL apoc.util.validate(NOT ((exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
+CALL {
+	WITH this_content_Comment0_to_delete
+	UNWIND this_content_Comment0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_Postparam0
+WITH this, this_content_Post0
+CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
+CALL {
+	WITH this_content_Post0_to_delete
+	UNWIND this_content_Post0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -501,42 +501,42 @@ describe("@auth allow with interface relationships", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -592,58 +592,58 @@ describe("@auth allow with interface relationships", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_content0
-            CALL {
-            WITH this, this_disconnect_content0
-            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
-            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Commentparam0
-            WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0))) AND (exists((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0_comments0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            	UNWIND this_disconnect_content0_comments0 as x
-            	DELETE this_disconnect_content0_comments0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content0_comments_Comment
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_content0
+CALL {
+WITH this, this_disconnect_content0
+OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
+WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Commentparam0
+WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0))) AND (exists((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0_comments0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+	UNWIND this_disconnect_content0_comments0 as x
+	DELETE this_disconnect_content0_comments0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content0_comments_Comment
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -708,44 +708,44 @@ describe("@auth allow with interface relationships", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/bind.test.ts
@@ -332,36 +332,36 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Post\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_creator0_node:User)
-            	WHERE this_connect_creator0_node.id = $this_connect_creator0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_creator0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_creator0_node
-            		MERGE (this)<-[:HAS_POST]-(this_connect_creator0_node)
-            		RETURN count(*)
-            	}
-            	WITH this, this_connect_creator0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_creator0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_creator0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_creator0_nodeauth_param0))) AND (this_connect_creator0_node.id IS NOT NULL AND this_connect_creator0_node.id = $this_connect_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*) AS connect_this_connect_creator_User
-            }
-            WITH *
-            WITH *
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
-            	WITH count(this_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
-            	RETURN c AS this_creator_User_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Post\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_creator0_node:User)
+	WHERE this_connect_creator0_node.id = $this_connect_creator0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_creator0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_creator0_node
+		MERGE (this)<-[:HAS_POST]-(this_connect_creator0_node)
+		RETURN count(*) AS _
+	}
+	WITH this, this_connect_creator0_node
+	CALL apoc.util.validate(NOT ((exists((this_connect_creator0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_creator0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_creator0_nodeauth_param0))) AND (this_connect_creator0_node.id IS NOT NULL AND this_connect_creator0_node.id = $this_connect_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	RETURN count(*) AS connect_this_connect_creator_User
+}
+WITH *
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+	WITH count(this_creator_User_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
+	RETURN c AS this_creator_User_unique_ignored
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -390,35 +390,35 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Post\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_creator0_rel:HAS_POST]-(this_disconnect_creator0:User)
-            WHERE this_disconnect_creator0.id = $updatePosts_args_disconnect_creator_where_Userparam0
-            CALL {
-            	WITH this_disconnect_creator0, this_disconnect_creator0_rel
-            	WITH collect(this_disconnect_creator0) as this_disconnect_creator0, this_disconnect_creator0_rel
-            	UNWIND this_disconnect_creator0 as x
-            	DELETE this_disconnect_creator0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_creator0
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_creator0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_creator0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_creator0auth_param0))) AND (this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*) AS disconnect_this_disconnect_creator_User
-            }
-            WITH *
-            WITH *
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
-            	WITH count(this_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
-            	RETURN c AS this_creator_User_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Post\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_creator0_rel:HAS_POST]-(this_disconnect_creator0:User)
+WHERE this_disconnect_creator0.id = $updatePosts_args_disconnect_creator_where_Userparam0
+CALL {
+	WITH this_disconnect_creator0, this_disconnect_creator0_rel
+	WITH collect(this_disconnect_creator0) as this_disconnect_creator0, this_disconnect_creator0_rel
+	UNWIND this_disconnect_creator0 as x
+	DELETE this_disconnect_creator0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_creator0
+CALL apoc.util.validate(NOT ((exists((this_disconnect_creator0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_creator0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_creator0auth_param0))) AND (this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+RETURN count(*) AS disconnect_this_disconnect_creator_User
+}
+WITH *
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+	WITH count(this_creator_User_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
+	RETURN c AS this_creator_User_unique_ignored
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -393,44 +393,44 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -462,42 +462,42 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_content0
+CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_content0
+CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
@@ -307,44 +307,44 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -376,42 +376,42 @@ describe("Cypher Auth Allow", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_content0
+CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_content0
+CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
@@ -253,39 +253,39 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -323,37 +323,37 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -459,29 +459,29 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
-            CALL {
-            	WITH this_content_Comment0_to_delete
-            	UNWIND this_content_Comment0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WITH this, this_content_Post0
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
-            CALL {
-            	WITH this_content_Post0_to_delete
-            	UNWIND this_content_Post0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
+CALL {
+	WITH this_content_Comment0_to_delete
+	UNWIND this_content_Comment0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+WITH this, this_content_Post0
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
+CALL {
+	WITH this_content_Post0_to_delete
+	UNWIND this_content_Post0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
@@ -200,41 +200,41 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WITH this, this_connect_content0_node
+	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -272,39 +272,39 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WITH this, this_disconnect_content0, this_disconnect_content0_rel
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -388,33 +388,33 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WITH this, this_content_Comment0
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
-            CALL {
-            	WITH this_content_Comment0_to_delete
-            	UNWIND this_content_Comment0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WITH this, this_content_Post0
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
-            CALL {
-            	WITH this_content_Post0_to_delete
-            	UNWIND this_content_Post0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+WITH this, this_content_Comment0
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
+CALL {
+	WITH this_content_Comment0_to_delete
+	UNWIND this_content_Comment0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+WITH this, this_content_Post0
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
+CALL {
+	WITH this_content_Post0_to_delete
+	UNWIND this_content_Post0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
@@ -411,26 +411,26 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -468,25 +468,25 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -570,22 +570,22 @@ describe("Cypher Auth isAuthenticated", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WITH this, this_posts0
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
-            CALL {
-            	WITH this_posts0_to_delete
-            	UNWIND this_posts0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+WITH this, this_posts0
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
+CALL {
+	WITH this_posts0_to_delete
+	UNWIND this_posts0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/roles-where.test.ts
@@ -805,24 +805,24 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            WITH this, this_posts0
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
-            CALL {
-            	WITH this_posts0_to_delete
-            	UNWIND this_posts0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+WITH this, this_posts0
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
+CALL {
+	WITH this_posts0_to_delete
+	UNWIND this_posts0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -865,33 +865,33 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            	WITH this0, this0_posts_connect0_node
-            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_posts_connect0_node
-            		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_posts_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+	WITH this0, this0_posts_connect0_node
+	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_posts_connect0_node
+		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_posts_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -942,33 +942,33 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            	WITH this0, this0_posts_connect0_node
-            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_posts_connect0_node
-            		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_posts_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+	WITH this0, this0_posts_connect0_node
+	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_posts_connect0_node
+		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_posts_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1011,31 +1011,31 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            	WITH this, this_posts0_connect0_node
-            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_posts0_connect0_node
-            		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_posts0_connect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+	WITH this, this_posts0_connect0_node
+	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_posts0_connect0_node
+		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_posts0_connect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1075,31 +1075,31 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            	WITH this, this_posts0_connect0_node
-            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_posts0_connect0_node
-            		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_posts0_connect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+	WITH this, this_posts0_connect0_node
+	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_posts0_connect0_node
+		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_posts0_connect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1140,30 +1140,30 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1203,30 +1203,30 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1267,30 +1267,30 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	UNWIND this_posts0_disconnect0 as x
-            	DELETE this_posts0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
+	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
+	UNWIND this_posts0_disconnect0 as x
+	DELETE this_posts0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1330,30 +1330,30 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Postparam0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	UNWIND this_posts0_disconnect0 as x
-            	DELETE this_posts0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Postparam0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
+	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
+	UNWIND this_posts0_disconnect0 as x
+	DELETE this_posts0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1413,29 +1413,29 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1486,29 +1486,29 @@ describe("Cypher Auth Where with Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
-            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/roles/roles.test.ts
@@ -417,26 +417,26 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WITH this, this_connect_posts0_node
+	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -478,48 +478,48 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Comment\`)
-            WITH this
-            OPTIONAL MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
-            CALL apoc.do.when(this_post0 IS NOT NULL, \\"
-            WITH this, this_post0
-            CALL {
-            	WITH this, this_post0
-            	OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
-            	WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_param0
-            	WITH this, this_post0, this_post0_creator0_connect0_node
-            	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\\\\\"admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\\\\\"super-admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_post0_creator0_connect0_node) as connectedNodes, collect(this_post0) as parentNodes
-            		UNWIND parentNodes as this_post0
-            		UNWIND connectedNodes as this_post0_creator0_connect0_node
-            		MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_post0_creator0_connect_User
-            }
-            WITH this, this_post0
-            CALL {
-            	WITH this_post0
-            	MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
-            	WITH count(this_post0_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
-            	RETURN c AS this_post0_creator_User_unique_ignored
-            }
-            RETURN count(*) AS _
-            \\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,this_post0_creator0_connect0_node_param0:$this_post0_creator0_connect0_node_param0})
-            YIELD value AS _
-            WITH this
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
-            	WITH count(this_post_Post_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
-            	RETURN c AS this_post_Post_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .content }) AS data"
-        `);
+"MATCH (this:\`Comment\`)
+WITH this
+OPTIONAL MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+CALL apoc.do.when(this_post0 IS NOT NULL, \\"
+WITH this, this_post0
+CALL {
+	WITH this, this_post0
+	OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
+	WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_param0
+	WITH this, this_post0, this_post0_creator0_connect0_node
+	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\\\\\"admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\\\\\"super-admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
+	CALL {
+		WITH *
+		WITH this, collect(this_post0_creator0_connect0_node) as connectedNodes, collect(this_post0) as parentNodes
+		UNWIND parentNodes as this_post0
+		UNWIND connectedNodes as this_post0_creator0_connect0_node
+		MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_post0_creator0_connect_User
+}
+WITH this, this_post0
+CALL {
+	WITH this_post0
+	MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+	WITH count(this_post0_creator_User_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
+	RETURN c AS this_post0_creator_User_unique_ignored
+}
+RETURN count(*) AS _
+\\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,this_post0_creator0_connect0_node_param0:$this_post0_creator0_connect0_node_param0})
+YIELD value AS _
+WITH this
+CALL {
+	WITH this
+	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+	WITH count(this_post_Post_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
+	RETURN c AS this_post_Post_unique_ignored
+}
+RETURN collect(DISTINCT this { .content }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -579,25 +579,25 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -648,47 +648,47 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Comment\`)
-            WITH this
-            OPTIONAL MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
-            CALL apoc.do.when(this_post0 IS NOT NULL, \\"
-            WITH this, this_post0
-            CALL {
-            WITH this, this_post0
-            OPTIONAL MATCH (this_post0)-[this_post0_creator0_disconnect0_rel:HAS_POST]->(this_post0_creator0_disconnect0:User)
-            WHERE this_post0_creator0_disconnect0.id = $updateComments_args_update_post_update_node_creator_disconnect_where_Userparam0
-            WITH this, this_post0, this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
-            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\\\\\"super-admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\\\\\"admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
-            CALL {
-            	WITH this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
-            	WITH collect(this_post0_creator0_disconnect0) as this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
-            	UNWIND this_post0_creator0_disconnect0 as x
-            	DELETE this_post0_creator0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_post0_creator0_disconnect_User
-            }
-            WITH this, this_post0
-            CALL {
-            	WITH this_post0
-            	MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
-            	WITH count(this_post0_creator_User_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
-            	RETURN c AS this_post0_creator_User_unique_ignored
-            }
-            RETURN count(*) AS _
-            \\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,updateComments_args_update_post_update_node_creator_disconnect_where_Userparam0:$updateComments_args_update_post_update_node_creator_disconnect_where_Userparam0})
-            YIELD value AS _
-            WITH this
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
-            	WITH count(this_post_Post_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
-            	RETURN c AS this_post_Post_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .content }) AS data"
-        `);
+"MATCH (this:\`Comment\`)
+WITH this
+OPTIONAL MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+CALL apoc.do.when(this_post0 IS NOT NULL, \\"
+WITH this, this_post0
+CALL {
+WITH this, this_post0
+OPTIONAL MATCH (this_post0)-[this_post0_creator0_disconnect0_rel:HAS_POST]->(this_post0_creator0_disconnect0:User)
+WHERE this_post0_creator0_disconnect0.id = $updateComments_args_update_post_update_node_creator_disconnect_where_Userparam0
+WITH this, this_post0, this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
+CALL apoc.util.validate(NOT (any(auth_var1 IN [\\\\\\"super-admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\\\\\"admin\\\\\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\\\\\"@neo4j/graphql/FORBIDDEN\\\\\\", [0])
+CALL {
+	WITH this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
+	WITH collect(this_post0_creator0_disconnect0) as this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
+	UNWIND this_post0_creator0_disconnect0 as x
+	DELETE this_post0_creator0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_post0_creator0_disconnect_User
+}
+WITH this, this_post0
+CALL {
+	WITH this_post0
+	MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+	WITH count(this_post0_creator_User_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required', [0])
+	RETURN c AS this_post0_creator_User_unique_ignored
+}
+RETURN count(*) AS _
+\\", \\"\\", {this:this, updateComments: $updateComments, this_post0:this_post0, auth:$auth,updateComments_args_update_post_update_node_creator_disconnect_where_Userparam0:$updateComments_args_update_post_update_node_creator_disconnect_where_Userparam0})
+YIELD value AS _
+WITH this
+CALL {
+	WITH this
+	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+	WITH count(this_post_Post_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required', [0])
+	RETURN c AS this_post_Post_unique_ignored
+}
+RETURN collect(DISTINCT this { .content }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -785,22 +785,22 @@ describe("Cypher Auth Roles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WITH this, this_posts0
-            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
-            CALL {
-            	WITH this_posts0_to_delete
-            	UNWIND this_posts0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+WITH this, this_posts0
+CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
+CALL {
+	WITH this_posts0_to_delete
+	UNWIND this_posts0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -552,29 +552,29 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
-            CALL {
-            	WITH this_content_Comment0_to_delete
-            	UNWIND this_content_Comment0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
-            WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
-            CALL {
-            	WITH this_content_Post0_to_delete
-            	UNWIND this_content_Post0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
+CALL {
+	WITH this_content_Comment0_to_delete
+	UNWIND this_content_Comment0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
+WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
+CALL {
+	WITH this_content_Post0_to_delete
+	UNWIND this_content_Post0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -605,44 +605,44 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Comment
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Post)
-            	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Comment
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Post)
+	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -681,45 +681,45 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Comment
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Post)
-            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Comment
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Post)
+	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -750,52 +750,52 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Post)
+	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -823,53 +823,53 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Post)
+	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -898,41 +898,41 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -960,42 +960,42 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1024,50 +1024,50 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1095,51 +1095,51 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Commentparam0
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Postparam0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Commentparam0
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Postparam0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1188,39 +1188,39 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1259,40 +1259,40 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -558,30 +558,30 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WHERE (exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))
-            WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
-            CALL {
-            	WITH this_content_Comment0_to_delete
-            	UNWIND this_content_Comment0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
-            WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
-            CALL {
-            	WITH this_content_Post0_to_delete
-            	UNWIND this_content_Post0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+WHERE (exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))
+WITH this, collect(DISTINCT this_content_Comment0) as this_content_Comment0_to_delete
+CALL {
+	WITH this_content_Comment0_to_delete
+	UNWIND this_content_Comment0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
+WITH this, collect(DISTINCT this_content_Post0) as this_content_Post0_to_delete
+CALL {
+	WITH this_content_Post0_to_delete
+	UNWIND this_content_Post0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -613,45 +613,45 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Comment
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Post)
-            	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Comment
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Post)
+	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -690,45 +690,45 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Comment
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_content_connect0_node:Post)
-            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_content_connect0_node
-            		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_content_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Comment
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_content_connect0_node:Post)
+	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_content_connect0_node
+		MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_content_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -759,53 +759,53 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Post)
+	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -833,53 +833,53 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_content0_connect0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_content0_connect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_content0_connect0_node:Post)
+	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_content0_connect0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_content0_connect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -908,42 +908,42 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -971,42 +971,42 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Comment
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_content0_node:Post)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_content0_node
-            		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Comment)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Comment
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_content0_node:Post)
+	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_content0_node
+		MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1035,51 +1035,51 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1107,51 +1107,51 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	 WITH this
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Commentparam0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
-            }
-            RETURN count(*) AS update_this_Comment
-            }
-            CALL {
-            	 WITH this
-            	WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Postparam0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_content0_disconnect0, this_content0_disconnect0_rel
-            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
-            	UNWIND this_content0_disconnect0 as x
-            	DELETE this_content0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_content0_disconnect_Post
-            }
-            RETURN count(*) AS update_this_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	 WITH this
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Commentparam0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+}
+RETURN count(*) AS update_this_Comment
+}
+CALL {
+	 WITH this
+	WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Postparam0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+CALL {
+	WITH this_content0_disconnect0, this_content0_disconnect0_rel
+	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel
+	UNWIND this_content0_disconnect0 as x
+	DELETE this_content0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_content0_disconnect_Post
+}
+RETURN count(*) AS update_this_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1200,40 +1200,40 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1272,40 +1272,40 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Comment
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
-            CALL {
-            	WITH this_disconnect_content0, this_disconnect_content0_rel
-            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
-            	UNWIND this_disconnect_content0 as x
-            	DELETE this_disconnect_content0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_content_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Commentparam0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Comment
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Postparam0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+CALL {
+	WITH this_disconnect_content0, this_disconnect_content0_rel
+	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel
+	UNWIND this_disconnect_content0 as x
+	DELETE this_disconnect_content0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_content_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/where.test.ts
@@ -668,20 +668,20 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
-            WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
-            CALL {
-            	WITH this_posts0_to_delete
-            	UNWIND this_posts0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+WHERE (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
+WITH this, collect(DISTINCT this_posts0) as this_posts0_to_delete
+CALL {
+	WITH this_posts0_to_delete
+	UNWIND this_posts0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -712,31 +712,31 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_posts_connect0_node
-            		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_posts_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+	WHERE (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_posts_connect0_node
+		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_posts_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -775,31 +775,31 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:User)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            SET this0.password = $this0_password
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_posts_connect0_node
-            		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_posts_connect_Post
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:User)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+SET this0.password = $this0_password
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_posts_connect0_node
+		MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_posts_connect_Post
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -830,27 +830,27 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_posts0_connect0_node
-            		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_posts0_connect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+	WHERE (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_posts0_connect0_node
+		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_posts0_connect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -878,27 +878,27 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_posts0_connect0_node
-            		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_posts0_connect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_posts0_connect0_node
+		MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_posts0_connect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -927,28 +927,28 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -976,28 +976,28 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_posts0_node
-            		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_posts0_node:Post)
+	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
+	CALL {
+		WITH *
+		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_posts0_node
+		MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1026,26 +1026,26 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	UNWIND this_posts0_disconnect0 as x
-            	DELETE this_posts0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+WHERE (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
+CALL {
+	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
+	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
+	UNWIND this_posts0_disconnect0 as x
+	DELETE this_posts0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1073,26 +1073,26 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Postparam0 AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
-            CALL {
-            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
-            	UNWIND this_posts0_disconnect0 as x
-            	DELETE this_posts0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Postparam0 AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
+CALL {
+	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel
+	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel
+	UNWIND this_posts0_disconnect0 as x
+	DELETE this_posts0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1140,27 +1140,27 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WHERE (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1199,27 +1199,27 @@ describe("Cypher Auth Where", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0 AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
-            CALL {
-            	WITH this_disconnect_posts0, this_disconnect_posts0_rel
-            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
-            	UNWIND this_disconnect_posts0 as x
-            	DELETE this_disconnect_posts0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_posts_Post
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Postparam0 AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
+CALL {
+	WITH this_disconnect_posts0, this_disconnect_posts0_rel
+	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel
+	UNWIND this_disconnect_posts0 as x
+	DELETE this_disconnect_posts0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_posts_Post
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
@@ -94,59 +94,59 @@ describe("Interface Relationships - Create connect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Actor)
-            SET this0.name = $this0_name
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_actedIn_connect0_node:Movie)
-            	WHERE this0_actedIn_connect0_node.title STARTS WITH $this0_actedIn_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_actedIn_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_actedIn_connect0_node
-            		MERGE (this0)-[this0_actedIn_connect0_relationship:ACTED_IN]->(this0_actedIn_connect0_node)
-            SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_actedIn_connect_Movie
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_actedIn_connect0_node:Series)
-            	WHERE this0_actedIn_connect0_node.title STARTS WITH $this0_actedIn_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_actedIn_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_actedIn_connect0_node
-            		MERGE (this0)-[this0_actedIn_connect0_relationship:ACTED_IN]->(this0_actedIn_connect0_node)
-            SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_actedIn_connect_Series
-            }
-            RETURN this0
-            }
-            WITH *
-            CALL {
-            WITH this0
-            CALL {
-                WITH this0
-                MATCH (this0)-[create_this0:ACTED_IN]->(this0_Movie:\`Movie\`)
-                RETURN { __resolveType: \\"Movie\\", runtime: this0_Movie.runtime, title: this0_Movie.title } AS this0_actedIn
-                UNION
-                WITH this0
-                MATCH (this0)-[create_this1:ACTED_IN]->(this0_Series:\`Series\`)
-                RETURN { __resolveType: \\"Series\\", episodes: this0_Series.episodes, title: this0_Series.title } AS this0_actedIn
-            }
-            RETURN collect(this0_actedIn) AS this0_actedIn
-            }
-            RETURN [
-            this0 { .name, actedIn: this0_actedIn }] AS data"
-        `);
+"CALL {
+CREATE (this0:Actor)
+SET this0.name = $this0_name
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_actedIn_connect0_node:Movie)
+	WHERE this0_actedIn_connect0_node.title STARTS WITH $this0_actedIn_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_actedIn_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_actedIn_connect0_node
+		MERGE (this0)-[this0_actedIn_connect0_relationship:ACTED_IN]->(this0_actedIn_connect0_node)
+SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_actedIn_connect_Movie
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_actedIn_connect0_node:Series)
+	WHERE this0_actedIn_connect0_node.title STARTS WITH $this0_actedIn_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_actedIn_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_actedIn_connect0_node
+		MERGE (this0)-[this0_actedIn_connect0_relationship:ACTED_IN]->(this0_actedIn_connect0_node)
+SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_actedIn_connect_Series
+}
+RETURN this0
+}
+WITH *
+CALL {
+WITH this0
+CALL {
+    WITH this0
+    MATCH (this0)-[create_this0:ACTED_IN]->(this0_Movie:\`Movie\`)
+    RETURN { __resolveType: \\"Movie\\", runtime: this0_Movie.runtime, title: this0_Movie.title } AS this0_actedIn
+    UNION
+    WITH this0
+    MATCH (this0)-[create_this1:ACTED_IN]->(this0_Series:\`Series\`)
+    RETURN { __resolveType: \\"Series\\", episodes: this0_Series.episodes, title: this0_Series.title } AS this0_actedIn
+}
+RETURN collect(this0_actedIn) AS this0_actedIn
+}
+RETURN [
+this0 { .name, actedIn: this0_actedIn }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
@@ -78,29 +78,29 @@ describe("Interface Relationships - Delete delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
-            WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_to_delete
-            	UNWIND this_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
-            WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_actedIn_Series0_to_delete
-            	UNWIND this_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
+WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_to_delete
+	UNWIND this_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
+CALL {
+	WITH this_actedIn_Series0_to_delete
+	UNWIND this_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -148,49 +148,49 @@ describe("Interface Relationships - Delete delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
-            WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, this_actedIn_Movie0
-            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
-            WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
-            WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) as this_actedIn_Movie0_actors0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_actors0_to_delete
-            	UNWIND this_actedIn_Movie0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_to_delete
-            	UNWIND this_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
-            WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, this_actedIn_Series0
-            OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_actedIn_Series0_actors0:Actor)
-            WHERE this_actedIn_Series0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
-            WITH this, this_actedIn_Series0, collect(DISTINCT this_actedIn_Series0_actors0) as this_actedIn_Series0_actors0_to_delete
-            CALL {
-            	WITH this_actedIn_Series0_actors0_to_delete
-            	UNWIND this_actedIn_Series0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_actedIn_Series0_to_delete
-            	UNWIND this_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
+WITH this, this_actedIn_Movie0
+OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
+WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
+WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) as this_actedIn_Movie0_actors0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_actors0_to_delete
+	UNWIND this_actedIn_Movie0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_to_delete
+	UNWIND this_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, this_actedIn_Series0
+OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_actedIn_Series0_actors0:Actor)
+WHERE this_actedIn_Series0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
+WITH this, this_actedIn_Series0, collect(DISTINCT this_actedIn_Series0_actors0) as this_actedIn_Series0_actors0_to_delete
+CALL {
+	WITH this_actedIn_Series0_actors0_to_delete
+	UNWIND this_actedIn_Series0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
+CALL {
+	WITH this_actedIn_Series0_to_delete
+	UNWIND this_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -250,39 +250,39 @@ describe("Interface Relationships - Delete delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
-            WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, this_actedIn_Movie0
-            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
-            WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
-            WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) as this_actedIn_Movie0_actors0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_actors0_to_delete
-            	UNWIND this_actedIn_Movie0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_to_delete
-            	UNWIND this_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
-            WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_actedIn_Series0_to_delete
-            	UNWIND this_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
+WITH this, this_actedIn_Movie0
+OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
+WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
+WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) as this_actedIn_Movie0_actors0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_actors0_to_delete
+	UNWIND this_actedIn_Movie0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_to_delete
+	UNWIND this_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
+CALL {
+	WITH this_actedIn_Series0_to_delete
+	UNWIND this_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -351,49 +351,49 @@ describe("Interface Relationships - Delete delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
-            WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, this_actedIn_Movie0
-            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
-            WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
-            WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) as this_actedIn_Movie0_actors0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_actors0_to_delete
-            	UNWIND this_actedIn_Movie0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_actedIn_Movie0_to_delete
-            	UNWIND this_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
-            WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, this_actedIn_Series0
-            OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_actedIn_Series0_actors0:Actor)
-            WHERE this_actedIn_Series0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
-            WITH this, this_actedIn_Series0, collect(DISTINCT this_actedIn_Series0_actors0) as this_actedIn_Series0_actors0_to_delete
-            CALL {
-            	WITH this_actedIn_Series0_actors0_to_delete
-            	UNWIND this_actedIn_Series0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_actedIn_Series0_to_delete
-            	UNWIND this_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Movieparam0
+WITH this, this_actedIn_Movie0
+OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
+WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
+WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) as this_actedIn_Movie0_actors0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_actors0_to_delete
+	UNWIND this_actedIn_Movie0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actedIn_Movie0) as this_actedIn_Movie0_to_delete
+CALL {
+	WITH this_actedIn_Movie0_to_delete
+	UNWIND this_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, this_actedIn_Series0
+OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_actedIn_Series0_actors0:Actor)
+WHERE this_actedIn_Series0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
+WITH this, this_actedIn_Series0, collect(DISTINCT this_actedIn_Series0_actors0) as this_actedIn_Series0_actors0_to_delete
+CALL {
+	WITH this_actedIn_Series0_actors0_to_delete
+	UNWIND this_actedIn_Series0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actedIn_Series0) as this_actedIn_Series0_to_delete
+CALL {
+	WITH this_actedIn_Series0_to_delete
+	UNWIND this_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
@@ -81,41 +81,41 @@ describe("Interface Relationships - Update connect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn_Movie
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn_Movie
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -154,73 +154,73 @@ describe("Interface Relationships - Update connect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            WITH this, this_connect_actedIn0_node
-            CALL {
-            	WITH this, this_connect_actedIn0_node
-            	OPTIONAL MATCH (this_connect_actedIn0_node_actors0_node:Actor)
-            	WHERE this_connect_actedIn0_node_actors0_node.name = $this_connect_actedIn0_node_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_connect_actedIn0_node_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
-            		UNWIND parentNodes as this_connect_actedIn0_node
-            		UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
-            		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
-            SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn0_node_actors_Actor
-            }
-            	RETURN count(*) AS connect_this_connect_actedIn_Movie
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            WITH this, this_connect_actedIn0_node
-            CALL {
-            	WITH this, this_connect_actedIn0_node
-            	OPTIONAL MATCH (this_connect_actedIn0_node_actors0_node:Actor)
-            	WHERE this_connect_actedIn0_node_actors0_node.name = $this_connect_actedIn0_node_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_connect_actedIn0_node_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
-            		UNWIND parentNodes as this_connect_actedIn0_node
-            		UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
-            		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
-            SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn0_node_actors_Actor
-            }
-            	RETURN count(*) AS connect_this_connect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+WITH this, this_connect_actedIn0_node
+CALL {
+	WITH this, this_connect_actedIn0_node
+	OPTIONAL MATCH (this_connect_actedIn0_node_actors0_node:Actor)
+	WHERE this_connect_actedIn0_node_actors0_node.name = $this_connect_actedIn0_node_actors0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_connect_actedIn0_node_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
+		UNWIND parentNodes as this_connect_actedIn0_node
+		UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
+		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
+SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn0_node_actors_Actor
+}
+	RETURN count(*) AS connect_this_connect_actedIn_Movie
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+WITH this, this_connect_actedIn0_node
+CALL {
+	WITH this, this_connect_actedIn0_node
+	OPTIONAL MATCH (this_connect_actedIn0_node_actors0_node:Actor)
+	WHERE this_connect_actedIn0_node_actors0_node.name = $this_connect_actedIn0_node_actors0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_connect_actedIn0_node_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
+		UNWIND parentNodes as this_connect_actedIn0_node
+		UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
+		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
+SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn0_node_actors_Actor
+}
+	RETURN count(*) AS connect_this_connect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -268,57 +268,57 @@ describe("Interface Relationships - Update connect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            WITH this, this_connect_actedIn0_node
-            CALL {
-            	WITH this, this_connect_actedIn0_node
-            	OPTIONAL MATCH (this_connect_actedIn0_node_on_Movie0_actors0_node:Actor)
-            	WHERE this_connect_actedIn0_node_on_Movie0_actors0_node.name = $this_connect_actedIn0_node_on_Movie0_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_connect_actedIn0_node_on_Movie0_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
-            		UNWIND parentNodes as this_connect_actedIn0_node
-            		UNWIND connectedNodes as this_connect_actedIn0_node_on_Movie0_actors0_node
-            		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
-            SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn0_node_on_Movie0_actors_Actor
-            }
-            	RETURN count(*) AS connect_this_connect_actedIn_Movie
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+WITH this, this_connect_actedIn0_node
+CALL {
+	WITH this, this_connect_actedIn0_node
+	OPTIONAL MATCH (this_connect_actedIn0_node_on_Movie0_actors0_node:Actor)
+	WHERE this_connect_actedIn0_node_on_Movie0_actors0_node.name = $this_connect_actedIn0_node_on_Movie0_actors0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_connect_actedIn0_node_on_Movie0_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
+		UNWIND parentNodes as this_connect_actedIn0_node
+		UNWIND connectedNodes as this_connect_actedIn0_node_on_Movie0_actors0_node
+		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
+SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn0_node_on_Movie0_actors_Actor
+}
+	RETURN count(*) AS connect_this_connect_actedIn_Movie
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -372,73 +372,73 @@ describe("Interface Relationships - Update connect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            WITH this, this_connect_actedIn0_node
-            CALL {
-            	WITH this, this_connect_actedIn0_node
-            	OPTIONAL MATCH (this_connect_actedIn0_node_on_Movie0_actors0_node:Actor)
-            	WHERE this_connect_actedIn0_node_on_Movie0_actors0_node.name = $this_connect_actedIn0_node_on_Movie0_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_connect_actedIn0_node_on_Movie0_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
-            		UNWIND parentNodes as this_connect_actedIn0_node
-            		UNWIND connectedNodes as this_connect_actedIn0_node_on_Movie0_actors0_node
-            		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
-            SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn0_node_on_Movie0_actors_Actor
-            }
-            	RETURN count(*) AS connect_this_connect_actedIn_Movie
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
-            	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actedIn0_node
-            		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
-            SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            WITH this, this_connect_actedIn0_node
-            CALL {
-            	WITH this, this_connect_actedIn0_node
-            	OPTIONAL MATCH (this_connect_actedIn0_node_actors0_node:Actor)
-            	WHERE this_connect_actedIn0_node_actors0_node.name = $this_connect_actedIn0_node_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_connect_actedIn0_node_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
-            		UNWIND parentNodes as this_connect_actedIn0_node
-            		UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
-            		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
-            SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actedIn0_node_actors_Actor
-            }
-            	RETURN count(*) AS connect_this_connect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Movie)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+WITH this, this_connect_actedIn0_node
+CALL {
+	WITH this, this_connect_actedIn0_node
+	OPTIONAL MATCH (this_connect_actedIn0_node_on_Movie0_actors0_node:Actor)
+	WHERE this_connect_actedIn0_node_on_Movie0_actors0_node.name = $this_connect_actedIn0_node_on_Movie0_actors0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_connect_actedIn0_node_on_Movie0_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
+		UNWIND parentNodes as this_connect_actedIn0_node
+		UNWIND connectedNodes as this_connect_actedIn0_node_on_Movie0_actors0_node
+		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
+SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn0_node_on_Movie0_actors_Actor
+}
+	RETURN count(*) AS connect_this_connect_actedIn_Movie
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_actedIn0_node:Series)
+	WHERE this_connect_actedIn0_node.title STARTS WITH $this_connect_actedIn0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actedIn0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actedIn0_node
+		MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+WITH this, this_connect_actedIn0_node
+CALL {
+	WITH this, this_connect_actedIn0_node
+	OPTIONAL MATCH (this_connect_actedIn0_node_actors0_node:Actor)
+	WHERE this_connect_actedIn0_node_actors0_node.name = $this_connect_actedIn0_node_actors0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_connect_actedIn0_node_actors0_node) as connectedNodes, collect(this_connect_actedIn0_node) as parentNodes
+		UNWIND parentNodes as this_connect_actedIn0_node
+		UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
+		MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
+SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actedIn0_node_actors_Actor
+}
+	RETURN count(*) AS connect_this_connect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
@@ -79,30 +79,30 @@ describe("Interface Relationships - Update delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
-            WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
-            WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Series0_to_delete
-            	UNWIND this_delete_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
+WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_to_delete
+	UNWIND this_delete_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
+CALL {
+	WITH this_delete_actedIn_Series0_to_delete
+	UNWIND this_delete_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -152,50 +152,50 @@ describe("Interface Relationships - Update delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
-            WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, this_delete_actedIn_Movie0
-            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
-            WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
-            WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) as this_delete_actedIn_Movie0_actors0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_actors0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
-            WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, this_delete_actedIn_Series0
-            OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Series0_actors0:Actor)
-            WHERE this_delete_actedIn_Series0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
-            WITH this, this_delete_actedIn_Series0, collect(DISTINCT this_delete_actedIn_Series0_actors0) as this_delete_actedIn_Series0_actors0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Series0_actors0_to_delete
-            	UNWIND this_delete_actedIn_Series0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Series0_to_delete
-            	UNWIND this_delete_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
+WITH this, this_delete_actedIn_Movie0
+OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
+WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
+WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) as this_delete_actedIn_Movie0_actors0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_actors0_to_delete
+	UNWIND this_delete_actedIn_Movie0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_to_delete
+	UNWIND this_delete_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, this_delete_actedIn_Series0
+OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Series0_actors0:Actor)
+WHERE this_delete_actedIn_Series0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
+WITH this, this_delete_actedIn_Series0, collect(DISTINCT this_delete_actedIn_Series0_actors0) as this_delete_actedIn_Series0_actors0_to_delete
+CALL {
+	WITH this_delete_actedIn_Series0_actors0_to_delete
+	UNWIND this_delete_actedIn_Series0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
+CALL {
+	WITH this_delete_actedIn_Series0_to_delete
+	UNWIND this_delete_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -257,40 +257,40 @@ describe("Interface Relationships - Update delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
-            WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, this_delete_actedIn_Movie0
-            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
-            WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
-            WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) as this_delete_actedIn_Movie0_actors0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_actors0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
-            WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Series0_to_delete
-            	UNWIND this_delete_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
+WITH this, this_delete_actedIn_Movie0
+OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
+WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
+WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) as this_delete_actedIn_Movie0_actors0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_actors0_to_delete
+	UNWIND this_delete_actedIn_Movie0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_to_delete
+	UNWIND this_delete_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
+CALL {
+	WITH this_delete_actedIn_Series0_to_delete
+	UNWIND this_delete_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -361,50 +361,50 @@ describe("Interface Relationships - Update delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
-            WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
-            WITH this, this_delete_actedIn_Movie0
-            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
-            WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
-            WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) as this_delete_actedIn_Movie0_actors0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_actors0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Movie0_to_delete
-            	UNWIND this_delete_actedIn_Movie0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
-            WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
-            WITH this, this_delete_actedIn_Series0
-            OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Series0_actors0:Actor)
-            WHERE this_delete_actedIn_Series0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
-            WITH this, this_delete_actedIn_Series0, collect(DISTINCT this_delete_actedIn_Series0_actors0) as this_delete_actedIn_Series0_actors0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Series0_actors0_to_delete
-            	UNWIND this_delete_actedIn_Series0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
-            CALL {
-            	WITH this_delete_actedIn_Series0_to_delete
-            	UNWIND this_delete_actedIn_Series0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Movieparam0
+WITH this, this_delete_actedIn_Movie0
+OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
+WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_Actorparam0
+WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) as this_delete_actedIn_Movie0_actors0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_actors0_to_delete
+	UNWIND this_delete_actedIn_Movie0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_actedIn_Movie0) as this_delete_actedIn_Movie0_to_delete
+CALL {
+	WITH this_delete_actedIn_Movie0_to_delete
+	UNWIND this_delete_actedIn_Movie0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_Seriesparam0
+WITH this, this_delete_actedIn_Series0
+OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Series0_actors0:Actor)
+WHERE this_delete_actedIn_Series0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_Actorparam0
+WITH this, this_delete_actedIn_Series0, collect(DISTINCT this_delete_actedIn_Series0_actors0) as this_delete_actedIn_Series0_actors0_to_delete
+CALL {
+	WITH this_delete_actedIn_Series0_actors0_to_delete
+	UNWIND this_delete_actedIn_Series0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_actedIn_Series0) as this_delete_actedIn_Series0_to_delete
+CALL {
+	WITH this_delete_actedIn_Series0_to_delete
+	UNWIND this_delete_actedIn_Series0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
@@ -79,37 +79,37 @@ describe("Interface Relationships - Update disconnect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -159,65 +159,65 @@ describe("Interface Relationships - Update disconnect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_actedIn0
-            CALL {
-            WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
-            WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	UNWIND this_disconnect_actedIn0_actors0 as x
-            	DELETE this_disconnect_actedIn0_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_actedIn0
-            CALL {
-            WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
-            WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	UNWIND this_disconnect_actedIn0_actors0 as x
-            	DELETE this_disconnect_actedIn0_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_actedIn0
+CALL {
+WITH this, this_disconnect_actedIn0
+OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	UNWIND this_disconnect_actedIn0_actors0 as x
+	DELETE this_disconnect_actedIn0_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_actedIn0
+CALL {
+WITH this, this_disconnect_actedIn0
+OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	UNWIND this_disconnect_actedIn0_actors0 as x
+	DELETE this_disconnect_actedIn0_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -279,51 +279,51 @@ describe("Interface Relationships - Update disconnect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_actedIn0
-            CALL {
-            WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
-            WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect__on_Movie0_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	UNWIND this_disconnect_actedIn0_actors0 as x
-            	DELETE this_disconnect_actedIn0_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_actedIn0
+CALL {
+WITH this, this_disconnect_actedIn0
+OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect__on_Movie0_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	UNWIND this_disconnect_actedIn0_actors0 as x
+	DELETE this_disconnect_actedIn0_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -394,65 +394,65 @@ describe("Interface Relationships - Update disconnect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Actor\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_actedIn0
-            CALL {
-            WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
-            WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect__on_Movie0_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	UNWIND this_disconnect_actedIn0_actors0 as x
-            	DELETE this_disconnect_actedIn0_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
-            }
-            CALL {
-            	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
-            WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
-            CALL {
-            	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
-            	UNWIND this_disconnect_actedIn0 as x
-            	DELETE this_disconnect_actedIn0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_actedIn0
-            CALL {
-            WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
-            WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
-            	UNWIND this_disconnect_actedIn0_actors0 as x
-            	DELETE this_disconnect_actedIn0_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .name }) AS data"
-        `);
+"MATCH (this:\`Actor\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movieparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_actedIn0
+CALL {
+WITH this, this_disconnect_actedIn0
+OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect__on_Movie0_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	UNWIND this_disconnect_actedIn0_actors0 as x
+	DELETE this_disconnect_actedIn0_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Movie
+}
+CALL {
+	WITH this
+OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Seriesparam0
+CALL {
+	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	WITH collect(this_disconnect_actedIn0) as this_disconnect_actedIn0, this_disconnect_actedIn0_rel
+	UNWIND this_disconnect_actedIn0 as x
+	DELETE this_disconnect_actedIn0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_actedIn0
+CALL {
+WITH this, this_disconnect_actedIn0
+OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	WITH collect(this_disconnect_actedIn0_actors0) as this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel
+	UNWIND this_disconnect_actedIn0_actors0 as x
+	DELETE this_disconnect_actedIn0_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn0_actors_Actor
+}
+RETURN count(*) AS disconnect_this_disconnect_actedIn_Series
+}
+WITH *
+RETURN collect(DISTINCT this { .name }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label.test.ts
@@ -355,26 +355,26 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Film\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors0_node:\`Person\`)
-            	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors0_node
-            		MERGE (this)<-[:ACTED_IN]-(this_connect_actors0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_Actor
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Film\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors0_node:\`Person\`)
+	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors0_node
+		MERGE (this)<-[:ACTED_IN]-(this_connect_actors0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_Actor
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -402,25 +402,25 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Film\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:\`Person\`)
-            WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actors0, this_disconnect_actors0_rel
-            	WITH collect(this_disconnect_actors0) as this_disconnect_actors0, this_disconnect_actors0_rel
-            	UNWIND this_disconnect_actors0 as x
-            	DELETE this_disconnect_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actors_Actor
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Film\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:\`Person\`)
+WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actors0, this_disconnect_actors0_rel
+	WITH collect(this_disconnect_actors0) as this_disconnect_actors0, this_disconnect_actors0_rel
+	UNWIND this_disconnect_actors0 as x
+	DELETE this_disconnect_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actors_Actor
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -488,20 +488,20 @@ describe("Label in Node directive", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Film\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:\`Person\`)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Film\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:\`Person\`)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/issues/1132.test.ts
@@ -58,27 +58,27 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Source\`)
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_targets0_node:Target)
-            	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_param0
-            	WITH this, this_connect_targets0_node
-            	CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_targets0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_targets0_node
-            		MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_targets_Target
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Source\`)
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_targets0_node:Target)
+	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_param0
+	WITH this, this_connect_targets0_node
+	CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+	CALL {
+		WITH *
+		WITH collect(this_connect_targets0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_targets0_node
+		MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_targets_Target
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -123,26 +123,26 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Source\`)
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_targets0_rel:HAS_TARGET]->(this_disconnect_targets0:Target)
-            WHERE this_disconnect_targets0.id = $updateSources_args_disconnect_targets0_where_Targetparam0
-            WITH this, this_disconnect_targets0, this_disconnect_targets0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            CALL {
-            	WITH this_disconnect_targets0, this_disconnect_targets0_rel
-            	WITH collect(this_disconnect_targets0) as this_disconnect_targets0, this_disconnect_targets0_rel
-            	UNWIND this_disconnect_targets0 as x
-            	DELETE this_disconnect_targets0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_targets_Target
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Source\`)
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_targets0_rel:HAS_TARGET]->(this_disconnect_targets0:Target)
+WHERE this_disconnect_targets0.id = $updateSources_args_disconnect_targets0_where_Targetparam0
+WITH this, this_disconnect_targets0, this_disconnect_targets0_rel
+CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+CALL {
+	WITH this_disconnect_targets0, this_disconnect_targets0_rel
+	WITH collect(this_disconnect_targets0) as this_disconnect_targets0, this_disconnect_targets0_rel
+	UNWIND this_disconnect_targets0 as x
+	DELETE this_disconnect_targets0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_targets_Target
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/1430.test.ts
+++ b/packages/graphql/tests/tck/issues/1430.test.ts
@@ -131,52 +131,52 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`ABCE\`)
-            WHERE this.id = $param0
-            CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildOne)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
-            CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildTwo)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_interface0_node:ChildOne)
-            	WHERE this_connect_interface0_node.name = $this_connect_interface0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_interface0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_interface0_node
-            		MERGE (this)-[:HAS_INTERFACE]->(this_connect_interface0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_interface_ChildOne
-            }
-            CALL {
-            		WITH this
-            	OPTIONAL MATCH (this_connect_interface0_node:ChildTwo)
-            	WHERE this_connect_interface0_node.name = $this_connect_interface0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_interface0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_interface0_node
-            		MERGE (this)-[:HAS_INTERFACE]->(this_connect_interface0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_interface_ChildTwo
-            }
-            WITH *
-            WITH this
-            CALL {
-                WITH this
-                MATCH (this)-[update_this0:HAS_INTERFACE]->(this_ChildOne:\`ChildOne\`)
-                RETURN { __resolveType: \\"ChildOne\\", id: this_ChildOne.id, name: this_ChildOne.name } AS this_interface
-                UNION
-                WITH this
-                MATCH (this)-[update_this1:HAS_INTERFACE]->(this_ChildTwo:\`ChildTwo\`)
-                RETURN { __resolveType: \\"ChildTwo\\", id: this_ChildTwo.id, name: this_ChildTwo.name } AS this_interface
-            }
-            RETURN collect(DISTINCT this { .id, interface: this_interface }) AS data"
-        `);
+"MATCH (this:\`ABCE\`)
+WHERE this.id = $param0
+CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildOne)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
+CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildTwo)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_interface0_node:ChildOne)
+	WHERE this_connect_interface0_node.name = $this_connect_interface0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_interface0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_interface0_node
+		MERGE (this)-[:HAS_INTERFACE]->(this_connect_interface0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_interface_ChildOne
+}
+CALL {
+		WITH this
+	OPTIONAL MATCH (this_connect_interface0_node:ChildTwo)
+	WHERE this_connect_interface0_node.name = $this_connect_interface0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_interface0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_interface0_node
+		MERGE (this)-[:HAS_INTERFACE]->(this_connect_interface0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_interface_ChildTwo
+}
+WITH *
+WITH this
+CALL {
+    WITH this
+    MATCH (this)-[update_this0:HAS_INTERFACE]->(this_ChildOne:\`ChildOne\`)
+    RETURN { __resolveType: \\"ChildOne\\", id: this_ChildOne.id, name: this_ChildOne.name } AS this_interface
+    UNION
+    WITH this
+    MATCH (this)-[update_this1:HAS_INTERFACE]->(this_ChildTwo:\`ChildTwo\`)
+    RETURN { __resolveType: \\"ChildTwo\\", id: this_ChildTwo.id, name: this_ChildTwo.name } AS this_interface
+}
+RETURN collect(DISTINCT this { .id, interface: this_interface }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/1751.test.ts
+++ b/packages/graphql/tests/tck/issues/1751.test.ts
@@ -80,22 +80,22 @@ describe("https://github.com/neo4j/graphql/issues/1751", () => {
         const result = await translateQuery(neoSchema, query, { variableValues });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Organization\`)
-            WHERE this.title = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_admins0_relationship:HAS_ADMINISTRATOR]->(this_admins0:Admin)
-            WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this_admins0)<-[aggr_edge:HAS_ADMINISTRATOR]-(aggr_node:Organization)
-            RETURN count(aggr_node) = $aggr_count
-            \\", { this_admins0: this_admins0, aggr_count: $aggr_count })
-            WITH this, collect(DISTINCT this_admins0) as this_admins0_to_delete
-            CALL {
-            	WITH this_admins0_to_delete
-            	UNWIND this_admins0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Organization\`)
+WHERE this.title = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_admins0_relationship:HAS_ADMINISTRATOR]->(this_admins0:Admin)
+WHERE apoc.cypher.runFirstColumnSingle(\\" MATCH (this_admins0)<-[aggr_edge:HAS_ADMINISTRATOR]-(aggr_node:Organization)
+RETURN count(aggr_node) = $aggr_count
+\\", { this_admins0: this_admins0, aggr_count: $aggr_count })
+WITH this, collect(DISTINCT this_admins0) as this_admins0_to_delete
+CALL {
+	WITH this_admins0_to_delete
+	UNWIND this_admins0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/324.test.ts
+++ b/packages/graphql/tests/tck/issues/324.test.ts
@@ -93,62 +93,62 @@ describe("#324", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Person\`)
-            WHERE this.identifier = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_car0_relationship:CAR]->(this_car0:Car)
-            CALL apoc.do.when(this_car0 IS NOT NULL, \\"
-            WITH this, this_car0
-            OPTIONAL MATCH (this_car0)-[this_car0_manufacturer0_relationship:MANUFACTURER]->(this_car0_manufacturer0:Manufacturer)
-            CALL apoc.do.when(this_car0_manufacturer0 IS NOT NULL, \\\\\\"
-            SET this_car0_manufacturer0.name = $this_update_car0_manufacturer0_name
-            WITH this, this_car0, this_car0_manufacturer0
-            CALL {
-            	WITH this, this_car0, this_car0_manufacturer0
-            	OPTIONAL MATCH (this_car0_manufacturer0_logo0_connect0_node:Logo)
-            	WHERE this_car0_manufacturer0_logo0_connect0_node.identifier = $this_car0_manufacturer0_logo0_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, this_car0, collect(this_car0_manufacturer0_logo0_connect0_node) as connectedNodes, collect(this_car0_manufacturer0) as parentNodes
-            		UNWIND parentNodes as this_car0_manufacturer0
-            		UNWIND connectedNodes as this_car0_manufacturer0_logo0_connect0_node
-            		MERGE (this_car0_manufacturer0)-[:LOGO]->(this_car0_manufacturer0_logo0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_car0_manufacturer0_logo0_connect_Logo
-            }
-            WITH this, this_car0, this_car0_manufacturer0
-            CALL {
-            	WITH this_car0_manufacturer0
-            	MATCH (this_car0_manufacturer0)-[this_car0_manufacturer0_logo_Logo_unique:LOGO]->(:Logo)
-            	WITH count(this_car0_manufacturer0_logo_Logo_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDManufacturer.logo required', [0])
-            	RETURN c AS this_car0_manufacturer0_logo_Logo_unique_ignored
-            }
-            RETURN count(*) AS _
-            \\\\\\", \\\\\\"\\\\\\", {this:this, this_car0:this_car0, updatePeople: $updatePeople, this_car0_manufacturer0:this_car0_manufacturer0, auth:$auth,this_update_car0_manufacturer0_name:$this_update_car0_manufacturer0_name,this_car0_manufacturer0_logo0_connect0_node_param0:$this_car0_manufacturer0_logo0_connect0_node_param0})
-            YIELD value AS _
-            WITH this, this_car0
-            CALL {
-            	WITH this_car0
-            	MATCH (this_car0)-[this_car0_manufacturer_Manufacturer_unique:MANUFACTURER]->(:Manufacturer)
-            	WITH count(this_car0_manufacturer_Manufacturer_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDCar.manufacturer required', [0])
-            	RETURN c AS this_car0_manufacturer_Manufacturer_unique_ignored
-            }
-            RETURN count(*) AS _
-            \\", \\"\\", {this:this, updatePeople: $updatePeople, this_car0:this_car0, auth:$auth,this_update_car0_manufacturer0_name:$this_update_car0_manufacturer0_name,this_car0_manufacturer0_logo0_connect0_node_param0:$this_car0_manufacturer0_logo0_connect0_node_param0})
-            YIELD value AS _
-            WITH this
-            CALL {
-            	WITH this
-            	MATCH (this)-[this_car_Car_unique:CAR]->(:Car)
-            	WITH count(this_car_Car_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPerson.car required', [0])
-            	RETURN c AS this_car_Car_unique_ignored
-            }
-            RETURN collect(DISTINCT this { .identifier }) AS data"
-        `);
+"MATCH (this:\`Person\`)
+WHERE this.identifier = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_car0_relationship:CAR]->(this_car0:Car)
+CALL apoc.do.when(this_car0 IS NOT NULL, \\"
+WITH this, this_car0
+OPTIONAL MATCH (this_car0)-[this_car0_manufacturer0_relationship:MANUFACTURER]->(this_car0_manufacturer0:Manufacturer)
+CALL apoc.do.when(this_car0_manufacturer0 IS NOT NULL, \\\\\\"
+SET this_car0_manufacturer0.name = $this_update_car0_manufacturer0_name
+WITH this, this_car0, this_car0_manufacturer0
+CALL {
+	WITH this, this_car0, this_car0_manufacturer0
+	OPTIONAL MATCH (this_car0_manufacturer0_logo0_connect0_node:Logo)
+	WHERE this_car0_manufacturer0_logo0_connect0_node.identifier = $this_car0_manufacturer0_logo0_connect0_node_param0
+	CALL {
+		WITH *
+		WITH this, this_car0, collect(this_car0_manufacturer0_logo0_connect0_node) as connectedNodes, collect(this_car0_manufacturer0) as parentNodes
+		UNWIND parentNodes as this_car0_manufacturer0
+		UNWIND connectedNodes as this_car0_manufacturer0_logo0_connect0_node
+		MERGE (this_car0_manufacturer0)-[:LOGO]->(this_car0_manufacturer0_logo0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_car0_manufacturer0_logo0_connect_Logo
+}
+WITH this, this_car0, this_car0_manufacturer0
+CALL {
+	WITH this_car0_manufacturer0
+	MATCH (this_car0_manufacturer0)-[this_car0_manufacturer0_logo_Logo_unique:LOGO]->(:Logo)
+	WITH count(this_car0_manufacturer0_logo_Logo_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDManufacturer.logo required', [0])
+	RETURN c AS this_car0_manufacturer0_logo_Logo_unique_ignored
+}
+RETURN count(*) AS _
+\\\\\\", \\\\\\"\\\\\\", {this:this, this_car0:this_car0, updatePeople: $updatePeople, this_car0_manufacturer0:this_car0_manufacturer0, auth:$auth,this_update_car0_manufacturer0_name:$this_update_car0_manufacturer0_name,this_car0_manufacturer0_logo0_connect0_node_param0:$this_car0_manufacturer0_logo0_connect0_node_param0})
+YIELD value AS _
+WITH this, this_car0
+CALL {
+	WITH this_car0
+	MATCH (this_car0)-[this_car0_manufacturer_Manufacturer_unique:MANUFACTURER]->(:Manufacturer)
+	WITH count(this_car0_manufacturer_Manufacturer_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDCar.manufacturer required', [0])
+	RETURN c AS this_car0_manufacturer_Manufacturer_unique_ignored
+}
+RETURN count(*) AS _
+\\", \\"\\", {this:this, updatePeople: $updatePeople, this_car0:this_car0, auth:$auth,this_update_car0_manufacturer0_name:$this_update_car0_manufacturer0_name,this_car0_manufacturer0_logo0_connect0_node_param0:$this_car0_manufacturer0_logo0_connect0_node_param0})
+YIELD value AS _
+WITH this
+CALL {
+	WITH this
+	MATCH (this)-[this_car_Car_unique:CAR]->(:Car)
+	WITH count(this_car_Car_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPerson.car required', [0])
+	RETURN c AS this_car_Car_unique_ignored
+}
+RETURN collect(DISTINCT this { .identifier }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/832.test.ts
+++ b/packages/graphql/tests/tck/issues/832.test.ts
@@ -85,138 +85,138 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Interaction)
-            SET this0.id = randomUUID()
-            SET this0.kind = $this0_kind
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Place
-            }
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Person)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Place)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Place
-            }
-            RETURN this0
-            }
-            CALL {
-            CREATE (this1:Interaction)
-            SET this1.id = randomUUID()
-            SET this1.kind = $this1_kind
-            WITH this1
-            CALL {
-            	WITH this1
-            	OPTIONAL MATCH (this1_subjects_connect0_node:Person)
-            	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_subjects_connect0_node
-            		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_subjects_connect_Person
-            }
-            CALL {
-            		WITH this1
-            	OPTIONAL MATCH (this1_subjects_connect0_node:Place)
-            	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_subjects_connect0_node
-            		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_subjects_connect_Place
-            }
-            WITH this1
-            CALL {
-            	WITH this1
-            	OPTIONAL MATCH (this1_objects_connect0_node:Person)
-            	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_objects_connect0_node
-            		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_objects_connect_Person
-            }
-            CALL {
-            		WITH this1
-            	OPTIONAL MATCH (this1_objects_connect0_node:Place)
-            	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_objects_connect0_node
-            		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_objects_connect_Place
-            }
-            RETURN this1
-            }
-            RETURN [
-            this0 { .id },
-            this1 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Interaction)
+SET this0.id = randomUUID()
+SET this0.kind = $this0_kind
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Place
+}
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Person)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Place)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Place
+}
+RETURN this0
+}
+CALL {
+CREATE (this1:Interaction)
+SET this1.id = randomUUID()
+SET this1.kind = $this1_kind
+WITH this1
+CALL {
+	WITH this1
+	OPTIONAL MATCH (this1_subjects_connect0_node:Person)
+	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_subjects_connect0_node
+		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_subjects_connect_Person
+}
+CALL {
+		WITH this1
+	OPTIONAL MATCH (this1_subjects_connect0_node:Place)
+	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_subjects_connect0_node
+		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_subjects_connect_Place
+}
+WITH this1
+CALL {
+	WITH this1
+	OPTIONAL MATCH (this1_objects_connect0_node:Person)
+	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_objects_connect0_node
+		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_objects_connect_Person
+}
+CALL {
+		WITH this1
+	OPTIONAL MATCH (this1_objects_connect0_node:Place)
+	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_objects_connect0_node
+		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_objects_connect_Place
+}
+RETURN this1
+}
+RETURN [
+this0 { .id },
+this1 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -266,73 +266,73 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Interaction)
-            SET this0.id = randomUUID()
-            SET this0.kind = $this0_kind
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Place
-            }
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Person)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Place)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Place
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Interaction)
+SET this0.id = randomUUID()
+SET this0.kind = $this0_kind
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Place
+}
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Person)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Place)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Place
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -374,73 +374,73 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Interaction)
-            SET this0.id = randomUUID()
-            SET this0.kind = $this0_kind
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Place
-            }
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Person)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Place)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Place
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Interaction)
+SET this0.id = randomUUID()
+SET this0.kind = $this0_kind
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Place
+}
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Person)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Place)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Place
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -493,194 +493,194 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Interaction)
-            SET this0.id = randomUUID()
-            SET this0.kind = $this0_kind
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Place
-            }
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Person)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_objects_connect0_node:Place)
-            	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_objects_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_objects_connect_Place
-            }
-            RETURN this0
-            }
-            CALL {
-            CREATE (this1:Interaction)
-            SET this1.id = randomUUID()
-            SET this1.kind = $this1_kind
-            WITH this1
-            CALL {
-            	WITH this1
-            	OPTIONAL MATCH (this1_subjects_connect0_node:Person)
-            	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_subjects_connect0_node
-            		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_subjects_connect_Person
-            }
-            CALL {
-            		WITH this1
-            	OPTIONAL MATCH (this1_subjects_connect0_node:Place)
-            	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_subjects_connect0_node
-            		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_subjects_connect_Place
-            }
-            WITH this1
-            CALL {
-            	WITH this1
-            	OPTIONAL MATCH (this1_objects_connect0_node:Person)
-            	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_objects_connect0_node
-            		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_objects_connect_Person
-            }
-            CALL {
-            		WITH this1
-            	OPTIONAL MATCH (this1_objects_connect0_node:Place)
-            	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
-            		UNWIND parentNodes as this1
-            		UNWIND connectedNodes as this1_objects_connect0_node
-            		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this1_objects_connect_Place
-            }
-            RETURN this1
-            }
-            WITH *
-            CALL {
-            WITH this0
-            CALL {
-                WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(this0_Person:\`Person\`)
-                RETURN { __resolveType: \\"Person\\", id: this0_Person.id } AS this0_subjects
-                UNION
-                WITH this0
-                MATCH (this0)<-[create_this1:ACTED_IN]-(this0_Place:\`Place\`)
-                RETURN { __resolveType: \\"Place\\", id: this0_Place.id } AS this0_subjects
-            }
-            RETURN collect(this0_subjects) AS this0_subjects
-            }
-            WITH *
-            CALL {
-            WITH this0
-            CALL {
-                WITH this0
-                MATCH (this0)-[create_this2:ACTED_IN]->(this0_Person:\`Person\`)
-                RETURN { __resolveType: \\"Person\\", id: this0_Person.id } AS this0_objects
-                UNION
-                WITH this0
-                MATCH (this0)-[create_this3:ACTED_IN]->(this0_Place:\`Place\`)
-                RETURN { __resolveType: \\"Place\\", id: this0_Place.id } AS this0_objects
-            }
-            RETURN collect(this0_objects) AS this0_objects
-            }
-            WITH *
-            CALL {
-            WITH this1
-            CALL {
-                WITH this1
-                MATCH (this1)<-[create_this0:ACTED_IN]-(this1_Person:\`Person\`)
-                RETURN { __resolveType: \\"Person\\", id: this1_Person.id } AS this1_subjects
-                UNION
-                WITH this1
-                MATCH (this1)<-[create_this1:ACTED_IN]-(this1_Place:\`Place\`)
-                RETURN { __resolveType: \\"Place\\", id: this1_Place.id } AS this1_subjects
-            }
-            RETURN collect(this1_subjects) AS this1_subjects
-            }
-            WITH *
-            CALL {
-            WITH this1
-            CALL {
-                WITH this1
-                MATCH (this1)-[create_this2:ACTED_IN]->(this1_Person:\`Person\`)
-                RETURN { __resolveType: \\"Person\\", id: this1_Person.id } AS this1_objects
-                UNION
-                WITH this1
-                MATCH (this1)-[create_this3:ACTED_IN]->(this1_Place:\`Place\`)
-                RETURN { __resolveType: \\"Place\\", id: this1_Place.id } AS this1_objects
-            }
-            RETURN collect(this1_objects) AS this1_objects
-            }
-            RETURN [
-            this0 { .id, subjects: this0_subjects, objects: this0_objects },
-            this1 { .id, subjects: this1_subjects, objects: this1_objects }] AS data"
-        `);
+"CALL {
+CREATE (this0:Interaction)
+SET this0.id = randomUUID()
+SET this0.kind = $this0_kind
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Place
+}
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Person)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_objects_connect0_node:Place)
+	WHERE this0_objects_connect0_node.id IN $this0_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_objects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_objects_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_objects_connect_Place
+}
+RETURN this0
+}
+CALL {
+CREATE (this1:Interaction)
+SET this1.id = randomUUID()
+SET this1.kind = $this1_kind
+WITH this1
+CALL {
+	WITH this1
+	OPTIONAL MATCH (this1_subjects_connect0_node:Person)
+	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_subjects_connect0_node
+		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_subjects_connect_Person
+}
+CALL {
+		WITH this1
+	OPTIONAL MATCH (this1_subjects_connect0_node:Place)
+	WHERE this1_subjects_connect0_node.id IN $this1_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_subjects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_subjects_connect0_node
+		MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_subjects_connect_Place
+}
+WITH this1
+CALL {
+	WITH this1
+	OPTIONAL MATCH (this1_objects_connect0_node:Person)
+	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_objects_connect0_node
+		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_objects_connect_Person
+}
+CALL {
+		WITH this1
+	OPTIONAL MATCH (this1_objects_connect0_node:Place)
+	WHERE this1_objects_connect0_node.id IN $this1_objects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this1_objects_connect0_node) as connectedNodes, collect(this1) as parentNodes
+		UNWIND parentNodes as this1
+		UNWIND connectedNodes as this1_objects_connect0_node
+		MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this1_objects_connect_Place
+}
+RETURN this1
+}
+WITH *
+CALL {
+WITH this0
+CALL {
+    WITH this0
+    MATCH (this0)<-[create_this0:ACTED_IN]-(this0_Person:\`Person\`)
+    RETURN { __resolveType: \\"Person\\", id: this0_Person.id } AS this0_subjects
+    UNION
+    WITH this0
+    MATCH (this0)<-[create_this1:ACTED_IN]-(this0_Place:\`Place\`)
+    RETURN { __resolveType: \\"Place\\", id: this0_Place.id } AS this0_subjects
+}
+RETURN collect(this0_subjects) AS this0_subjects
+}
+WITH *
+CALL {
+WITH this0
+CALL {
+    WITH this0
+    MATCH (this0)-[create_this2:ACTED_IN]->(this0_Person:\`Person\`)
+    RETURN { __resolveType: \\"Person\\", id: this0_Person.id } AS this0_objects
+    UNION
+    WITH this0
+    MATCH (this0)-[create_this3:ACTED_IN]->(this0_Place:\`Place\`)
+    RETURN { __resolveType: \\"Place\\", id: this0_Place.id } AS this0_objects
+}
+RETURN collect(this0_objects) AS this0_objects
+}
+WITH *
+CALL {
+WITH this1
+CALL {
+    WITH this1
+    MATCH (this1)<-[create_this0:ACTED_IN]-(this1_Person:\`Person\`)
+    RETURN { __resolveType: \\"Person\\", id: this1_Person.id } AS this1_subjects
+    UNION
+    WITH this1
+    MATCH (this1)<-[create_this1:ACTED_IN]-(this1_Place:\`Place\`)
+    RETURN { __resolveType: \\"Place\\", id: this1_Place.id } AS this1_subjects
+}
+RETURN collect(this1_subjects) AS this1_subjects
+}
+WITH *
+CALL {
+WITH this1
+CALL {
+    WITH this1
+    MATCH (this1)-[create_this2:ACTED_IN]->(this1_Person:\`Person\`)
+    RETURN { __resolveType: \\"Person\\", id: this1_Person.id } AS this1_objects
+    UNION
+    WITH this1
+    MATCH (this1)-[create_this3:ACTED_IN]->(this1_Place:\`Place\`)
+    RETURN { __resolveType: \\"Place\\", id: this1_Place.id } AS this1_objects
+}
+RETURN collect(this1_objects) AS this1_objects
+}
+RETURN [
+this0 { .id, subjects: this0_subjects, objects: this0_objects },
+this1 { .id, subjects: this1_subjects, objects: this1_objects }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -727,51 +727,51 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Interaction)
-            SET this0.id = randomUUID()
-            SET this0.kind = $this0_kind
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Person
-            }
-            CALL {
-            		WITH this0
-            	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
-            	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_subjects_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_subjects_connect_Place
-            }
-            RETURN this0
-            }
-            CALL {
-            CREATE (this1:Interaction)
-            SET this1.id = randomUUID()
-            SET this1.kind = $this1_kind
-            RETURN this1
-            }
-            RETURN [
-            this0 { .id },
-            this1 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Interaction)
+SET this0.id = randomUUID()
+SET this0.kind = $this0_kind
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Person)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Person
+}
+CALL {
+		WITH this0
+	OPTIONAL MATCH (this0_subjects_connect0_node:Place)
+	WHERE this0_subjects_connect0_node.id IN $this0_subjects_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_subjects_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_subjects_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_subjects_connect_Place
+}
+RETURN this0
+}
+CALL {
+CREATE (this1:Interaction)
+SET this1.id = randomUUID()
+SET this1.kind = $this1_kind
+RETURN this1
+}
+RETURN [
+this0 { .id },
+this1 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/894.test.ts
+++ b/packages/graphql/tests/tck/issues/894.test.ts
@@ -68,48 +68,48 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`User\`)
-            WHERE this.name = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_activeOrganization0_node:Organization)
-            	WHERE this_connect_activeOrganization0_node._id = $this_connect_activeOrganization0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_activeOrganization0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_activeOrganization0_node
-            		MERGE (this)-[:ACTIVELY_MANAGING]->(this_connect_activeOrganization0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_activeOrganization_Organization
-            }
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_activeOrganization0_rel:ACTIVELY_MANAGING]->(this_disconnect_activeOrganization0:Organization)
-            WHERE NOT (this_disconnect_activeOrganization0._id = $updateUsers_args_disconnect_activeOrganization_where_Organizationparam0)
-            CALL {
-            	WITH this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel
-            	WITH collect(this_disconnect_activeOrganization0) as this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel
-            	UNWIND this_disconnect_activeOrganization0 as x
-            	DELETE this_disconnect_activeOrganization0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_activeOrganization_Organization
-            }
-            WITH *
-            WITH *
-            CALL {
-            	WITH this
-            	MATCH (this)-[this_activeOrganization_Organization_unique:ACTIVELY_MANAGING]->(:Organization)
-            	WITH count(this_activeOrganization_Organization_unique) as c
-            	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDUser.activeOrganization must be less than or equal to one', [0])
-            	RETURN c AS this_activeOrganization_Organization_unique_ignored
-            }
-            RETURN collect(DISTINCT this { id: this._id }) AS data"
-        `);
+"MATCH (this:\`User\`)
+WHERE this.name = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_activeOrganization0_node:Organization)
+	WHERE this_connect_activeOrganization0_node._id = $this_connect_activeOrganization0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_activeOrganization0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_activeOrganization0_node
+		MERGE (this)-[:ACTIVELY_MANAGING]->(this_connect_activeOrganization0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_activeOrganization_Organization
+}
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_activeOrganization0_rel:ACTIVELY_MANAGING]->(this_disconnect_activeOrganization0:Organization)
+WHERE NOT (this_disconnect_activeOrganization0._id = $updateUsers_args_disconnect_activeOrganization_where_Organizationparam0)
+CALL {
+	WITH this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel
+	WITH collect(this_disconnect_activeOrganization0) as this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel
+	UNWIND this_disconnect_activeOrganization0 as x
+	DELETE this_disconnect_activeOrganization0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_activeOrganization_Organization
+}
+WITH *
+WITH *
+CALL {
+	WITH this
+	MATCH (this)-[this_activeOrganization_Organization_unique:ACTIVELY_MANAGING]->(:Organization)
+	WITH count(this_activeOrganization_Organization_unique) as c
+	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDUser.activeOrganization must be less than or equal to one', [0])
+	RETURN c AS this_activeOrganization_Organization_unique_ignored
+}
+RETURN collect(DISTINCT this { id: this._id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/nested-unions.test.ts
+++ b/packages/graphql/tests/tck/nested-unions.test.ts
@@ -103,73 +103,73 @@ describe("Nested Unions", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors_LeadActor0_node:LeadActor)
+	WHERE this_connect_actors_LeadActor0_node.name = $this_connect_actors_LeadActor0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors_LeadActor0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors_LeadActor0_node
+		MERGE (this)<-[:ACTED_IN]-(this_connect_actors_LeadActor0_node)
+		RETURN count(*) AS _
+	}
+WITH this, this_connect_actors_LeadActor0_node
+CALL {
+	WITH this, this_connect_actors_LeadActor0_node
+	OPTIONAL MATCH (this_connect_actors_LeadActor0_node_actedIn_Series0_node:Series)
+	WHERE this_connect_actors_LeadActor0_node_actedIn_Series0_node.name = $this_connect_actors_LeadActor0_node_actedIn_Series0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_connect_actors_LeadActor0_node_actedIn_Series0_node) as connectedNodes, collect(this_connect_actors_LeadActor0_node) as parentNodes
+		UNWIND parentNodes as this_connect_actors_LeadActor0_node
+		UNWIND connectedNodes as this_connect_actors_LeadActor0_node_actedIn_Series0_node
+		MERGE (this_connect_actors_LeadActor0_node)-[:ACTED_IN]->(this_connect_actors_LeadActor0_node_actedIn_Series0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_LeadActor0_node_actedIn_Series_Series
+}
+	RETURN count(*) AS connect_this_connect_actors_LeadActor_LeadActor
+}
+WITH *
+CALL {
+    WITH this
+    CALL {
+        WITH this
+        MATCH (this_actors:\`LeadActor\`)-[update_this0:ACTED_IN]->(this)
+        CALL {
+            WITH this_actors
             CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors_LeadActor0_node:LeadActor)
-            	WHERE this_connect_actors_LeadActor0_node.name = $this_connect_actors_LeadActor0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors_LeadActor0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors_LeadActor0_node
-            		MERGE (this)<-[:ACTED_IN]-(this_connect_actors_LeadActor0_node)
-            		RETURN count(*)
-            	}
-            WITH this, this_connect_actors_LeadActor0_node
-            CALL {
-            	WITH this, this_connect_actors_LeadActor0_node
-            	OPTIONAL MATCH (this_connect_actors_LeadActor0_node_actedIn_Series0_node:Series)
-            	WHERE this_connect_actors_LeadActor0_node_actedIn_Series0_node.name = $this_connect_actors_LeadActor0_node_actedIn_Series0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_connect_actors_LeadActor0_node_actedIn_Series0_node) as connectedNodes, collect(this_connect_actors_LeadActor0_node) as parentNodes
-            		UNWIND parentNodes as this_connect_actors_LeadActor0_node
-            		UNWIND connectedNodes as this_connect_actors_LeadActor0_node_actedIn_Series0_node
-            		MERGE (this_connect_actors_LeadActor0_node)-[:ACTED_IN]->(this_connect_actors_LeadActor0_node_actedIn_Series0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_LeadActor0_node_actedIn_Series_Series
-            }
-            	RETURN count(*) AS connect_this_connect_actors_LeadActor_LeadActor
-            }
-            WITH *
-            CALL {
-                WITH this
-                CALL {
-                    WITH this
-                    MATCH (this_actors:\`LeadActor\`)-[update_this0:ACTED_IN]->(this)
-                    CALL {
-                        WITH this_actors
-                        CALL {
-                            WITH this_actors
-                            MATCH (this_actors)-[update_this1:ACTED_IN]->(this_actors_actedIn:\`Movie\`)
-                            WITH this_actors_actedIn { __resolveType: \\"Movie\\" } AS this_actors_actedIn
-                            RETURN this_actors_actedIn AS this_actors_actedIn
-                            UNION
-                            WITH this_actors
-                            MATCH (this_actors)-[update_this2:ACTED_IN]->(this_actors_actedIn:\`Series\`)
-                            WITH this_actors_actedIn  { __resolveType: \\"Series\\",  .name } AS this_actors_actedIn
-                            RETURN this_actors_actedIn AS this_actors_actedIn
-                        }
-                        WITH this_actors_actedIn
-                        RETURN collect(this_actors_actedIn) AS this_actors_actedIn
-                    }
-                    WITH this_actors  { __resolveType: \\"LeadActor\\",  .name, actedIn: this_actors_actedIn } AS this_actors
-                    RETURN this_actors AS this_actors
-                    UNION
-                    WITH this
-                    MATCH (this_actors:\`Extra\`)-[update_this3:ACTED_IN]->(this)
-                    WITH this_actors { __resolveType: \\"Extra\\" } AS this_actors
-                    RETURN this_actors AS this_actors
-                }
                 WITH this_actors
-                RETURN collect(this_actors) AS this_actors
+                MATCH (this_actors)-[update_this1:ACTED_IN]->(this_actors_actedIn:\`Movie\`)
+                WITH this_actors_actedIn { __resolveType: \\"Movie\\" } AS this_actors_actedIn
+                RETURN this_actors_actedIn AS this_actors_actedIn
+                UNION
+                WITH this_actors
+                MATCH (this_actors)-[update_this2:ACTED_IN]->(this_actors_actedIn:\`Series\`)
+                WITH this_actors_actedIn  { __resolveType: \\"Series\\",  .name } AS this_actors_actedIn
+                RETURN this_actors_actedIn AS this_actors_actedIn
             }
-            RETURN collect(DISTINCT this { .title, actors: this_actors }) AS data"
-        `);
+            WITH this_actors_actedIn
+            RETURN collect(this_actors_actedIn) AS this_actors_actedIn
+        }
+        WITH this_actors  { __resolveType: \\"LeadActor\\",  .name, actedIn: this_actors_actedIn } AS this_actors
+        RETURN this_actors AS this_actors
+        UNION
+        WITH this
+        MATCH (this_actors:\`Extra\`)-[update_this3:ACTED_IN]->(this)
+        WITH this_actors { __resolveType: \\"Extra\\" } AS this_actors
+        RETURN this_actors AS this_actors
+    }
+    WITH this_actors
+    RETURN collect(this_actors) AS this_actors
+}
+RETURN collect(DISTINCT this { .title, actors: this_actors }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -218,71 +218,71 @@ describe("Nested Unions", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_actors_LeadActor0_rel:ACTED_IN]-(this_disconnect_actors_LeadActor0:LeadActor)
+WHERE this_disconnect_actors_LeadActor0.name = $updateMovies_args_disconnect_actors_LeadActor0_where_LeadActorparam0
+CALL {
+	WITH this_disconnect_actors_LeadActor0, this_disconnect_actors_LeadActor0_rel
+	WITH collect(this_disconnect_actors_LeadActor0) as this_disconnect_actors_LeadActor0, this_disconnect_actors_LeadActor0_rel
+	UNWIND this_disconnect_actors_LeadActor0 as x
+	DELETE this_disconnect_actors_LeadActor0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_disconnect_actors_LeadActor0
+CALL {
+WITH this, this_disconnect_actors_LeadActor0
+OPTIONAL MATCH (this_disconnect_actors_LeadActor0)-[this_disconnect_actors_LeadActor0_actedIn_Series0_rel:ACTED_IN]->(this_disconnect_actors_LeadActor0_actedIn_Series0:Series)
+WHERE this_disconnect_actors_LeadActor0_actedIn_Series0.name = $updateMovies_args_disconnect_actors_LeadActor0_disconnect_actedIn_Series0_where_Seriesparam0
+CALL {
+	WITH this_disconnect_actors_LeadActor0_actedIn_Series0, this_disconnect_actors_LeadActor0_actedIn_Series0_rel
+	WITH collect(this_disconnect_actors_LeadActor0_actedIn_Series0) as this_disconnect_actors_LeadActor0_actedIn_Series0, this_disconnect_actors_LeadActor0_actedIn_Series0_rel
+	UNWIND this_disconnect_actors_LeadActor0_actedIn_Series0 as x
+	DELETE this_disconnect_actors_LeadActor0_actedIn_Series0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actors_LeadActor0_actedIn_Series_Series
+}
+RETURN count(*) AS disconnect_this_disconnect_actors_LeadActor_LeadActor
+}
+WITH *
+CALL {
+    WITH this
+    CALL {
+        WITH this
+        MATCH (this_actors:\`LeadActor\`)-[update_this0:ACTED_IN]->(this)
+        CALL {
+            WITH this_actors
             CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors_LeadActor0_rel:ACTED_IN]-(this_disconnect_actors_LeadActor0:LeadActor)
-            WHERE this_disconnect_actors_LeadActor0.name = $updateMovies_args_disconnect_actors_LeadActor0_where_LeadActorparam0
-            CALL {
-            	WITH this_disconnect_actors_LeadActor0, this_disconnect_actors_LeadActor0_rel
-            	WITH collect(this_disconnect_actors_LeadActor0) as this_disconnect_actors_LeadActor0, this_disconnect_actors_LeadActor0_rel
-            	UNWIND this_disconnect_actors_LeadActor0 as x
-            	DELETE this_disconnect_actors_LeadActor0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_disconnect_actors_LeadActor0
-            CALL {
-            WITH this, this_disconnect_actors_LeadActor0
-            OPTIONAL MATCH (this_disconnect_actors_LeadActor0)-[this_disconnect_actors_LeadActor0_actedIn_Series0_rel:ACTED_IN]->(this_disconnect_actors_LeadActor0_actedIn_Series0:Series)
-            WHERE this_disconnect_actors_LeadActor0_actedIn_Series0.name = $updateMovies_args_disconnect_actors_LeadActor0_disconnect_actedIn_Series0_where_Seriesparam0
-            CALL {
-            	WITH this_disconnect_actors_LeadActor0_actedIn_Series0, this_disconnect_actors_LeadActor0_actedIn_Series0_rel
-            	WITH collect(this_disconnect_actors_LeadActor0_actedIn_Series0) as this_disconnect_actors_LeadActor0_actedIn_Series0, this_disconnect_actors_LeadActor0_actedIn_Series0_rel
-            	UNWIND this_disconnect_actors_LeadActor0_actedIn_Series0 as x
-            	DELETE this_disconnect_actors_LeadActor0_actedIn_Series0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actors_LeadActor0_actedIn_Series_Series
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actors_LeadActor_LeadActor
-            }
-            WITH *
-            CALL {
-                WITH this
-                CALL {
-                    WITH this
-                    MATCH (this_actors:\`LeadActor\`)-[update_this0:ACTED_IN]->(this)
-                    CALL {
-                        WITH this_actors
-                        CALL {
-                            WITH this_actors
-                            MATCH (this_actors)-[update_this1:ACTED_IN]->(this_actors_actedIn:\`Movie\`)
-                            WITH this_actors_actedIn { __resolveType: \\"Movie\\" } AS this_actors_actedIn
-                            RETURN this_actors_actedIn AS this_actors_actedIn
-                            UNION
-                            WITH this_actors
-                            MATCH (this_actors)-[update_this2:ACTED_IN]->(this_actors_actedIn:\`Series\`)
-                            WITH this_actors_actedIn  { __resolveType: \\"Series\\",  .name } AS this_actors_actedIn
-                            RETURN this_actors_actedIn AS this_actors_actedIn
-                        }
-                        WITH this_actors_actedIn
-                        RETURN collect(this_actors_actedIn) AS this_actors_actedIn
-                    }
-                    WITH this_actors  { __resolveType: \\"LeadActor\\",  .name, actedIn: this_actors_actedIn } AS this_actors
-                    RETURN this_actors AS this_actors
-                    UNION
-                    WITH this
-                    MATCH (this_actors:\`Extra\`)-[update_this3:ACTED_IN]->(this)
-                    WITH this_actors { __resolveType: \\"Extra\\" } AS this_actors
-                    RETURN this_actors AS this_actors
-                }
                 WITH this_actors
-                RETURN collect(this_actors) AS this_actors
+                MATCH (this_actors)-[update_this1:ACTED_IN]->(this_actors_actedIn:\`Movie\`)
+                WITH this_actors_actedIn { __resolveType: \\"Movie\\" } AS this_actors_actedIn
+                RETURN this_actors_actedIn AS this_actors_actedIn
+                UNION
+                WITH this_actors
+                MATCH (this_actors)-[update_this2:ACTED_IN]->(this_actors_actedIn:\`Series\`)
+                WITH this_actors_actedIn  { __resolveType: \\"Series\\",  .name } AS this_actors_actedIn
+                RETURN this_actors_actedIn AS this_actors_actedIn
             }
-            RETURN collect(DISTINCT this { .title, actors: this_actors }) AS data"
-        `);
+            WITH this_actors_actedIn
+            RETURN collect(this_actors_actedIn) AS this_actors_actedIn
+        }
+        WITH this_actors  { __resolveType: \\"LeadActor\\",  .name, actedIn: this_actors_actedIn } AS this_actors
+        RETURN this_actors AS this_actors
+        UNION
+        WITH this
+        MATCH (this_actors:\`Extra\`)-[update_this3:ACTED_IN]->(this)
+        WITH this_actors { __resolveType: \\"Extra\\" } AS this_actors
+        RETURN this_actors AS this_actors
+    }
+    WITH this_actors
+    RETURN collect(this_actors) AS this_actors
+}
+RETURN collect(DISTINCT this { .title, actors: this_actors }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/operations/connect.test.ts
+++ b/packages/graphql/tests/tck/operations/connect.test.ts
@@ -113,152 +113,152 @@ describe("Cypher Connect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Product)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_colors_connect0_node:Color)
-            	WHERE this0_colors_connect0_node.name = $this0_colors_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_colors_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_colors_connect0_node
-            		MERGE (this0)-[:HAS_COLOR]->(this0_colors_connect0_node)
-            		RETURN count(*)
-            	}
-            WITH this0, this0_colors_connect0_node
-            CALL {
-            	WITH this0, this0_colors_connect0_node
-            	OPTIONAL MATCH (this0_colors_connect0_node_photos0_node:Photo)
-            	WHERE this0_colors_connect0_node_photos0_node.id = $this0_colors_connect0_node_photos0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this0, collect(this0_colors_connect0_node_photos0_node) as connectedNodes, collect(this0_colors_connect0_node) as parentNodes
-            		UNWIND parentNodes as this0_colors_connect0_node
-            		UNWIND connectedNodes as this0_colors_connect0_node_photos0_node
-            		MERGE (this0_colors_connect0_node)<-[:OF_COLOR]-(this0_colors_connect0_node_photos0_node)
-            		RETURN count(*)
-            	}
-            	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
-            CALL {
-            	WITH this0_colors_connect0_node_photos0_node
-            	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_colors_connect0_node_photos0_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
-            }
-            WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
-            CALL {
-            	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
-            	OPTIONAL MATCH (this0_colors_connect0_node_photos0_node_color0_node:Color)
-            	WHERE this0_colors_connect0_node_photos0_node_color0_node.id = $this0_colors_connect0_node_photos0_node_color0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this0, this0_colors_connect0_node, collect(this0_colors_connect0_node_photos0_node_color0_node) as connectedNodes, collect(this0_colors_connect0_node_photos0_node) as parentNodes
-            		UNWIND parentNodes as this0_colors_connect0_node_photos0_node
-            		UNWIND connectedNodes as this0_colors_connect0_node_photos0_node_color0_node
-            		MERGE (this0_colors_connect0_node_photos0_node)-[:OF_COLOR]->(this0_colors_connect0_node_photos0_node_color0_node)
-            		RETURN count(*)
-            	}
-            	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node, this0_colors_connect0_node_photos0_node_color0_node
-            CALL {
-            	WITH this0_colors_connect0_node_photos0_node
-            	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_colors_connect0_node_photos0_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
-            }
-            	RETURN count(*) AS connect_this0_colors_connect0_node_photos0_node_color_Color
-            }
-            	RETURN count(*) AS connect_this0_colors_connect0_node_photos_Photo
-            }
-            	RETURN count(*) AS connect_this0_colors_connect_Color
-            }
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_photos_connect0_node:Photo)
-            	WHERE this0_photos_connect0_node.id = $this0_photos_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_photos_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_photos_connect0_node
-            		MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect0_node)
-            		RETURN count(*)
-            	}
-            WITH this0, this0_photos_connect0_node
-            CALL {
-            	WITH this0, this0_photos_connect0_node
-            	OPTIONAL MATCH (this0_photos_connect0_node_color0_node:Color)
-            	WHERE this0_photos_connect0_node_color0_node.name = $this0_photos_connect0_node_color0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this0, collect(this0_photos_connect0_node_color0_node) as connectedNodes, collect(this0_photos_connect0_node) as parentNodes
-            		UNWIND parentNodes as this0_photos_connect0_node
-            		UNWIND connectedNodes as this0_photos_connect0_node_color0_node
-            		MERGE (this0_photos_connect0_node)-[:OF_COLOR]->(this0_photos_connect0_node_color0_node)
-            		RETURN count(*)
-            	}
-            	WITH this0, this0_photos_connect0_node, this0_photos_connect0_node_color0_node
-            CALL {
-            	WITH this0_photos_connect0_node
-            	MATCH (this0_photos_connect0_node)-[this0_photos_connect0_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_photos_connect0_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_photos_connect0_node_color_Color_unique_ignored
-            }
-            	RETURN count(*) AS connect_this0_photos_connect0_node_color_Color
-            }
-            	RETURN count(*) AS connect_this0_photos_connect_Photo
-            }
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_photos_connect1_node:Photo)
-            	WHERE this0_photos_connect1_node.id = $this0_photos_connect1_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_photos_connect1_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_photos_connect1_node
-            		MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect1_node)
-            		RETURN count(*)
-            	}
-            WITH this0, this0_photos_connect1_node
-            CALL {
-            	WITH this0, this0_photos_connect1_node
-            	OPTIONAL MATCH (this0_photos_connect1_node_color0_node:Color)
-            	WHERE this0_photos_connect1_node_color0_node.name = $this0_photos_connect1_node_color0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this0, collect(this0_photos_connect1_node_color0_node) as connectedNodes, collect(this0_photos_connect1_node) as parentNodes
-            		UNWIND parentNodes as this0_photos_connect1_node
-            		UNWIND connectedNodes as this0_photos_connect1_node_color0_node
-            		MERGE (this0_photos_connect1_node)-[:OF_COLOR]->(this0_photos_connect1_node_color0_node)
-            		RETURN count(*)
-            	}
-            	WITH this0, this0_photos_connect1_node, this0_photos_connect1_node_color0_node
-            CALL {
-            	WITH this0_photos_connect1_node
-            	MATCH (this0_photos_connect1_node)-[this0_photos_connect1_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_photos_connect1_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_photos_connect1_node_color_Color_unique_ignored
-            }
-            	RETURN count(*) AS connect_this0_photos_connect1_node_color_Color
-            }
-            	RETURN count(*) AS connect_this0_photos_connect_Photo
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Product)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_colors_connect0_node:Color)
+	WHERE this0_colors_connect0_node.name = $this0_colors_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_colors_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_colors_connect0_node
+		MERGE (this0)-[:HAS_COLOR]->(this0_colors_connect0_node)
+		RETURN count(*) AS _
+	}
+WITH this0, this0_colors_connect0_node
+CALL {
+	WITH this0, this0_colors_connect0_node
+	OPTIONAL MATCH (this0_colors_connect0_node_photos0_node:Photo)
+	WHERE this0_colors_connect0_node_photos0_node.id = $this0_colors_connect0_node_photos0_node_param0
+	CALL {
+		WITH *
+		WITH this0, collect(this0_colors_connect0_node_photos0_node) as connectedNodes, collect(this0_colors_connect0_node) as parentNodes
+		UNWIND parentNodes as this0_colors_connect0_node
+		UNWIND connectedNodes as this0_colors_connect0_node_photos0_node
+		MERGE (this0_colors_connect0_node)<-[:OF_COLOR]-(this0_colors_connect0_node_photos0_node)
+		RETURN count(*) AS _
+	}
+	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
+CALL {
+	WITH this0_colors_connect0_node_photos0_node
+	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_colors_connect0_node_photos0_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
+}
+WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
+CALL {
+	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
+	OPTIONAL MATCH (this0_colors_connect0_node_photos0_node_color0_node:Color)
+	WHERE this0_colors_connect0_node_photos0_node_color0_node.id = $this0_colors_connect0_node_photos0_node_color0_node_param0
+	CALL {
+		WITH *
+		WITH this0, this0_colors_connect0_node, collect(this0_colors_connect0_node_photos0_node_color0_node) as connectedNodes, collect(this0_colors_connect0_node_photos0_node) as parentNodes
+		UNWIND parentNodes as this0_colors_connect0_node_photos0_node
+		UNWIND connectedNodes as this0_colors_connect0_node_photos0_node_color0_node
+		MERGE (this0_colors_connect0_node_photos0_node)-[:OF_COLOR]->(this0_colors_connect0_node_photos0_node_color0_node)
+		RETURN count(*) AS _
+	}
+	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node, this0_colors_connect0_node_photos0_node_color0_node
+CALL {
+	WITH this0_colors_connect0_node_photos0_node
+	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_colors_connect0_node_photos0_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
+}
+	RETURN count(*) AS connect_this0_colors_connect0_node_photos0_node_color_Color
+}
+	RETURN count(*) AS connect_this0_colors_connect0_node_photos_Photo
+}
+	RETURN count(*) AS connect_this0_colors_connect_Color
+}
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_photos_connect0_node:Photo)
+	WHERE this0_photos_connect0_node.id = $this0_photos_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_photos_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_photos_connect0_node
+		MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect0_node)
+		RETURN count(*) AS _
+	}
+WITH this0, this0_photos_connect0_node
+CALL {
+	WITH this0, this0_photos_connect0_node
+	OPTIONAL MATCH (this0_photos_connect0_node_color0_node:Color)
+	WHERE this0_photos_connect0_node_color0_node.name = $this0_photos_connect0_node_color0_node_param0
+	CALL {
+		WITH *
+		WITH this0, collect(this0_photos_connect0_node_color0_node) as connectedNodes, collect(this0_photos_connect0_node) as parentNodes
+		UNWIND parentNodes as this0_photos_connect0_node
+		UNWIND connectedNodes as this0_photos_connect0_node_color0_node
+		MERGE (this0_photos_connect0_node)-[:OF_COLOR]->(this0_photos_connect0_node_color0_node)
+		RETURN count(*) AS _
+	}
+	WITH this0, this0_photos_connect0_node, this0_photos_connect0_node_color0_node
+CALL {
+	WITH this0_photos_connect0_node
+	MATCH (this0_photos_connect0_node)-[this0_photos_connect0_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_photos_connect0_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_photos_connect0_node_color_Color_unique_ignored
+}
+	RETURN count(*) AS connect_this0_photos_connect0_node_color_Color
+}
+	RETURN count(*) AS connect_this0_photos_connect_Photo
+}
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_photos_connect1_node:Photo)
+	WHERE this0_photos_connect1_node.id = $this0_photos_connect1_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_photos_connect1_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_photos_connect1_node
+		MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect1_node)
+		RETURN count(*) AS _
+	}
+WITH this0, this0_photos_connect1_node
+CALL {
+	WITH this0, this0_photos_connect1_node
+	OPTIONAL MATCH (this0_photos_connect1_node_color0_node:Color)
+	WHERE this0_photos_connect1_node_color0_node.name = $this0_photos_connect1_node_color0_node_param0
+	CALL {
+		WITH *
+		WITH this0, collect(this0_photos_connect1_node_color0_node) as connectedNodes, collect(this0_photos_connect1_node) as parentNodes
+		UNWIND parentNodes as this0_photos_connect1_node
+		UNWIND connectedNodes as this0_photos_connect1_node_color0_node
+		MERGE (this0_photos_connect1_node)-[:OF_COLOR]->(this0_photos_connect1_node_color0_node)
+		RETURN count(*) AS _
+	}
+	WITH this0, this0_photos_connect1_node, this0_photos_connect1_node_color0_node
+CALL {
+	WITH this0_photos_connect1_node
+	MATCH (this0_photos_connect1_node)-[this0_photos_connect1_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_photos_connect1_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_photos_connect1_node_color_Color_unique_ignored
+}
+	RETURN count(*) AS connect_this0_photos_connect1_node_color_Color
+}
+	RETURN count(*) AS connect_this0_photos_connect_Photo
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/operations/create.test.ts
+++ b/packages/graphql/tests/tck/operations/create.test.ts
@@ -270,29 +270,29 @@ describe("Cypher Create", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Movie)
-            SET this0.id = $this0_id
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_actors_connect0_node:Actor)
-            	WHERE this0_actors_connect0_node.name = $this0_actors_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_actors_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_actors_connect0_node
-            		MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_actors_connect_Actor
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.id = $this0_id
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_actors_connect0_node:Actor)
+	WHERE this0_actors_connect0_node.name = $this0_actors_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_actors_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_actors_connect0_node
+		MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_actors_connect_Actor
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -330,44 +330,44 @@ describe("Cypher Create", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Actor)
-            SET this0.name = $this0_name
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_movies_connect0_node:Movie)
-            	WHERE this0_movies_connect0_node.id = $this0_movies_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_movies_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_movies_connect0_node
-            		MERGE (this0)-[:ACTED_IN]->(this0_movies_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_movies_connect_Movie
-            }
-            RETURN this0
-            }
-            CALL {
-                WITH this0
-                MATCH (this0)-[create_this0:ACTED_IN]->(this0_movies:\`Movie\`)
-                CALL {
-                    WITH this0_movies
-                    MATCH (this0_movies)<-[this0_movies_connection_actorsConnectionthis0:ACTED_IN]-(this0_movies_Actor:\`Actor\`)
-                    WHERE this0_movies_Actor.name = $projection_movies_connection_actorsConnectionparam0
-                    WITH { node: { name: this0_movies_Actor.name } } AS edge
-                    WITH collect(edge) AS edges
-                    WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS this0_movies_actorsConnection
-                }
-                WITH this0_movies { actorsConnection: this0_movies_actorsConnection } AS this0_movies
-                RETURN collect(this0_movies) AS this0_movies
-            }
-            RETURN [
-            this0 { .name, movies: this0_movies }] AS data"
-        `);
+"CALL {
+CREATE (this0:Actor)
+SET this0.name = $this0_name
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_movies_connect0_node:Movie)
+	WHERE this0_movies_connect0_node.id = $this0_movies_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_movies_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_movies_connect0_node
+		MERGE (this0)-[:ACTED_IN]->(this0_movies_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_movies_connect_Movie
+}
+RETURN this0
+}
+CALL {
+    WITH this0
+    MATCH (this0)-[create_this0:ACTED_IN]->(this0_movies:\`Movie\`)
+    CALL {
+        WITH this0_movies
+        MATCH (this0_movies)<-[this0_movies_connection_actorsConnectionthis0:ACTED_IN]-(this0_movies_Actor:\`Actor\`)
+        WHERE this0_movies_Actor.name = $projection_movies_connection_actorsConnectionparam0
+        WITH { node: { name: this0_movies_Actor.name } } AS edge
+        WITH collect(edge) AS edges
+        WITH edges, size(edges) AS totalCount
+        RETURN { edges: edges, totalCount: totalCount } AS this0_movies_actorsConnection
+    }
+    WITH this0_movies { actorsConnection: this0_movies_actorsConnection } AS this0_movies
+    RETURN collect(this0_movies) AS this0_movies
+}
+RETURN [
+this0 { .name, movies: this0_movies }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/operations/delete.test.ts
+++ b/packages/graphql/tests/tck/operations/delete.test.ts
@@ -89,20 +89,20 @@ describe("Cypher Delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -150,30 +150,30 @@ describe("Cypher Delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors1_relationship:ACTED_IN]-(this_actors1:Actor)
-            WHERE this_actors1.name = $this_deleteMovies_args_delete_actors1_where_Actorparam0
-            WITH this, collect(DISTINCT this_actors1) as this_actors1_to_delete
-            CALL {
-            	WITH this_actors1_to_delete
-            	UNWIND this_actors1_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this
+OPTIONAL MATCH (this)<-[this_actors1_relationship:ACTED_IN]-(this_actors1:Actor)
+WHERE this_actors1.name = $this_deleteMovies_args_delete_actors1_where_Actorparam0
+WITH this, collect(DISTINCT this_actors1) as this_actors1_to_delete
+CALL {
+	WITH this_actors1_to_delete
+	UNWIND this_actors1_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -229,30 +229,30 @@ describe("Cypher Delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, this_actors0
-            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
-            WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_Movieparam0
-            WITH this, this_actors0, collect(DISTINCT this_actors0_movies0) as this_actors0_movies0_to_delete
-            CALL {
-            	WITH this_actors0_movies0_to_delete
-            	UNWIND this_actors0_movies0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, this_actors0
+OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_Movieparam0
+WITH this, this_actors0, collect(DISTINCT this_actors0_movies0) as this_actors0_movies0_to_delete
+CALL {
+	WITH this_actors0_movies0_to_delete
+	UNWIND this_actors0_movies0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -317,40 +317,40 @@ describe("Cypher Delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, this_actors0
-            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
-            WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_Movieparam0
-            WITH this, this_actors0, this_actors0_movies0
-            OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:ACTED_IN]-(this_actors0_movies0_actors0:Actor)
-            WHERE this_actors0_movies0_actors0.name = $this_deleteMovies_args_delete_actors0_delete_movies0_delete_actors0_where_Actorparam0
-            WITH this, this_actors0, this_actors0_movies0, collect(DISTINCT this_actors0_movies0_actors0) as this_actors0_movies0_actors0_to_delete
-            CALL {
-            	WITH this_actors0_movies0_actors0_to_delete
-            	UNWIND this_actors0_movies0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, this_actors0, collect(DISTINCT this_actors0_movies0) as this_actors0_movies0_to_delete
-            CALL {
-            	WITH this_actors0_movies0_to_delete
-            	UNWIND this_actors0_movies0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, this_actors0
+OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_Movieparam0
+WITH this, this_actors0, this_actors0_movies0
+OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:ACTED_IN]-(this_actors0_movies0_actors0:Actor)
+WHERE this_actors0_movies0_actors0.name = $this_deleteMovies_args_delete_actors0_delete_movies0_delete_actors0_where_Actorparam0
+WITH this, this_actors0, this_actors0_movies0, collect(DISTINCT this_actors0_movies0_actors0) as this_actors0_movies0_actors0_to_delete
+CALL {
+	WITH this_actors0_movies0_actors0_to_delete
+	UNWIND this_actors0_movies0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, this_actors0, collect(DISTINCT this_actors0_movies0) as this_actors0_movies0_to_delete
+CALL {
+	WITH this_actors0_movies0_to_delete
+	UNWIND this_actors0_movies0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actors0) as this_actors0_to_delete
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/operations/disconnect.test.ts
+++ b/packages/graphql/tests/tck/operations/disconnect.test.ts
@@ -111,109 +111,109 @@ describe("Cypher Disconnect", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Product\`)
-            SET this.id = $this_update_id
-            SET this.name = $this_update_name
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_colors0_disconnect0_rel:HAS_COLOR]->(this_colors0_disconnect0:Color)
-            WHERE this_colors0_disconnect0.name = $updateProducts_args_update_colors0_disconnect0_where_Colorparam0
-            CALL {
-            	WITH this_colors0_disconnect0, this_colors0_disconnect0_rel
-            	WITH collect(this_colors0_disconnect0) as this_colors0_disconnect0, this_colors0_disconnect0_rel
-            	UNWIND this_colors0_disconnect0 as x
-            	DELETE this_colors0_disconnect0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_colors0_disconnect0
-            CALL {
-            WITH this, this_colors0_disconnect0
-            OPTIONAL MATCH (this_colors0_disconnect0)<-[this_colors0_disconnect0_photos0_rel:OF_COLOR]-(this_colors0_disconnect0_photos0:Photo)
-            WHERE this_colors0_disconnect0_photos0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos0_where_Photoparam0
-            CALL {
-            	WITH this_colors0_disconnect0_photos0, this_colors0_disconnect0_photos0_rel
-            	WITH collect(this_colors0_disconnect0_photos0) as this_colors0_disconnect0_photos0, this_colors0_disconnect0_photos0_rel
-            	UNWIND this_colors0_disconnect0_photos0 as x
-            	DELETE this_colors0_disconnect0_photos0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_colors0_disconnect0, this_colors0_disconnect0_photos0
-            CALL {
-            WITH this, this_colors0_disconnect0, this_colors0_disconnect0_photos0
-            OPTIONAL MATCH (this_colors0_disconnect0_photos0)-[this_colors0_disconnect0_photos0_color0_rel:OF_COLOR]->(this_colors0_disconnect0_photos0_color0:Color)
-            WHERE this_colors0_disconnect0_photos0_color0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos_disconnect_color_where_Colorparam0
-            CALL {
-            	WITH this_colors0_disconnect0_photos0_color0, this_colors0_disconnect0_photos0_color0_rel
-            	WITH collect(this_colors0_disconnect0_photos0_color0) as this_colors0_disconnect0_photos0_color0, this_colors0_disconnect0_photos0_color0_rel
-            	UNWIND this_colors0_disconnect0_photos0_color0 as x
-            	DELETE this_colors0_disconnect0_photos0_color0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_colors0_disconnect0_photos0_color_Color
-            }
-            RETURN count(*) AS disconnect_this_colors0_disconnect0_photos_Photo
-            }
-            RETURN count(*) AS disconnect_this_colors0_disconnect_Color
-            }
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_photos0_disconnect0_rel:HAS_PHOTO]->(this_photos0_disconnect0:Photo)
-            WHERE this_photos0_disconnect0.id = $updateProducts_args_update_photos0_disconnect0_where_Photoparam0
-            CALL {
-            	WITH this_photos0_disconnect0, this_photos0_disconnect0_rel
-            	WITH collect(this_photos0_disconnect0) as this_photos0_disconnect0, this_photos0_disconnect0_rel
-            	UNWIND this_photos0_disconnect0 as x
-            	DELETE this_photos0_disconnect0_rel
-            	RETURN count(*)
-            }
-            WITH this, this_photos0_disconnect0
-            CALL {
-            WITH this, this_photos0_disconnect0
-            OPTIONAL MATCH (this_photos0_disconnect0)-[this_photos0_disconnect0_color0_rel:OF_COLOR]->(this_photos0_disconnect0_color0:Color)
-            WHERE this_photos0_disconnect0_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Colorparam0
-            CALL {
-            	WITH this_photos0_disconnect0_color0, this_photos0_disconnect0_color0_rel
-            	WITH collect(this_photos0_disconnect0_color0) as this_photos0_disconnect0_color0, this_photos0_disconnect0_color0_rel
-            	UNWIND this_photos0_disconnect0_color0 as x
-            	DELETE this_photos0_disconnect0_color0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_photos0_disconnect0_color_Color
-            }
-            RETURN count(*) AS disconnect_this_photos0_disconnect_Photo
-            }
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_photos0_disconnect1_rel:HAS_PHOTO]->(this_photos0_disconnect1:Photo)
-            WHERE this_photos0_disconnect1.id = $updateProducts_args_update_photos0_disconnect1_where_Photoparam0
-            CALL {
-            	WITH this_photos0_disconnect1, this_photos0_disconnect1_rel
-            	WITH collect(this_photos0_disconnect1) as this_photos0_disconnect1, this_photos0_disconnect1_rel
-            	UNWIND this_photos0_disconnect1 as x
-            	DELETE this_photos0_disconnect1_rel
-            	RETURN count(*)
-            }
-            WITH this, this_photos0_disconnect1
-            CALL {
-            WITH this, this_photos0_disconnect1
-            OPTIONAL MATCH (this_photos0_disconnect1)-[this_photos0_disconnect1_color0_rel:OF_COLOR]->(this_photos0_disconnect1_color0:Color)
-            WHERE this_photos0_disconnect1_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Colorparam0
-            CALL {
-            	WITH this_photos0_disconnect1_color0, this_photos0_disconnect1_color0_rel
-            	WITH collect(this_photos0_disconnect1_color0) as this_photos0_disconnect1_color0, this_photos0_disconnect1_color0_rel
-            	UNWIND this_photos0_disconnect1_color0 as x
-            	DELETE this_photos0_disconnect1_color0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_photos0_disconnect1_color_Color
-            }
-            RETURN count(*) AS disconnect_this_photos0_disconnect_Photo
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Product\`)
+SET this.id = $this_update_id
+SET this.name = $this_update_name
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_colors0_disconnect0_rel:HAS_COLOR]->(this_colors0_disconnect0:Color)
+WHERE this_colors0_disconnect0.name = $updateProducts_args_update_colors0_disconnect0_where_Colorparam0
+CALL {
+	WITH this_colors0_disconnect0, this_colors0_disconnect0_rel
+	WITH collect(this_colors0_disconnect0) as this_colors0_disconnect0, this_colors0_disconnect0_rel
+	UNWIND this_colors0_disconnect0 as x
+	DELETE this_colors0_disconnect0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_colors0_disconnect0
+CALL {
+WITH this, this_colors0_disconnect0
+OPTIONAL MATCH (this_colors0_disconnect0)<-[this_colors0_disconnect0_photos0_rel:OF_COLOR]-(this_colors0_disconnect0_photos0:Photo)
+WHERE this_colors0_disconnect0_photos0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos0_where_Photoparam0
+CALL {
+	WITH this_colors0_disconnect0_photos0, this_colors0_disconnect0_photos0_rel
+	WITH collect(this_colors0_disconnect0_photos0) as this_colors0_disconnect0_photos0, this_colors0_disconnect0_photos0_rel
+	UNWIND this_colors0_disconnect0_photos0 as x
+	DELETE this_colors0_disconnect0_photos0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_colors0_disconnect0, this_colors0_disconnect0_photos0
+CALL {
+WITH this, this_colors0_disconnect0, this_colors0_disconnect0_photos0
+OPTIONAL MATCH (this_colors0_disconnect0_photos0)-[this_colors0_disconnect0_photos0_color0_rel:OF_COLOR]->(this_colors0_disconnect0_photos0_color0:Color)
+WHERE this_colors0_disconnect0_photos0_color0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos_disconnect_color_where_Colorparam0
+CALL {
+	WITH this_colors0_disconnect0_photos0_color0, this_colors0_disconnect0_photos0_color0_rel
+	WITH collect(this_colors0_disconnect0_photos0_color0) as this_colors0_disconnect0_photos0_color0, this_colors0_disconnect0_photos0_color0_rel
+	UNWIND this_colors0_disconnect0_photos0_color0 as x
+	DELETE this_colors0_disconnect0_photos0_color0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_colors0_disconnect0_photos0_color_Color
+}
+RETURN count(*) AS disconnect_this_colors0_disconnect0_photos_Photo
+}
+RETURN count(*) AS disconnect_this_colors0_disconnect_Color
+}
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_photos0_disconnect0_rel:HAS_PHOTO]->(this_photos0_disconnect0:Photo)
+WHERE this_photos0_disconnect0.id = $updateProducts_args_update_photos0_disconnect0_where_Photoparam0
+CALL {
+	WITH this_photos0_disconnect0, this_photos0_disconnect0_rel
+	WITH collect(this_photos0_disconnect0) as this_photos0_disconnect0, this_photos0_disconnect0_rel
+	UNWIND this_photos0_disconnect0 as x
+	DELETE this_photos0_disconnect0_rel
+	RETURN count(*) AS _
+}
+WITH this, this_photos0_disconnect0
+CALL {
+WITH this, this_photos0_disconnect0
+OPTIONAL MATCH (this_photos0_disconnect0)-[this_photos0_disconnect0_color0_rel:OF_COLOR]->(this_photos0_disconnect0_color0:Color)
+WHERE this_photos0_disconnect0_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Colorparam0
+CALL {
+	WITH this_photos0_disconnect0_color0, this_photos0_disconnect0_color0_rel
+	WITH collect(this_photos0_disconnect0_color0) as this_photos0_disconnect0_color0, this_photos0_disconnect0_color0_rel
+	UNWIND this_photos0_disconnect0_color0 as x
+	DELETE this_photos0_disconnect0_color0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_photos0_disconnect0_color_Color
+}
+RETURN count(*) AS disconnect_this_photos0_disconnect_Photo
+}
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_photos0_disconnect1_rel:HAS_PHOTO]->(this_photos0_disconnect1:Photo)
+WHERE this_photos0_disconnect1.id = $updateProducts_args_update_photos0_disconnect1_where_Photoparam0
+CALL {
+	WITH this_photos0_disconnect1, this_photos0_disconnect1_rel
+	WITH collect(this_photos0_disconnect1) as this_photos0_disconnect1, this_photos0_disconnect1_rel
+	UNWIND this_photos0_disconnect1 as x
+	DELETE this_photos0_disconnect1_rel
+	RETURN count(*) AS _
+}
+WITH this, this_photos0_disconnect1
+CALL {
+WITH this, this_photos0_disconnect1
+OPTIONAL MATCH (this_photos0_disconnect1)-[this_photos0_disconnect1_color0_rel:OF_COLOR]->(this_photos0_disconnect1_color0:Color)
+WHERE this_photos0_disconnect1_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Colorparam0
+CALL {
+	WITH this_photos0_disconnect1_color0, this_photos0_disconnect1_color0_rel
+	WITH collect(this_photos0_disconnect1_color0) as this_photos0_disconnect1_color0, this_photos0_disconnect1_color0_rel
+	UNWIND this_photos0_disconnect1_color0 as x
+	DELETE this_photos0_disconnect1_color0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_photos0_disconnect1_color_Color
+}
+RETURN count(*) AS disconnect_this_photos0_disconnect_Photo
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/operations/update.test.ts
+++ b/packages/graphql/tests/tck/operations/update.test.ts
@@ -277,26 +277,26 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors0_node:Actor)
-            	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors0_node
-            		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_Actor
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors0_node:Actor)
+	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors0_node
+		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_Actor
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -329,41 +329,41 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors0_node:Actor)
-            	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors0_node
-            		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_Actor
-            }
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_actors1_node:Actor)
-            	WHERE this_connect_actors1_node.name = $this_connect_actors1_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_actors1_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_actors1_node
-            		MERGE (this)<-[this_connect_actors1_relationship:ACTED_IN]-(this_connect_actors1_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_actors_Actor
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors0_node:Actor)
+	WHERE this_connect_actors0_node.name = $this_connect_actors0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors0_node
+		MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_Actor
+}
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_actors1_node:Actor)
+	WHERE this_connect_actors1_node.name = $this_connect_actors1_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_actors1_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_actors1_node
+		MERGE (this)<-[this_connect_actors1_relationship:ACTED_IN]-(this_connect_actors1_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_actors_Actor
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -392,25 +392,25 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Actor)
-            WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actors0, this_disconnect_actors0_rel
-            	WITH collect(this_disconnect_actors0) as this_disconnect_actors0, this_disconnect_actors0_rel
-            	UNWIND this_disconnect_actors0 as x
-            	DELETE this_disconnect_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actors_Actor
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Actor)
+WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actors0, this_disconnect_actors0_rel
+	WITH collect(this_disconnect_actors0) as this_disconnect_actors0, this_disconnect_actors0_rel
+	UNWIND this_disconnect_actors0 as x
+	DELETE this_disconnect_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actors_Actor
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -458,39 +458,39 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Actor)
-            WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actors0, this_disconnect_actors0_rel
-            	WITH collect(this_disconnect_actors0) as this_disconnect_actors0, this_disconnect_actors0_rel
-            	UNWIND this_disconnect_actors0 as x
-            	DELETE this_disconnect_actors0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actors_Actor
-            }
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors1_rel:ACTED_IN]-(this_disconnect_actors1:Actor)
-            WHERE this_disconnect_actors1.name = $updateMovies_args_disconnect_actors1_where_Actorparam0
-            CALL {
-            	WITH this_disconnect_actors1, this_disconnect_actors1_rel
-            	WITH collect(this_disconnect_actors1) as this_disconnect_actors1, this_disconnect_actors1_rel
-            	UNWIND this_disconnect_actors1 as x
-            	DELETE this_disconnect_actors1_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_actors_Actor
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Actor)
+WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actorparam0
+CALL {
+	WITH this_disconnect_actors0, this_disconnect_actors0_rel
+	WITH collect(this_disconnect_actors0) as this_disconnect_actors0, this_disconnect_actors0_rel
+	UNWIND this_disconnect_actors0 as x
+	DELETE this_disconnect_actors0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actors_Actor
+}
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_actors1_rel:ACTED_IN]-(this_disconnect_actors1:Actor)
+WHERE this_disconnect_actors1.name = $updateMovies_args_disconnect_actors1_where_Actorparam0
+CALL {
+	WITH this_disconnect_actors1, this_disconnect_actors1_rel
+	WITH collect(this_disconnect_actors1) as this_disconnect_actors1, this_disconnect_actors1_rel
+	UNWIND this_disconnect_actors1 as x
+	DELETE this_disconnect_actors1_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_actors_Actor
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -706,21 +706,21 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
-            WHERE (this_delete_actors0_relationship.screenTime = $updateMovies_args_delete_actors0_where_Actorparam0 AND this_delete_actors0.name = $updateMovies_args_delete_actors0_where_Actorparam1)
-            WITH this, collect(DISTINCT this_delete_actors0) as this_delete_actors0_to_delete
-            CALL {
-            	WITH this_delete_actors0_to_delete
-            	UNWIND this_delete_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
+WHERE (this_delete_actors0_relationship.screenTime = $updateMovies_args_delete_actors0_where_Actorparam0 AND this_delete_actors0.name = $updateMovies_args_delete_actors0_where_Actorparam1)
+WITH this, collect(DISTINCT this_delete_actors0) as this_delete_actors0_to_delete
+CALL {
+	WITH this_delete_actors0_to_delete
+	UNWIND this_delete_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -782,29 +782,29 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $updateMovies_args_update_actors0_where_Actorparam0
-            CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
-            SET this_actors0.name = $this_update_actors0_name
-            RETURN count(*) AS _
-            \\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
-            YIELD value AS _
-            WITH this
-            OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
-            WHERE this_delete_actors0.name = $updateMovies_args_delete_actors0_where_Actorparam0
-            WITH this, collect(DISTINCT this_delete_actors0) as this_delete_actors0_to_delete
-            CALL {
-            	WITH this_delete_actors0_to_delete
-            	UNWIND this_delete_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $updateMovies_args_update_actors0_where_Actorparam0
+CALL apoc.do.when(this_actors0 IS NOT NULL, \\"
+SET this_actors0.name = $this_update_actors0_name
+RETURN count(*) AS _
+\\", \\"\\", {this:this, updateMovies: $updateMovies, this_actors0:this_actors0, auth:$auth,this_update_actors0_name:$this_update_actors0_name})
+YIELD value AS _
+WITH this
+OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
+WHERE this_delete_actors0.name = $updateMovies_args_delete_actors0_where_Actorparam0
+WITH this, collect(DISTINCT this_delete_actors0) as this_delete_actors0_to_delete
+CALL {
+	WITH this_delete_actors0_to_delete
+	UNWIND this_delete_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -872,20 +872,20 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:ACTED_IN]-(this_actors0_delete0:Actor)
-            WHERE this_actors0_delete0.name = $updateMovies_args_update_actors0_delete0_where_Actorparam0
-            WITH this, collect(DISTINCT this_actors0_delete0) as this_actors0_delete0_to_delete
-            CALL {
-            	WITH this_actors0_delete0_to_delete
-            	UNWIND this_actors0_delete0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:ACTED_IN]-(this_actors0_delete0:Actor)
+WHERE this_actors0_delete0.name = $updateMovies_args_update_actors0_delete0_where_Actorparam0
+WITH this, collect(DISTINCT this_actors0_delete0) as this_actors0_delete0_to_delete
+CALL {
+	WITH this_actors0_delete0_to_delete
+	UNWIND this_actors0_delete0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -942,30 +942,30 @@ describe("Cypher Update", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:ACTED_IN]-(this_actors0_delete0:Actor)
-            WHERE this_actors0_delete0.name = $updateMovies_args_update_actors0_delete0_where_Actorparam0
-            WITH this, this_actors0_delete0
-            OPTIONAL MATCH (this_actors0_delete0)-[this_actors0_delete0_movies0_relationship:ACTED_IN]->(this_actors0_delete0_movies0:Movie)
-            WHERE this_actors0_delete0_movies0.id = $updateMovies_args_update_actors0_delete0_delete_movies0_where_Movieparam0
-            WITH this, this_actors0_delete0, collect(DISTINCT this_actors0_delete0_movies0) as this_actors0_delete0_movies0_to_delete
-            CALL {
-            	WITH this_actors0_delete0_movies0_to_delete
-            	UNWIND this_actors0_delete0_movies0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, collect(DISTINCT this_actors0_delete0) as this_actors0_delete0_to_delete
-            CALL {
-            	WITH this_actors0_delete0_to_delete
-            	UNWIND this_actors0_delete0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:ACTED_IN]-(this_actors0_delete0:Actor)
+WHERE this_actors0_delete0.name = $updateMovies_args_update_actors0_delete0_where_Actorparam0
+WITH this, this_actors0_delete0
+OPTIONAL MATCH (this_actors0_delete0)-[this_actors0_delete0_movies0_relationship:ACTED_IN]->(this_actors0_delete0_movies0:Movie)
+WHERE this_actors0_delete0_movies0.id = $updateMovies_args_update_actors0_delete0_delete_movies0_where_Movieparam0
+WITH this, this_actors0_delete0, collect(DISTINCT this_actors0_delete0_movies0) as this_actors0_delete0_movies0_to_delete
+CALL {
+	WITH this_actors0_delete0_movies0_to_delete
+	UNWIND this_actors0_delete0_movies0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_actors0_delete0) as this_actors0_delete0_to_delete
+CALL {
+	WITH this_actors0_delete0_to_delete
+	UNWIND this_actors0_delete0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/pringles.test.ts
+++ b/packages/graphql/tests/tck/pringles.test.ts
@@ -119,107 +119,107 @@ describe("Cypher Create Pringles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Product)
-            SET this0.id = $this0_id
-            SET this0.name = $this0_name
-            WITH this0
-            CREATE (this0_sizes0_node:Size)
-            SET this0_sizes0_node.id = $this0_sizes0_node_id
-            SET this0_sizes0_node.name = $this0_sizes0_node_name
-            MERGE (this0)-[:HAS_SIZE]->(this0_sizes0_node)
-            WITH this0
-            CREATE (this0_sizes1_node:Size)
-            SET this0_sizes1_node.id = $this0_sizes1_node_id
-            SET this0_sizes1_node.name = $this0_sizes1_node_name
-            MERGE (this0)-[:HAS_SIZE]->(this0_sizes1_node)
-            WITH this0
-            CREATE (this0_colors0_node:Color)
-            SET this0_colors0_node.id = $this0_colors0_node_id
-            SET this0_colors0_node.name = $this0_colors0_node_name
-            MERGE (this0)-[:HAS_COLOR]->(this0_colors0_node)
-            WITH this0
-            CREATE (this0_colors1_node:Color)
-            SET this0_colors1_node.id = $this0_colors1_node_id
-            SET this0_colors1_node.name = $this0_colors1_node_name
-            MERGE (this0)-[:HAS_COLOR]->(this0_colors1_node)
-            WITH this0
-            CREATE (this0_photos0_node:Photo)
-            SET this0_photos0_node.id = $this0_photos0_node_id
-            SET this0_photos0_node.description = $this0_photos0_node_description
-            SET this0_photos0_node.url = $this0_photos0_node_url
-            MERGE (this0)-[:HAS_PHOTO]->(this0_photos0_node)
-            WITH this0, this0_photos0_node
-            CALL {
-            	WITH this0_photos0_node
-            	MATCH (this0_photos0_node)-[this0_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_photos0_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_photos0_node_color_Color_unique_ignored
-            }
-            WITH this0
-            CREATE (this0_photos1_node:Photo)
-            SET this0_photos1_node.id = $this0_photos1_node_id
-            SET this0_photos1_node.description = $this0_photos1_node_description
-            SET this0_photos1_node.url = $this0_photos1_node_url
-            WITH this0, this0_photos1_node
-            CALL {
-            	WITH this0, this0_photos1_node
-            	OPTIONAL MATCH (this0_photos1_node_color_connect0_node:Color)
-            	WHERE this0_photos1_node_color_connect0_node.id = $this0_photos1_node_color_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this0, collect(this0_photos1_node_color_connect0_node) as connectedNodes, collect(this0_photos1_node) as parentNodes
-            		UNWIND parentNodes as this0_photos1_node
-            		UNWIND connectedNodes as this0_photos1_node_color_connect0_node
-            		MERGE (this0_photos1_node)-[:OF_COLOR]->(this0_photos1_node_color_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_photos1_node_color_connect_Color
-            }
-            MERGE (this0)-[:HAS_PHOTO]->(this0_photos1_node)
-            WITH this0, this0_photos1_node
-            CALL {
-            	WITH this0_photos1_node
-            	MATCH (this0_photos1_node)-[this0_photos1_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_photos1_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_photos1_node_color_Color_unique_ignored
-            }
-            WITH this0
-            CREATE (this0_photos2_node:Photo)
-            SET this0_photos2_node.id = $this0_photos2_node_id
-            SET this0_photos2_node.description = $this0_photos2_node_description
-            SET this0_photos2_node.url = $this0_photos2_node_url
-            WITH this0, this0_photos2_node
-            CALL {
-            	WITH this0, this0_photos2_node
-            	OPTIONAL MATCH (this0_photos2_node_color_connect0_node:Color)
-            	WHERE this0_photos2_node_color_connect0_node.id = $this0_photos2_node_color_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this0, collect(this0_photos2_node_color_connect0_node) as connectedNodes, collect(this0_photos2_node) as parentNodes
-            		UNWIND parentNodes as this0_photos2_node
-            		UNWIND connectedNodes as this0_photos2_node_color_connect0_node
-            		MERGE (this0_photos2_node)-[:OF_COLOR]->(this0_photos2_node_color_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_photos2_node_color_connect_Color
-            }
-            MERGE (this0)-[:HAS_PHOTO]->(this0_photos2_node)
-            WITH this0, this0_photos2_node
-            CALL {
-            	WITH this0_photos2_node
-            	MATCH (this0_photos2_node)-[this0_photos2_node_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this0_photos2_node_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this0_photos2_node_color_Color_unique_ignored
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .id }] AS data"
-        `);
+"CALL {
+CREATE (this0:Product)
+SET this0.id = $this0_id
+SET this0.name = $this0_name
+WITH this0
+CREATE (this0_sizes0_node:Size)
+SET this0_sizes0_node.id = $this0_sizes0_node_id
+SET this0_sizes0_node.name = $this0_sizes0_node_name
+MERGE (this0)-[:HAS_SIZE]->(this0_sizes0_node)
+WITH this0
+CREATE (this0_sizes1_node:Size)
+SET this0_sizes1_node.id = $this0_sizes1_node_id
+SET this0_sizes1_node.name = $this0_sizes1_node_name
+MERGE (this0)-[:HAS_SIZE]->(this0_sizes1_node)
+WITH this0
+CREATE (this0_colors0_node:Color)
+SET this0_colors0_node.id = $this0_colors0_node_id
+SET this0_colors0_node.name = $this0_colors0_node_name
+MERGE (this0)-[:HAS_COLOR]->(this0_colors0_node)
+WITH this0
+CREATE (this0_colors1_node:Color)
+SET this0_colors1_node.id = $this0_colors1_node_id
+SET this0_colors1_node.name = $this0_colors1_node_name
+MERGE (this0)-[:HAS_COLOR]->(this0_colors1_node)
+WITH this0
+CREATE (this0_photos0_node:Photo)
+SET this0_photos0_node.id = $this0_photos0_node_id
+SET this0_photos0_node.description = $this0_photos0_node_description
+SET this0_photos0_node.url = $this0_photos0_node_url
+MERGE (this0)-[:HAS_PHOTO]->(this0_photos0_node)
+WITH this0, this0_photos0_node
+CALL {
+	WITH this0_photos0_node
+	MATCH (this0_photos0_node)-[this0_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_photos0_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_photos0_node_color_Color_unique_ignored
+}
+WITH this0
+CREATE (this0_photos1_node:Photo)
+SET this0_photos1_node.id = $this0_photos1_node_id
+SET this0_photos1_node.description = $this0_photos1_node_description
+SET this0_photos1_node.url = $this0_photos1_node_url
+WITH this0, this0_photos1_node
+CALL {
+	WITH this0, this0_photos1_node
+	OPTIONAL MATCH (this0_photos1_node_color_connect0_node:Color)
+	WHERE this0_photos1_node_color_connect0_node.id = $this0_photos1_node_color_connect0_node_param0
+	CALL {
+		WITH *
+		WITH this0, collect(this0_photos1_node_color_connect0_node) as connectedNodes, collect(this0_photos1_node) as parentNodes
+		UNWIND parentNodes as this0_photos1_node
+		UNWIND connectedNodes as this0_photos1_node_color_connect0_node
+		MERGE (this0_photos1_node)-[:OF_COLOR]->(this0_photos1_node_color_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_photos1_node_color_connect_Color
+}
+MERGE (this0)-[:HAS_PHOTO]->(this0_photos1_node)
+WITH this0, this0_photos1_node
+CALL {
+	WITH this0_photos1_node
+	MATCH (this0_photos1_node)-[this0_photos1_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_photos1_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_photos1_node_color_Color_unique_ignored
+}
+WITH this0
+CREATE (this0_photos2_node:Photo)
+SET this0_photos2_node.id = $this0_photos2_node_id
+SET this0_photos2_node.description = $this0_photos2_node_description
+SET this0_photos2_node.url = $this0_photos2_node_url
+WITH this0, this0_photos2_node
+CALL {
+	WITH this0, this0_photos2_node
+	OPTIONAL MATCH (this0_photos2_node_color_connect0_node:Color)
+	WHERE this0_photos2_node_color_connect0_node.id = $this0_photos2_node_color_connect0_node_param0
+	CALL {
+		WITH *
+		WITH this0, collect(this0_photos2_node_color_connect0_node) as connectedNodes, collect(this0_photos2_node) as parentNodes
+		UNWIND parentNodes as this0_photos2_node
+		UNWIND connectedNodes as this0_photos2_node_color_connect0_node
+		MERGE (this0_photos2_node)-[:OF_COLOR]->(this0_photos2_node_color_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_photos2_node_color_connect_Color
+}
+MERGE (this0)-[:HAS_PHOTO]->(this0_photos2_node)
+WITH this0, this0_photos2_node
+CALL {
+	WITH this0_photos2_node
+	MATCH (this0_photos2_node)-[this0_photos2_node_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this0_photos2_node_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this0_photos2_node_color_Color_unique_ignored
+}
+RETURN this0
+}
+RETURN [
+this0 { .id }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -284,55 +284,55 @@ describe("Cypher Create Pringles", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Product\`)
-            WHERE this.name = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_has_photo0_relationship:HAS_PHOTO]->(this_photos0:Photo)
-            WHERE this_photos0.description = $updateProducts_args_update_photos0_where_Photoparam0
-            CALL apoc.do.when(this_photos0 IS NOT NULL, \\"
-            SET this_photos0.description = $this_update_photos0_description
-            WITH this, this_photos0
-            CALL {
-            WITH this, this_photos0
-            OPTIONAL MATCH (this_photos0)-[this_photos0_color0_disconnect0_rel:OF_COLOR]->(this_photos0_color0_disconnect0:Color)
-            WHERE this_photos0_color0_disconnect0.name = $updateProducts_args_update_photos0_update_node_color_disconnect_where_Colorparam0
-            CALL {
-            	WITH this_photos0_color0_disconnect0, this_photos0_color0_disconnect0_rel
-            	WITH collect(this_photos0_color0_disconnect0) as this_photos0_color0_disconnect0, this_photos0_color0_disconnect0_rel
-            	UNWIND this_photos0_color0_disconnect0 as x
-            	DELETE this_photos0_color0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_photos0_color0_disconnect_Color
-            }
-            WITH this, this_photos0
-            CALL {
-            	WITH this, this_photos0
-            	OPTIONAL MATCH (this_photos0_color0_connect0_node:Color)
-            	WHERE this_photos0_color0_connect0_node.name = $this_photos0_color0_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH this, collect(this_photos0_color0_connect0_node) as connectedNodes, collect(this_photos0) as parentNodes
-            		UNWIND parentNodes as this_photos0
-            		UNWIND connectedNodes as this_photos0_color0_connect0_node
-            		MERGE (this_photos0)-[:OF_COLOR]->(this_photos0_color0_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_photos0_color0_connect_Color
-            }
-            WITH this, this_photos0
-            CALL {
-            	WITH this_photos0
-            	MATCH (this_photos0)-[this_photos0_color_Color_unique:OF_COLOR]->(:Color)
-            	WITH count(this_photos0_color_Color_unique) as c
-            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
-            	RETURN c AS this_photos0_color_Color_unique_ignored
-            }
-            RETURN count(*) AS _
-            \\", \\"\\", {this:this, updateProducts: $updateProducts, this_photos0:this_photos0, auth:$auth,this_update_photos0_description:$this_update_photos0_description,updateProducts_args_update_photos0_update_node_color_disconnect_where_Colorparam0:$updateProducts_args_update_photos0_update_node_color_disconnect_where_Colorparam0,this_photos0_color0_connect0_node_param0:$this_photos0_color0_connect0_node_param0})
-            YIELD value AS _
-            RETURN collect(DISTINCT this { .id }) AS data"
-        `);
+"MATCH (this:\`Product\`)
+WHERE this.name = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_has_photo0_relationship:HAS_PHOTO]->(this_photos0:Photo)
+WHERE this_photos0.description = $updateProducts_args_update_photos0_where_Photoparam0
+CALL apoc.do.when(this_photos0 IS NOT NULL, \\"
+SET this_photos0.description = $this_update_photos0_description
+WITH this, this_photos0
+CALL {
+WITH this, this_photos0
+OPTIONAL MATCH (this_photos0)-[this_photos0_color0_disconnect0_rel:OF_COLOR]->(this_photos0_color0_disconnect0:Color)
+WHERE this_photos0_color0_disconnect0.name = $updateProducts_args_update_photos0_update_node_color_disconnect_where_Colorparam0
+CALL {
+	WITH this_photos0_color0_disconnect0, this_photos0_color0_disconnect0_rel
+	WITH collect(this_photos0_color0_disconnect0) as this_photos0_color0_disconnect0, this_photos0_color0_disconnect0_rel
+	UNWIND this_photos0_color0_disconnect0 as x
+	DELETE this_photos0_color0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_photos0_color0_disconnect_Color
+}
+WITH this, this_photos0
+CALL {
+	WITH this, this_photos0
+	OPTIONAL MATCH (this_photos0_color0_connect0_node:Color)
+	WHERE this_photos0_color0_connect0_node.name = $this_photos0_color0_connect0_node_param0
+	CALL {
+		WITH *
+		WITH this, collect(this_photos0_color0_connect0_node) as connectedNodes, collect(this_photos0) as parentNodes
+		UNWIND parentNodes as this_photos0
+		UNWIND connectedNodes as this_photos0_color0_connect0_node
+		MERGE (this_photos0)-[:OF_COLOR]->(this_photos0_color0_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_photos0_color0_connect_Color
+}
+WITH this, this_photos0
+CALL {
+	WITH this_photos0
+	MATCH (this_photos0)-[this_photos0_color_Color_unique:OF_COLOR]->(:Color)
+	WITH count(this_photos0_color_Color_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required', [0])
+	RETURN c AS this_photos0_color_Color_unique_ignored
+}
+RETURN count(*) AS _
+\\", \\"\\", {this:this, updateProducts: $updateProducts, this_photos0:this_photos0, auth:$auth,this_update_photos0_description:$this_update_photos0_description,updateProducts_args_update_photos0_update_node_color_disconnect_where_Colorparam0:$updateProducts_args_update_photos0_update_node_color_disconnect_where_Colorparam0,this_photos0_color0_connect0_node_param0:$this_photos0_color0_connect0_node_param0})
+YIELD value AS _
+RETURN collect(DISTINCT this { .id }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
@@ -711,46 +711,46 @@ describe("tck/rfs/003", () => {
                         });
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:\`Movie\`)
-                            WHERE this.id = $param0
-                            WITH this
-                            OPTIONAL MATCH (this)<-[this_delete_director0_relationship:DIRECTED]-(this_delete_director0:Director)
-                            WHERE this_delete_director0.id = $updateMovies_args_delete_director_where_Directorparam0
-                            WITH this, this_delete_director0
-                            OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:HAS_ADDRESS]->(this_delete_director0_address0:Address)
-                            WHERE this_delete_director0_address0.id = $updateMovies_args_delete_director_delete_address_where_Addressparam0
-                            WITH this, this_delete_director0, collect(DISTINCT this_delete_director0_address0) as this_delete_director0_address0_to_delete
-                            CALL {
-                            	WITH this_delete_director0_address0_to_delete
-                            	UNWIND this_delete_director0_address0_to_delete AS x
-                            	DETACH DELETE x
-                            	RETURN count(*)
-                            }
-                            WITH this, collect(DISTINCT this_delete_director0) as this_delete_director0_to_delete
-                            CALL {
-                            	WITH this_delete_director0_to_delete
-                            	UNWIND this_delete_director0_to_delete AS x
-                            	DETACH DELETE x
-                            	RETURN count(*)
-                            }
-                            WITH *
-                            WITH *
-                            CALL {
-                            	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
-                            	WITH count(this_director_Director_unique) as c
-                            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
-                            	RETURN c AS this_director_Director_unique_ignored
-                            }
-                            CALL {
-                            	WITH this
-                            	MATCH (this)<-[this_coDirector_CoDirector_unique:CO_DIRECTED]-(:CoDirector)
-                            	WITH count(this_coDirector_CoDirector_unique) as c
-                            	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.coDirector must be less than or equal to one', [0])
-                            	RETURN c AS this_coDirector_CoDirector_unique_ignored
-                            }
-                            RETURN 'Query cannot conclude with CALL'"
-                        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_delete_director0_relationship:DIRECTED]-(this_delete_director0:Director)
+WHERE this_delete_director0.id = $updateMovies_args_delete_director_where_Directorparam0
+WITH this, this_delete_director0
+OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:HAS_ADDRESS]->(this_delete_director0_address0:Address)
+WHERE this_delete_director0_address0.id = $updateMovies_args_delete_director_delete_address_where_Addressparam0
+WITH this, this_delete_director0, collect(DISTINCT this_delete_director0_address0) as this_delete_director0_address0_to_delete
+CALL {
+	WITH this_delete_director0_address0_to_delete
+	UNWIND this_delete_director0_address0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_director0) as this_delete_director0_to_delete
+CALL {
+	WITH this_delete_director0_to_delete
+	UNWIND this_delete_director0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
+	RETURN c AS this_director_Director_unique_ignored
+}
+CALL {
+	WITH this
+	MATCH (this)<-[this_coDirector_CoDirector_unique:CO_DIRECTED]-(:CoDirector)
+	WITH count(this_coDirector_CoDirector_unique) as c
+	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.coDirector must be less than or equal to one', [0])
+	RETURN c AS this_coDirector_CoDirector_unique_ignored
+}
+RETURN 'Query cannot conclude with CALL'"
+`);
 
                         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                             "{
@@ -834,46 +834,46 @@ describe("tck/rfs/003", () => {
                         });
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "MATCH (this:\`Movie\`)
-                            WHERE this.id = $param0
-                            WITH this
-                            OPTIONAL MATCH (this)<-[this_delete_director0_relationship:DIRECTED]-(this_delete_director0:Director)
-                            WHERE this_delete_director0.id = $updateMovies_args_delete_director_where_Directorparam0
-                            WITH this, this_delete_director0
-                            OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:HAS_ADDRESS]->(this_delete_director0_address0:Address)
-                            WHERE this_delete_director0_address0.id = $updateMovies_args_delete_director_delete_address_where_Addressparam0
-                            WITH this, this_delete_director0, collect(DISTINCT this_delete_director0_address0) as this_delete_director0_address0_to_delete
-                            CALL {
-                            	WITH this_delete_director0_address0_to_delete
-                            	UNWIND this_delete_director0_address0_to_delete AS x
-                            	DETACH DELETE x
-                            	RETURN count(*)
-                            }
-                            WITH this, collect(DISTINCT this_delete_director0) as this_delete_director0_to_delete
-                            CALL {
-                            	WITH this_delete_director0_to_delete
-                            	UNWIND this_delete_director0_to_delete AS x
-                            	DETACH DELETE x
-                            	RETURN count(*)
-                            }
-                            WITH *
-                            WITH *
-                            CALL {
-                            	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
-                            	WITH count(this_director_Director_unique) as c
-                            	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
-                            	RETURN c AS this_director_Director_unique_ignored
-                            }
-                            CALL {
-                            	WITH this
-                            	MATCH (this)<-[this_coDirector_CoDirector_unique:CO_DIRECTED]-(:CoDirector)
-                            	WITH count(this_coDirector_CoDirector_unique) as c
-                            	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.coDirector must be less than or equal to one', [0])
-                            	RETURN c AS this_coDirector_CoDirector_unique_ignored
-                            }
-                            RETURN 'Query cannot conclude with CALL'"
-                        `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+OPTIONAL MATCH (this)<-[this_delete_director0_relationship:DIRECTED]-(this_delete_director0:Director)
+WHERE this_delete_director0.id = $updateMovies_args_delete_director_where_Directorparam0
+WITH this, this_delete_director0
+OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:HAS_ADDRESS]->(this_delete_director0_address0:Address)
+WHERE this_delete_director0_address0.id = $updateMovies_args_delete_director_delete_address_where_Addressparam0
+WITH this, this_delete_director0, collect(DISTINCT this_delete_director0_address0) as this_delete_director0_address0_to_delete
+CALL {
+	WITH this_delete_director0_address0_to_delete
+	UNWIND this_delete_director0_address0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, collect(DISTINCT this_delete_director0) as this_delete_director0_to_delete
+CALL {
+	WITH this_delete_director0_to_delete
+	UNWIND this_delete_director0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
+	RETURN c AS this_director_Director_unique_ignored
+}
+CALL {
+	WITH this
+	MATCH (this)<-[this_coDirector_CoDirector_unique:CO_DIRECTED]-(:CoDirector)
+	WITH count(this_coDirector_CoDirector_unique) as c
+	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.coDirector must be less than or equal to one', [0])
+	RETURN c AS this_coDirector_CoDirector_unique_ignored
+}
+RETURN 'Query cannot conclude with CALL'"
+`);
 
                         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                             "{
@@ -942,36 +942,36 @@ describe("tck/rfs/003", () => {
                     });
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "CALL {
-                        CREATE (this0:Movie)
-                        SET this0.id = $this0_id
-                        WITH this0
-                        CALL {
-                        	WITH this0
-                        	OPTIONAL MATCH (this0_director_connect0_node:Director)
-                        	WHERE this0_director_connect0_node.id = $this0_director_connect0_node_param0
-                        	CALL {
-                        		WITH *
-                        		WITH collect(this0_director_connect0_node) as connectedNodes, collect(this0) as parentNodes
-                        		UNWIND parentNodes as this0
-                        		UNWIND connectedNodes as this0_director_connect0_node
-                        		MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
-                        		RETURN count(*)
-                        	}
-                        	RETURN count(*) AS connect_this0_director_connect_Director
-                        }
-                        WITH this0
-                        CALL {
-                        	WITH this0
-                        	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
-                        	WITH count(this0_director_Director_unique) as c
-                        	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
-                        	RETURN c AS this0_director_Director_unique_ignored
-                        }
-                        RETURN this0
-                        }
-                        RETURN 'Query cannot conclude with CALL'"
-                    `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.id = $this0_id
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_director_connect0_node:Director)
+	WHERE this0_director_connect0_node.id = $this0_director_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_director_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_director_connect0_node
+		MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_director_connect_Director
+}
+WITH this0
+CALL {
+	WITH this0
+	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this0_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
+	RETURN c AS this0_director_Director_unique_ignored
+}
+RETURN this0
+}
+RETURN 'Query cannot conclude with CALL'"
+`);
 
                     expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{
@@ -1014,36 +1014,36 @@ describe("tck/rfs/003", () => {
                     });
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "CALL {
-                        CREATE (this0:Movie)
-                        SET this0.id = $this0_id
-                        WITH this0
-                        CALL {
-                        	WITH this0
-                        	OPTIONAL MATCH (this0_director_connect0_node:Director)
-                        	WHERE this0_director_connect0_node.id = $this0_director_connect0_node_param0
-                        	CALL {
-                        		WITH *
-                        		WITH collect(this0_director_connect0_node) as connectedNodes, collect(this0) as parentNodes
-                        		UNWIND parentNodes as this0
-                        		UNWIND connectedNodes as this0_director_connect0_node
-                        		MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
-                        		RETURN count(*)
-                        	}
-                        	RETURN count(*) AS connect_this0_director_connect_Director
-                        }
-                        WITH this0
-                        CALL {
-                        	WITH this0
-                        	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
-                        	WITH count(this0_director_Director_unique) as c
-                        	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
-                        	RETURN c AS this0_director_Director_unique_ignored
-                        }
-                        RETURN this0
-                        }
-                        RETURN 'Query cannot conclude with CALL'"
-                    `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.id = $this0_id
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_director_connect0_node:Director)
+	WHERE this0_director_connect0_node.id = $this0_director_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_director_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_director_connect0_node
+		MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_director_connect_Director
+}
+WITH this0
+CALL {
+	WITH this0
+	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this0_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
+	RETURN c AS this0_director_Director_unique_ignored
+}
+RETURN this0
+}
+RETURN 'Query cannot conclude with CALL'"
+`);
 
                     expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{
@@ -1104,59 +1104,59 @@ describe("tck/rfs/003", () => {
                         });
 
                         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                            "CALL {
-                            CREATE (this0:Movie)
-                            SET this0.id = $this0_id
-                            WITH this0
-                            CALL {
-                            	WITH this0
-                            	OPTIONAL MATCH (this0_director_connect0_node:Director)
-                            	WHERE this0_director_connect0_node.id = $this0_director_connect0_node_param0
-                            	CALL {
-                            		WITH *
-                            		WITH collect(this0_director_connect0_node) as connectedNodes, collect(this0) as parentNodes
-                            		UNWIND parentNodes as this0
-                            		UNWIND connectedNodes as this0_director_connect0_node
-                            		MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
-                            		RETURN count(*)
-                            	}
-                            WITH this0, this0_director_connect0_node
-                            CALL {
-                            	WITH this0, this0_director_connect0_node
-                            	OPTIONAL MATCH (this0_director_connect0_node_address0_node:Address)
-                            	WHERE this0_director_connect0_node_address0_node.street = $this0_director_connect0_node_address0_node_param0
-                            	CALL {
-                            		WITH *
-                            		WITH this0, collect(this0_director_connect0_node_address0_node) as connectedNodes, collect(this0_director_connect0_node) as parentNodes
-                            		UNWIND parentNodes as this0_director_connect0_node
-                            		UNWIND connectedNodes as this0_director_connect0_node_address0_node
-                            		MERGE (this0_director_connect0_node)-[:HAS_ADDRESS]->(this0_director_connect0_node_address0_node)
-                            		RETURN count(*)
-                            	}
-                            	WITH this0, this0_director_connect0_node, this0_director_connect0_node_address0_node
-                            CALL {
-                            	WITH this0_director_connect0_node
-                            	MATCH (this0_director_connect0_node)-[this0_director_connect0_node_address_Address_unique:HAS_ADDRESS]->(:Address)
-                            	WITH count(this0_director_connect0_node_address_Address_unique) as c
-                            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required', [0])
-                            	RETURN c AS this0_director_connect0_node_address_Address_unique_ignored
-                            }
-                            	RETURN count(*) AS connect_this0_director_connect0_node_address_Address
-                            }
-                            	RETURN count(*) AS connect_this0_director_connect_Director
-                            }
-                            WITH this0
-                            CALL {
-                            	WITH this0
-                            	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
-                            	WITH count(this0_director_Director_unique) as c
-                            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
-                            	RETURN c AS this0_director_Director_unique_ignored
-                            }
-                            RETURN this0
-                            }
-                            RETURN 'Query cannot conclude with CALL'"
-                        `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.id = $this0_id
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_director_connect0_node:Director)
+	WHERE this0_director_connect0_node.id = $this0_director_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_director_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_director_connect0_node
+		MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
+		RETURN count(*) AS _
+	}
+WITH this0, this0_director_connect0_node
+CALL {
+	WITH this0, this0_director_connect0_node
+	OPTIONAL MATCH (this0_director_connect0_node_address0_node:Address)
+	WHERE this0_director_connect0_node_address0_node.street = $this0_director_connect0_node_address0_node_param0
+	CALL {
+		WITH *
+		WITH this0, collect(this0_director_connect0_node_address0_node) as connectedNodes, collect(this0_director_connect0_node) as parentNodes
+		UNWIND parentNodes as this0_director_connect0_node
+		UNWIND connectedNodes as this0_director_connect0_node_address0_node
+		MERGE (this0_director_connect0_node)-[:HAS_ADDRESS]->(this0_director_connect0_node_address0_node)
+		RETURN count(*) AS _
+	}
+	WITH this0, this0_director_connect0_node, this0_director_connect0_node_address0_node
+CALL {
+	WITH this0_director_connect0_node
+	MATCH (this0_director_connect0_node)-[this0_director_connect0_node_address_Address_unique:HAS_ADDRESS]->(:Address)
+	WITH count(this0_director_connect0_node_address_Address_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required', [0])
+	RETURN c AS this0_director_connect0_node_address_Address_unique_ignored
+}
+	RETURN count(*) AS connect_this0_director_connect0_node_address_Address
+}
+	RETURN count(*) AS connect_this0_director_connect_Director
+}
+WITH this0
+CALL {
+	WITH this0
+	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this0_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
+	RETURN c AS this0_director_Director_unique_ignored
+}
+RETURN this0
+}
+RETURN 'Query cannot conclude with CALL'"
+`);
 
                         expect(formatParams(result.params)).toMatchInlineSnapshot(`
                             "{
@@ -1203,33 +1203,33 @@ describe("tck/rfs/003", () => {
                     });
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:\`Movie\`)
-                        WHERE this.id = $param0
-                        WITH this
-                        CALL {
-                        WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
-                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Directorparam0
-                        CALL {
-                        	WITH this_disconnect_director0, this_disconnect_director0_rel
-                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel
-                        	UNWIND this_disconnect_director0 as x
-                        	DELETE this_disconnect_director0_rel
-                        	RETURN count(*)
-                        }
-                        RETURN count(*) AS disconnect_this_disconnect_director_Director
-                        }
-                        WITH *
-                        WITH *
-                        CALL {
-                        	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
-                        	WITH count(this_director_Director_unique) as c
-                        	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
-                        	RETURN c AS this_director_Director_unique_ignored
-                        }
-                        RETURN 'Query cannot conclude with CALL'"
-                    `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Directorparam0
+CALL {
+	WITH this_disconnect_director0, this_disconnect_director0_rel
+	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel
+	UNWIND this_disconnect_director0 as x
+	DELETE this_disconnect_director0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_director_Director
+}
+WITH *
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
+	RETURN c AS this_director_Director_unique_ignored
+}
+RETURN 'Query cannot conclude with CALL'"
+`);
 
                     expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{
@@ -1299,54 +1299,54 @@ describe("tck/rfs/003", () => {
                     });
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:\`Movie\`)
-                        WHERE this.id = $param0
-                        WITH this
-                        CALL {
-                        	WITH this
-                        	OPTIONAL MATCH (this_connect_director0_node:Director)
-                        	WHERE this_connect_director0_node.id = $this_connect_director0_node_param0
-                        	CALL {
-                        		WITH *
-                        		WITH collect(this_connect_director0_node) as connectedNodes, collect(this) as parentNodes
-                        		UNWIND parentNodes as this
-                        		UNWIND connectedNodes as this_connect_director0_node
-                        		MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
-                        		RETURN count(*)
-                        	}
-                        	RETURN count(*) AS connect_this_connect_director_Director
-                        }
-                        WITH this
-                        CALL {
-                        WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
-                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Directorparam0
-                        CALL {
-                        	WITH this_disconnect_director0, this_disconnect_director0_rel
-                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel
-                        	UNWIND this_disconnect_director0 as x
-                        	DELETE this_disconnect_director0_rel
-                        	RETURN count(*)
-                        }
-                        RETURN count(*) AS disconnect_this_disconnect_director_Director
-                        }
-                        WITH *
-                        CALL {
-                            WITH this
-                            MATCH (this_director:\`Director\`)-[update_this0:DIRECTED]->(this)
-                            WITH this_director { .id } AS this_director
-                            RETURN head(collect(this_director)) AS this_director
-                        }
-                        WITH *
-                        CALL {
-                        	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
-                        	WITH count(this_director_Director_unique) as c
-                        	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
-                        	RETURN c AS this_director_Director_unique_ignored
-                        }
-                        RETURN collect(DISTINCT this { .id, director: this_director }) AS data"
-                    `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_director0_node:Director)
+	WHERE this_connect_director0_node.id = $this_connect_director0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_director0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_director0_node
+		MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_director_Director
+}
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Directorparam0
+CALL {
+	WITH this_disconnect_director0, this_disconnect_director0_rel
+	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel
+	UNWIND this_disconnect_director0 as x
+	DELETE this_disconnect_director0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_director_Director
+}
+WITH *
+CALL {
+    WITH this
+    MATCH (this_director:\`Director\`)-[update_this0:DIRECTED]->(this)
+    WITH this_director { .id } AS this_director
+    RETURN head(collect(this_director)) AS this_director
+}
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required', [0])
+	RETURN c AS this_director_Director_unique_ignored
+}
+RETURN collect(DISTINCT this { .id, director: this_director }) AS data"
+`);
 
                     expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{
@@ -1415,54 +1415,54 @@ describe("tck/rfs/003", () => {
                     });
 
                     expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-                        "MATCH (this:\`Movie\`)
-                        WHERE this.id = $param0
-                        WITH this
-                        CALL {
-                        	WITH this
-                        	OPTIONAL MATCH (this_connect_director0_node:Director)
-                        	WHERE this_connect_director0_node.id = $this_connect_director0_node_param0
-                        	CALL {
-                        		WITH *
-                        		WITH collect(this_connect_director0_node) as connectedNodes, collect(this) as parentNodes
-                        		UNWIND parentNodes as this
-                        		UNWIND connectedNodes as this_connect_director0_node
-                        		MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
-                        		RETURN count(*)
-                        	}
-                        	RETURN count(*) AS connect_this_connect_director_Director
-                        }
-                        WITH this
-                        CALL {
-                        WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
-                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Directorparam0
-                        CALL {
-                        	WITH this_disconnect_director0, this_disconnect_director0_rel
-                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel
-                        	UNWIND this_disconnect_director0 as x
-                        	DELETE this_disconnect_director0_rel
-                        	RETURN count(*)
-                        }
-                        RETURN count(*) AS disconnect_this_disconnect_director_Director
-                        }
-                        WITH *
-                        CALL {
-                            WITH this
-                            MATCH (this_director:\`Director\`)-[update_this0:DIRECTED]->(this)
-                            WITH this_director { .id } AS this_director
-                            RETURN head(collect(this_director)) AS this_director
-                        }
-                        WITH *
-                        CALL {
-                        	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
-                        	WITH count(this_director_Director_unique) as c
-                        	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
-                        	RETURN c AS this_director_Director_unique_ignored
-                        }
-                        RETURN collect(DISTINCT this { .id, director: this_director }) AS data"
-                    `);
+"MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_director0_node:Director)
+	WHERE this_connect_director0_node.id = $this_connect_director0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_director0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_director0_node
+		MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_director_Director
+}
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Directorparam0
+CALL {
+	WITH this_disconnect_director0, this_disconnect_director0_rel
+	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel
+	UNWIND this_disconnect_director0 as x
+	DELETE this_disconnect_director0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_director_Director
+}
+WITH *
+CALL {
+    WITH this
+    MATCH (this_director:\`Director\`)-[update_this0:DIRECTED]->(this)
+    WITH this_director { .id } AS this_director
+    RETURN head(collect(this_director)) AS this_director
+}
+WITH *
+CALL {
+	WITH this
+	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+	WITH count(this_director_Director_unique) as c
+	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
+	RETURN c AS this_director_Director_unique_ignored
+}
+RETURN collect(DISTINCT this { .id, director: this_director }) AS data"
+`);
 
                     expect(formatParams(result.params)).toMatchInlineSnapshot(`
                         "{

--- a/packages/graphql/tests/tck/subscriptions/delete.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/delete.test.ts
@@ -99,26 +99,26 @@ describe("Subscriptions metadata on delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "WITH [] AS meta
-            MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this, meta + { event: \\"delete\\", id: id(this), properties: { old: this { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
-            WITH this, meta
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, meta, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            WITH this, this_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" }) AS meta
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this
-            WITH meta
-            UNWIND meta AS m
-            RETURN collect(DISTINCT m) AS meta"
-        `);
+"WITH [] AS meta
+MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this, meta + { event: \\"delete\\", id: id(this), properties: { old: this { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
+WITH this, meta
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, meta, collect(DISTINCT this_actors0) as this_actors0_to_delete
+WITH this, this_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" }) AS meta
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this
+WITH meta
+UNWIND meta AS m
+RETURN collect(DISTINCT m) AS meta"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -170,48 +170,48 @@ describe("Subscriptions metadata on delete", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "WITH [] AS meta
-            MATCH (this:\`Movie\`)
-            WHERE this.id = $param0
-            WITH this, meta + { event: \\"delete\\", id: id(this), properties: { old: this { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
-            WITH this, meta
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
-            WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
-            WITH this, meta, this_actors0
-            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
-            WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_Movieparam0
-            WITH this, meta, this_actors0, this_actors0_movies0
-            OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:ACTED_IN]-(this_actors0_movies0_actors0:Actor)
-            WHERE this_actors0_movies0_actors0.name = $this_deleteMovies_args_delete_actors0_delete_movies0_delete_actors0_where_Actorparam0
-            WITH this, meta, this_actors0, this_actors0_movies0, collect(DISTINCT this_actors0_movies0_actors0) as this_actors0_movies0_actors0_to_delete
-            WITH this, this_actors0, this_actors0_movies0, this_actors0_movies0_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_movies0_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" }) AS meta
-            CALL {
-            	WITH this_actors0_movies0_actors0_to_delete
-            	UNWIND this_actors0_movies0_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, meta, this_actors0, collect(DISTINCT this_actors0_movies0) as this_actors0_movies0_to_delete
-            WITH this, this_actors0, this_actors0_movies0_to_delete, REDUCE(m=meta, n IN this_actors0_movies0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" }) AS meta
-            CALL {
-            	WITH this_actors0_movies0_to_delete
-            	UNWIND this_actors0_movies0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH this, meta, collect(DISTINCT this_actors0) as this_actors0_to_delete
-            WITH this, this_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" }) AS meta
-            CALL {
-            	WITH this_actors0_to_delete
-            	UNWIND this_actors0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            DETACH DELETE this
-            WITH meta
-            UNWIND meta AS m
-            RETURN collect(DISTINCT m) AS meta"
-        `);
+"WITH [] AS meta
+MATCH (this:\`Movie\`)
+WHERE this.id = $param0
+WITH this, meta + { event: \\"delete\\", id: id(this), properties: { old: this { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
+WITH this, meta
+OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_Actorparam0
+WITH this, meta, this_actors0
+OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_Movieparam0
+WITH this, meta, this_actors0, this_actors0_movies0
+OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:ACTED_IN]-(this_actors0_movies0_actors0:Actor)
+WHERE this_actors0_movies0_actors0.name = $this_deleteMovies_args_delete_actors0_delete_movies0_delete_actors0_where_Actorparam0
+WITH this, meta, this_actors0, this_actors0_movies0, collect(DISTINCT this_actors0_movies0_actors0) as this_actors0_movies0_actors0_to_delete
+WITH this, this_actors0, this_actors0_movies0, this_actors0_movies0_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_movies0_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" }) AS meta
+CALL {
+	WITH this_actors0_movies0_actors0_to_delete
+	UNWIND this_actors0_movies0_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, meta, this_actors0, collect(DISTINCT this_actors0_movies0) as this_actors0_movies0_to_delete
+WITH this, this_actors0, this_actors0_movies0_to_delete, REDUCE(m=meta, n IN this_actors0_movies0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" }) AS meta
+CALL {
+	WITH this_actors0_movies0_to_delete
+	UNWIND this_actors0_movies0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH this, meta, collect(DISTINCT this_actors0) as this_actors0_to_delete
+WITH this, this_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" }) AS meta
+CALL {
+	WITH this_actors0_to_delete
+	UNWIND this_actors0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+DETACH DELETE this
+WITH meta
+UNWIND meta AS m
+RETURN collect(DISTINCT m) AS meta"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/union.test.ts
+++ b/packages/graphql/tests/tck/union.test.ts
@@ -317,29 +317,29 @@ describe("Cypher Union", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "CALL {
-            CREATE (this0:Movie)
-            SET this0.title = $this0_title
-            WITH this0
-            CALL {
-            	WITH this0
-            	OPTIONAL MATCH (this0_search_Genre_connect0_node:Genre)
-            	WHERE this0_search_Genre_connect0_node.name = $this0_search_Genre_connect0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this0_search_Genre_connect0_node) as connectedNodes, collect(this0) as parentNodes
-            		UNWIND parentNodes as this0
-            		UNWIND connectedNodes as this0_search_Genre_connect0_node
-            		MERGE (this0)-[:SEARCH]->(this0_search_Genre_connect0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this0_search_Genre_connect_Genre
-            }
-            RETURN this0
-            }
-            RETURN [
-            this0 { .title }] AS data"
-        `);
+"CALL {
+CREATE (this0:Movie)
+SET this0.title = $this0_title
+WITH this0
+CALL {
+	WITH this0
+	OPTIONAL MATCH (this0_search_Genre_connect0_node:Genre)
+	WHERE this0_search_Genre_connect0_node.name = $this0_search_Genre_connect0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this0_search_Genre_connect0_node) as connectedNodes, collect(this0) as parentNodes
+		UNWIND parentNodes as this0
+		UNWIND connectedNodes as this0_search_Genre_connect0_node
+		MERGE (this0)-[:SEARCH]->(this0_search_Genre_connect0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this0_search_Genre_connect_Genre
+}
+RETURN this0
+}
+RETURN [
+this0 { .title }] AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -449,24 +449,24 @@ describe("Cypher Union", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_search_Genre0_disconnect0_rel:SEARCH]->(this_search_Genre0_disconnect0:Genre)
-            WHERE this_search_Genre0_disconnect0.name = $updateMovies_args_update_search_Genre0_disconnect0_where_Genreparam0
-            CALL {
-            	WITH this_search_Genre0_disconnect0, this_search_Genre0_disconnect0_rel
-            	WITH collect(this_search_Genre0_disconnect0) as this_search_Genre0_disconnect0, this_search_Genre0_disconnect0_rel
-            	UNWIND this_search_Genre0_disconnect0 as x
-            	DELETE this_search_Genre0_disconnect0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_search_Genre0_disconnect_Genre
-            }
-            RETURN collect(DISTINCT this { .title }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_search_Genre0_disconnect0_rel:SEARCH]->(this_search_Genre0_disconnect0:Genre)
+WHERE this_search_Genre0_disconnect0.name = $updateMovies_args_update_search_Genre0_disconnect0_where_Genreparam0
+CALL {
+	WITH this_search_Genre0_disconnect0, this_search_Genre0_disconnect0_rel
+	WITH collect(this_search_Genre0_disconnect0) as this_search_Genre0_disconnect0, this_search_Genre0_disconnect0_rel
+	UNWIND this_search_Genre0_disconnect0 as x
+	DELETE this_search_Genre0_disconnect0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_search_Genre0_disconnect_Genre
+}
+RETURN collect(DISTINCT this { .title }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -518,25 +518,25 @@ describe("Cypher Union", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_search_Genre0_rel:SEARCH]->(this_disconnect_search_Genre0:Genre)
-            WHERE this_disconnect_search_Genre0.name = $updateMovies_args_disconnect_search_Genre0_where_Genreparam0
-            CALL {
-            	WITH this_disconnect_search_Genre0, this_disconnect_search_Genre0_rel
-            	WITH collect(this_disconnect_search_Genre0) as this_disconnect_search_Genre0, this_disconnect_search_Genre0_rel
-            	UNWIND this_disconnect_search_Genre0 as x
-            	DELETE this_disconnect_search_Genre0_rel
-            	RETURN count(*)
-            }
-            RETURN count(*) AS disconnect_this_disconnect_search_Genre_Genre
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .title }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+WITH this
+OPTIONAL MATCH (this)-[this_disconnect_search_Genre0_rel:SEARCH]->(this_disconnect_search_Genre0:Genre)
+WHERE this_disconnect_search_Genre0.name = $updateMovies_args_disconnect_search_Genre0_where_Genreparam0
+CALL {
+	WITH this_disconnect_search_Genre0, this_disconnect_search_Genre0_rel
+	WITH collect(this_disconnect_search_Genre0) as this_disconnect_search_Genre0, this_disconnect_search_Genre0_rel
+	UNWIND this_disconnect_search_Genre0 as x
+	DELETE this_disconnect_search_Genre0_rel
+	RETURN count(*) AS _
+}
+RETURN count(*) AS disconnect_this_disconnect_search_Genre_Genre
+}
+WITH *
+RETURN collect(DISTINCT this { .title }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -584,26 +584,26 @@ describe("Cypher Union", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
-            CALL {
-            	WITH this
-            	OPTIONAL MATCH (this_connect_search_Genre0_node:Genre)
-            	WHERE this_connect_search_Genre0_node.name = $this_connect_search_Genre0_node_param0
-            	CALL {
-            		WITH *
-            		WITH collect(this_connect_search_Genre0_node) as connectedNodes, collect(this) as parentNodes
-            		UNWIND parentNodes as this
-            		UNWIND connectedNodes as this_connect_search_Genre0_node
-            		MERGE (this)-[:SEARCH]->(this_connect_search_Genre0_node)
-            		RETURN count(*)
-            	}
-            	RETURN count(*) AS connect_this_connect_search_Genre_Genre
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .title }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+CALL {
+	WITH this
+	OPTIONAL MATCH (this_connect_search_Genre0_node:Genre)
+	WHERE this_connect_search_Genre0_node.name = $this_connect_search_Genre0_node_param0
+	CALL {
+		WITH *
+		WITH collect(this_connect_search_Genre0_node) as connectedNodes, collect(this) as parentNodes
+		UNWIND parentNodes as this
+		UNWIND connectedNodes as this_connect_search_Genre0_node
+		MERGE (this)-[:SEARCH]->(this_connect_search_Genre0_node)
+		RETURN count(*) AS _
+	}
+	RETURN count(*) AS connect_this_connect_search_Genre_Genre
+}
+WITH *
+RETURN collect(DISTINCT this { .title }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -634,21 +634,21 @@ describe("Cypher Union", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Movie\`)
-            WHERE this.title = $param0
-            WITH this
-            OPTIONAL MATCH (this)-[this_delete_search_Genre0_relationship:SEARCH]->(this_delete_search_Genre0:Genre)
-            WHERE this_delete_search_Genre0.name = $updateMovies_args_delete_search_Genre0_where_Genreparam0
-            WITH this, collect(DISTINCT this_delete_search_Genre0) as this_delete_search_Genre0_to_delete
-            CALL {
-            	WITH this_delete_search_Genre0_to_delete
-            	UNWIND this_delete_search_Genre0_to_delete AS x
-            	DETACH DELETE x
-            	RETURN count(*)
-            }
-            WITH *
-            RETURN collect(DISTINCT this { .title }) AS data"
-        `);
+"MATCH (this:\`Movie\`)
+WHERE this.title = $param0
+WITH this
+OPTIONAL MATCH (this)-[this_delete_search_Genre0_relationship:SEARCH]->(this_delete_search_Genre0:Genre)
+WHERE this_delete_search_Genre0.name = $updateMovies_args_delete_search_Genre0_where_Genreparam0
+WITH this, collect(DISTINCT this_delete_search_Genre0) as this_delete_search_Genre0_to_delete
+CALL {
+	WITH this_delete_search_Genre0_to_delete
+	UNWIND this_delete_search_Genre0_to_delete AS x
+	DETACH DELETE x
+	RETURN count(*) AS _
+}
+WITH *
+RETURN collect(DISTINCT this { .title }) AS data"
+`);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{


### PR DESCRIPTION
# Description
This PR fixes a 5.0 incompatibility introduced in #2223 by adding an alias on `RETURN count(*)` in subqueries
