### PR TITLE
boyscouting: no codecov upload for scheduled nightly dev builds

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,12 +23,12 @@ jobs:
   unit-tests:
     uses: ./.github/workflows/reusable-unit-tests.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   api-library-tests:
     uses: ./.github/workflows/reusable-api-library-tests.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   # nextjs-app-setup:
   #   uses: ./.github/workflows/reusable-nextjs-app-setup.yml
@@ -39,12 +39,12 @@ jobs:
   integration-tests-on-prem:
     uses: ./.github/workflows/reusable-integration-tests-on-prem.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   integration-tests-on-prem-nightly:
     uses: ./.github/workflows/reusable-integration-tests-on-prem-nightly.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_NEO4J_DEV_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_NEO4J_DEV_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -87,7 +87,7 @@ jobs:
   api-library-tests:
     uses: ./.github/workflows/reusable-api-library-tests.yml
     secrets:
-      CODECOV_TOKEN: ${{ github.event_name == 'schedule' && secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # nextjs-app-setup:
   #   uses: ./.github/workflows/reusable-nextjs-app-setup.yml

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -75,6 +75,8 @@ jobs:
 
   unit-tests:
     uses: ./.github/workflows/reusable-unit-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   cypher-builder-tests:
     uses: ./.github/workflows/reusable-cypher-builder-tests.yml
@@ -84,6 +86,8 @@ jobs:
 
   api-library-tests:
     uses: ./.github/workflows/reusable-api-library-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ github.event_name == 'schedule' && secrets.CODECOV_TOKEN }}
 
   # nextjs-app-setup:
   #   uses: ./.github/workflows/reusable-nextjs-app-setup.yml


### PR DESCRIPTION
Disable upload to codecov for nightly builds of `dev`. Only for the scheduled nightly builds.