### PR TITLE
Check for enums as well as scalars when doing UNWIND CREATE

### DIFF
--- a/.changeset/fast-carpets-grow.md
+++ b/.changeset/fast-carpets-grow.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fixes #2889 where nodes could not be created with enum list as a property

--- a/packages/graphql/src/translate/batch-create/parser.ts
+++ b/packages/graphql/src/translate/batch-create/parser.ts
@@ -66,15 +66,15 @@ export function inputTreeToCypherMap(
                     (x) => x.properties === relationField.properties
                 ) as unknown as Relationship;
             }
-            let scalar = false;
+            let scalarOrEnum = false;
             if (parentKey === "edge") {
-                scalar = isScalar(key, relationship as Relationship);
+                scalarOrEnum = isScalarOrEnum(key, relationship as Relationship);
             }
             // it assume that if parentKey is not defined then it means that the key belong to a Node
             else if (parentKey === "node" || parentKey === undefined) {
-                scalar = isScalar(key, node);
+                scalarOrEnum = isScalarOrEnum(key, node);
             }
-            if (typeof value === "object" && value !== null && (relationField || !scalar)) {
+            if (typeof value === "object" && value !== null && (relationField || !scalarOrEnum)) {
                 if (Array.isArray(value)) {
                     obj[key] = new Cypher.List(
                         value.map((GraphQLCreateInput: GraphQLCreateInput) =>
@@ -106,13 +106,14 @@ export function inputTreeToCypherMap(
     return new Cypher.Map(properties);
 }
 
-function isScalar(fieldName: string, graphElement: GraphElement) {
+function isScalarOrEnum(fieldName: string, graphElement: GraphElement) {
     const scalarPredicate = (x) => x.fieldName === fieldName;
     const scalarFields = [
         graphElement.primitiveFields,
         graphElement.temporalFields,
         graphElement.pointFields,
         graphElement.scalarFields,
+        graphElement.enumFields
     ];
     return scalarFields.flat().some(scalarPredicate);
 }
@@ -133,15 +134,15 @@ export function getTreeDescriptor(
                 ) as unknown as Relationship;
             }
 
-            let scalar = false;
+            let scalarOrEnum = false;
             if (parentKey === "edge") {
-                scalar = isScalar(key, relationship as Relationship);
+                scalarOrEnum = isScalarOrEnum(key, relationship as Relationship);
             }
             // it assume that if parentKey is not defined then it means that the key belong to a Node
             else if (parentKey === "node" || parentKey === undefined) {
-                scalar = isScalar(key, node);
+                scalarOrEnum = isScalarOrEnum(key, node);
             }
-            if (typeof value === "object" && value !== null && !scalar) {
+            if (typeof value === "object" && value !== null && !scalarOrEnum) {
                 // TODO: supports union/interfaces
                 const innerNode = relationField && relatedNodes[0] ? relatedNodes[0] : node;
 

--- a/packages/graphql/src/translate/batch-create/parser.ts
+++ b/packages/graphql/src/translate/batch-create/parser.ts
@@ -107,15 +107,15 @@ export function inputTreeToCypherMap(
 }
 
 function isScalarOrEnum(fieldName: string, graphElement: GraphElement) {
-    const scalarPredicate = (x) => x.fieldName === fieldName;
-    const scalarFields = [
+    const scalarOrEnumPredicate = (x) => x.fieldName === fieldName;
+    const scalarOrEnumFields = [
         graphElement.primitiveFields,
         graphElement.temporalFields,
         graphElement.pointFields,
         graphElement.scalarFields,
         graphElement.enumFields
     ];
-    return scalarFields.flat().some(scalarPredicate);
+    return scalarOrEnumFields.flat().some(scalarOrEnumPredicate);
 }
 
 export function getTreeDescriptor(

--- a/packages/graphql/tests/integration/issues/2889.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2889.int.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { UniqueType } from "../../utils/graphql-types";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { Neo4jGraphQLAuthJWTPlugin } from "../../../../plugins/graphql-plugin-auth/src";
+
+describe("https://github.com/neo4j/graphql/issues/2889", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neoSchema: Neo4jGraphQL;
+    let session: Session;
+
+    let MyEnumHolder: UniqueType;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+
+        MyEnumHolder = new UniqueType("MyEnumHolder");
+
+        const typeDefs = `
+            enum MyEnum {
+                FIRST
+                SECOND
+            }
+
+            type ${MyEnumHolder} {
+                myEnums: [MyEnum!]!
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret: "secret"
+                })
+            }
+        });
+    });
+
+    afterEach(async () => {
+        await cleanNodes(session, [MyEnumHolder]);
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should be able to create node with list of enums", async () => {
+        const query = `
+            mutation {
+                ${MyEnumHolder.operations.create}(input: [{ myEnums: [FIRST, SECOND] }]) {
+                    ${MyEnumHolder.plural} {
+                        myEnums
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues()
+        });
+
+        expect(result.errors).toBeFalsy();
+        expect((result.data?.[MyEnumHolder.operations.create] as any)[MyEnumHolder.plural]).toEqual([
+            { myEnums: ["FIRST", "SECOND"] }
+        ]);
+    });
+});


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

When generating Cypher for an `UNWIND CREATE`, input should have been checked for enums as well as scalars.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes #2889