### PR TITLE
Add comma-dangle to .eslintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,7 +6,7 @@ module.exports = {
         es2021: true,
     },
     rules: {
-        "comma-dangle": ["error", "only-multiline"],
+        "comma-dangle": ["error", "always-multiline"],
         "eslint-comments/no-unused-disable": "error",
         // Expensive rules disabled below
         "import/default": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
         es2021: true,
     },
     rules: {
+        "comma-dangle": ["error", "only-multiline"],
         "eslint-comments/no-unused-disable": "error",
         // Expensive rules disabled below
         "import/default": "off",
@@ -53,7 +54,7 @@ module.exports = {
                 "@typescript-eslint/ban-ts-comment": "off",
                 "@typescript-eslint/no-unsafe-assignment": "off",
                 "@typescript-eslint/no-explicit-any": "off",
-                "jest/expect-expect": [ "warn", {"assertFunctionNames": [ "expect", "expectTypeOf" ]}],
+                "jest/expect-expect": ["warn", { assertFunctionNames: ["expect", "expectTypeOf"] }],
             },
         },
         {


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

The current combined Prettier+ESLint combination does not add trailing commas for multi-line statements as Prettier would like. This adds the comma-dangle rule to our .eslintrc which will fix this behaviour.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low