### PR TITLE
docs: Passing Neo4j database info version

### DIFF
--- a/docs/modules/ROOT/pages/driver-configuration.adoc
+++ b/docs/modules/ROOT/pages/driver-configuration.adoc
@@ -231,7 +231,7 @@ const neoSchema = new Neo4jGraphQL({ typeDefs, driver });
 neoSchema.getSchema().then((schema) => {
     const server = new ApolloServer({
         schema,
-        context: { neo4jDatabaseInfo: new Neo4jDatabaseInfo("4.4") },
+        context: { neo4jDatabaseInfo: { version: "4.4" } },
     });
 });
 ----


### PR DESCRIPTION
This allows a user to use this functionality, setting the `neo4jDatabaseInfo` version to X.X, without using the full `Neo4jDatabaseInfo` class (which is not exported by the library).
