### PR TITLE
Add functionality to get type definitions and resolvers from library

### DIFF
--- a/.changeset/few-ravens-design.md
+++ b/.changeset/few-ravens-design.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add functionality to get type defintions and resolvers from the library instead of a generated schema


### PR DESCRIPTION
# Description

Adds `getSchemaDefinition` to `Neo4jGraphQL`, which returns an object containing type definitions and resolvers. This can then be passed directly into an Apollo Server, `makeExecutableSchema`, etc., to give more flexibility with the library's output. Primarily implemented to unblock an implementation of Apollo Federation.