### PR TITLE
feat: Toolbox banner for GraphQLaaS interest redirect

### DIFF
--- a/packages/graphql-toolbox/package.json
+++ b/packages/graphql-toolbox/package.json
@@ -81,7 +81,7 @@
         "jest-environment-jsdom": "29.3.1",
         "node-polyfill-webpack-plugin": "2.0.1",
         "parse5": "5.1.1",
-        "postcss": "8.4.18",
+        "postcss": "8.4.19",
         "postcss-loader": "7.0.1",
         "randomstring": "1.2.3",
         "style-loader": "3.3.1",

--- a/packages/graphql-toolbox/src/modules/Main/Main.tsx
+++ b/packages/graphql-toolbox/src/modules/Main/Main.tsx
@@ -55,7 +55,7 @@ export const Main = () => {
 
     const Banner = () => {
         const handleInterestedInGraphQLaaSClick = () => {
-            window.open("https://forms.gle/uQgai8zaemJz6X4B6", "_blank");
+            window.open("https://forms.gle/uQgai8zaemJz6X4B6", "GraphQLaaSInterestForm");
             tracking.trackExploreGraphQLaaSLink({ screen: screen.view });
         };
 

--- a/packages/graphql-toolbox/src/modules/Main/Main.tsx
+++ b/packages/graphql-toolbox/src/modules/Main/Main.tsx
@@ -67,7 +67,7 @@ export const Main = () => {
                 role="button"
                 tabIndex={0}
             >
-                Interested in a managed <strong>Neo4j GraphQL API</strong>? Click here!
+                Want us to manage your <strong>Neo4j GraphQL API</strong>? Register your interest here!
             </div>
         );
     };

--- a/packages/graphql-toolbox/src/modules/Main/Main.tsx
+++ b/packages/graphql-toolbox/src/modules/Main/Main.tsx
@@ -26,6 +26,7 @@ import { Editor } from "../EditorView/Editor";
 import { AuthContext } from "../../contexts/auth";
 import { ScreenContext, Screen } from "../../contexts/screen";
 import { invokeSegmentAnalytics } from "../../analytics/segment-snippet";
+import { tracking } from "../../analytics/tracking";
 
 export const Main = () => {
     const auth = useContext(AuthContext);
@@ -52,8 +53,28 @@ export const Main = () => {
         );
     }
 
+    const Banner = () => {
+        const handleInterestedInGraphQLaaSClick = () => {
+            window.open("https://forms.gle/uQgai8zaemJz6X4B6", "_blank");
+            tracking.trackExploreGraphQLaaSLink({ screen: screen.view });
+        };
+
+        return (
+            <div
+                className="h-8 w-full n-bg-primary-70 text-white text-center cursor-pointer leading-8"
+                onClick={handleInterestedInGraphQLaaSClick}
+                onKeyDown={handleInterestedInGraphQLaaSClick}
+                role="button"
+                tabIndex={0}
+            >
+                Interested in a managed <strong>Neo4j GraphQL API</strong>? Click here!
+            </div>
+        );
+    };
+
     return (
         <div className="flex w-full h-full flex-col">
+            <Banner />
             <TopBar />
             <div className="h-content-container w-full overflow-y-auto bg-contentBlue">
                 {screen.view === Screen.TYPEDEFS ? (

--- a/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
+++ b/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
@@ -48,9 +48,9 @@ export const TopBar = () => {
         tracking.trackChangeDatabase({ screen: "type definitions" });
     };
 
-    const handleExploreGraphQLaaSClick = () => {
-        window.open("https://forms.gle/uQgai8zaemJz6X4B6", "_blank");
-        tracking.trackExploreGraphQLaaSLink({ screen: screen.view });
+    const handleSendFeedbackClick = () => {
+        window.open("https://feedback.neo4j.com/graphql", "_blank");
+        tracking.trackHelpLearnFeatureLinks({ screen: screen.view, actionLabel: "Send Feedback" });
     };
 
     const constructDbmsUrlWithUsername = (): string => {
@@ -103,14 +103,14 @@ export const TopBar = () => {
             <div className="flex-1 flex justify-end">
                 <div className="flex items-center text-sm">
                     <Button
-                        data-test-graphqlaas-interest-button
-                        className="w-52 mr-4"
+                        data-test-send-feedback-topbar
+                        className="w-44 mr-4"
                         color="primary"
                         fill="outlined"
-                        onClick={handleExploreGraphQLaaSClick}
+                        onClick={handleSendFeedbackClick}
                     >
                         <HeroIcon className="w-full h-full" iconName="SparklesIcon" type="outline" />
-                        <span className="whitespace-nowrap">Explore GraphQLaaS</span>
+                        <span className="whitespace-nowrap">Send feedback</span>
                     </Button>
                     {!auth.isNeo4jDesktop ? (
                         <div className="mr-4 pr-4 border-r border-gray-700">

--- a/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
+++ b/packages/graphql-toolbox/src/modules/TopBar/TopBar.tsx
@@ -49,7 +49,7 @@ export const TopBar = () => {
     };
 
     const handleSendFeedbackClick = () => {
-        window.open("https://feedback.neo4j.com/graphql", "_blank");
+        window.open("https://feedback.neo4j.com/graphql", "SendFeedback");
         tracking.trackHelpLearnFeatureLinks({ screen: screen.view, actionLabel: "Send Feedback" });
     };
 

--- a/packages/graphql-toolbox/tailwind.config.js
+++ b/packages/graphql-toolbox/tailwind.config.js
@@ -3,9 +3,9 @@ module.exports = {
   theme: {
     extend: {
       height: {
-        "content-container": "calc(100vh - 4rem)",
-        "content-container-extended": "calc(100vh - 7rem)",
-        "content-docs-container": "calc(100vh - 7rem - 10px)",
+        "content-container": "calc(100vh - 6rem)",
+        "content-container-extended": "calc(100vh - 9rem)",
+        "content-docs-container": "calc(100vh - 9rem - 10px)",
         "favorite": "35rem",
       },
       width: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2634,7 +2634,7 @@ __metadata:
     neo4j-driver: 5.2.0
     node-polyfill-webpack-plugin: 2.0.1
     parse5: 5.1.1
-    postcss: 8.4.18
+    postcss: 8.4.19
     postcss-loader: 7.0.1
     prettier: 2.7.1
     process: 0.11.10
@@ -16347,7 +16347,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:8.4.18, postcss@npm:^8.4.12, postcss@npm:^8.4.18, postcss@npm:^8.4.7":
+"postcss@npm:8.4.19":
+  version: 8.4.19
+  resolution: "postcss@npm:8.4.19"
+  dependencies:
+    nanoid: ^3.3.4
+    picocolors: ^1.0.0
+    source-map-js: ^1.0.2
+  checksum: 62782723a385f92b7525f66d29614624de7c5643855423db3a5efd9287e677650300192749adddbbb6734cea9b1d5f5fd4f6ea00ca3f9a95dbbb88f835f5ca64
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.4.12, postcss@npm:^8.4.18, postcss@npm:^8.4.7":
   version: 8.4.18
   resolution: "postcss@npm:8.4.18"
   dependencies:


### PR DESCRIPTION
This PR contains:
- A clickable banner to open a new tab with the GraphQLaaS interest form
- Re-use the former "GraphQLaaS interest" button to instead redirect users to the Canny page in a new tab to provide feedback