### PR TITLE
fix: set node.js version for reviewdog-eslint&package-tests GHA to v18.13.0

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 16
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.13.0
           cache: yarn
       - name: Install dependencies
         run: yarn --immutable

--- a/.github/workflows/reusable-package-tests.yml
+++ b/.github/workflows/reusable-package-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: lts/*
+          node-version: 16
           cache: yarn
       - name: Install dependencies
         run: yarn

--- a/.github/workflows/reusable-package-tests.yml
+++ b/.github/workflows/reusable-package-tests.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 18.13.0
           cache: yarn
       - name: Install dependencies
         run: yarn


### PR DESCRIPTION
The latest opened PRs are failing due to errors in the reviewdog action-eslint and the package-tests Github actions.
See for the reviewdog eslint-action: https://github.com/neo4j/graphql/actions/runs/4139641732/jobs/7161364297
And also for the package-tests: https://github.com/neo4j/graphql/actions/runs/4139641732/jobs/7161375522

The execution fails on node.js v18.14.0. Setting the node.js version to v18.13.0 in these two Github actions resolves this.

Info on the Github action `actions/setup-node@v3`:
```
node: v18.13.0
npm: 8.19.3
yarn: 3.4.1
```
```
node: v18.14.0
npm: 9.3.1
yarn: 3.4.1
```
Note the large difference of `npm` versions.

It could be likely that the errors are due to this increase in the npm version.