### PR TITLE
Add schema generation benchmark

### DIFF
--- a/docs/contributing/DEVELOPING.md
+++ b/docs/contributing/DEVELOPING.md
@@ -146,9 +146,13 @@ query SimpleUnionQuery_only {
 
 To update the file `performance.json`, with the results of the performance test, run `yarn performance -u`
 
-## Running with Cypher
+#### Running with Cypher
 
 The performance tests can also run raw Cypher, to enable it, run `yarn performance --cypher`. Cypher queries must be located at `tests/performance/cypher`
+
+#### Schema Generation
+
+Running `yarn performance --schema` will run instead the schema generation performance test.
 
 ## Linting/formatting
 

--- a/packages/graphql/tests/performance/graphql/batch-create/batch-create-interface.graphql
+++ b/packages/graphql/tests/performance/graphql/batch-create/batch-create-interface.graphql
@@ -1,4 +1,4 @@
-mutation BatchCreateInterface {
+mutation BatchCreateInterface_skip {
     createPeople(
         input: [
             { name: "s0", born: 0, likes: { Person: { create: [{ node: { name: "a0", born: 10000 } }] } } }

--- a/packages/graphql/tests/performance/performance.ts
+++ b/packages/graphql/tests/performance/performance.ts
@@ -29,6 +29,7 @@ import { ResultsWriter } from "./utils/ResultsWriter";
 import { ResultsDisplay } from "./utils/ResultsDisplay";
 import { TestRunner } from "./utils/TestRunner";
 import type * as Performance from "./types";
+import { schemaPerformance } from "./schema-performance";
 
 let driver: Driver;
 
@@ -45,7 +46,12 @@ const typeDefs = gql`
         likes: [Likable!]! @relationship(type: "LIKES", direction: OUT)
     }
 
-    type Movie @fulltext(indexes: [{ queryName: "movieTaglineFulltextQuery", name: "MovieTaglineFulltextIndex", fields: ["tagline"] }]) {
+    type Movie
+        @fulltext(
+            indexes: [
+                { queryName: "movieTaglineFulltextQuery", name: "MovieTaglineFulltextIndex", fields: ["tagline"] }
+            ]
+        ) {
         id: ID!
         title: String!
         tagline: String
@@ -95,6 +101,14 @@ async function afterAll() {
 }
 
 async function main() {
+    if (process.argv.includes("--schema")) {
+        await schemaPerformance();
+    } else {
+        await queryPerformance();
+    }
+}
+
+async function queryPerformance() {
     try {
         await beforeAll();
         const resultsWriter = new ResultsWriter(path.join(__dirname, "/performance.json"));

--- a/packages/graphql/tests/performance/schema-performance.ts
+++ b/packages/graphql/tests/performance/schema-performance.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Neo4jGraphQL from "../../src/classes/Neo4jGraphQL";
+
+const basicTypeDefs = `
+    type Journalist {
+        articles: [Article!]! @relationship(type: "HAS_ARTICLE", direction: OUT, properties: "HasArticle")
+    }
+
+    interface HasArticle @relationshipProperties {
+        createdAt: DateTime! @timestamp
+    }
+
+    type Article {
+        id: ID! @id
+        blocks: [Block!]! @relationship(type: "HAS_BLOCK", direction: OUT, properties: "HasBlock")
+        images: [Image!]! @relationship(type: "HAS_IMAGE", direction: OUT)
+    }
+
+    interface HasBlock @relationshipProperties {
+        order: Int!
+    }
+
+    interface Block {
+        id: ID @id
+    }
+
+    type TextBlock implements Block {
+        id: ID @id
+        text: String
+    }
+
+    type DividerBlock implements Block {
+        id: ID @id
+    }
+
+    type ImageBlock implements Block {
+        id: ID @id
+        images: [Image!]! @relationship(type: "HAS_IMAGE", direction: OUT)
+    }
+
+    interface Image {
+        featuredIn: [Article!]
+    }
+
+    type PDFImage implements Image {
+        featuredIn: [Article!]! @relationship(type: "HAS_IMAGE", direction: IN)
+        url: String!
+    }
+`;
+
+export async function schemaPerformance() {
+    let typeDefs = "";
+    const toReplace =
+        /(Journalist|Article|HasArticle|Block|Image|HasBlock|TextBlock|DividerBlock|ImageBlock|PDFImage|HAS_ARTICLE|HAS_BLOCK|HAS_IMAGE)/g;
+
+    for (let i = 0; i < 500; i++) {
+        const partialTypes = basicTypeDefs.replaceAll(toReplace, `$1${i}`);
+        typeDefs = typeDefs + partialTypes;
+    }
+    const neoSchema = new Neo4jGraphQL({
+        typeDefs,
+    });
+    console.time("Schema Generation");
+    await neoSchema.getSchema();
+    console.timeEnd("Schema Generation");
+}


### PR DESCRIPTION
# Description
Adds performance tests on `getSchema` (i.e. server startup) by running `yarn performance --schema`
