### PR TITLE
rfc-034-mutation-connections

### DIFF
--- a/docs/rfcs/rfc-034-mutation-connections.md
+++ b/docs/rfcs/rfc-034-mutation-connections.md
@@ -1,0 +1,66 @@
+# Mutation connections
+
+## Problem
+
+To support better the logic separation between connections described in the RFC-033, this RFC proposes to introduce the support for root connections fields for Mutation query.
+
+Given the following Type definitions:
+
+```graphql
+type Actor {
+    id: ID!
+    name: String
+    movies: [Movie!]! @relationship(type: "EMPLOYED", direction: OUT, properties: "ActedIn")
+}
+
+type Movie {
+    id: ID!
+    name: String
+    actors: [Actor!]! @relationship(type: "EMPLOYED", direction: IN, properties: "ActedIn")
+}
+
+interface ActedIn @relationshipProperties {
+    year: Int
+}
+```
+
+For instance, consider the following GraphQL mutation:
+
+```graphql
+mutation CreateActors($input: [ActorCreateInput!]!) {
+    createActors(input: $input) {
+        actors {
+            name
+        }
+    }
+}
+```
+
+This RFC proposes to achieve the same by adding the type `ActorsConnection` as a possible response of the mutation `createActors` as:
+
+```graphql
+mutation CreateActors($input: [ActorCreateInput!]!) {
+    createActors(input: $input) {
+        actorsConnection {
+            edges {
+                node {
+                    name
+                }
+            }
+        }
+    }
+}
+```
+
+## Proposed Solution
+
+This solution proposes to add `ActorsConnection` to the types `CreateActorsMutationResponse` and `UpdateActorsMutationResponse`,
+as well as the type `MoviesConnection` to the type `CreateMoviesMutationResponse` and `UpdateMoviesMutationResponse`.
+
+## Risks
+
+-   None
+
+### Security consideration
+
+-   None

--- a/docs/rfcs/rfc-034-mutation-connections.md
+++ b/docs/rfcs/rfc-034-mutation-connections.md
@@ -36,7 +36,8 @@ mutation CreateActors($input: [ActorCreateInput!]!) {
 }
 ```
 
-This RFC proposes to achieve the same by adding the type `ActorsConnection` as a possible response of the mutation `createActors` as:
+This RFC proposes to make connection fields queryable directly in the Selection Set.
+For instance:
 
 ```graphql
 mutation CreateActors($input: [ActorCreateInput!]!) {

--- a/docs/rfcs/rfc-034-mutation-connections.md
+++ b/docs/rfcs/rfc-034-mutation-connections.md
@@ -36,7 +36,7 @@ mutation CreateActors($input: [ActorCreateInput!]!) {
 }
 ```
 
-This RFC proposes to make connection fields queryable directly in the Selection Set.
+This RFC proposes to make connection fields queryable directly in the Selection Set of the mutations response.
 For instance:
 
 ```graphql

--- a/docs/rfcs/rfc-034-mutation-connections.md
+++ b/docs/rfcs/rfc-034-mutation-connections.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-To support better the logic separation between connections described in the RFC-033, this RFC proposes to introduce the support for root connections fields for Mutation query.
+To support better the logic separation between connections described in the RFC-033, this RFC proposes to introduce support for the top-level connections field in the Mutation responses.
 
 Given the following Type definitions:
 
@@ -55,7 +55,7 @@ mutation CreateActors($input: [ActorCreateInput!]!) {
 ## Proposed Solution
 
 This solution proposes to add `ActorsConnection` to the types `CreateActorsMutationResponse` and `UpdateActorsMutationResponse`,
-as well as the type `MoviesConnection` to the type `CreateMoviesMutationResponse` and `UpdateMoviesMutationResponse`.
+as well as the types `MoviesConnection` to the type `CreateMoviesMutationResponse` and `UpdateMoviesMutationResponse`.
 
 ## Risks
 


### PR DESCRIPTION
# Description

This RFC, proposes a solution for making connection fields queryable as part of the Mutations responses.

## Complexity

Complexity: Low.
