### PR TITLE
feat: GHA matrix with node versions for nightly build

### DIFF
--- a/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        node: [ "lts/*", 19 ]
+        node: [ "lts/*", "latest"]
         packages:
           [
             { package: "ogm", shard: 1/1 },

--- a/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
@@ -39,6 +39,7 @@ jobs:
 
     strategy:
       matrix:
+        node: [ "lts/*", 19 ]
         packages:
           [
             { package: "ogm", shard: 1/1 },
@@ -70,9 +71,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Setting up Node.js with version ${{ matrix.node }}
+        uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: Login to ECR
         uses: docker/login-action@v2

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -14,6 +14,7 @@ jobs:
   integration-tests:
     strategy:
       matrix:
+        node: [ "lts/*", 19 ]
         packages:
           [
             { package: "ogm", shard: 1/1 },
@@ -48,9 +49,10 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - name: Setting up Node.js with version ${{ matrix.node }}
+        uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: ${{ matrix.node }}
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -14,7 +14,6 @@ jobs:
   integration-tests:
     strategy:
       matrix:
-        node: [ "lts/*", 19 ]
         packages:
           [
             { package: "ogm", shard: 1/1 },
@@ -49,10 +48,9 @@ jobs:
     steps:
       - name: Check out repository code
         uses: actions/checkout@v3
-      - name: Setting up Node.js with version ${{ matrix.node }}
-        uses: actions/setup-node@v3
+      - uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node }}
+          node-version: lts/*
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable


### PR DESCRIPTION
With this PR we test if the library passes integration tests with Node.js version 19.
At the moment we only test it on GHA against the latest node.js lts (v18.X)
For now, we only check it for the nightly build.
