### PR TITLE
boyscouting: Slack notify after release to publish docs

### DIFF
--- a/.github/workflows/changesets-dev.yml
+++ b/.github/workflows/changesets-dev.yml
@@ -74,7 +74,7 @@ jobs:
           git merge --no-ff origin/dev --strategy-option theirs
           git push
 
-  slack-notify:
+  slack-release-notify:
     needs:
       - release
 
@@ -93,3 +93,18 @@ jobs:
           payload: '{"version":"${{ matrix.package.version }}"}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_ANNOUNCEMENT_WEBHOOK_URL }}
+
+  slack-publish-public-docs-notify:
+    needs:
+      - release
+
+    if: ${{ needs.release.outputs.published == 'true' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Slack notification to publish the public GraphQL docs
+        if: matrix.package.name == '@neo4j/graphql'
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PUBLISH_PUBLIC_DOCS_NOTIFICATION_WEBHOOK_URL }}

--- a/.github/workflows/changesets-dev.yml
+++ b/.github/workflows/changesets-dev.yml
@@ -101,6 +101,9 @@ jobs:
     if: ${{ needs.release.outputs.published == 'true' }}
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.release.outputs.published-packages) }}
 
     steps:
       - name: Send Slack notification to publish the public GraphQL docs

--- a/.github/workflows/changesets-master.yml
+++ b/.github/workflows/changesets-master.yml
@@ -78,7 +78,7 @@ jobs:
           pr_title: "Merge ${{ github.ref }} into dev"
           github_token: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}
 
-  slack-notify:
+  slack-release-notify:
     needs:
       - release
 
@@ -97,3 +97,18 @@ jobs:
           payload: '{"version":"${{ matrix.package.version }}"}'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_ANNOUNCEMENT_WEBHOOK_URL }}
+
+  slack-publish-public-docs-notify:
+    needs:
+      - release
+
+    if: ${{ needs.release.outputs.published == 'true' }}
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Send Slack notification to publish the public GraphQL docs
+        if: matrix.package.name == '@neo4j/graphql'
+        uses: slackapi/slack-github-action@v1.23.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PUBLISH_PUBLIC_DOCS_NOTIFICATION_WEBHOOK_URL }}

--- a/.github/workflows/changesets-master.yml
+++ b/.github/workflows/changesets-master.yml
@@ -105,6 +105,9 @@ jobs:
     if: ${{ needs.release.outputs.published == 'true' }}
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: ${{ fromJson(needs.release.outputs.published-packages) }}
 
     steps:
       - name: Send Slack notification to publish the public GraphQL docs


### PR DESCRIPTION
This PR adds a Slack webhook with a message to publish the GraphQL docs after a release of `dev` or `master`.