### PR TITLE
Add experimental option to disable bump on peer dependency bump

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -8,5 +8,8 @@
     "baseBranch": "dev",
     "updateInternalDependencies": "patch",
     "ignore": ["graphql-manual", "migration"],
-    "privatePackages": { "version": true, "tag": true }
+    "privatePackages": { "version": true, "tag": true },
+    "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+        "onlyUpdatePeerDependentsWhenOutOfRange": true
+    }
 }


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

If you check the current changesets PR, it wants to bump the AMQP Subscriptions plugin to 3.0.0 - we obviously don't want to do that! We have already accidentally released 2.0.0 (please check the proposed changelogs before merging!).

This is due to https://github.com/changesets/changesets/blob/main/docs/decisions.md#the-versioning-of-peer-dependencies

This adds an experimental option to disable this behaviour, but we will need to keep an eye on this.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low