### PR TITLE
Fix counting source not target nodes

### DIFF
--- a/packages/graphql/src/translate/field-aggregations/create-field-aggregation.ts
+++ b/packages/graphql/src/translate/field-aggregations/create-field-aggregation.ts
@@ -104,7 +104,7 @@ export function createFieldAggregation({
     let countFunction: Cypher.Function | undefined;
 
     if (aggregationFields.count) {
-        countFunction = Cypher.count(sourceRef);
+        countFunction = Cypher.count(targetRef);
         projectionMap.set({
             count: countRef,
         });

--- a/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
@@ -214,7 +214,7 @@ describe("aggregations-where-count", () => {
 
             expect(gqlResult.errors).toBeUndefined();
 
-            expect((gqlResult.data as any).posts).toEqual([
+            expect((gqlResult.data as any).posts).toIncludeSameMembers([
                 {
                     testString,
                     likes: [{ testString }],

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-auth.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-auth.test.ts
@@ -77,7 +77,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this_actorsAggregate_this1:\`Actor\`)-[this_actorsAggregate_this0:ACTED_IN]->(this)
-                RETURN count(this) AS this_actorsAggregate_var2
+                RETURN count(this_actorsAggregate_this1) AS this_actorsAggregate_var2
             }
             RETURN this { .title, actorsAggregate: { count: this_actorsAggregate_var2 } } AS this"
         `);
@@ -119,7 +119,7 @@ describe("Field Level Aggregations", () => {
                 WITH this
                 MATCH (this)-[this_moviesAggregate_this0:ACTED_IN]->(this_moviesAggregate_this1:\`Movie\`)
                 WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                RETURN count(this) AS this_moviesAggregate_var2
+                RETURN count(this_moviesAggregate_this1) AS this_moviesAggregate_var2
             }
             RETURN this { .name, moviesAggregate: { count: this_moviesAggregate_var2 } } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
@@ -72,7 +72,7 @@ describe("Field Level Aggregations Where", () => {
                 WITH this
                 MATCH (this_actorsAggregate_this1:\`Person\`)-[this_actorsAggregate_this0:ACTED_IN]->(this)
                 WHERE this_actorsAggregate_this1.age > $this_actorsAggregate_param0
-                RETURN count(this) AS this_actorsAggregate_var2
+                RETURN count(this_actorsAggregate_this1) AS this_actorsAggregate_var2
             }
             RETURN this { .title, actorsAggregate: { count: this_actorsAggregate_var2 } } AS this"
         `);
@@ -113,13 +113,13 @@ describe("Field Level Aggregations Where", () => {
                 WITH this
                 MATCH (this_actorsAggregate_this1:\`Person\`)-[this_actorsAggregate_this0:ACTED_IN]->(this)
                 WHERE this_actorsAggregate_this1.name CONTAINS $this_actorsAggregate_param0
-                RETURN count(this) AS this_actorsAggregate_var2
+                RETURN count(this_actorsAggregate_this1) AS this_actorsAggregate_var2
             }
             CALL {
                 WITH this
                 MATCH (this_directorsAggregate_this1:\`Person\`)-[this_directorsAggregate_this0:DIRECTED]->(this)
                 WHERE this_directorsAggregate_this1.name CONTAINS $this_directorsAggregate_param0
-                RETURN count(this) AS this_directorsAggregate_var2
+                RETURN count(this_directorsAggregate_this1) AS this_directorsAggregate_var2
             }
             RETURN this { .title, actorsAggregate: { count: this_actorsAggregate_var2 }, directorsAggregate: { count: this_directorsAggregate_var2 } } AS this"
         `);

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -70,7 +70,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this_actorsAggregate_this1:\`Actor\`)-[this_actorsAggregate_this0:ACTED_IN]->(this)
-                RETURN count(this) AS this_actorsAggregate_var2
+                RETURN count(this_actorsAggregate_this1) AS this_actorsAggregate_var2
             }
             RETURN this { .title, actorsAggregate: { count: this_actorsAggregate_var2 } } AS this"
         `);
@@ -105,7 +105,7 @@ describe("Field Level Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this_actorsAggregate_this1:\`Actor\`)-[this_actorsAggregate_this0:ACTED_IN]->(this)
-                RETURN count(this) AS this_actorsAggregate_var2
+                RETURN count(this_actorsAggregate_this1) AS this_actorsAggregate_var2
             }
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/issues/1320.test.ts
+++ b/packages/graphql/tests/tck/issues/1320.test.ts
@@ -73,13 +73,13 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
                 WITH this
                 MATCH (this)-[this_accepted_this0:OWNS_RISK]->(this_accepted_this1:\`Risk\`)
                 WHERE $this_accepted_param0 IN this_accepted_this1.mitigationState
-                RETURN count(this) AS this_accepted_var2
+                RETURN count(this_accepted_this1) AS this_accepted_var2
             }
             CALL {
                 WITH this
                 MATCH (this)-[this_identified_this0:OWNS_RISK]->(this_identified_this1:\`Risk\`)
                 WHERE $this_identified_param0 IN this_identified_this1.mitigationState
-                RETURN count(this) AS this_identified_var2
+                RETURN count(this_identified_this1) AS this_identified_var2
             }
             RETURN this { accepted: { count: this_accepted_var2 }, identified: { count: this_identified_var2 } } AS this"
         `);

--- a/packages/graphql/tests/tck/issues/1933.test.ts
+++ b/packages/graphql/tests/tck/issues/1933.test.ts
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this_projectsAggregate_this0:PARTICIPATES]->(this_projectsAggregate_this1:\`Project\`)
-                RETURN count(this) AS this_projectsAggregate_var2
+                RETURN count(this_projectsAggregate_this1) AS this_projectsAggregate_var2
             }
             CALL {
                 WITH this
@@ -143,7 +143,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this_projectsAggregate_this0:PARTICIPATES]->(this_projectsAggregate_this1:\`Project\`)
-                RETURN count(this) AS this_projectsAggregate_var2
+                RETURN count(this_projectsAggregate_this1) AS this_projectsAggregate_var2
             }
             CALL {
                 WITH this

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
@@ -66,7 +66,7 @@ describe("QueryDirection in relationships aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this_friendsAggregate_this0:FRIENDS_WITH]-(this_friendsAggregate_this1:\`User\`)
-                RETURN count(this) AS this_friendsAggregate_var2
+                RETURN count(this_friendsAggregate_this1) AS this_friendsAggregate_var2
             }
             RETURN this { friendsAggregate: { count: this_friendsAggregate_var2 } } AS this"
         `);
@@ -109,7 +109,7 @@ describe("QueryDirection in relationships aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this_friendsAggregate_this0:FRIENDS_WITH]->(this_friendsAggregate_this1:\`User\`)
-                RETURN count(this) AS this_friendsAggregate_var2
+                RETURN count(this_friendsAggregate_this1) AS this_friendsAggregate_var2
             }
             RETURN this { friendsAggregate: { count: this_friendsAggregate_var2 } } AS this"
         `);
@@ -152,7 +152,7 @@ describe("QueryDirection in relationships aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this_friendsAggregate_this0:FRIENDS_WITH]-(this_friendsAggregate_this1:\`User\`)
-                RETURN count(this) AS this_friendsAggregate_var2
+                RETURN count(this_friendsAggregate_this1) AS this_friendsAggregate_var2
             }
             RETURN this { friendsAggregate: { count: this_friendsAggregate_var2 } } AS this"
         `);

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-aggregations.test.ts
@@ -65,7 +65,7 @@ describe("Undirected Aggregations", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this_friendsAggregate_this0:FRIENDS_WITH]-(this_friendsAggregate_this1:\`User\`)
-                RETURN count(this) AS this_friendsAggregate_var2
+                RETURN count(this_friendsAggregate_this1) AS this_friendsAggregate_var2
             }
             RETURN this { friendsAggregate: { count: this_friendsAggregate_var2 } } AS this"
         `);


### PR DESCRIPTION
# Description

Fixes #2665.

Turns out this behaviour is already well covered by integration tests and the weird looking cypher was actually still producing the expected results. This is because a row was still being created for each aggregate target node which meant that the count of the source node is equal to the count of the aggregate node. However, changing the cypher is still worthwhile to make it more readable and reliable.

## Complexity

Complexity: Low

# Issue

Closes #2665

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
