### PR TITLE
Add `.vscode/settings.json` to ensure uniform formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ tmp/
 .vscode/*
 !.vscode/extensions.json
 !.vscode/graphql.code-snippets
+!.vscode/settings.json
 
 # OSX
 .DS_Store

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,12 +2,7 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
     // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
     // List of extensions which should be recommended for users of this workspace.
-    "recommendations": [
-        "asciidoctor.asciidoctor-vscode",
-        "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode",
-        "orta.vscode-jest"
-    ],
+    "recommendations": ["rvest.vs-code-prettier-eslint"],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
+    "editor.formatOnPaste": false,
+    "editor.formatOnType": false
+}


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

We still have a problem of PRs with completely wrong formatting.

As I was setting up my machine, I started completely from scratch, and have come up with the barest project configuration to ensure that formatting happens as it should.

This depends on the `rvest.vs-code-prettier-eslint` extension, which I have add as a recommended extension. It takes into account both ESLint and Prettier rules, unlike when using those two extensions separately. The ESLint can still be used for syntax highlighting linting errors.

This can of course be overridden by user settings.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low