### PR TITLE
boyscouting: disable CodeCov upload for dev nightly build

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -23,12 +23,12 @@ jobs:
   unit-tests:
     uses: ./.github/workflows/reusable-unit-tests.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   api-library-tests:
     uses: ./.github/workflows/reusable-api-library-tests.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   # nextjs-app-setup:
   #   uses: ./.github/workflows/reusable-nextjs-app-setup.yml
@@ -39,12 +39,12 @@ jobs:
   integration-tests-on-prem:
     uses: ./.github/workflows/reusable-integration-tests-on-prem.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   integration-tests-on-prem-nightly:
     uses: ./.github/workflows/reusable-integration-tests-on-prem-nightly.yml
     secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_NEO4J_DEV_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_NEO4J_DEV_SECRET_ACCESS_KEY }}
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -75,8 +75,6 @@ jobs:
 
   unit-tests:
     uses: ./.github/workflows/reusable-unit-tests.yml
-    secrets:
-      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   cypher-builder-tests:
     uses: ./.github/workflows/reusable-cypher-builder-tests.yml
@@ -86,8 +84,6 @@ jobs:
 
   api-library-tests:
     uses: ./.github/workflows/reusable-api-library-tests.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # nextjs-app-setup:
   #   uses: ./.github/workflows/reusable-nextjs-app-setup.yml

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -75,6 +75,8 @@ jobs:
 
   unit-tests:
     uses: ./.github/workflows/reusable-unit-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ github.event_name != 'schedule' && secrets.CODECOV_TOKEN }}
 
   cypher-builder-tests:
     uses: ./.github/workflows/reusable-cypher-builder-tests.yml
@@ -84,6 +86,8 @@ jobs:
 
   api-library-tests:
     uses: ./.github/workflows/reusable-api-library-tests.yml
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # nextjs-app-setup:
   #   uses: ./.github/workflows/reusable-nextjs-app-setup.yml

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           VERIFY_TCK: true
           NEO_USER: neo4j
-      - if: ${{ env.CODECOV_TOKEN != '' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -78,7 +78,7 @@ jobs:
         run: yarn
       - name: Run Schema tests
         run: yarn --cwd packages/graphql run test:schema --coverage
-      - if: ${{ env.CODECOV_TOKEN != '' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -86,7 +86,7 @@ jobs:
           directory: ./packages/graphql/coverage/
           flags: graphql,schema
           fail_ci_if_error: true
-      - if: ${{ env.CODECOV_TOKEN != '' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' }}
         name: Archive coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
@@ -108,7 +108,7 @@ jobs:
           NEO_USER: neo4j
           NEO_PASSWORD: password
           NEO_URL: neo4j://localhost:7687
-      - if: ${{ env.CODECOV_TOKEN != '' && matrix.packages.package == 'graphql' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' && matrix.packages.package == 'graphql' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -116,7 +116,7 @@ jobs:
           directory: ./packages/${{ matrix.packages.package }}/coverage-nightly/
           flags: ${{ matrix.packages.package }},nightly,integration
           fail_ci_if_error: true
-      - if: ${{ env.CODECOV_TOKEN != '' && matrix.packages.package == 'graphql' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' && matrix.packages.package == 'graphql' }}
         name: Archive coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -65,7 +65,7 @@ jobs:
           NEO_USER: neo4j
           NEO_PASSWORD: password
           NEO_URL: bolt://localhost:7687
-      - if: ${{ env.CODECOV_TOKEN != '' && matrix.packages.package == 'graphql' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' && matrix.packages.package == 'graphql' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -73,7 +73,7 @@ jobs:
           directory: ./packages/${{ matrix.packages.package }}/coverage-${{ matrix.neo4j-version }}/
           flags: ${{ matrix.packages.package }},${{ matrix.neo4j-version }},integration
           fail_ci_if_error: true
-      - if: ${{ env.CODECOV_TOKEN != '' && matrix.packages.package == 'graphql' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' && matrix.packages.package == 'graphql' }}
         name: Archive coverage report
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/reusable-unit-tests.yml
+++ b/.github/workflows/reusable-unit-tests.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Run packages/${{ matrix.package }} unit tests
         run: yarn run test:unit --coverage
         working-directory: packages/${{ matrix.package }}
-      - if: ${{ env.CODECOV_TOKEN != '' && matrix.package == 'graphql' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' && matrix.package == 'graphql' }}
         name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
@@ -47,7 +47,7 @@ jobs:
           directory: ./packages/${{ matrix.package }}/coverage/
           flags: ${{ matrix.package }},unit
           fail_ci_if_error: true
-      - if: ${{ env.CODECOV_TOKEN != '' && matrix.package == 'graphql' }}
+      - if: ${{ env.CODECOV_TOKEN != '' && env.CODECOV_TOKEN != 'false' && matrix.package == 'graphql' }}
         name: Archive coverage report
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Disable upload to CodeCov for nightly builds of the `dev` branch due to an increasing amount of `Too many uploads to the commit` error messages of `dev` nightly builds. It's disabled only for the scheduled nightly builds.