### PR TITLE
fix: use expect.toIncludeSameMembers to check array content

### DIFF
--- a/packages/graphql/tests/integration/issues/2709.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2709.int.test.ts
@@ -368,18 +368,18 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
-            [Movie.plural]: [
+            [Movie.plural]: expect.toIncludeSameMembers([
                 {
                     title: "A Netflix movie",
                 },
                 {
                     title: "A Dishney movie",
                 },
-            ],
+            ]),
         });
         // Note: to not equal
         expect(result.data as any).not.toEqual({
-            [Movie.plural]: [
+            [Movie.plural]: expect.toIncludeSameMembers([
                 {
                     title: "A Netflix movie",
                 },
@@ -389,7 +389,7 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
                 {
                     title: "A Publisher movie",
                 },
-            ],
+            ]),
         });
     });
 });


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

In https://github.com/neo4j/graphql/pull/2715 I missed using `expect.toIncludeSameMembers()` to check the content of the response array. The "hard coded" order in a response (array) can cause flakiness in the integration tests.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low
