### PR TITLE
Replace deprecated "set-output" workflow command

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           number=$(<prnumber)
           case "$number" in ''|*[!0-9]*) echo "Provided PR number is not an integer"; exit 1 ;; esac
-          echo "::set-output name=pr-number::$number"
+          echo "pr-number=$number" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/ui-stage-publish.yml
+++ b/.github/workflows/ui-stage-publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           number=$(<prnumber)
           case "$number" in ''|*[!0-9]*) echo "Provided PR number is not an integer"; exit 1 ;; esac
-          echo "::set-output name=pr-number::$number"
+          echo "pr-number=$number" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*

--- a/.github/workflows/yarn-update.yml
+++ b/.github/workflows/yarn-update.yml
@@ -31,8 +31,9 @@ jobs:
       - name: Set output variables
         id: vars
         run: |
-          echo ::set-output name=title::"[Test] Update yarn $(date +%Y-%m-%d)"
-          echo ::set-output name=branch::"yarn-update-$(date +%Y-%m-%d)"
+          today="$(date +%Y-%m-%d)"
+          echo "title=[Test] Update yarn $today" >> "$GITHUB_OUTPUT"
+          echo "branch=yarn-update-$today" >> "$GITHUB_OUTPUT"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # tag=v4.2.0
         with:

--- a/.github/workflows/yarn-update.yml
+++ b/.github/workflows/yarn-update.yml
@@ -32,7 +32,7 @@ jobs:
         id: vars
         run: |
           today="$(date +%Y-%m-%d)"
-          echo "title=[Test] Update yarn $today" >> "$GITHUB_OUTPUT"
+          echo "title=[YARN UPDATE] Update yarn $today" >> "$GITHUB_OUTPUT"
           echo "branch=yarn-update-$today" >> "$GITHUB_OUTPUT"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@b4d51739f96fca8047ad065eccef63442d8e99f7 # tag=v4.2.0


### PR DESCRIPTION
"set-output" was deprecated as shown in our failing actions linting workflows, so this PR replaces it with the new suggested variable assignment method.