### PR TITLE
Fix Cypher translation for aliased database relationship properties

### DIFF
--- a/.changeset/odd-tables-lie.md
+++ b/.changeset/odd-tables-lie.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix aggregation Cypher translation when aliasing relationship properties using the `@alias` directive

--- a/packages/graphql/src/translate/field-aggregations/create-field-aggregation.ts
+++ b/packages/graphql/src/translate/field-aggregations/create-field-aggregation.ts
@@ -18,7 +18,7 @@
  */
 
 import type { ResolveTree } from "graphql-parse-resolve-info";
-import type { Node } from "../../classes";
+import type { GraphElement, Node } from "../../classes";
 import type { Context, GraphQLWhereArg } from "../../types";
 import { getFieldType, AggregationType, getReferenceNode, getFieldByName, getReferenceRelation } from "./utils";
 import * as AggregationSubQueries from "./aggregation-sub-queries";
@@ -116,7 +116,7 @@ export function createFieldAggregation({
     if (nodeFields) {
         const { innerProjectionMap: nodeProjectionMap, innerProjectionSubqueries } =
             getAggregationProjectionAndSubqueries({
-                referenceNode,
+                referenceNodeOrRelationship: referenceNode,
                 matchWherePattern,
                 targetRef,
                 sourceRef,
@@ -129,7 +129,7 @@ export function createFieldAggregation({
     if (edgeFields) {
         const { innerProjectionMap: edgeProjectionMap, innerProjectionSubqueries } =
             getAggregationProjectionAndSubqueries({
-                referenceNode,
+                referenceNodeOrRelationship: referenceRelation,
                 matchWherePattern,
                 targetRef: targetPattern,
                 sourceRef,
@@ -155,13 +155,13 @@ export function createFieldAggregation({
 }
 
 function getAggregationProjectionAndSubqueries({
-    referenceNode,
+    referenceNodeOrRelationship,
     matchWherePattern,
     targetRef,
     sourceRef,
     fields,
 }: {
-    referenceNode: Node;
+    referenceNodeOrRelationship: GraphElement;
     matchWherePattern: Cypher.Clause;
     targetRef: Cypher.Node | Cypher.Relationship;
     sourceRef: Cypher.Node;
@@ -171,11 +171,11 @@ function getAggregationProjectionAndSubqueries({
     const innerProjectionMap = new Cypher.Map();
 
     Object.values(fields).forEach((field) => {
-        const dbProperty = mapToDbProperty(referenceNode, field.name);
+        const dbProperty = mapToDbProperty(referenceNodeOrRelationship, field.name);
         const fieldType = getFieldType(field);
         const fieldName = dbProperty || field.name;
         const fieldRef = new Cypher.Variable();
-        innerProjectionMap.set(fieldName, fieldRef);
+        innerProjectionMap.set(field.name, fieldRef);
         const subquery = getAggregationSubquery({
             matchWherePattern,
             fieldName,

--- a/packages/graphql/tests/integration/issues/2669.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2669.int.test.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { generateUniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/2669", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+    let typeDefs: string;
+
+    const typeMovie = generateUniqueType("Movie");
+    const typeActor = generateUniqueType("Actor");
+
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+
+        typeDefs = `
+        type ${typeMovie.name} {
+            title: String
+            actors: [${typeActor.name}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+        }
+
+        type ${typeActor.name} {
+            myName: String @alias(property: "name")
+            age: Int
+            movies: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+        }
+
+        interface ActedIn {
+            time: Int @alias(property: "screentime")
+        }
+        `;
+
+        neoSchema = new Neo4jGraphQL({ typeDefs });
+        session = await neo4j.getSession();
+        await session.run(`CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
+        CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})`);
+    });
+
+    afterAll(async () => {
+        await session.close();
+        await driver.close();
+    });
+
+    test("Field Node Aggregation alias", async () => {
+        const query = `
+            query {
+                ${typeMovie.plural} {
+                    actorsAggregate {
+                        node {
+                            myName {
+                                shortest
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
+            node: {
+                myName: {
+                    shortest: "Linda",
+                },
+            },
+        });
+    });
+
+    test("Field Edge Aggregation alias", async () => {
+        const query = `
+            query {
+                ${typeMovie.plural} {
+                    actorsAggregate {
+                        edge {
+                            time {
+                                max
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
+            edge: {
+                time: {
+                    max: 120,
+                },
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
@@ -81,7 +81,7 @@ describe("Field Level Aggregations Alias", () => {
                 WITH collect(this_actorsAggregate_this0.name) AS list
                 RETURN { longest: head(list), shortest: last(list) } AS this_actorsAggregate_var2
             }
-            RETURN this { actorsAggregate: { node: { name: this_actorsAggregate_var2 } } } AS this"
+            RETURN this { actorsAggregate: { node: { myName: this_actorsAggregate_var2 } } } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -112,7 +112,7 @@ describe("Field Level Aggregations Alias", () => {
             CALL {
                 WITH this
                 MATCH (this_actorsAggregate_this1:\`Actor\`)-[this_actorsAggregate_this0:ACTED_IN]->(this)
-                RETURN { min: min(this_actorsAggregate_this0.time), max: max(this_actorsAggregate_this0.time), average: avg(this_actorsAggregate_this0.time), sum: sum(this_actorsAggregate_this0.time) }  AS this_actorsAggregate_var2
+                RETURN { min: min(this_actorsAggregate_this0.screentime), max: max(this_actorsAggregate_this0.screentime), average: avg(this_actorsAggregate_this0.screentime), sum: sum(this_actorsAggregate_this0.screentime) }  AS this_actorsAggregate_var2
             }
             RETURN this { actorsAggregate: { edge: { time: this_actorsAggregate_var2 } } } AS this"
         `);


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Aliases from GraphQL fields to database relationship properties were not being translated in aggregations.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes #2669

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
