### PR TITLE
Revert "fix: set neo4j-version in GHA to older version for 4.x"

### DIFF
--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -25,9 +25,9 @@ jobs:
           - "^15.0.0"
           - "^16.0.0"
         neo4j-version:
-          - 4.3.22-enterprise
-          - 4.4.15-community
-          - 4.4.15-enterprise
+          - 4.3-enterprise
+          - 4.4-community
+          - 4.4-enterprise
           - 5-community
           - 5-enterprise
 

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -24,9 +24,9 @@ jobs:
             { package: "graphql", shard: 4/4 },
           ]
         neo4j-version:
-          - 4.3.22-enterprise
+          - 4.3-enterprise
           #   - 4.4-community
-          - 4.4.15-enterprise
+          - 4.4-enterprise
           #   - 5-community
           - 5-enterprise
         graphql-version:

--- a/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
+++ b/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
@@ -12,9 +12,9 @@ jobs:
           - "^15.0.0"
           - "^16.0.0"
         neo4j-version:
-          - 4.3.22-enterprise
+          - 4.3-enterprise
           #   - 4.4-community
-          - 4.4.15-enterprise
+          - 4.4-enterprise
           #   - 5-community
           - 5-enterprise
     services:


### PR DESCRIPTION
Reverts neo4j/graphql#2621

From the APOC lib maintenance team (cypher surface): `This has now been fixed, and tests have been added to make sure it won't happen again`