### PR TITLE
Fix SortDirection in input bug

### DIFF
--- a/.changeset/lovely-numbers-jam.md
+++ b/.changeset/lovely-numbers-jam.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Allow SortDirection to be used in input type definitions

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -656,4 +656,25 @@ describe("validateDocument", () => {
             expect(res).toBeUndefined();
         });
     });
+
+    describe("https://github.com/neo4j/graphql/issues/2325 - SortDirection", () => {
+        test("should not throw error when using SortDirection", () => {
+            const doc = gql`
+                type Movie {
+                    title: String
+                    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                }
+                type Actor {
+                    name: String
+                    movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT)
+                }
+                type Mutation {
+                    hello(direction: SortDirection): Boolean!
+                }
+            `;
+
+            const res = validateDocument(doc);
+            expect(res).toBeUndefined();
+        });
+    });
 });

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -23,17 +23,13 @@ import type {
     ObjectTypeDefinitionNode,
     InputValueDefinitionNode,
     FieldDefinitionNode,
-    TypeNode} from "graphql";
-import {
-    GraphQLSchema,
-    extendSchema,
-    validateSchema,
-    specifiedDirectives,
-    Kind,
+    TypeNode,
 } from "graphql";
+import { GraphQLSchema, extendSchema, validateSchema, specifiedDirectives, Kind } from "graphql";
 import pluralize from "pluralize";
 import * as scalars from "../../graphql/scalars";
 import * as directives from "../../graphql/directives";
+import { SortDirection } from "../../graphql/enums/SortDirection";
 import { Point } from "../../graphql/objects/Point";
 import { CartesianPoint } from "../../graphql/objects/CartesianPoint";
 import { PointInput } from "../../graphql/input-objects/PointInput";
@@ -173,6 +169,7 @@ function validateDocument(document: DocumentNode): void {
             PointDistance,
             CartesianPointInput,
             CartesianPointDistance,
+            SortDirection,
         ],
     });
 


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Allows `SortDirection` to be used in input type definitions and not break validation.

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes #2325 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
