### PR TITLE
subscriptions exclude fixes

### DIFF
--- a/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
+++ b/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
@@ -273,13 +273,18 @@ export function generateSubscriptionTypes({
             },
         });
 
-        const { created: createdWhere, deleted: deletedWhere } = generateSubscriptionConnectionWhereType({
-            node,
-            schemaComposer,
-            relationshipFields,
-            interfaceCommonFields,
-        });
-        if (node.relationFields.length > 0) {
+        const shouldCreateConnectionWhereTypes =
+            node.relationFields.length > 0 &&
+            node.relationFields.filter((rf) => nodesWithSubscriptionOperation.find((n) => n.name === rf.typeMeta.name))
+                .length > 0;
+        if (shouldCreateConnectionWhereTypes) {
+            const { created: createdWhere, deleted: deletedWhere } = generateSubscriptionConnectionWhereType({
+                node,
+                schemaComposer,
+                relationshipFields,
+                interfaceCommonFields,
+            });
+            // if (node.relationFields.length > 0) {
             subscriptionComposer.addFields({
                 [subscribeOperation.relationship_created]: {
                     args: { where: createdWhere },
@@ -304,6 +309,7 @@ export function generateSubscriptionTypes({
                     resolve: subscriptionResolve,
                 },
             });
+            // }
         }
     });
 }


### PR DESCRIPTION
# Description

Fixes *type*SubscriptionWhere does not exist error for relationship to type with @exclude subscriptions
Adds test - **in progress**

Related issue: same error on types that have only relationship fields. - draft #2833 

## Complexity

Complexity: Low
