### PR TITLE
Change performance runner config to increase predictability

### DIFF
--- a/packages/graphql/tests/performance/utils/TestRunner.ts
+++ b/packages/graphql/tests/performance/utils/TestRunner.ts
@@ -118,6 +118,7 @@ export class TestRunner {
         return `CYPHER
         planner=dp
         runtime=pipelined
+        replan=force
         PROFILE ${query}`;
     }
 


### PR DESCRIPTION
# Description
Changes the runtime and force replan to try and improve predictability on performance tests

Note that the performance report on this PR is not valid, as the runtime config has changed