### PR TITLE
fix connection where with logical operator

### DIFF
--- a/packages/graphql/src/translate/create-aggregate-where-and-params.ts
+++ b/packages/graphql/src/translate/create-aggregate-where-and-params.ts
@@ -139,8 +139,7 @@ function aggregateWhere(
         } else if (isLogicalOperator(key)) {
             const cypherBuilderFunction = getCypherLogicalOperator(key);
             const logicalPredicates: Cypher.Predicate[] = [];
-            value = Array.isArray(value) ? value : [value];
-            value.forEach((whereInput) => {
+            (Array.isArray(value) ? value : [value]).forEach((whereInput) => {
                 const {
                     returnProjections: innerReturnProjections,
                     predicates: innerPredicates,
@@ -209,8 +208,7 @@ function aggregateEntityWhere(
         if (isLogicalOperator(key)) {
             const cypherBuilderFunction = getCypherLogicalOperator(key);
             const logicalPredicates: Cypher.Predicate[] = [];
-            value = Array.isArray(value) ? value : [value];
-            value.forEach((whereInput) => {
+            (Array.isArray(value) ? value : [value]).forEach((whereInput) => {
                 const {
                     returnProjections: innerReturnProjections,
                     predicates: innerPredicates,

--- a/packages/graphql/src/translate/create-aggregate-where-and-params.ts
+++ b/packages/graphql/src/translate/create-aggregate-where-and-params.ts
@@ -28,6 +28,7 @@ import {
 import { NODE_OR_EDGE_KEYS, AGGREGATION_AGGREGATE_COUNT_OPERATORS } from "../constants";
 import { getCypherLogicalOperator, isLogicalOperator, LogicalOperator } from "./utils/logical-operators";
 import mapToDbProperty from "../utils/map-to-db-property";
+import { asArray } from "../utils/utils";
 
 type WhereFilter = Record<string | LogicalOperator, any>;
 
@@ -139,7 +140,7 @@ function aggregateWhere(
         } else if (isLogicalOperator(key)) {
             const cypherBuilderFunction = getCypherLogicalOperator(key);
             const logicalPredicates: Cypher.Predicate[] = [];
-            (Array.isArray(value) ? value : [value]).forEach((whereInput) => {
+            asArray(value).forEach((whereInput) => {
                 const {
                     returnProjections: innerReturnProjections,
                     predicates: innerPredicates,
@@ -208,7 +209,7 @@ function aggregateEntityWhere(
         if (isLogicalOperator(key)) {
             const cypherBuilderFunction = getCypherLogicalOperator(key);
             const logicalPredicates: Cypher.Predicate[] = [];
-            (Array.isArray(value) ? value : [value]).forEach((whereInput) => {
+            asArray(value).forEach((whereInput) => {
                 const {
                     returnProjections: innerReturnProjections,
                     predicates: innerPredicates,

--- a/packages/graphql/src/translate/where/create-where-predicate.ts
+++ b/packages/graphql/src/translate/where/create-where-predicate.ts
@@ -24,6 +24,7 @@ import Cypher from "@neo4j/cypher-builder";
 import { createPropertyWhere } from "./property-operations/create-property-where";
 import { getCypherLogicalOperator, isLogicalOperator, LogicalOperator } from "../utils/logical-operators";
 import type { ListPredicate } from "./utils";
+import { asArray } from "../../utils/utils";
 
 /** Translate a target node and GraphQL input into a Cypher operation o valid where expression */
 export function createWherePredicate({
@@ -56,7 +57,7 @@ export function createWherePredicate({
                 element,
                 targetElement,
                 context,
-                value: Array.isArray(value) ? value : [value],
+                value: asArray(value),
                 listPredicateStr,
                 requiredVariables,
             });

--- a/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
@@ -197,8 +197,7 @@ export function createConnectionWherePropertyOperation({
     Object.entries(whereInput).forEach(([key, value]) => {
         if (isLogicalOperator(key)) {
             const subOperations: (Cypher.Predicate | undefined)[] = [];
-            value = Array.isArray(value) ? value : [value];
-            (value as Array<any>).forEach((input) => {
+            (Array.isArray(value) ? value : [value]).forEach((input) => {
                 const {
                     predicate,
                     preComputedSubqueries,

--- a/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
@@ -25,7 +25,7 @@ import type { WhereOperator } from "../types";
 // Recursive function
 
 import { createWherePredicate } from "../create-where-predicate";
-import { filterTruthy } from "../../../utils/utils";
+import { asArray, filterTruthy } from "../../../utils/utils";
 import { getCypherLogicalOperator, isLogicalOperator } from "../../utils/logical-operators";
 import { createRelationshipPredicate } from "./create-relationship-operation";
 
@@ -197,7 +197,7 @@ export function createConnectionWherePropertyOperation({
     Object.entries(whereInput).forEach(([key, value]) => {
         if (isLogicalOperator(key)) {
             const subOperations: (Cypher.Predicate | undefined)[] = [];
-            (Array.isArray(value) ? value : [value]).forEach((input) => {
+            asArray(value).forEach((input) => {
                 const {
                     predicate,
                     preComputedSubqueries,

--- a/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
@@ -197,6 +197,7 @@ export function createConnectionWherePropertyOperation({
     Object.entries(whereInput).forEach(([key, value]) => {
         if (isLogicalOperator(key)) {
             const subOperations: (Cypher.Predicate | undefined)[] = [];
+            value = Array.isArray(value) ? value : [value];
             (value as Array<any>).forEach((input) => {
                 const {
                     predicate,


### PR DESCRIPTION
# Bug-fix Connection where with logical operator

Fix a bug introduced with the `NOT` operator PR, logical filters inside a connection field was treated as an array, but the `NOT` operator value is an object. 

## Complexity

Complexity: Literally one change

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
