### PR TITLE
fix: Toolbox default product usage tracking state

### DIFF
--- a/.changeset/eighty-apes-knock.md
+++ b/.changeset/eighty-apes-knock.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-toolbox": patch
+---
+
+fix: Toolbox set default product usage tracking state

--- a/packages/graphql-toolbox/src/contexts/appsettings.tsx
+++ b/packages/graphql-toolbox/src/contexts/appsettings.tsx
@@ -67,6 +67,13 @@ export function AppSettingsProvider(props: React.PropsWithChildren<any>) {
         if (!constraintState) {
             Storage.store(LOCAL_STATE_CONSTRAINT, ConstraintState.ignore.toString());
         }
+
+        // On load of the application, if LOCAL_STATE_ENABLE_PRODUCT_USAGE_TRACKING is not set, set it to true.
+        // The user can at any point opt out of product usage tracking.
+        const isEnabledProductUsageTracking = Storage.retrieve(LOCAL_STATE_ENABLE_PRODUCT_USAGE_TRACKING);
+        if (isEnabledProductUsageTracking === null) {
+            Storage.store(LOCAL_STATE_ENABLE_PRODUCT_USAGE_TRACKING, "true");
+        }
     }, []);
 
     return <AppSettingsContext.Provider value={value}>{props.children}</AppSettingsContext.Provider>;


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

On load of the application, if `LOCAL_STATE_ENABLE_PRODUCT_USAGE_TRACKING` is not set in the web browser local storage, set it to `true`. This ensures product usage tracking is turned on properly on load of the application.
NOTE: The user can at any point opt out of product usage tracking!

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

