### PR TITLE
Add header to sticky comments, prevents overwrite

### DIFF
--- a/.github/workflows/docs-publish.yml
+++ b/.github/workflows/docs-publish.yml
@@ -50,6 +50,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # v2.3.1
         with:
           number: ${{ steps.get-pr-number.outputs.pr-number }}
+          header: docs
           message: |
             Looks like you've updated the documentation!
 

--- a/.github/workflows/performance-tests-comment.yml
+++ b/.github/workflows/performance-tests-comment.yml
@@ -43,5 +43,6 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # v2.3.1
         with:
           number: ${{ steps.get-pr-number.outputs.pr-number }}
+          header: performance
           path: ./performanceReport
           GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/ui-stage-publish.yml
+++ b/.github/workflows/ui-stage-publish.yml
@@ -50,6 +50,7 @@ jobs:
         uses: marocchino/sticky-pull-request-comment@fcf6fe9e4a0409cd9316a5011435be0f3327f1e1 # v2.3.1
         with:
           number: ${{ steps.get-pr-number.outputs.pr-number }}
+          header: toolbox
           message: |
             Made some changes to the GraphQL Toolbox? Or made some changes to the core library perhaps?
 


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Our various sticky comment calls were colliding - hence why we've been missing docs and Toolbox publish messages lately - they were being overridden by the performance report! 🤦 

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low