### PR TITLE
Add missing conditional which is causing excess branches to be created

### DIFF
--- a/.github/workflows/changesets-master.yml
+++ b/.github/workflows/changesets-master.yml
@@ -63,6 +63,7 @@ jobs:
           YARN_ENABLE_IMMUTABLE_INSTALLS: false
 
       - name: Create release branch for merging into dev
+        if: steps.changesets.outputs.published == 'true'
         uses: peterjgrainger/action-create-branch@08259812c8ebdbf1973747f9297e332fa078d3c1 # v2.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}


### PR DESCRIPTION
# Description

For every merge into `master` (on release from `dev`), we are creating a branch due to a missing conditional. This fixes that issue. I will tidy the branches.
