### PR TITLE
fix: Toolbox E2E tests, connectivty issues 

### DIFF
--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -18,6 +18,9 @@ jobs:
           - 7687:7687
 
     steps:
+      - name: Update system (Ubuntu)
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-18.04'
+        run: sudo apt update && sudo apt upgrade -y
       - name: Check out repository code
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -19,8 +19,16 @@ jobs:
 
     steps:
       - name: Update system (Ubuntu)
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-18.04'
-        run: sudo apt update && sudo apt upgrade -y
+        run: |
+          # use apt-spy2 to select closest apt mirror,
+          # which helps avoid connectivity issues in Azure;
+          # see https://github.com/actions/virtual-environments/issues/675
+          sudo gem install apt-spy2
+          sudo apt-spy2 check
+          sudo apt-spy2 fix --commit
+          # end of apt-spy2 workaround
+          sudo apt-get update
+          sudo apt upgrade -y
       - name: Check out repository code
         uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -18,6 +18,8 @@ jobs:
           - 7687:7687
 
     steps:
+      - name: Check out repository code
+        uses: actions/checkout@v3
       - name: Update system (Ubuntu)
         run: |
           # use apt-spy2 to select closest apt mirror,
@@ -26,11 +28,9 @@ jobs:
           sudo gem install apt-spy2
           sudo apt-spy2 check
           sudo apt-spy2 fix --commit
+          # need to run apt-get update after running apt-spy2 fix
+          sudo apt-get -o Acquire::Retries=3 update
           # end of apt-spy2 workaround
-          sudo apt-get update
-          sudo apt upgrade -y
-      - name: Check out repository code
-        uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
           node-version: lts/*


### PR DESCRIPTION
The E2E tests for the Toolbox fail due to connectivity issues when installing Playwright (the test runner).
See for instance: https://github.com/neo4j/graphql/actions/runs/3878819827/jobs/6680638507#step:6:644 
This workaround should fix this.
It introduces a bit of a delay (ca 2 mins) due to the `apt-spy2 check` command.