### PR TITLE
feat: expose all package configurations for user

### DIFF
--- a/docs/modules/ROOT/pages/auth/setup.adoc
+++ b/docs/modules/ROOT/pages/auth/setup.adoc
@@ -50,13 +50,15 @@ const neoSchema = new Neo4jGraphQL({
     typeDefs,
     plugins: {
         auth: new Neo4jGraphQLAuthJWKSPlugin({
-            jwksEndpoint: "https://YOUR_DOMAIN/well-known/jwks.json",
+            jwksOptions: {
+                jwksUri: "https://YOUR_DOMAIN/well-known/jwks.json",
+            }
         })
     }
 });
 ----
 
-Or you can pass a function as `jskwsEndpoint` to compute the endpoint when the request comes in.
+Or you can pass a function as `jwksEndpoint` to compute the endpoint when the request comes in.
 
 [source, javascript, indent=0]
 ----
@@ -67,16 +69,26 @@ const neoSchema = new Neo4jGraphQL({
     typeDefs,
     plugins: {
         auth: new Neo4jGraphQLAuthJWKSPlugin({
-            jwksEndpoint: (req) => {
-                let url = "https://YOUR_DOMAIN/well-known/{file}.json";
-                const fileHeader = req.headers["file"];
-                url = url.replace("{file}", fileHeader);
-                return url;
+            jwksOptions: {
+                jwksUri: (req) => {
+                    let url = "https://YOUR_DOMAIN/well-known/{file}.json";
+                    const fileHeader = req.headers["file"];
+                    url = url.replace("{file}", fileHeader);
+                    return url;
+                }
             },
         }),
     }
 });
 ----
+
+Verification is provided using the [jsonwebtoken package](https://github.com/auth0/node-jsonwebtoken).
+- All verify options are exposed and follow their [documentation](https://github.com/auth0/node-jsonwebtoken).
+- By default, if verification is enabled, the code verifies uses the "HS256" and "RS256" algorithms.
+
+Jwks validation is provided using the [jwks-rsa package](https://www.npmjs.com/package/jwks-rsa).
+- All Jwks options are exposed and follow their [types](https://github.com/auth0/node-jwks-rsa/tree/9574b04ed621744c1aeac05f9138d074a0ab23a4#readme)
+- Note that JwksEndpoint is now named jwksOptions.JwksUri to avoid duplication of variables.
 
 If you need to create your own auth plugin then ensure it adheres to the following interface:
 
@@ -90,7 +102,7 @@ interface Neo4jGraphQLAuthPlugin {
 }
 ----
 
-It is also possible to pass in JWTs which have already been decoded, in which case the `jwt` option is _not necessary_. This is covered in the section xref::auth/setup.adoc#auth-setup-passing-in[Passing in JWTs] below. Note that the plugin's base decode method only supports HS256 and RS256 algorithms.
+It is also possible to pass in JWTs which have already been decoded, in which case the `jwt` option is _not necessary_. This is covered in the section xref::auth/setup.adoc#auth-setup-passing-in[Passing in JWTs] below.
 
 === Auth Roles Object Paths
 

--- a/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWTPlugin.test.ts
+++ b/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWTPlugin.test.ts
@@ -22,13 +22,13 @@ import * as jsonwebtoken from "jsonwebtoken";
 import Neo4jGraphQLAuthJWTPlugin from "./Neo4jGraphQLAuthJWTPlugin";
 
 describe("Neo4jGraphQLAuthJWTPlugin", () => {
-    const secret = "secret";
+    const secret: string = "secret";
     const payload = {
         sub: "my-id",
     };
-    test("should decode token", async () => {
-        const encoded = jsonwebtoken.sign(payload, secret);
+    const encoded = jsonwebtoken.sign(payload, secret);
 
+    test("should decode token", async () => {
         const plugin = new Neo4jGraphQLAuthJWTPlugin({
             secret,
         });
@@ -39,12 +39,8 @@ describe("Neo4jGraphQLAuthJWTPlugin", () => {
     });
 
     test("should decode token when secret is a generic", async () => {
-        const encoded = jsonwebtoken.sign(payload, secret);
-
         const plugin = new Neo4jGraphQLAuthJWTPlugin({
-            secret: () => {
-                return secret;
-            },
+            secret: () => secret
         });
 
         plugin.tryToResolveKeys({
@@ -59,12 +55,8 @@ describe("Neo4jGraphQLAuthJWTPlugin", () => {
     });
 
     test(`should throw '${AUTH_JWT_PLUGIN_NULL_SECRET_EXCEPTION}' exception, when a function for calculating the secret is passed but the result is null`, async () => {
-        const encoded = jsonwebtoken.sign(payload, secret);
-
         const plugin = new Neo4jGraphQLAuthJWTPlugin({
-            secret: () => {
-                return secret;
-            },
+            secret: () => secret
         });
 
         await expect(async () => {
@@ -73,8 +65,6 @@ describe("Neo4jGraphQLAuthJWTPlugin", () => {
     });
 
     test("should decode token when using noVerify", async () => {
-        const encoded = jsonwebtoken.sign(payload, secret);
-
         const plugin = new Neo4jGraphQLAuthJWTPlugin({
             secret,
             noVerify: true,
@@ -86,8 +76,6 @@ describe("Neo4jGraphQLAuthJWTPlugin", () => {
     });
 
     test("should decode JWT token with globalAuthentication enabled", async () => {
-        const encoded = jsonwebtoken.sign(payload, secret);
-
         const plugin = new Neo4jGraphQLAuthJWTPlugin({
             secret,
             globalAuthentication: true,
@@ -101,12 +89,6 @@ describe("Neo4jGraphQLAuthJWTPlugin", () => {
     test("should throw an error if both noVerify and globalAuthentication are enabled", async () => {
         let initError: Error | null | unknown = null;
         try {
-            const payload = {
-                sub: "my-id",
-            };
-
-            const encoded = jsonwebtoken.sign(payload, secret);
-
             const plugin = new Neo4jGraphQLAuthJWTPlugin({
                 secret,
                 noVerify: true,


### PR DESCRIPTION
# Description
Exposes all auth configurations from [jsonwebtoken](https://github.com/auth0/node-jsonwebtoken) and [jwks-rsa ](https://www.npmjs.com/package/jwks-rsa) packages to user.

# Notes
- Small breaking change: JwksEndpoint is removed in favor of jwksOptions.JwksUri to avoid duplication of variables.

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Integration tests have been updated
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
