### PR TITLE
Remove services from library tests workflow

### DIFF
--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -31,16 +31,6 @@ jobs:
           - 5-community
           - 5-enterprise
 
-    services:
-      neo4j:
-        image: neo4j:${{ matrix.neo4j-version }}
-        env:
-          NEO4J_AUTH: neo4j/password
-          NEO4JLABS_PLUGINS: '["apoc"]'
-          NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
-        ports:
-          - 7687:7687
-
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
We shouldn't need a database connection for these tests
