### PR TITLE
fix: custom resolvers as array

### DIFF
--- a/.changeset/lovely-mugs-matter.md
+++ b/.changeset/lovely-mugs-matter.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+fix: resolvers input for Neo4jGraphQL class accepts a IResolvers array

--- a/packages/graphql/src/schema/get-nodes.ts
+++ b/packages/graphql/src/schema/get-nodes.ts
@@ -119,6 +119,13 @@ function getNodes(
             nodeDirective = parseNodeDirective(nodeDirectiveDefinition);
         }
 
+        let customResolvers = options.userCustomResolvers?.[definition.name.value];
+        if (Array.isArray(options.userCustomResolvers)) {
+            customResolvers = options.userCustomResolvers.find((r) => !!r[definition.name.value])?.[
+                definition.name.value
+            ];
+        }
+
         const nodeFields = getObjFieldMeta({
             obj: definition,
             enums: definitionNodes.enumTypes,
@@ -127,7 +134,7 @@ function getNodes(
             scalars: definitionNodes.scalarTypes,
             unions: definitionNodes.unionTypes,
             callbacks: options.callbacks,
-            customResolvers: options.userCustomResolvers?.[definition.name.value],
+            customResolvers,
         });
 
         // Ensure that all required fields are returning either a scalar type or an enum

--- a/packages/graphql/src/schema/get-nodes.ts
+++ b/packages/graphql/src/schema/get-nodes.ts
@@ -32,6 +32,7 @@ import parseNodeDirective from "./parse-node-directive";
 import parseExcludeDirective from "./parse-exclude-directive";
 import getAuth from "./get-auth";
 import type { DefinitionNodes } from "./get-definition-nodes";
+import { asArray } from "../utils/utils";
 
 type Nodes = {
     nodes: Node[];
@@ -119,12 +120,10 @@ function getNodes(
             nodeDirective = parseNodeDirective(nodeDirectiveDefinition);
         }
 
-        let customResolvers = options.userCustomResolvers?.[definition.name.value];
-        if (Array.isArray(options.userCustomResolvers)) {
-            customResolvers = options.userCustomResolvers.find((r) => !!r[definition.name.value])?.[
-                definition.name.value
-            ];
-        }
+        const userCustomResolvers = asArray(options.userCustomResolvers);
+        const customResolvers = userCustomResolvers.find((r) => !!r[definition.name.value])?.[
+            definition.name.value
+        ] as IResolvers;
 
         const nodeFields = getObjFieldMeta({
             obj: definition,

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { generateUniqueType, UniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/2560", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neoSchema: Neo4jGraphQL;
+    let session: Session;
+
+    let User: UniqueType;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+        User = generateUniqueType("User");
+
+        const typeDefs = `
+            type ${User} {
+                firstName: String!
+                lastName: String!
+                fullName: String! @customResolver(requires: ["firstName", "lastName"])
+            }
+        `;
+
+        // Pass resolvers as an array of objects instead of an object
+        const resolvers = [
+            {
+                [User.name]: {
+                    fullName(source) {
+                        return `${source.firstName} ${source.lastName}`;
+                    },
+                },
+            },
+        ];
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            resolvers,
+        });
+    });
+
+    afterEach(async () => {
+        await cleanNodes(session, [User]);
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should accept resolvers as an array of objects", async () => {
+        const mutation = `
+            mutation {
+                ${User.operations.create}(input: [{ firstName: "Tom", lastName: "Hanks" }]) {
+                    ${User.plural} {
+                        firstName
+                        lastName
+                        fullName
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: mutation,
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [User.operations.create]: {
+                [User.plural]: [
+                    {
+                        firstName: "Tom",
+                        lastName: "Hanks",
+                        fullName: "Tom Hanks",
+                    },
+                ],
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -49,7 +49,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
             }
         `;
 
-        // Pass resolvers as an array of objects instead of an object
+        // Pass resolvers as an array of objects instead of just an object
         const resolvers = [
             {
                 [User.name]: {
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
         await driver.close();
     });
 
-    test("should accept resolvers as an array of objects", async () => {
+    test("should accept resolvers which are an array of objects", async () => {
         const mutation = `
             mutation {
                 ${User.operations.create}(input: [{ firstName: "Tom", lastName: "Hanks" }]) {

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -27,7 +27,6 @@ import { generateUniqueType, UniqueType } from "../../utils/graphql-types";
 describe("https://github.com/neo4j/graphql/issues/2560", () => {
     let driver: Driver;
     let neo4j: Neo4j;
-    let neoSchema: Neo4jGraphQL;
     let session: Session;
 
     let User: UniqueType;
@@ -70,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
             },
         ];
 
-        neoSchema = new Neo4jGraphQL({
+        const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
             resolvers,
@@ -144,7 +143,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
             },
         ];
 
-        neoSchema = new Neo4jGraphQL({
+        const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
             resolvers,


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

The `resolvers` input for the `Neo4jGraphQL` class accepts both `IResolvers` and `IResolvers[]`. With this PR we add support for the latter.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes #2560 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Integration tests have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
