### PR TITLE
Fix to properly check subscription context for JWT

### DIFF
--- a/packages/graphql/src/schema/resolvers/wrapper.ts
+++ b/packages/graphql/src/schema/resolvers/wrapper.ts
@@ -143,7 +143,9 @@ export const wrapSubscription =
             plugin: plugins.subscriptions,
         };
 
-        if (!context?.jwt && contextParams.authorization) {
+        if (context?.jwt) {
+            subscriptionContext.jwt = context.jwt;
+        } else if (!context?.jwt && contextParams.authorization) {
             const token = parseBearerToken(contextParams.authorization);
             subscriptionContext.jwt = await decodeToken(token, plugins.auth);
         }


### PR DESCRIPTION
# Description

Documentation mentions it's possible to [place JWT directly to context](https://neo4j.com/docs/graphql-manual/current/auth/setup/#_decoded_jwts) and that works well for normal requests, but did not work properly for subscriptions.

JWT can be placed to subscription context by using `useServer({ context })` as described here https://github.com/enisdenjo/graphql-ws#recipes

Added a simple unit test to cover this case. This previously would have thrown 'Unauthorized' error, even when JWT was in the context.

## Complexity

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
