### PR TITLE
Escape relationship type strings

### DIFF
--- a/.changeset/witty-penguins-collect.md
+++ b/.changeset/witty-penguins-collect.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+Escape relationship type strings

--- a/.changeset/witty-penguins-collect.md
+++ b/.changeset/witty-penguins-collect.md
@@ -2,4 +2,4 @@
 "@neo4j/graphql": major
 ---
 
-Escape relationship type strings
+Relationship type strings are now automatically escaped using backticks. If you were using backticks in the `type` argument of your `@relationship` directives, these should now be removed to avoid backticks being added into your relationship type labels.

--- a/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
+++ b/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
@@ -482,6 +482,10 @@ If it is not included, an error will be thrown.
 
 As a result, in version 4.0.0, the following type definitions are invalid:
 
+=== Relationship types are now automatically escaped
+
+Relationship types are now automatically escaped. If you users have previously escaped their relationship types, you should now remove the escape strings as this is covered by the library.
+
 [source, graphql, indent=0]
 ----
 type Person {

--- a/docs/modules/ROOT/pages/type-definitions/relationships.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/relationships.adoc
@@ -291,12 +291,3 @@ type User {
 }
 ----
 
-Not this:
-
-[source, graphql, indent=0]
-----
-type User {
-    name: String!
-    posts: [Post!]! @relationship(type: "`HAS_POST`", direction: OUT)
-}
-----

--- a/docs/modules/ROOT/pages/type-definitions/relationships.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/relationships.adoc
@@ -278,3 +278,25 @@ type Post {
 ----
 
 The relationship at `User.posts` is considered a "many" relationship. Relationships such as the one above should always be of type `NonNullListType` and `NonNullNamedType`, meaning both the array and the type inside of it should have a `!`.
+
+== Relationship types are automatically escaped
+
+Relationship types are automatically escaped (wrapped with backticks ``), so there's no need to add escape characters around the relationship type names. For example, do this:
+
+[source, graphql, indent=0]
+----
+type User {
+    name: String!
+    posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+}
+----
+
+Not this:
+
+[source, graphql, indent=0]
+----
+type User {
+    name: String!
+    posts: [Post!]! @relationship(type: "`HAS_POST`", direction: OUT)
+}
+----

--- a/packages/graphql/src/schema/create-relationship-fields/index.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/index.ts
@@ -63,10 +63,10 @@ function createRelationshipFields({
     const nodeCreateInput = schemaComposer.getITC(`${sourceName}CreateInput`);
     const nodeUpdateInput = schemaComposer.getITC(`${sourceName}UpdateInput`);
 
-    let nodeConnectInput: InputTypeComposer<any> = undefined as unknown as InputTypeComposer<any>;
-    let nodeDeleteInput: InputTypeComposer<any> = undefined as unknown as InputTypeComposer<any>;
-    let nodeDisconnectInput: InputTypeComposer<any> = undefined as unknown as InputTypeComposer<any>;
-    let nodeRelationInput: InputTypeComposer<any> = undefined as unknown as InputTypeComposer<any>;
+    let nodeConnectInput: InputTypeComposer<any>;
+    let nodeDeleteInput: InputTypeComposer<any>;
+    let nodeDisconnectInput: InputTypeComposer<any>;
+    let nodeRelationInput: InputTypeComposer<any>;
 
     if (relationshipFields.length) {
         [nodeConnectInput, nodeDeleteInput, nodeDisconnectInput, nodeRelationInput] = [
@@ -432,10 +432,10 @@ function createRelationshipFields({
                     },
                 });
 
-                const fieldInputFields = {
+                const fieldInputFields: Record<string, string> = {
                     create,
                     connect,
-                } as Record<string, string>;
+                };
 
                 if (connectOrCreate) {
                     fieldInputFields.connectOrCreate = connectOrCreate;

--- a/packages/graphql/src/schema/get-obj-field-meta.ts
+++ b/packages/graphql/src/schema/get-obj-field-meta.ts
@@ -106,7 +106,7 @@ function getObjFieldMeta({
     validateResolvers: boolean;
     callbacks?: Neo4jGraphQLCallbacks;
     customResolvers?: IResolvers | Array<IResolvers>;
-}) {
+}): ObjectFields {
     const objInterfaceNames = [...(obj.interfaces || [])] as NamedTypeNode[];
     const objInterfaces = interfaces.filter((i) => objInterfaceNames.map((n) => n.name.value).includes(i.name.value));
 

--- a/packages/graphql/src/schema/get-relationship-meta.test.ts
+++ b/packages/graphql/src/schema/get-relationship-meta.test.ts
@@ -261,7 +261,7 @@ describe("getRelationshipMeta", () => {
         const result = getRelationshipMeta(field);
 
         expect(result).toMatchObject({
-            type: "ACTED_IN",
+            type: "`ACTED_IN`",
             direction: "IN",
         });
     });

--- a/packages/graphql/src/schema/get-relationship-meta.ts
+++ b/packages/graphql/src/schema/get-relationship-meta.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import Cypher from "@neo4j/cypher-builder";
 import type { DirectiveNode, FieldDefinitionNode, StringValueNode } from "graphql";
 import { RelationshipQueryDirectionOption } from "../constants";
 
@@ -66,7 +67,7 @@ function getRelationshipMeta(
     }
 
     const direction = directionArg.value.value as "IN" | "OUT";
-    const type = `\`${typeArg.value.value}\``;
+    const type = Cypher.utils.escapeLabel(typeArg.value.value);
     const typeUnescaped = typeArg.value.value;
     const properties = (propertiesArg?.value as StringValueNode)?.value;
 

--- a/packages/graphql/src/schema/get-relationship-meta.ts
+++ b/packages/graphql/src/schema/get-relationship-meta.ts
@@ -23,6 +23,7 @@ import { RelationshipQueryDirectionOption } from "../constants";
 type RelationshipMeta = {
     direction: "IN" | "OUT";
     type: string;
+    typeUnescaped: string;
     properties?: string;
     queryDirection: RelationshipQueryDirectionOption;
 };
@@ -65,12 +66,14 @@ function getRelationshipMeta(
     }
 
     const direction = directionArg.value.value as "IN" | "OUT";
-    const type = typeArg.value.value;
+    const type = `\`${typeArg.value.value}\``;
+    const typeUnescaped = typeArg.value.value;
     const properties = (propertiesArg?.value as StringValueNode)?.value;
 
     return {
         direction,
         type,
+        typeUnescaped,
         properties,
         queryDirection,
     };

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -810,8 +810,8 @@ function makeAugmentedSchema(
     }
 
     ["Mutation", "Query"].forEach((type) => {
-        const objectComposer = composer[type] as ObjectTypeComposer;
-        const cypherType = customResolvers[`customCypher${type}`] as ObjectTypeDefinitionNode;
+        const objectComposer: ObjectTypeComposer = composer[type];
+        const cypherType: ObjectTypeDefinitionNode = customResolvers[`customCypher${type}`];
 
         if (cypherType) {
             const objectFields = getObjFieldMeta({
@@ -885,7 +885,7 @@ function makeAugmentedSchema(
 
     let parsedDoc = parse(generatedTypeDefs);
 
-    function definionNodeHasName(x: DefinitionNode): x is DefinitionNode & { name: NameNode } {
+    function definitionNodeHasName(x: DefinitionNode): x is DefinitionNode & { name: NameNode } {
         return "name" in x;
     }
 
@@ -903,7 +903,7 @@ function makeAugmentedSchema(
         );
     }
 
-    const documentNames = new Set(parsedDoc.definitions.filter(definionNodeHasName).map((x) => x.name.value));
+    const documentNames = new Set(parsedDoc.definitions.filter(definitionNodeHasName).map((x) => x.name.value));
     const resolveMethods = getResolveAndSubscriptionMethods(composer);
 
     const generatedResolveMethods: Record<string, any> = {};

--- a/packages/graphql/src/schema/resolvers/subscriptions/subscribe.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/subscribe.ts
@@ -84,7 +84,7 @@ export function generateSubscribeMethod({
                     return false;
                 }
                 const relationFieldName = node.relationFields.find(
-                    (r) => r.type === relationEventPayload.relationshipName
+                    (r) => r.typeUnescaped === relationEventPayload.relationshipName
                 )?.fieldName;
 
                 return (

--- a/packages/graphql/src/schema/resolvers/subscriptions/utils/compare-properties.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/utils/compare-properties.ts
@@ -237,7 +237,7 @@ export function filterByRelationshipProperties({
 }): boolean {
     const receivedEventProperties = receivedEvent.properties;
     const receivedEventRelationshipType = receivedEvent.relationshipName;
-    const relationships = node.relationFields.filter((f) => f.type === receivedEventRelationshipType);
+    const relationships = node.relationFields.filter((f) => f.typeUnescaped === receivedEventRelationshipType);
     if (!relationships.length) {
         return false;
     }

--- a/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
+++ b/packages/graphql/src/schema/subscriptions/generate-subscription-types.ts
@@ -371,7 +371,7 @@ function getRelationField({
         relationshipNameToRelationField = nodeToRelationFieldMap.get(node) as Map<string, RelationField | undefined>;
     }
     if (!relationshipNameToRelationField.has(relationshipName)) {
-        const relationField = node.relationFields.find((f) => f.type === relationshipName);
+        const relationField = node.relationFields.find((f) => f.typeUnescaped === relationshipName);
         relationshipNameToRelationField.set(relationshipName, relationField);
     }
     return relationshipNameToRelationField.get(relationshipName);

--- a/packages/graphql/src/translate/create-connect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.test.ts
@@ -34,7 +34,8 @@ describe("createConnectAndParams", () => {
             relationFields: [
                 {
                     direction: "OUT",
-                    type: "SIMILAR",
+                    type: "`SIMILAR`",
+                    typeUnescaped: "SIMILAR",
                     fieldName: "similarMovies",
                     queryDirection: RelationshipQueryDirectionOption.DEFAULT_DIRECTED,
                     inherited: false,
@@ -104,7 +105,7 @@ describe("createConnectAndParams", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this0_node
-            			MERGE (this)-[:SIMILAR]->(this0_node)
+            			MERGE (this)-[:\`SIMILAR\`]->(this0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -121,7 +122,7 @@ describe("createConnectAndParams", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_node
             			UNWIND connectedNodes as this0_node_similarMovies0_node
-            			MERGE (this0_node)-[:SIMILAR]->(this0_node_similarMovies0_node)
+            			MERGE (this0_node)-[:\`SIMILAR\`]->(this0_node_similarMovies0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -282,7 +282,7 @@ function createConnectAndParams({
                 relVariable: relationshipName,
                 fromVariable,
                 toVariable,
-                typename: relationField.type,
+                typename: relationField.typeUnescaped,
                 fromTypename,
                 toTypename,
             });

--- a/packages/graphql/src/translate/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-or-create-and-params.ts
@@ -258,7 +258,7 @@ function mergeStatement({
                 relVariable: relationship.getCypher(env),
                 fromVariable: fromNode.getCypher(env),
                 toVariable: toNode.getCypher(env),
-                typename: relationField.type,
+                typename: relationField.typeUnescaped,
                 fromTypename,
                 toTypename,
             });

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -176,7 +176,7 @@ function createCreateAndParams({
                                 relVariable: propertiesName,
                                 fromVariable,
                                 toVariable,
-                                typename: relationField.type,
+                                typename: relationField.typeUnescaped,
                                 fromTypename,
                                 toTypename,
                             });

--- a/packages/graphql/src/translate/create-delete-and-params.ts
+++ b/packages/graphql/src/translate/create-delete-and-params.ts
@@ -269,7 +269,7 @@ function createDeleteAndParams({
                             relVariable: relationshipVariable,
                             fromVariable,
                             toVariable,
-                            typename: relationField.type,
+                            typename: relationField.typeUnescaped,
                             fromTypename,
                             toTypename,
                         });

--- a/packages/graphql/src/translate/create-disconnect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.test.ts
@@ -31,7 +31,8 @@ describe("createDisconnectAndParams", () => {
             relationFields: [
                 {
                     direction: "OUT",
-                    type: "SIMILAR",
+                    typeUnescaped: "SIMILAR",
+                    type: "`SIMILAR`",
                     fieldName: "similarMovies",
                     queryDirection: RelationshipQueryDirectionOption.DEFAULT_DIRECTED,
                     inherited: false,
@@ -107,7 +108,7 @@ describe("createDisconnectAndParams", () => {
             "WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this0_rel:SIMILAR]->(this0:Movie)
+            OPTIONAL MATCH (this)-[this0_rel:\`SIMILAR\`]->(this0:Movie)
             WHERE this0.title = $this0_where_Movie_this0param0
             CALL {
             	WITH this0, this0_rel, this
@@ -118,7 +119,7 @@ describe("createDisconnectAndParams", () => {
             }
             CALL {
             WITH this, this0
-            OPTIONAL MATCH (this0)-[this0_similarMovies0_rel:SIMILAR]->(this0_similarMovies0:Movie)
+            OPTIONAL MATCH (this0)-[this0_similarMovies0_rel:\`SIMILAR\`]->(this0_similarMovies0:Movie)
             WHERE this0_similarMovies0.title = $this0_disconnect_similarMovies0_where_Movie_this0_similarMovies0param0
             CALL {
             	WITH this0_similarMovies0, this0_similarMovies0_rel, this0

--- a/packages/graphql/src/translate/create-disconnect-and-params.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.ts
@@ -196,7 +196,7 @@ function createDisconnectAndParams({
                 relVariable: relVarName,
                 fromVariable,
                 toVariable,
-                typename: relationField.type,
+                typename: relationField.typeUnescaped,
                 fromTypename,
                 toTypename,
             });

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -134,7 +134,7 @@ export default function createUpdateAndParams({
                 let returnMetaStatement = "";
 
                 updates.forEach((update, index) => {
-                    const relationshipVariable = `${varName}_${relationField.type.toLowerCase()}${index}_relationship`;
+                    const relationshipVariable = `${varName}_${relationField.typeUnescaped.toLowerCase()}${index}_relationship`;
                     const relTypeStr = `[${relationshipVariable}:${relationField.type}]`;
                     const variableName = `${varName}_${key}${relationField.union ? `_${refNode.name}` : ""}${index}`;
 
@@ -450,7 +450,7 @@ export default function createUpdateAndParams({
                                     relVariable: propertiesName,
                                     fromVariable,
                                     toVariable,
-                                    typename: relationField.type,
+                                    typename: relationField.typeUnescaped,
                                     fromTypename,
                                     toTypename,
                                 });

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -187,8 +187,8 @@ export default async function translateUpdate({
                     const inStr = relationField.direction === "IN" ? "<-" : "-";
                     const outStr = relationField.direction === "OUT" ? "->" : "-";
                     refNodes.forEach((refNode) => {
-                        const validateRelationshipExistance = `CALL apoc.util.validate(EXISTS((${varName})${inStr}[:${relationField.type}]${outStr}(:${refNode.name})),'Relationship field "%s.%s" cannot have more than one node linked',["${relationField.connectionPrefix}","${relationField.fieldName}"])`;
-                        connectStrs.push(validateRelationshipExistance);
+                        const validateRelationshipExistence = `CALL apoc.util.validate(EXISTS((${varName})${inStr}[:${relationField.type}]${outStr}(:${refNode.name})),'Relationship field "%s.%s" cannot have more than one node linked',["${relationField.connectionPrefix}","${relationField.fieldName}"])`;
+                        connectStrs.push(validateRelationshipExistence);
                     });
                 }
 
@@ -281,8 +281,8 @@ export default async function translateUpdate({
                     const relTypeStr = `[${relationVarName}:${relationField.type}]`;
 
                     if (!relationField.typeMeta.array) {
-                        const validateRelationshipExistance = `CALL apoc.util.validate(EXISTS((${varName})${inStr}[:${relationField.type}]${outStr}(:${refNode.name})),'Relationship field "%s.%s" cannot have more than one node linked',["${relationField.connectionPrefix}","${relationField.fieldName}"])`;
-                        createStrs.push(validateRelationshipExistance);
+                        const validateRelationshipExistence = `CALL apoc.util.validate(EXISTS((${varName})${inStr}[:${relationField.type}]${outStr}(:${refNode.name})),'Relationship field "%s.%s" cannot have more than one node linked',["${relationField.connectionPrefix}","${relationField.fieldName}"])`;
+                        createStrs.push(validateRelationshipExistence);
                     }
 
                     const createAndParams = createCreateAndParams({
@@ -324,7 +324,7 @@ export default async function translateUpdate({
                             relVariable: propertiesName,
                             fromVariable,
                             toVariable,
-                            typename: relationField.type,
+                            typename: relationField.typeUnescaped,
                             fromTypename,
                             toTypename,
                         });

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -150,6 +150,7 @@ export interface BaseField {
  */
 export interface RelationField extends BaseField {
     direction: "OUT" | "IN";
+    typeUnescaped: string;
     type: string;
     connectionPrefix?: string;
     inherited: boolean;

--- a/packages/graphql/tests/tck/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/advanced-filtering.test.ts
@@ -709,7 +709,7 @@ describe("Cypher Advanced Filtering", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:\`Movie\`)
                 WHERE EXISTS {
-                    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
+                    MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
                     WHERE this0.name = $param0
                 }
                 RETURN this { .actorCount } AS this"
@@ -739,7 +739,7 @@ describe("Cypher Advanced Filtering", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:\`Movie\`)
                 WHERE NOT (EXISTS {
-                    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
+                    MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
                     WHERE this0.name = $param0
                 })
                 RETURN this { .actorCount } AS this"
@@ -772,10 +772,10 @@ describe("Cypher Advanced Filtering", () => {
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
                     WHERE (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
+                        MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
                         WHERE this0.name = $param0
                     } AND NOT (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
+                        MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
                         WHERE NOT (this0.name = $param0)
                     }))
                     RETURN this { .actorCount } AS this"
@@ -795,7 +795,7 @@ describe("Cypher Advanced Filtering", () => {
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
                     WHERE NOT (EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
+                        MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
                         WHERE this0.name = $param0
                     })
                     RETURN this { .actorCount } AS this"
@@ -814,7 +814,7 @@ describe("Cypher Advanced Filtering", () => {
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
-                    WHERE single(this0 IN [(this)-[:IN_GENRE]->(this0:\`Genre\`) WHERE this0.name = $param0 | 1] WHERE true)
+                    WHERE single(this0 IN [(this)-[:\`IN_GENRE\`]->(this0:\`Genre\`) WHERE this0.name = $param0 | 1] WHERE true)
                     RETURN this { .actorCount } AS this"
                 `);
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -832,7 +832,7 @@ describe("Cypher Advanced Filtering", () => {
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
                     WHERE EXISTS {
-                        MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
+                        MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
                         WHERE this0.name = $param0
                     }
                     RETURN this { .actorCount } AS this"
@@ -864,7 +864,7 @@ describe("Cypher Advanced Filtering", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:\`Movie\`)
                 WHERE EXISTS {
-                    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
+                    MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
                     WHERE this1.name = $param0
                 }
                 RETURN this { .actorCount } AS this"
@@ -894,7 +894,7 @@ describe("Cypher Advanced Filtering", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "MATCH (this:\`Movie\`)
                 WHERE NOT (EXISTS {
-                    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
+                    MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
                     WHERE this1.name = $param0
                 })
                 RETURN this { .actorCount } AS this"
@@ -927,10 +927,10 @@ describe("Cypher Advanced Filtering", () => {
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
                     WHERE (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
+                        MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
                         WHERE this1.name = $param0
                     } AND NOT (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
+                        MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
                         WHERE NOT (this1.name = $param0)
                     }))
                     RETURN this { .actorCount } AS this"
@@ -950,7 +950,7 @@ describe("Cypher Advanced Filtering", () => {
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
                     WHERE NOT (EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
+                        MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
                         WHERE this1.name = $param0
                     })
                     RETURN this { .actorCount } AS this"
@@ -969,7 +969,7 @@ describe("Cypher Advanced Filtering", () => {
 
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
-                    WHERE single(this0 IN [(this)-[this1:IN_GENRE]->(this0:\`Genre\`) WHERE this0.name = $param0 | 1] WHERE true)
+                    WHERE single(this0 IN [(this)-[this1:\`IN_GENRE\`]->(this0:\`Genre\`) WHERE this0.name = $param0 | 1] WHERE true)
                     RETURN this { .actorCount } AS this"
                 `);
                 expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -987,7 +987,7 @@ describe("Cypher Advanced Filtering", () => {
                 expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                     "MATCH (this:\`Movie\`)
                     WHERE EXISTS {
-                        MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
+                        MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
                         WHERE this1.name = $param0
                     }
                     RETURN this { .actorCount } AS this"

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-alias.test.ts
@@ -75,7 +75,7 @@ describe("Field Level Aggregations Alias", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this1:ACTED_IN]-(this0:\`Actor\`)
+                MATCH (this)<-[this1:\`ACTED_IN\`]-(this0:\`Actor\`)
                 WITH this0
                 ORDER BY size(this0.name) DESC
                 WITH collect(this0.name) AS list
@@ -111,7 +111,7 @@ describe("Field Level Aggregations Alias", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 RETURN { min: min(this0.screentime), max: max(this0.screentime), average: avg(this0.screentime), sum: sum(this0.screentime) }  AS var2
             }
             RETURN this { actorsAggregate: { edge: { time: var2 } } } AS this"

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-auth.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-auth.test.ts
@@ -76,7 +76,7 @@ describe("Field Level Aggregations", () => {
             WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 RETURN count(this1) AS var2
             }
             RETURN this { .title, actorsAggregate: { count: var2 } } AS this"
@@ -117,7 +117,7 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Actor\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                 WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN count(this1) AS var2
             }

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-edge.test.ts
@@ -78,7 +78,7 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 RETURN { min: min(this0.screentime), max: max(this0.screentime), average: avg(this0.screentime), sum: sum(this0.screentime) }  AS var2
             }
             RETURN this { actorsAggregate: { edge: { screentime: var2 } } } AS this"

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-labels.test.ts
@@ -75,7 +75,7 @@ describe("Field Level Aggregations Alias", () => {
             "MATCH (this:\`Film\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this1:ACTED_IN]-(this0:\`Person\`)
+                MATCH (this)<-[this1:\`ACTED_IN\`]-(this0:\`Person\`)
                 WITH this0
                 ORDER BY size(this0.name) DESC
                 WITH collect(this0.name) AS list

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations-where.test.ts
@@ -70,7 +70,7 @@ describe("Field Level Aggregations Where", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                 WHERE this1.age > $param0
                 RETURN count(this1) AS var2
             }
@@ -111,13 +111,13 @@ describe("Field Level Aggregations Where", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                 WHERE this1.name CONTAINS $param0
                 RETURN count(this1) AS var2
             }
             CALL {
                 WITH this
-                MATCH (this)<-[this3:DIRECTED]-(this4:\`Person\`)
+                MATCH (this)<-[this3:\`DIRECTED\`]-(this4:\`Person\`)
                 WHERE this4.name CONTAINS $param1
                 RETURN count(this4) AS var5
             }

--- a/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
+++ b/packages/graphql/tests/tck/aggregations/field-level-aggregations/field-level-aggregations.test.ts
@@ -69,7 +69,7 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 RETURN count(this1) AS var2
             }
             RETURN this { .title, actorsAggregate: { count: var2 } } AS this"
@@ -104,12 +104,12 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 RETURN count(this1) AS var2
             }
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH this1
                 ORDER BY size(this1.name) DESC
                 WITH collect(this1.name) AS list
@@ -148,7 +148,7 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this1:ACTED_IN]-(this0:\`Actor\`)
+                MATCH (this)<-[this1:\`ACTED_IN\`]-(this0:\`Actor\`)
                 RETURN { min: min(this0.age), max: max(this0.age), average: avg(this0.age), sum: sum(this0.age) }  AS var2
             }
             RETURN this { actorsAggregate: { node: { age: var2 } } } AS this"
@@ -183,7 +183,7 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this1:ACTED_IN]-(this0:\`Actor\`)
+                MATCH (this)<-[this1:\`ACTED_IN\`]-(this0:\`Actor\`)
                 WITH this0
                 ORDER BY size(this0.name) DESC
                 WITH collect(this0.name) AS list
@@ -219,7 +219,7 @@ describe("Field Level Aggregations", () => {
             "MATCH (this:\`Actor\`)
             CALL {
                 WITH this
-                MATCH (this)-[this1:ACTED_IN]->(this0:\`Movie\`)
+                MATCH (this)-[this1:\`ACTED_IN\`]->(this0:\`Movie\`)
                 RETURN { min: apoc.date.convertFormat(toString(min(this0.released)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this0.released)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS var2
             }
             RETURN this { moviesAggregate: { node: { released: var2 } } } AS this"

--- a/packages/graphql/tests/tck/aggregations/where/count.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/count.test.ts
@@ -63,7 +63,7 @@ describe("Cypher Aggregations where with count", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) = $param0 AS var2
             }
             WITH *
@@ -99,7 +99,7 @@ describe("Cypher Aggregations where with count", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) < $param0 AS var2
             }
             WITH *
@@ -135,7 +135,7 @@ describe("Cypher Aggregations where with count", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) <= $param0 AS var2
             }
             WITH *
@@ -171,7 +171,7 @@ describe("Cypher Aggregations where with count", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) > $param0 AS var2
             }
             WITH *
@@ -207,7 +207,7 @@ describe("Cypher Aggregations where with count", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) >= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/bigint.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someBigInt) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -104,7 +104,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someBigIntAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -140,7 +140,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someBigInt) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -176,7 +176,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someBigInt) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -212,7 +212,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someBigInt) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -248,7 +248,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someBigInt) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -284,7 +284,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -320,7 +320,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -356,7 +356,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -392,7 +392,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -428,7 +428,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
@@ -464,7 +464,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -500,7 +500,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -536,7 +536,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -572,7 +572,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -608,7 +608,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
@@ -644,7 +644,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -680,7 +680,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -716,7 +716,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -752,7 +752,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -788,7 +788,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someBigInt) <= $param0 AS var2
             }
             WITH *
@@ -824,7 +824,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -860,7 +860,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -896,7 +896,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -932,7 +932,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -968,7 +968,7 @@ describe("Cypher Aggregations where edge with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someBigInt) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/datetime.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDateTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -110,7 +110,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someDateTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -152,7 +152,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDateTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -194,7 +194,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDateTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -236,7 +236,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDateTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -278,7 +278,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDateTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -320,7 +320,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDateTime) = $param0 AS var2
             }
             WITH *
@@ -362,7 +362,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDateTime) > $param0 AS var2
             }
             WITH *
@@ -404,7 +404,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDateTime) >= $param0 AS var2
             }
             WITH *
@@ -446,7 +446,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDateTime) < $param0 AS var2
             }
             WITH *
@@ -488,7 +488,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDateTime) <= $param0 AS var2
             }
             WITH *
@@ -530,7 +530,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDateTime) = $param0 AS var2
             }
             WITH *
@@ -572,7 +572,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDateTime) > $param0 AS var2
             }
             WITH *
@@ -614,7 +614,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDateTime) >= $param0 AS var2
             }
             WITH *
@@ -656,7 +656,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDateTime) < $param0 AS var2
             }
             WITH *
@@ -698,7 +698,7 @@ describe("Cypher Aggregations where edge with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDateTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/duration.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDuration) WHERE datetime() + var2 = datetime() + $param0) AS var3
             }
             WITH *
@@ -112,7 +112,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someDurationAlias) WHERE datetime() + var2 = datetime() + $param0) AS var3
             }
             WITH *
@@ -156,7 +156,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDuration) WHERE datetime() + var2 > datetime() + $param0) AS var3
             }
             WITH *
@@ -200,7 +200,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDuration) WHERE datetime() + var2 >= datetime() + $param0) AS var3
             }
             WITH *
@@ -244,7 +244,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDuration) WHERE datetime() + var2 < datetime() + $param0) AS var3
             }
             WITH *
@@ -288,7 +288,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someDuration) WHERE datetime() + var2 <= datetime() + $param0) AS var3
             }
             WITH *
@@ -332,7 +332,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someDuration) = $param0 AS var2
             }
             WITH *
@@ -376,7 +376,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someDuration) > $param0 AS var2
             }
             WITH *
@@ -420,7 +420,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someDuration) >= $param0 AS var2
             }
             WITH *
@@ -464,7 +464,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someDuration) < $param0 AS var2
             }
             WITH *
@@ -508,7 +508,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someDuration) <= $param0 AS var2
             }
             WITH *
@@ -552,7 +552,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDuration) = $param0 AS var2
             }
             WITH *
@@ -596,7 +596,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDuration) > $param0 AS var2
             }
             WITH *
@@ -640,7 +640,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDuration) >= $param0 AS var2
             }
             WITH *
@@ -684,7 +684,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDuration) < $param0 AS var2
             }
             WITH *
@@ -728,7 +728,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someDuration) <= $param0 AS var2
             }
             WITH *
@@ -772,7 +772,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDuration) = $param0 AS var2
             }
             WITH *
@@ -816,7 +816,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDuration) > $param0 AS var2
             }
             WITH *
@@ -860,7 +860,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDuration) >= $param0 AS var2
             }
             WITH *
@@ -904,7 +904,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDuration) < $param0 AS var2
             }
             WITH *
@@ -948,7 +948,7 @@ describe("Cypher Aggregations where edge with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someDuration) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/float.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -101,7 +101,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someFloatAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -134,7 +134,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -167,7 +167,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -200,7 +200,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -233,7 +233,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -266,7 +266,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someFloat) = $param0 AS var2
             }
             WITH *
@@ -299,7 +299,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someFloat) > $param0 AS var2
             }
             WITH *
@@ -332,7 +332,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -365,7 +365,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someFloat) < $param0 AS var2
             }
             WITH *
@@ -398,7 +398,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someFloat) <= $param0 AS var2
             }
             WITH *
@@ -431,7 +431,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someFloat) = $param0 AS var2
             }
             WITH *
@@ -464,7 +464,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someFloat) > $param0 AS var2
             }
             WITH *
@@ -497,7 +497,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -530,7 +530,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someFloat) < $param0 AS var2
             }
             WITH *
@@ -563,7 +563,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someFloat) <= $param0 AS var2
             }
             WITH *
@@ -596,7 +596,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someFloat) = $param0 AS var2
             }
             WITH *
@@ -629,7 +629,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someFloat) > $param0 AS var2
             }
             WITH *
@@ -662,7 +662,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -695,7 +695,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someFloat) < $param0 AS var2
             }
             WITH *
@@ -728,7 +728,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someFloat) <= $param0 AS var2
             }
             WITH *
@@ -761,7 +761,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someFloat) = $param0 AS var2
             }
             WITH *
@@ -794,7 +794,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someFloat) > $param0 AS var2
             }
             WITH *
@@ -827,7 +827,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -860,7 +860,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someFloat) < $param0 AS var2
             }
             WITH *
@@ -893,7 +893,7 @@ describe("Cypher Aggregations where edge with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someFloat) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/id.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/id.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with ID", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.id) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -101,7 +101,7 @@ describe("Cypher Aggregations where edge with ID", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someIdAlias) WHERE var2 = $param0) AS var3
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/int.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someInt) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -104,7 +104,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someIntAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -140,7 +140,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someInt) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -176,7 +176,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someInt) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -212,7 +212,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someInt) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -248,7 +248,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someInt) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -284,7 +284,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someInt) = $param0 AS var2
             }
             WITH *
@@ -317,7 +317,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someInt) > $param0 AS var2
             }
             WITH *
@@ -350,7 +350,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someInt) >= $param0 AS var2
             }
             WITH *
@@ -383,7 +383,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someInt) < $param0 AS var2
             }
             WITH *
@@ -416,7 +416,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this0.someInt) <= $param0 AS var2
             }
             WITH *
@@ -449,7 +449,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someInt) = $param0 AS var2
             }
             WITH *
@@ -485,7 +485,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someInt) > $param0 AS var2
             }
             WITH *
@@ -521,7 +521,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someInt) >= $param0 AS var2
             }
             WITH *
@@ -557,7 +557,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someInt) < $param0 AS var2
             }
             WITH *
@@ -593,7 +593,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this0.someInt) <= $param0 AS var2
             }
             WITH *
@@ -629,7 +629,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someInt) = $param0 AS var2
             }
             WITH *
@@ -665,7 +665,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someInt) > $param0 AS var2
             }
             WITH *
@@ -701,7 +701,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someInt) >= $param0 AS var2
             }
             WITH *
@@ -737,7 +737,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someInt) < $param0 AS var2
             }
             WITH *
@@ -773,7 +773,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someInt) <= $param0 AS var2
             }
             WITH *
@@ -809,7 +809,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someInt) = $param0 AS var2
             }
             WITH *
@@ -845,7 +845,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someInt) > $param0 AS var2
             }
             WITH *
@@ -881,7 +881,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someInt) >= $param0 AS var2
             }
             WITH *
@@ -917,7 +917,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someInt) < $param0 AS var2
             }
             WITH *
@@ -953,7 +953,7 @@ describe("Cypher Aggregations where edge with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someInt) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/localdatetime.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalDateTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -109,7 +109,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someLocalDateTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -150,7 +150,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalDateTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -191,7 +191,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalDateTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -232,7 +232,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalDateTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -273,7 +273,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalDateTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -314,7 +314,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalDateTime) = $param0 AS var2
             }
             WITH *
@@ -355,7 +355,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalDateTime) > $param0 AS var2
             }
             WITH *
@@ -396,7 +396,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
@@ -437,7 +437,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalDateTime) < $param0 AS var2
             }
             WITH *
@@ -478,7 +478,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalDateTime) <= $param0 AS var2
             }
             WITH *
@@ -519,7 +519,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalDateTime) = $param0 AS var2
             }
             WITH *
@@ -560,7 +560,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalDateTime) > $param0 AS var2
             }
             WITH *
@@ -601,7 +601,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
@@ -642,7 +642,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalDateTime) < $param0 AS var2
             }
             WITH *
@@ -683,7 +683,7 @@ describe("Cypher Aggregations where edge with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalDateTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/localtime.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -106,7 +106,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someLocalTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -144,7 +144,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -182,7 +182,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -220,7 +220,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -258,7 +258,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someLocalTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -296,7 +296,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalTime) = $param0 AS var2
             }
             WITH *
@@ -334,7 +334,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalTime) > $param0 AS var2
             }
             WITH *
@@ -372,7 +372,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalTime) >= $param0 AS var2
             }
             WITH *
@@ -410,7 +410,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalTime) < $param0 AS var2
             }
             WITH *
@@ -448,7 +448,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someLocalTime) <= $param0 AS var2
             }
             WITH *
@@ -486,7 +486,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalTime) = $param0 AS var2
             }
             WITH *
@@ -524,7 +524,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalTime) > $param0 AS var2
             }
             WITH *
@@ -562,7 +562,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalTime) >= $param0 AS var2
             }
             WITH *
@@ -600,7 +600,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalTime) < $param0 AS var2
             }
             WITH *
@@ -638,7 +638,7 @@ describe("Cypher Aggregations where edge with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someLocalTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/logical.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/logical.test.ts
@@ -69,7 +69,7 @@ describe("Cypher Aggregations where edge with Logical AND + OR + NOT", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 = $param0) AS var3, any(var4 IN collect(this0.someFloat) WHERE var4 = $param1) AS var5
             }
             WITH *
@@ -103,7 +103,7 @@ describe("Cypher Aggregations where edge with Logical AND + OR + NOT", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 = $param0) AS var3, any(var4 IN collect(this0.someFloat) WHERE var4 = $param1) AS var5
             }
             WITH *
@@ -137,7 +137,7 @@ describe("Cypher Aggregations where edge with Logical AND + OR + NOT", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someFloat) WHERE var2 = $param0) AS var3
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/string.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someString) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -101,7 +101,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someStringAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -134,7 +134,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this0.someString)) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -170,7 +170,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this0.someString)) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -206,7 +206,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this0.someString)) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -242,7 +242,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this0.someString)) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -278,7 +278,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this0.someString)) = $param0 AS var2
             }
             WITH *
@@ -314,7 +314,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this0.someString)) > $param0 AS var2
             }
             WITH *
@@ -350,7 +350,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this0.someString)) >= $param0 AS var2
             }
             WITH *
@@ -386,7 +386,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this0.someString)) < $param0 AS var2
             }
             WITH *
@@ -422,7 +422,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this0.someString)) <= $param0 AS var2
             }
             WITH *
@@ -458,7 +458,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this0.someString)) = $param0 AS var2
             }
             WITH *
@@ -494,7 +494,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this0.someString)) > $param0 AS var2
             }
             WITH *
@@ -530,7 +530,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this0.someString)) >= $param0 AS var2
             }
             WITH *
@@ -566,7 +566,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this0.someString)) < $param0 AS var2
             }
             WITH *
@@ -602,7 +602,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this0.someString)) <= $param0 AS var2
             }
             WITH *
@@ -638,7 +638,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this0.someString)) = $param0 AS var2
             }
             WITH *
@@ -671,7 +671,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this0.someString)) > $param0 AS var2
             }
             WITH *
@@ -704,7 +704,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this0.someString)) >= $param0 AS var2
             }
             WITH *
@@ -737,7 +737,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this0.someString)) < $param0 AS var2
             }
             WITH *
@@ -770,7 +770,7 @@ describe("Cypher Aggregations where edge with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this0.someString)) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/edge/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/edge/time.test.ts
@@ -68,7 +68,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -107,7 +107,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0._someTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -146,7 +146,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -185,7 +185,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -224,7 +224,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -263,7 +263,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this0.someTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -302,7 +302,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someTime) = $param0 AS var2
             }
             WITH *
@@ -341,7 +341,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someTime) > $param0 AS var2
             }
             WITH *
@@ -380,7 +380,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someTime) >= $param0 AS var2
             }
             WITH *
@@ -419,7 +419,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someTime) < $param0 AS var2
             }
             WITH *
@@ -458,7 +458,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this0.someTime) <= $param0 AS var2
             }
             WITH *
@@ -497,7 +497,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someTime) = $param0 AS var2
             }
             WITH *
@@ -536,7 +536,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someTime) > $param0 AS var2
             }
             WITH *
@@ -575,7 +575,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someTime) >= $param0 AS var2
             }
             WITH *
@@ -614,7 +614,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someTime) < $param0 AS var2
             }
             WITH *
@@ -653,7 +653,7 @@ describe("Cypher Aggregations where edge with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this0.someTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/logical.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/logical.test.ts
@@ -63,7 +63,7 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) > $param0 AS var2, count(this1) < $param1 AS var3
             }
             WITH *
@@ -103,7 +103,7 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) > $param0 AS var2, count(this1) < $param1 AS var3
             }
             WITH *
@@ -143,7 +143,7 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) > $param0 AS var2
             }
             WITH *
@@ -186,7 +186,7 @@ describe("Cypher Aggregations where with logical AND plus OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN count(this1) > $param0 AS var2, count(this1) < $param1 AS var3, count(this1) > $param2 AS var4, count(this1) < $param3 AS var5
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node.test.ts
@@ -63,7 +63,7 @@ describe("Cypher Where Aggregations with @node directive", () => {
             "MATCH (this:\`_Post\`:\`additionalPost\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`_User\`:\`additionalUser\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`_User\`:\`additionalUser\`)
                 RETURN any(var2 IN collect(size(this1.someName)) WHERE var2 > $param0) AS var3
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/bigint.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/bigint.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someBigInt) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -100,7 +100,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someBigIntAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -136,7 +136,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someBigInt) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -172,7 +172,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someBigInt) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -208,7 +208,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someBigInt) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -244,7 +244,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someBigInt) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -280,7 +280,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -316,7 +316,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -352,7 +352,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -388,7 +388,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -424,7 +424,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
@@ -460,7 +460,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -496,7 +496,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -532,7 +532,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -568,7 +568,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -604,7 +604,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
@@ -640,7 +640,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -676,7 +676,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -712,7 +712,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -748,7 +748,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -784,7 +784,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someBigInt) <= $param0 AS var2
             }
             WITH *
@@ -820,7 +820,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someBigInt) = $param0 AS var2
             }
             WITH *
@@ -856,7 +856,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someBigInt) > $param0 AS var2
             }
             WITH *
@@ -892,7 +892,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someBigInt) >= $param0 AS var2
             }
             WITH *
@@ -928,7 +928,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someBigInt) < $param0 AS var2
             }
             WITH *
@@ -964,7 +964,7 @@ describe("Cypher Aggregations where node with BigInt", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someBigInt) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/datetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/datetime.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDateTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -106,7 +106,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someDateTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -148,7 +148,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDateTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -190,7 +190,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDateTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -232,7 +232,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDateTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -274,7 +274,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDateTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -316,7 +316,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDateTime) = $param0 AS var2
             }
             WITH *
@@ -358,7 +358,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDateTime) > $param0 AS var2
             }
             WITH *
@@ -400,7 +400,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDateTime) >= $param0 AS var2
             }
             WITH *
@@ -442,7 +442,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDateTime) < $param0 AS var2
             }
             WITH *
@@ -484,7 +484,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDateTime) <= $param0 AS var2
             }
             WITH *
@@ -526,7 +526,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDateTime) = $param0 AS var2
             }
             WITH *
@@ -568,7 +568,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDateTime) > $param0 AS var2
             }
             WITH *
@@ -610,7 +610,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDateTime) >= $param0 AS var2
             }
             WITH *
@@ -652,7 +652,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDateTime) < $param0 AS var2
             }
             WITH *
@@ -694,7 +694,7 @@ describe("Cypher Aggregations where node with DateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDateTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/duration.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/duration.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDuration) WHERE datetime() + var2 = datetime() + $param0) AS var3
             }
             WITH *
@@ -108,7 +108,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someDurationAlias) WHERE datetime() + var2 = datetime() + $param0) AS var3
             }
             WITH *
@@ -152,7 +152,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDuration) WHERE datetime() + var2 > datetime() + $param0) AS var3
             }
             WITH *
@@ -196,7 +196,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDuration) WHERE datetime() + var2 >= datetime() + $param0) AS var3
             }
             WITH *
@@ -240,7 +240,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDuration) WHERE datetime() + var2 < datetime() + $param0) AS var3
             }
             WITH *
@@ -284,7 +284,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someDuration) WHERE datetime() + var2 <= datetime() + $param0) AS var3
             }
             WITH *
@@ -328,7 +328,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someDuration) = $param0 AS var2
             }
             WITH *
@@ -372,7 +372,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someDuration) > $param0 AS var2
             }
             WITH *
@@ -416,7 +416,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someDuration) >= $param0 AS var2
             }
             WITH *
@@ -460,7 +460,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someDuration) < $param0 AS var2
             }
             WITH *
@@ -504,7 +504,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someDuration) <= $param0 AS var2
             }
             WITH *
@@ -548,7 +548,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDuration) = $param0 AS var2
             }
             WITH *
@@ -592,7 +592,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDuration) > $param0 AS var2
             }
             WITH *
@@ -636,7 +636,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDuration) >= $param0 AS var2
             }
             WITH *
@@ -680,7 +680,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDuration) < $param0 AS var2
             }
             WITH *
@@ -724,7 +724,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someDuration) <= $param0 AS var2
             }
             WITH *
@@ -768,7 +768,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDuration) = $param0 AS var2
             }
             WITH *
@@ -812,7 +812,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDuration) > $param0 AS var2
             }
             WITH *
@@ -856,7 +856,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDuration) >= $param0 AS var2
             }
             WITH *
@@ -900,7 +900,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDuration) < $param0 AS var2
             }
             WITH *
@@ -944,7 +944,7 @@ describe("Cypher Aggregations where node with Duration", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someDuration) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/float.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/float.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -97,7 +97,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someFloatAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -130,7 +130,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -163,7 +163,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -196,7 +196,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -229,7 +229,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -262,7 +262,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someFloat) = $param0 AS var2
             }
             WITH *
@@ -295,7 +295,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someFloat) > $param0 AS var2
             }
             WITH *
@@ -328,7 +328,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -361,7 +361,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someFloat) < $param0 AS var2
             }
             WITH *
@@ -394,7 +394,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someFloat) <= $param0 AS var2
             }
             WITH *
@@ -427,7 +427,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someFloat) = $param0 AS var2
             }
             WITH *
@@ -460,7 +460,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someFloat) > $param0 AS var2
             }
             WITH *
@@ -493,7 +493,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -526,7 +526,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someFloat) < $param0 AS var2
             }
             WITH *
@@ -559,7 +559,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someFloat) <= $param0 AS var2
             }
             WITH *
@@ -592,7 +592,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someFloat) = $param0 AS var2
             }
             WITH *
@@ -625,7 +625,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someFloat) > $param0 AS var2
             }
             WITH *
@@ -658,7 +658,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -691,7 +691,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someFloat) < $param0 AS var2
             }
             WITH *
@@ -724,7 +724,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someFloat) <= $param0 AS var2
             }
             WITH *
@@ -757,7 +757,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someFloat) = $param0 AS var2
             }
             WITH *
@@ -790,7 +790,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someFloat) > $param0 AS var2
             }
             WITH *
@@ -823,7 +823,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someFloat) >= $param0 AS var2
             }
             WITH *
@@ -856,7 +856,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someFloat) < $param0 AS var2
             }
             WITH *
@@ -889,7 +889,7 @@ describe("Cypher Aggregations where node with Float", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someFloat) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/id.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/id.test.ts
@@ -65,7 +65,7 @@ describe("Cypher Aggregations where node with ID", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.id) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -98,7 +98,7 @@ describe("Cypher Aggregations where node with ID", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someIdAlias) WHERE var2 = $param0) AS var3
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/int.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/int.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someInt) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -100,7 +100,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someIntAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -136,7 +136,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someInt) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -172,7 +172,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someInt) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -208,7 +208,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someInt) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -244,7 +244,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someInt) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -280,7 +280,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someInt) = $param0 AS var2
             }
             WITH *
@@ -313,7 +313,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someInt) > $param0 AS var2
             }
             WITH *
@@ -346,7 +346,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someInt) >= $param0 AS var2
             }
             WITH *
@@ -379,7 +379,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someInt) < $param0 AS var2
             }
             WITH *
@@ -412,7 +412,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(this1.someInt) <= $param0 AS var2
             }
             WITH *
@@ -445,7 +445,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someInt) = $param0 AS var2
             }
             WITH *
@@ -481,7 +481,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someInt) > $param0 AS var2
             }
             WITH *
@@ -517,7 +517,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someInt) >= $param0 AS var2
             }
             WITH *
@@ -553,7 +553,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someInt) < $param0 AS var2
             }
             WITH *
@@ -589,7 +589,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN sum(this1.someInt) <= $param0 AS var2
             }
             WITH *
@@ -625,7 +625,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someInt) = $param0 AS var2
             }
             WITH *
@@ -661,7 +661,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someInt) > $param0 AS var2
             }
             WITH *
@@ -697,7 +697,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someInt) >= $param0 AS var2
             }
             WITH *
@@ -733,7 +733,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someInt) < $param0 AS var2
             }
             WITH *
@@ -769,7 +769,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someInt) <= $param0 AS var2
             }
             WITH *
@@ -805,7 +805,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someInt) = $param0 AS var2
             }
             WITH *
@@ -841,7 +841,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someInt) > $param0 AS var2
             }
             WITH *
@@ -877,7 +877,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someInt) >= $param0 AS var2
             }
             WITH *
@@ -913,7 +913,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someInt) < $param0 AS var2
             }
             WITH *
@@ -949,7 +949,7 @@ describe("Cypher Aggregations where node with Int", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someInt) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/localdatetime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/localdatetime.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalDateTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -105,7 +105,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someLocalDateTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -146,7 +146,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalDateTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -187,7 +187,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalDateTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -228,7 +228,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalDateTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -269,7 +269,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalDateTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -310,7 +310,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalDateTime) = $param0 AS var2
             }
             WITH *
@@ -351,7 +351,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalDateTime) > $param0 AS var2
             }
             WITH *
@@ -392,7 +392,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
@@ -433,7 +433,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalDateTime) < $param0 AS var2
             }
             WITH *
@@ -474,7 +474,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalDateTime) <= $param0 AS var2
             }
             WITH *
@@ -515,7 +515,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalDateTime) = $param0 AS var2
             }
             WITH *
@@ -556,7 +556,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalDateTime) > $param0 AS var2
             }
             WITH *
@@ -597,7 +597,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalDateTime) >= $param0 AS var2
             }
             WITH *
@@ -638,7 +638,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalDateTime) < $param0 AS var2
             }
             WITH *
@@ -679,7 +679,7 @@ describe("Cypher Aggregations where node with LocalDateTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalDateTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/localtime.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/localtime.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -102,7 +102,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someLocalTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -140,7 +140,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -178,7 +178,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -216,7 +216,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -254,7 +254,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someLocalTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -292,7 +292,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalTime) = $param0 AS var2
             }
             WITH *
@@ -330,7 +330,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalTime) > $param0 AS var2
             }
             WITH *
@@ -368,7 +368,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalTime) >= $param0 AS var2
             }
             WITH *
@@ -406,7 +406,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalTime) < $param0 AS var2
             }
             WITH *
@@ -444,7 +444,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someLocalTime) <= $param0 AS var2
             }
             WITH *
@@ -482,7 +482,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalTime) = $param0 AS var2
             }
             WITH *
@@ -520,7 +520,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalTime) > $param0 AS var2
             }
             WITH *
@@ -558,7 +558,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalTime) >= $param0 AS var2
             }
             WITH *
@@ -596,7 +596,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalTime) < $param0 AS var2
             }
             WITH *
@@ -634,7 +634,7 @@ describe("Cypher Aggregations where node with LocalTime", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someLocalTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/logical.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/logical.test.ts
@@ -65,7 +65,7 @@ describe("Cypher Aggregations where node with Logical AND + OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 = $param0) AS var3, any(var4 IN collect(this1.someFloat) WHERE var4 = $param1) AS var5
             }
             WITH *
@@ -99,7 +99,7 @@ describe("Cypher Aggregations where node with Logical AND + OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 = $param0) AS var3, any(var4 IN collect(this1.someFloat) WHERE var4 = $param1) AS var5
             }
             WITH *
@@ -133,7 +133,7 @@ describe("Cypher Aggregations where node with Logical AND + OR", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someFloat) WHERE var2 = $param0) AS var3
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/string.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/string.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.name) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -97,7 +97,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someStringAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -130,7 +130,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this1.name)) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -166,7 +166,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this1.name)) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -202,7 +202,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this1.name)) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -238,7 +238,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(size(this1.name)) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -274,7 +274,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this1.name)) = $param0 AS var2
             }
             WITH *
@@ -310,7 +310,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this1.name)) > $param0 AS var2
             }
             WITH *
@@ -346,7 +346,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this1.name)) >= $param0 AS var2
             }
             WITH *
@@ -382,7 +382,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this1.name)) < $param0 AS var2
             }
             WITH *
@@ -418,7 +418,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(size(this1.name)) <= $param0 AS var2
             }
             WITH *
@@ -454,7 +454,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this1.name)) = $param0 AS var2
             }
             WITH *
@@ -490,7 +490,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this1.name)) > $param0 AS var2
             }
             WITH *
@@ -526,7 +526,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this1.name)) >= $param0 AS var2
             }
             WITH *
@@ -562,7 +562,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this1.name)) < $param0 AS var2
             }
             WITH *
@@ -598,7 +598,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(size(this1.name)) <= $param0 AS var2
             }
             WITH *
@@ -634,7 +634,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this1.name)) = $param0 AS var2
             }
             WITH *
@@ -667,7 +667,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this1.name)) > $param0 AS var2
             }
             WITH *
@@ -700,7 +700,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this1.name)) >= $param0 AS var2
             }
             WITH *
@@ -733,7 +733,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this1.name)) < $param0 AS var2
             }
             WITH *
@@ -766,7 +766,7 @@ describe("Cypher Aggregations where node with String", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN avg(size(this1.name)) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/aggregations/where/node/time.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/node/time.test.ts
@@ -64,7 +64,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someTime) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -103,7 +103,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1._someTimeAlias) WHERE var2 = $param0) AS var3
             }
             WITH *
@@ -142,7 +142,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someTime) WHERE var2 > $param0) AS var3
             }
             WITH *
@@ -181,7 +181,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someTime) WHERE var2 >= $param0) AS var3
             }
             WITH *
@@ -220,7 +220,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someTime) WHERE var2 < $param0) AS var3
             }
             WITH *
@@ -259,7 +259,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN any(var2 IN collect(this1.someTime) WHERE var2 <= $param0) AS var3
             }
             WITH *
@@ -298,7 +298,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someTime) = $param0 AS var2
             }
             WITH *
@@ -337,7 +337,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someTime) > $param0 AS var2
             }
             WITH *
@@ -376,7 +376,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someTime) >= $param0 AS var2
             }
             WITH *
@@ -415,7 +415,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someTime) < $param0 AS var2
             }
             WITH *
@@ -454,7 +454,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN min(this1.someTime) <= $param0 AS var2
             }
             WITH *
@@ -493,7 +493,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someTime) = $param0 AS var2
             }
             WITH *
@@ -532,7 +532,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someTime) > $param0 AS var2
             }
             WITH *
@@ -571,7 +571,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someTime) >= $param0 AS var2
             }
             WITH *
@@ -610,7 +610,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someTime) < $param0 AS var2
             }
             WITH *
@@ -649,7 +649,7 @@ describe("Cypher Aggregations where node with Time", () => {
             "MATCH (this:\`Post\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:LIKES]-(this1:\`User\`)
+                MATCH (this)<-[this0:\`LIKES\`]-(this1:\`User\`)
                 RETURN max(this1.someTime) <= $param0 AS var2
             }
             WITH *

--- a/packages/graphql/tests/tck/alias.test.ts
+++ b/packages/graphql/tests/tck/alias.test.ts
@@ -85,7 +85,7 @@ describe("Cypher Alias", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH this1 { aliasActorsName: this1.name } AS this1
                 RETURN collect(this1) AS var2
             }

--- a/packages/graphql/tests/tck/array-methods.test.ts
+++ b/packages/graphql/tests/tck/array-methods.test.ts
@@ -548,20 +548,20 @@ describe("Arrays Methods", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	SET this_acted_in0_relationship.pay = this_acted_in0_relationship.pay + $updateActors.args.update.actedIn[0].update.edge.pay_PUSH
             	RETURN count(*) AS update_this_actedIn0
             }
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .title } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[update_this3:ACTED_IN]->(update_this4:\`Movie\`)
+                MATCH (this)-[update_this3:\`ACTED_IN\`]->(update_this4:\`Movie\`)
                 WITH { pay: update_this3.pay } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -652,20 +652,20 @@ describe("Arrays Methods", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	SET this_acted_in0_relationship.pay = this_acted_in0_relationship.pay[0..-$updateActors.args.update.actedIn[0].update.edge.pay_POP]
             	RETURN count(*) AS update_this_actedIn0
             }
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .title } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[update_this3:ACTED_IN]->(update_this4:\`Movie\`)
+                MATCH (this)-[update_this3:\`ACTED_IN\`]->(update_this4:\`Movie\`)
                 WITH { pay: update_this3.pay } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/connections/alias.test.ts
+++ b/packages/graphql/tests/tck/connections/alias.test.ts
@@ -70,7 +70,7 @@ describe("Connections Alias", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { __resolveType: \\"Actor\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -117,7 +117,7 @@ describe("Connections Alias", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name = $param1
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -126,7 +126,7 @@ describe("Connections Alias", () => {
             }
             CALL {
                 WITH this
-                MATCH (this)<-[this3:ACTED_IN]-(this4:\`Actor\`)
+                MATCH (this)<-[this3:\`ACTED_IN\`]-(this4:\`Actor\`)
                 WHERE this4.name = $param2
                 WITH { screenTime: this3.screenTime, node: { name: this4.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-auth.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-auth.test.ts
@@ -89,7 +89,7 @@ describe("connectOrCreate", () => {
                     MERGE (this0_genres_connectOrCreate0:\`Genre\` { name: $this0_genres_connectOrCreate_param0 })
                     ON CREATE SET
                         this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate_param1
-                    MERGE (this0)-[this0_genres_connectOrCreate_this0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                    MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -142,7 +142,7 @@ describe("connectOrCreate", () => {
                     MERGE (this0_genres_connectOrCreate0:\`Genre\` { name: $this0_genres_connectOrCreate_param0 })
                     ON CREATE SET
                         this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate_param1
-                    MERGE (this0)-[this0_genres_connectOrCreate_this0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                    MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -195,7 +195,7 @@ describe("connectOrCreate", () => {
                     MERGE (this0_genres_connectOrCreate0:\`Genre\` { name: $this0_genres_connectOrCreate_param0 })
                     ON CREATE SET
                         this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate_param1
-                    MERGE (this0)-[this0_genres_connectOrCreate_this0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                    MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -248,7 +248,7 @@ describe("connectOrCreate", () => {
                     MERGE (this0_genres_connectOrCreate0:\`Genre\` { name: $this0_genres_connectOrCreate_param0 })
                     ON CREATE SET
                         this0_genres_connectOrCreate0.name = $this0_genres_connectOrCreate_param1
-                    MERGE (this0)-[this0_genres_connectOrCreate_this0:IN_GENRE]->(this0_genres_connectOrCreate0)
+                    MERGE (this0)-[this0_genres_connectOrCreate_this0:\`IN_GENRE\`]->(this0_genres_connectOrCreate0)
                     RETURN COUNT(*) AS _
                 }
                 RETURN this0
@@ -312,7 +312,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_genres0_connectOrCreate0:\`Genre\` { name: $this_genres0_connectOrCreate_param0 })
                     ON CREATE SET
                         this_genres0_connectOrCreate0.name = $this_genres0_connectOrCreate_param1
-                    MERGE (this)-[this_genres0_connectOrCreate_this0:IN_GENRE]->(this_genres0_connectOrCreate0)
+                    MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -362,7 +362,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_genres0_connectOrCreate0:\`Genre\` { name: $this_genres0_connectOrCreate_param0 })
                     ON CREATE SET
                         this_genres0_connectOrCreate0.name = $this_genres0_connectOrCreate_param1
-                    MERGE (this)-[this_genres0_connectOrCreate_this0:IN_GENRE]->(this_genres0_connectOrCreate0)
+                    MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -412,7 +412,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_genres0_connectOrCreate0:\`Genre\` { name: $this_genres0_connectOrCreate_param0 })
                     ON CREATE SET
                         this_genres0_connectOrCreate0.name = $this_genres0_connectOrCreate_param1
-                    MERGE (this)-[this_genres0_connectOrCreate_this0:IN_GENRE]->(this_genres0_connectOrCreate0)
+                    MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -462,7 +462,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_genres0_connectOrCreate0:\`Genre\` { name: $this_genres0_connectOrCreate_param0 })
                     ON CREATE SET
                         this_genres0_connectOrCreate0.name = $this_genres0_connectOrCreate_param1
-                    MERGE (this)-[this_genres0_connectOrCreate_this0:IN_GENRE]->(this_genres0_connectOrCreate0)
+                    MERGE (this)-[this_genres0_connectOrCreate_this0:\`IN_GENRE\`]->(this_genres0_connectOrCreate0)
                     RETURN COUNT(*) AS _
                 }
                 RETURN collect(DISTINCT this { .title }) AS data"
@@ -520,7 +520,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_connectOrCreate_genres0:\`Genre\` { name: $this_connectOrCreate_genres_param0 })
                     ON CREATE SET
                         this_connectOrCreate_genres0.name = $this_connectOrCreate_genres_param1
-                    MERGE (this)-[this_connectOrCreate_genres_this0:IN_GENRE]->(this_connectOrCreate_genres0)
+                    MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -571,7 +571,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_connectOrCreate_genres0:\`Genre\` { name: $this_connectOrCreate_genres_param0 })
                     ON CREATE SET
                         this_connectOrCreate_genres0.name = $this_connectOrCreate_genres_param1
-                    MERGE (this)-[this_connectOrCreate_genres_this0:IN_GENRE]->(this_connectOrCreate_genres0)
+                    MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -622,7 +622,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_connectOrCreate_genres0:\`Genre\` { name: $this_connectOrCreate_genres_param0 })
                     ON CREATE SET
                         this_connectOrCreate_genres0.name = $this_connectOrCreate_genres_param1
-                    MERGE (this)-[this_connectOrCreate_genres_this0:IN_GENRE]->(this_connectOrCreate_genres0)
+                    MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres0)
                     WITH *
                     CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _
@@ -673,7 +673,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_connectOrCreate_genres0:\`Genre\` { name: $this_connectOrCreate_genres_param0 })
                     ON CREATE SET
                         this_connectOrCreate_genres0.name = $this_connectOrCreate_genres_param1
-                    MERGE (this)-[this_connectOrCreate_genres_this0:IN_GENRE]->(this_connectOrCreate_genres0)
+                    MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres0)
                     RETURN COUNT(*) AS _
                 }
                 WITH *
@@ -730,7 +730,7 @@ describe("connectOrCreate", () => {
                     MERGE (this_connectOrCreate_genres0:\`Genre\` { name: $this_connectOrCreate_genres_param0 })
                     ON CREATE SET
                         this_connectOrCreate_genres0.name = $this_connectOrCreate_genres_param1
-                    MERGE (this)-[this_connectOrCreate_genres_this0:IN_GENRE]->(this_connectOrCreate_genres0)
+                    MERGE (this)-[this_connectOrCreate_genres_this0:\`IN_GENRE\`]->(this_connectOrCreate_genres0)
                     WITH *
                     CALL apoc.util.validate(NOT ((this_connectOrCreate_genres0.name IS NOT NULL AND this_connectOrCreate_genres0.name = $this_connectOrCreate_genres0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN COUNT(*) AS _

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-unions.test.ts
@@ -120,7 +120,7 @@ describe("Create or connect with unions", () => {
                 ON CREATE SET
                     this0_actedIn_Movie_connectOrCreate0.title = $this0_actedIn_Movie_connectOrCreate_param1,
                     this0_actedIn_Movie_connectOrCreate0.isan = $this0_actedIn_Movie_connectOrCreate_param2
-                MERGE (this0)-[this0_actedIn_Movie_connectOrCreate_this0:ACTED_IN]->(this0_actedIn_Movie_connectOrCreate0)
+                MERGE (this0)-[this0_actedIn_Movie_connectOrCreate_this0:\`ACTED_IN\`]->(this0_actedIn_Movie_connectOrCreate0)
                 ON CREATE SET
                     this0_actedIn_Movie_connectOrCreate_this0.screentime = $this0_actedIn_Movie_connectOrCreate_param3
                 RETURN COUNT(*) AS _
@@ -132,7 +132,7 @@ describe("Create or connect with unions", () => {
                 ON CREATE SET
                     this0_actedIn_Series_connectOrCreate0.title = $this0_actedIn_Series_connectOrCreate_param1,
                     this0_actedIn_Series_connectOrCreate0.isan = $this0_actedIn_Series_connectOrCreate_param2
-                MERGE (this0)-[this0_actedIn_Series_connectOrCreate_this0:ACTED_IN]->(this0_actedIn_Series_connectOrCreate0)
+                MERGE (this0)-[this0_actedIn_Series_connectOrCreate_this0:\`ACTED_IN\`]->(this0_actedIn_Series_connectOrCreate0)
                 ON CREATE SET
                     this0_actedIn_Series_connectOrCreate_this0.screentime = $this0_actedIn_Series_connectOrCreate_param3
                 RETURN COUNT(*) AS _
@@ -215,7 +215,7 @@ describe("Create or connect with unions", () => {
                 ON CREATE SET
                     this_actedIn_Movie0_connectOrCreate0.title = $this_actedIn_Movie0_connectOrCreate_param1,
                     this_actedIn_Movie0_connectOrCreate0.isan = $this_actedIn_Movie0_connectOrCreate_param2
-                MERGE (this)-[this_actedIn_Movie0_connectOrCreate_this0:ACTED_IN]->(this_actedIn_Movie0_connectOrCreate0)
+                MERGE (this)-[this_actedIn_Movie0_connectOrCreate_this0:\`ACTED_IN\`]->(this_actedIn_Movie0_connectOrCreate0)
                 ON CREATE SET
                     this_actedIn_Movie0_connectOrCreate_this0.screentime = $this_actedIn_Movie0_connectOrCreate_param3
                 RETURN COUNT(*) AS _
@@ -227,7 +227,7 @@ describe("Create or connect with unions", () => {
                 ON CREATE SET
                     this_actedIn_Series0_connectOrCreate0.title = $this_actedIn_Series0_connectOrCreate_param1,
                     this_actedIn_Series0_connectOrCreate0.isan = $this_actedIn_Series0_connectOrCreate_param2
-                MERGE (this)-[this_actedIn_Series0_connectOrCreate_this0:ACTED_IN]->(this_actedIn_Series0_connectOrCreate0)
+                MERGE (this)-[this_actedIn_Series0_connectOrCreate_this0:\`ACTED_IN\`]->(this_actedIn_Series0_connectOrCreate0)
                 ON CREATE SET
                     this_actedIn_Series0_connectOrCreate_this0.screentime = $this_actedIn_Series0_connectOrCreate_param3
                 RETURN COUNT(*) AS _

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create.test.ts
@@ -96,7 +96,7 @@ describe("Create or Connect", () => {
                     MERGE (this0_movies_connectOrCreate0:\`Movie\` { title: $this0_movies_connectOrCreate_param0 })
                     ON CREATE SET
                         this0_movies_connectOrCreate0.title = $this0_movies_connectOrCreate_param1
-                    MERGE (this0)-[this0_movies_connectOrCreate_this0:ACTED_IN]->(this0_movies_connectOrCreate0)
+                    MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate0)
                     ON CREATE SET
                         this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param2
                     RETURN COUNT(*) AS _
@@ -157,7 +157,7 @@ describe("Create or Connect", () => {
                     MERGE (this_movies0_connectOrCreate0:\`Movie\` { title: $this_movies0_connectOrCreate_param0 })
                     ON CREATE SET
                         this_movies0_connectOrCreate0.title = $this_movies0_connectOrCreate_param1
-                    MERGE (this)-[this_movies0_connectOrCreate_this0:ACTED_IN]->(this_movies0_connectOrCreate0)
+                    MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate0)
                     ON CREATE SET
                         this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param2
                     RETURN COUNT(*) AS _
@@ -256,7 +256,7 @@ describe("Create or Connect", () => {
                         this0_movies_connectOrCreate0.createdAt = datetime(),
                         this0_movies_connectOrCreate0.id = randomUUID(),
                         this0_movies_connectOrCreate0.title = $this0_movies_connectOrCreate_param1
-                    MERGE (this0)-[this0_movies_connectOrCreate_this0:ACTED_IN]->(this0_movies_connectOrCreate0)
+                    MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate0)
                     ON CREATE SET
                         this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param2
                     RETURN COUNT(*) AS _
@@ -319,7 +319,7 @@ describe("Create or Connect", () => {
                     ON CREATE SET
                         this0_movies_connectOrCreate0.createdAt = datetime(),
                         this0_movies_connectOrCreate0.title = $this0_movies_connectOrCreate_param1
-                    MERGE (this0)-[this0_movies_connectOrCreate_this0:ACTED_IN]->(this0_movies_connectOrCreate0)
+                    MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate0)
                     ON CREATE SET
                         this0_movies_connectOrCreate_this0.screentime = $this0_movies_connectOrCreate_param2
                     RETURN COUNT(*) AS _
@@ -382,7 +382,7 @@ describe("Create or Connect", () => {
                         this_movies0_connectOrCreate0.createdAt = datetime(),
                         this_movies0_connectOrCreate0.id = randomUUID(),
                         this_movies0_connectOrCreate0.title = $this_movies0_connectOrCreate_param1
-                    MERGE (this)-[this_movies0_connectOrCreate_this0:ACTED_IN]->(this_movies0_connectOrCreate0)
+                    MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate0)
                     ON CREATE SET
                         this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param2
                     RETURN COUNT(*) AS _
@@ -443,7 +443,7 @@ describe("Create or Connect", () => {
                     ON CREATE SET
                         this_movies0_connectOrCreate0.createdAt = datetime(),
                         this_movies0_connectOrCreate0.title = $this_movies0_connectOrCreate_param1
-                    MERGE (this)-[this_movies0_connectOrCreate_this0:ACTED_IN]->(this_movies0_connectOrCreate0)
+                    MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate0)
                     ON CREATE SET
                         this_movies0_connectOrCreate_this0.screentime = $this_movies0_connectOrCreate_param2
                     RETURN COUNT(*) AS _
@@ -541,7 +541,7 @@ describe("Create or Connect", () => {
                     MERGE (this0_movies_connectOrCreate0:\`Movie\` { title: $this0_movies_connectOrCreate_param0 })
                     ON CREATE SET
                         this0_movies_connectOrCreate0.title = $this0_movies_connectOrCreate_param1
-                    MERGE (this0)-[this0_movies_connectOrCreate_this0:ACTED_IN]->(this0_movies_connectOrCreate0)
+                    MERGE (this0)-[this0_movies_connectOrCreate_this0:\`ACTED_IN\`]->(this0_movies_connectOrCreate0)
                     ON CREATE SET
                         this0_movies_connectOrCreate_this0.createdAt = datetime(),
                         this0_movies_connectOrCreate_this0.id = randomUUID(),
@@ -604,7 +604,7 @@ describe("Create or Connect", () => {
                     MERGE (this_movies0_connectOrCreate0:\`Movie\` { title: $this_movies0_connectOrCreate_param0 })
                     ON CREATE SET
                         this_movies0_connectOrCreate0.title = $this_movies0_connectOrCreate_param1
-                    MERGE (this)-[this_movies0_connectOrCreate_this0:ACTED_IN]->(this_movies0_connectOrCreate0)
+                    MERGE (this)-[this_movies0_connectOrCreate_this0:\`ACTED_IN\`]->(this_movies0_connectOrCreate0)
                     ON CREATE SET
                         this_movies0_connectOrCreate_this0.createdAt = datetime(),
                         this_movies0_connectOrCreate_this0.id = randomUUID(),

--- a/packages/graphql/tests/tck/connections/filtering/composite.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/composite.test.ts
@@ -91,7 +91,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE ((this0.screenTime > $param1 AND this0.screenTime < $param2) AND (this1.firstName = $param3 AND this1.lastName = $param4))
                 WITH { screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } } AS edge
                 WITH collect(edge) AS edges
@@ -151,7 +151,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE (NOT (this0.screenTime < $param1 AND this0.screenTime > $param2) AND NOT (this1.firstName = $param3 AND this1.lastName = $param4))
                 WITH { screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
@@ -85,7 +85,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE (this1.firstName = $param0 AND this1.lastName = $param1)
                 WITH { screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } } AS edge
                 WITH collect(edge) AS edges
@@ -130,7 +130,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this1.firstName = $param0)
                 WITH { screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
@@ -84,7 +84,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name IN $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -130,7 +130,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this1.name IN $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -177,7 +177,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE $param0 IN this1.favouriteColours
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, favouriteColours: this1.favouriteColours } } AS edge
                 WITH collect(edge) AS edges
@@ -221,7 +221,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT ($param0 IN this1.favouriteColours)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, favouriteColours: this1.favouriteColours } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
@@ -83,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name = $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -126,7 +126,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this1.name = $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
@@ -85,7 +85,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.age < $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } } AS edge
                 WITH collect(edge) AS edges
@@ -132,7 +132,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.age <= $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } } AS edge
                 WITH collect(edge) AS edges
@@ -179,7 +179,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.age > $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } } AS edge
                 WITH collect(edge) AS edges
@@ -226,7 +226,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.age >= $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
@@ -85,7 +85,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE (this1.firstName = $param0 OR this1.lastName = $param1)
                 WITH { screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
@@ -101,7 +101,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE point.distance(this1.currentLocation, point($param0.point)) = $param0.distance
                 WITH { screenTime: this0.screenTime, node: { name: this1.name, currentLocation: CASE
                     WHEN this1.currentLocation IS NOT NULL THEN { point: this1.currentLocation }

--- a/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/relationship.test.ts
@@ -78,9 +78,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Relationship", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE EXISTS {
-                    MATCH (this1)-[:ACTED_IN]->(this2:\`Movie\`)
+                    MATCH (this1)-[:\`ACTED_IN\`]->(this2:\`Movie\`)
                     WHERE this2.title = $param0
                 }
                 WITH { node: { name: this1.name } } AS edge

--- a/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
@@ -93,7 +93,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name CONTAINS $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -136,7 +136,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this1.name CONTAINS $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -179,7 +179,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name STARTS WITH $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -222,7 +222,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this1.name STARTS WITH $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -265,7 +265,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name ENDS WITH $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -308,7 +308,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this1.name ENDS WITH $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -351,7 +351,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name =~ $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
@@ -85,7 +85,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE (this0.role ENDS WITH $param0 AND this0.screenTime < $param1)
                 WITH { role: this0.role, screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -133,7 +133,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this0.role ENDS WITH $param0)
                 WITH { role: this0.role, screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
@@ -84,7 +84,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.screenTime IN $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -136,7 +136,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this0.screenTime IN $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -188,7 +188,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE $param0 IN this0.quotes
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -231,7 +231,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT ($param0 IN this0.quotes)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
@@ -83,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.screenTime = $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -129,7 +129,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this0.screenTime = $param0)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
@@ -83,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.screenTime < $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -129,7 +129,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.screenTime <= $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -175,7 +175,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.screenTime > $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -221,7 +221,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.screenTime >= $param0
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
@@ -85,7 +85,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE (this0.role ENDS WITH $param0 OR this0.screenTime < $param1)
                 WITH { role: this0.role, screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
@@ -99,7 +99,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE point.distance(this0.location, point($param0.point)) = $param0.distance
                 WITH { screenTime: this0.screenTime, location: CASE
                     WHEN this0.location IS NOT NULL THEN { point: this0.location }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
@@ -94,7 +94,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.role CONTAINS $param0
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -137,7 +137,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this0.role CONTAINS $param0)
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -180,7 +180,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.role STARTS WITH $param0
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -223,7 +223,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this0.role STARTS WITH $param0)
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -266,7 +266,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.role ENDS WITH $param0
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -309,7 +309,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE NOT (this0.role ENDS WITH $param0)
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -352,7 +352,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this0.role =~ $param0
                 WITH { role: this0.role, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
@@ -87,7 +87,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE (this0.startDate > $param0 AND this0.endDateTime < $param1)
                 WITH { startDate: this0.startDate, endDateTime: apoc.date.convertFormat(toString(this0.endDateTime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/interfaces.test.ts
@@ -93,12 +93,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
@@ -146,13 +146,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE this1.title STARTS WITH $param0
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WHERE this3.title STARTS WITH $param1
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
@@ -208,13 +208,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE this1.runtime > $param0
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WHERE this3.episodes > $param1
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
@@ -274,13 +274,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE this0.screenTime > $param0
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WHERE this2.screenTime > $param1
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
@@ -342,12 +342,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         WITH this
                         CALL {
                             WITH this
-                            MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                            MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                             WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
-                            MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                            MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                             WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
@@ -399,12 +399,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         WITH this
                         CALL {
                             WITH this
-                            MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                            MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                             WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
-                            MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                            MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                             WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
@@ -457,12 +457,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         WITH this
                         CALL {
                             WITH this
-                            MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                            MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                             WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
-                            MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                            MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                             WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
@@ -513,12 +513,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         WITH this
                         CALL {
                             WITH this
-                            MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                            MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                             WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
-                            MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                            MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                             WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }

--- a/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
@@ -80,11 +80,11 @@ describe("Mixed nesting", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name = $param1
                 CALL {
                     WITH this1
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     WHERE NOT (this3.title = $param2)
                     WITH this3 { .title } AS this3
                     RETURN collect(this3) AS var4
@@ -143,15 +143,15 @@ describe("Mixed nesting", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name = $param1
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Actor\`)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1:\`Actor\`)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     WHERE NOT (this3.title = $param2)
                     CALL {
                         WITH this3
-                        MATCH (this3)<-[this4:ACTED_IN]-(this5:\`Actor\`)
+                        MATCH (this3)<-[this4:\`ACTED_IN\`]-(this5:\`Actor\`)
                         WHERE NOT (this5.name = $param3)
                         WITH this5 { .name } AS this5
                         RETURN collect(this5) AS var6
@@ -209,11 +209,11 @@ describe("Mixed nesting", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name = $param1
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Actor\`)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1:\`Actor\`)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     WHERE NOT (this3.title = $param2)
                     WITH { screenTime: this2.screenTime, node: { title: this3.title } } AS edge
                     WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/create.test.ts
@@ -92,7 +92,7 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0:\`Movie\`)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0:\`Movie\`)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WITH { screenTime: create_this1.screenTime, node: { name: create_this2.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -148,7 +148,7 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0:\`Movie\`)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0:\`Movie\`)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WITH { screenTime: create_this1.screenTime, node: { name: create_this2.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -207,7 +207,7 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0:\`Movie\`)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0:\`Movie\`)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WHERE create_this2.name = $create_param0
                 WITH { screenTime: create_this1.screenTime, node: { name: create_this2.name } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/projections/projections.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/projections.test.ts
@@ -82,7 +82,7 @@ describe("Relay Cursor Connection projections", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { __resolveType: \\"Actor\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -125,7 +125,7 @@ describe("Relay Cursor Connection projections", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { __resolveType: \\"Actor\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -163,7 +163,7 @@ describe("Relay Cursor Connection projections", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { __resolveType: \\"Actor\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -215,12 +215,12 @@ describe("Relay Cursor Connection projections", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH { node: { __resolveType: \\"Movie\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WITH { node: { __resolveType: \\"Series\\", __id: id(this3) } } AS edge
                     RETURN edge
                 }
@@ -267,12 +267,12 @@ describe("Relay Cursor Connection projections", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH { node: { __resolveType: \\"Movie\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WITH { node: { __resolveType: \\"Series\\", __id: id(this3) } } AS edge
                     RETURN edge
                 }
@@ -317,7 +317,7 @@ describe("Relay Cursor Connection projections", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -360,7 +360,7 @@ describe("Relay Cursor Connection projections", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/update.test.ts
@@ -87,7 +87,7 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:\`Actor\`)
+                MATCH (this)<-[update_this0:\`ACTED_IN\`]-(update_this1:\`Actor\`)
                 WITH { screenTime: update_this0.screenTime, node: { name: update_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/connections/relationship-properties.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship-properties.test.ts
@@ -78,7 +78,7 @@ describe("Relationship Properties Cypher", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -121,7 +121,7 @@ describe("Relationship Properties Cypher", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WHERE this1.name = $param1
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
@@ -166,7 +166,7 @@ describe("Relationship Properties Cypher", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH this0, this1
                 ORDER BY this0.screenTime DESC
                 WITH { screenTime: this0.screenTime, node: { name: this1.name } } AS edge
@@ -217,7 +217,7 @@ describe("Relationship Properties Cypher", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH this0, this1
                 ORDER BY this0.year DESC, this1.name ASC
                 WITH { year: this0.year, node: { name: this1.name } } AS edge
@@ -263,7 +263,7 @@ describe("Relationship Properties Cypher", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH this0, this1
                 ORDER BY this1.name ASC, this0.year DESC
                 WITH { year: this0.year, node: { name: this1.name } } AS edge
@@ -320,10 +320,10 @@ describe("Relationship Properties Cypher", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Actor\`)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1:\`Actor\`)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     WITH { screenTime: this2.screenTime, node: { title: this3.title } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount
@@ -387,13 +387,13 @@ describe("Relationship Properties Cypher", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Actor\`)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1:\`Actor\`)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     CALL {
                         WITH this3
-                        MATCH (this3:\`Movie\`)<-[this4:ACTED_IN]-(this5:\`Actor\`)
+                        MATCH (this3:\`Movie\`)<-[this4:\`ACTED_IN\`]-(this5:\`Actor\`)
                         WITH { screenTime: this4.screenTime, node: { name: this5.name } } AS edge
                         WITH collect(edge) AS edges
                         WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
@@ -96,7 +96,7 @@ describe("Relationship Properties Connect Cypher", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_actors_connect0_node
-            			MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
+            			MERGE (this0)<-[this0_actors_connect0_relationship:\`ACTED_IN\`]-(this0_actors_connect0_node)
             			SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -109,7 +109,7 @@ describe("Relationship Properties Connect Cypher", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH { screenTime: create_this0.screenTime, node: { name: create_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -177,7 +177,7 @@ describe("Relationship Properties Connect Cypher", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_actors_connect0_node
-            			MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
+            			MERGE (this0)<-[this0_actors_connect0_relationship:\`ACTED_IN\`]-(this0_actors_connect0_node)
             			SET this0_actors_connect0_relationship.screenTime = $this0_actors_connect0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -190,7 +190,7 @@ describe("Relationship Properties Connect Cypher", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH { screenTime: create_this0.screenTime, node: { name: create_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -250,7 +250,7 @@ describe("Relationship Properties Connect Cypher", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors0_node
-            			MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+            			MERGE (this)<-[this_connect_actors0_relationship:\`ACTED_IN\`]-(this_connect_actors0_node)
             			SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -262,7 +262,7 @@ describe("Relationship Properties Connect Cypher", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:\`Actor\`)
+                MATCH (this)<-[update_this0:\`ACTED_IN\`]-(update_this1:\`Actor\`)
                 WITH { screenTime: update_this0.screenTime, node: { name: update_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -325,7 +325,7 @@ describe("Relationship Properties Connect Cypher", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors0_node
-            			MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+            			MERGE (this)<-[this_connect_actors0_relationship:\`ACTED_IN\`]-(this_connect_actors0_node)
             			SET this_connect_actors0_relationship.screenTime = $this_connect_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -337,7 +337,7 @@ describe("Relationship Properties Connect Cypher", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:\`Actor\`)
+                MATCH (this)<-[update_this0:\`ACTED_IN\`]-(update_this1:\`Actor\`)
                 WITH { screenTime: update_this0.screenTime, node: { name: update_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
@@ -103,7 +103,7 @@ describe("Relationship Properties Create Cypher", () => {
                     CREATE (create_this8:\`Actor\`)
                     SET
                         create_this8.name = create_var6.name
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     SET
                         create_this9.screenTime = create_var7.screenTime
                     RETURN collect(NULL) AS create_var10
@@ -112,7 +112,7 @@ describe("Relationship Properties Create Cypher", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0:\`Movie\`)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0:\`Movie\`)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WITH { screenTime: create_this1.screenTime, node: { name: create_this2.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/connections/relationship_properties/update.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/update.test.ts
@@ -77,7 +77,7 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	SET this_acted_in0_relationship.screenTime = $updateMovies.args.update.actors[0].update.edge.screenTime
             	RETURN count(*) AS update_this_actors0
@@ -149,7 +149,7 @@ describe("Cypher -> Connections -> Relationship Properties -> Update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	SET this_acted_in0_relationship.screenTime = $updateMovies.args.update.actors[0].update.edge.screenTime
             	SET this_actors0.name = $this_update_actors0_name

--- a/packages/graphql/tests/tck/connections/unions.test.ts
+++ b/packages/graphql/tests/tck/connections/unions.test.ts
@@ -90,12 +90,12 @@ describe("Cypher -> Connections -> Unions", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                    MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                     WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:WROTE]->(this3:\`Journal\`)
+                    MATCH (this)-[this2:\`WROTE\`]->(this3:\`Journal\`)
                     WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }
@@ -147,13 +147,13 @@ describe("Cypher -> Connections -> Unions", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                    MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                     WHERE this1.title = $param0
                     WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:WROTE]->(this3:\`Journal\`)
+                    MATCH (this)-[this2:\`WROTE\`]->(this3:\`Journal\`)
                     WHERE this3.subject = $param1
                     WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
@@ -208,13 +208,13 @@ describe("Cypher -> Connections -> Unions", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                    MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                     WHERE this0.words = $param0
                     WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:WROTE]->(this3:\`Journal\`)
+                    MATCH (this)-[this2:\`WROTE\`]->(this3:\`Journal\`)
                     WHERE this2.words = $param1
                     WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
@@ -278,13 +278,13 @@ describe("Cypher -> Connections -> Unions", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                    MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                     WHERE (this1.title = $param0 AND this0.words = $param1)
                     WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:WROTE]->(this3:\`Journal\`)
+                    MATCH (this)-[this2:\`WROTE\`]->(this3:\`Journal\`)
                     WHERE (this3.subject = $param2 AND this2.words = $param3)
                     WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
@@ -345,12 +345,12 @@ describe("Cypher -> Connections -> Unions", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                    MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                     WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:WROTE]->(this3:\`Journal\`)
+                    MATCH (this)-[this2:\`WROTE\`]->(this3:\`Journal\`)
                     WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }

--- a/packages/graphql/tests/tck/deprecated/1756.test.ts
+++ b/packages/graphql/tests/tck/deprecated/1756.test.ts
@@ -93,14 +93,14 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
                 ON CREATE SET
                     this0_genre_connectOrCreate0.value = $this0_genre_connectOrCreate_param1,
                     this0_genre_connectOrCreate0.id = $resolvedCallbacks.this0_genre_connectOrCreate0_id_nanoid
-                MERGE (this0)-[this0_genre_connectOrCreate_this0:HAS_GENRE]->(this0_genre_connectOrCreate0)
+                MERGE (this0)-[this0_genre_connectOrCreate_this0:\`HAS_GENRE\`]->(this0_genre_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             RETURN this0
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:HAS_GENRE]->(create_this1:\`Genre\`)
+                MATCH (this0)-[create_this0:\`HAS_GENRE\`]->(create_this1:\`Genre\`)
                 WITH create_this1 { .id, .value } AS create_this1
                 RETURN collect(create_this1) AS create_var2
             }

--- a/packages/graphql/tests/tck/directives/alias.test.ts
+++ b/packages/graphql/tests/tck/directives/alias.test.ts
@@ -75,7 +75,7 @@ describe("Cypher alias directive", () => {
             "MATCH (this:\`Actor\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                 WITH this1 { .title, rating: this1.ratingPropInDb } AS this1
                 RETURN collect(this1) AS var2
             }
@@ -114,7 +114,7 @@ describe("Cypher alias directive", () => {
             "MATCH (this:\`Actor\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                 WITH { character: this0.characterPropInDb, screenTime: this0.screenTime, node: { title: this1.title, rating: this1.ratingPropInDb } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -187,7 +187,7 @@ describe("Cypher alias directive", () => {
                     SET
                         create_this11.title = create_var9.title,
                         create_this11.ratingPropInDb = create_var9.rating
-                    MERGE (create_this0)-[create_this12:ACTED_IN]->(create_this11)
+                    MERGE (create_this0)-[create_this12:\`ACTED_IN\`]->(create_this11)
                     SET
                         create_this12.characterPropInDb = create_var10.character,
                         create_this12.screenTime = create_var10.screenTime
@@ -197,13 +197,13 @@ describe("Cypher alias directive", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)-[create_this1:ACTED_IN]->(create_this2:\`Movie\`)
+                MATCH (create_this0)-[create_this1:\`ACTED_IN\`]->(create_this2:\`Movie\`)
                 WITH create_this2 { .title, rating: create_this2.ratingPropInDb } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0:\`Actor\`)-[create_this4:ACTED_IN]->(create_this5:\`Movie\`)
+                MATCH (create_this0:\`Actor\`)-[create_this4:\`ACTED_IN\`]->(create_this5:\`Movie\`)
                 WITH { character: create_this4.characterPropInDb, screenTime: create_this4.screenTime, node: { title: create_this5.title, rating: create_this5.ratingPropInDb } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/allow.test.ts
@@ -168,8 +168,8 @@ describe("Cypher Auth Allow", () => {
             WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -202,10 +202,10 @@ describe("Cypher Auth Allow", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.util.validatePredicate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(this0 IN [(this)<-[:HAS_POST]-(this0:\`User\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ((exists((this)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this0 IN [(this)<-[:\`HAS_POST\`]-(this0:\`User\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)<-[this1:HAS_POST]-(this2:\`User\`)
+                MATCH (this)<-[this1:\`HAS_POST\`]-(this2:\`User\`)
                 WHERE (apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this2 { .password } AS this2
                 RETURN head(collect(this2)) AS var3
@@ -246,12 +246,12 @@ describe("Cypher Auth Allow", () => {
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 CALL {
                     WITH this1
-                    MATCH (this1)-[this3:HAS_COMMENT]->(this4:\`Comment\`)
-                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_COMMENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_COMMENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this1)-[this3:\`HAS_COMMENT\`]->(this4:\`Comment\`)
+                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:\`HAS_COMMENT\`]-(:\`User\`)) AND any(this5 IN [(this4)<-[:\`HAS_COMMENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this4 { .content } AS this4
                     RETURN collect(this4) AS var6
                 }
@@ -363,11 +363,11 @@ describe("Cypher Auth Allow", () => {
             "MATCH (this:\`Post\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	MATCH (this)<-[this_has_post0_relationship:\`HAS_POST\`]-(this_creator0:User)
             	WITH this, this_creator0
             	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.id = $this_update_creator0_id
@@ -376,7 +376,7 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_POST\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -418,11 +418,11 @@ describe("Cypher Auth Allow", () => {
             "MATCH (this:\`Post\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	MATCH (this)<-[this_has_post0_relationship:\`HAS_POST\`]-(this_creator0:User)
             	WITH this, this_creator0
             	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0) AND (this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.password = $this_update_creator0_password
@@ -431,7 +431,7 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_POST\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -498,10 +498,10 @@ describe("Cypher Auth Allow", () => {
             "MATCH (this:\`User\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            OPTIONAL MATCH (this)-[this_posts0_relationship:\`HAS_POST\`]->(this_posts0:Post)
             WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0
             WITH this, this_posts0
-            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -561,10 +561,10 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
             WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -629,13 +629,13 @@ describe("Cypher Auth Allow", () => {
             "MATCH (this:\`Comment\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_COMMENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_COMMENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
+            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:\`HAS_COMMENT\`]-(this_post0_disconnect0:Post)
             WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_COMMENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_COMMENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
             	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
@@ -645,10 +645,10 @@ describe("Cypher Auth Allow", () => {
             }
             CALL {
             WITH this, this_post0_disconnect0
-            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
+            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:\`HAS_POST\`]-(this_post0_disconnect0_creator0:User)
             WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0
             WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
             	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
@@ -663,14 +663,14 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_COMMENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
             }
             CALL {
             	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	MATCH (this)<-[this_post_Post_unique:\`HAS_COMMENT\`]-(:Post)
             	WITH count(this_post_Post_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
             	RETURN c AS this_post_Post_unique_ignored
@@ -734,7 +734,7 @@ describe("Cypher Auth Allow", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
             	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -742,7 +742,7 @@ describe("Cypher Auth Allow", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/inherited.test.ts
@@ -161,8 +161,8 @@ describe("@auth allow when inherited from interface", () => {
             WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -195,10 +195,10 @@ describe("@auth allow when inherited from interface", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE apoc.util.validatePredicate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(this0 IN [(this)<-[:HAS_POST]-(this0:\`User\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ((exists((this)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this0 IN [(this)<-[:\`HAS_POST\`]-(this0:\`User\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)<-[this1:HAS_POST]-(this2:\`User\`)
+                MATCH (this)<-[this1:\`HAS_POST\`]-(this2:\`User\`)
                 WHERE (apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this2 { .password } AS this2
                 RETURN head(collect(this2)) AS var3
@@ -239,12 +239,12 @@ describe("@auth allow when inherited from interface", () => {
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 CALL {
                     WITH this1
-                    MATCH (this1)-[this3:HAS_COMMENT]->(this4:\`Comment\`)
-                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_COMMENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_COMMENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this1)-[this3:\`HAS_COMMENT\`]->(this4:\`Comment\`)
+                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:\`HAS_COMMENT\`]-(:\`User\`)) AND any(this5 IN [(this4)<-[:\`HAS_COMMENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this4 { .content } AS this4
                     RETURN collect(this4) AS var6
                 }
@@ -356,11 +356,11 @@ describe("@auth allow when inherited from interface", () => {
             "MATCH (this:\`Post\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	MATCH (this)<-[this_has_post0_relationship:\`HAS_POST\`]-(this_creator0:User)
             	WITH this, this_creator0
             	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.id = $this_update_creator0_id
@@ -369,7 +369,7 @@ describe("@auth allow when inherited from interface", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_POST\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -411,11 +411,11 @@ describe("@auth allow when inherited from interface", () => {
             "MATCH (this:\`Post\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	MATCH (this)<-[this_has_post0_relationship:\`HAS_POST\`]-(this_creator0:User)
             	WITH this, this_creator0
             	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0) AND (this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.password = $this_update_creator0_password
@@ -424,7 +424,7 @@ describe("@auth allow when inherited from interface", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_POST\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -491,10 +491,10 @@ describe("@auth allow when inherited from interface", () => {
             "MATCH (this:\`User\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            OPTIONAL MATCH (this)-[this_posts0_relationship:\`HAS_POST\`]->(this_posts0:Post)
             WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0
             WITH this, this_posts0
-            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -554,10 +554,10 @@ describe("@auth allow when inherited from interface", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
             WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -622,13 +622,13 @@ describe("@auth allow when inherited from interface", () => {
             "MATCH (this:\`Comment\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_COMMENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_COMMENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
+            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:\`HAS_COMMENT\`]-(this_post0_disconnect0:Post)
             WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_COMMENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_COMMENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
             	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
@@ -638,10 +638,10 @@ describe("@auth allow when inherited from interface", () => {
             }
             CALL {
             WITH this, this_post0_disconnect0
-            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
+            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:\`HAS_POST\`]-(this_post0_disconnect0_creator0:User)
             WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0
             WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
-            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
             	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
@@ -656,14 +656,14 @@ describe("@auth allow when inherited from interface", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_COMMENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
             }
             CALL {
             	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	MATCH (this)<-[this_post_Post_unique:\`HAS_COMMENT\`]-(:Post)
             	WITH count(this_post_Post_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
             	RETURN c AS this_post_Post_unique_ignored
@@ -727,7 +727,7 @@ describe("@auth allow when inherited from interface", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
             	WITH this, this_connect_posts0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -735,7 +735,7 @@ describe("@auth allow when inherited from interface", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -101,13 +101,13 @@ describe("@auth allow on specific interface implementation", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
                     WITH this1 { __resolveType: \\"Comment\\", __id: id(this), .id, .content } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[this3:\`HAS_CONTENT\`]->(this4:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this4)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this5 IN [(this4)<-[:\`HAS_CONTENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this4
                     RETURN this4 AS var2
                 }
@@ -152,17 +152,17 @@ describe("@auth allow on specific interface implementation", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
                     WHERE this1.id = $param1
                     WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
-                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this)-[this3:\`HAS_CONTENT\`]->(this4:\`Post\`)
+                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this5 IN [(this4)<-[:\`HAS_CONTENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     CALL {
                         WITH this4
-                        MATCH (this4)-[this6:HAS_COMMENT]->(this7:\`Comment\`)
+                        MATCH (this4)-[this6:\`HAS_COMMENT\`]->(this7:\`Comment\`)
                         WHERE this7.id = $param4
                         WITH this7 { .content } AS this7
                         RETURN collect(this7) AS var8
@@ -215,19 +215,19 @@ describe("@auth allow on specific interface implementation", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Comment)
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
             	}
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_post_Post_unique:HAS_COMMENT]-(:Post)
+            		MATCH (this_content0)<-[this_content0_post_Post_unique:\`HAS_COMMENT\`]-(:Post)
             		WITH count(this_content0_post_Post_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
             		RETURN c AS this_content0_post_Post_unique_ignored
@@ -241,14 +241,14 @@ describe("@auth allow on specific interface implementation", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Post)
             	WITH this, this_content0
-            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -262,13 +262,13 @@ describe("@auth allow on specific interface implementation", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:HAS_CONTENT]->(update_this1:\`Comment\`)
+                    MATCH (this)-[update_this0:\`HAS_CONTENT\`]->(update_this1:\`Comment\`)
                     WITH update_this1 { __resolveType: \\"Comment\\", __id: id(this), .id } AS update_this1
                     RETURN update_this1 AS update_var2
                     UNION
                     WITH *
-                    MATCH (this)-[update_this3:HAS_CONTENT]->(update_this4:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this4)<-[:HAS_CONTENT]-(:\`User\`)) AND any(update_this5 IN [(update_this4)<-[:HAS_CONTENT]-(update_this5:\`User\`) | update_this5] WHERE (update_this5.id IS NOT NULL AND update_this5.id = $update_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[update_this3:\`HAS_CONTENT\`]->(update_this4:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this4)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(update_this5 IN [(update_this4)<-[:\`HAS_CONTENT\`]-(update_this5:\`User\`) | update_this5] WHERE (update_this5.id IS NOT NULL AND update_this5.id = $update_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH update_this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS update_this4
                     RETURN update_this4 AS update_var2
                 }
@@ -307,7 +307,7 @@ describe("@auth allow on specific interface implementation", () => {
             "MATCH (this:\`User\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:\`HAS_CONTENT\`]->(this_content_Comment0:Comment)
             WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_this_content_Comment0param0
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
             CALL {
@@ -317,10 +317,10 @@ describe("@auth allow on specific interface implementation", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:\`HAS_CONTENT\`]->(this_content_Post0:Post)
             WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0
             WITH this, this_content_Post0
-            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -378,7 +378,7 @@ describe("@auth allow on specific interface implementation", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -391,10 +391,10 @@ describe("@auth allow on specific interface implementation", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -464,7 +464,7 @@ describe("@auth allow on specific interface implementation", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -477,10 +477,10 @@ describe("@auth allow on specific interface implementation", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -490,10 +490,10 @@ describe("@auth allow on specific interface implementation", () => {
             }
             CALL {
             WITH this, this_disconnect_content0
-            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
+            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:\`HAS_COMMENT\`]->(this_disconnect_content0_comments0:Comment)
             WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
             	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
@@ -584,7 +584,7 @@ describe("@auth allow on specific interface implementation", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -597,7 +597,7 @@ describe("@auth allow on specific interface implementation", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0
             	WITH this, this_connect_content1_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -605,7 +605,7 @@ describe("@auth allow on specific interface implementation", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -109,14 +109,14 @@ describe("@auth allow with interface relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_CONTENT\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Comment\\", __id: id(this), .id, .content } AS this1
                     RETURN this1 AS var3
                     UNION
                     WITH *
-                    MATCH (this)-[this4:HAS_CONTENT]->(this5:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((this5)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this6 IN [(this5)<-[:HAS_CONTENT]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param2)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[this4:\`HAS_CONTENT\`]->(this5:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this5)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this6 IN [(this5)<-[:\`HAS_CONTENT\`]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param2)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this5 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this5
                     RETURN this5 AS var3
                 }
@@ -163,18 +163,18 @@ describe("@auth allow with interface relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
-                    WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
+                    WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_CONTENT\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
                     RETURN this1 AS var3
                     UNION
                     WITH *
-                    MATCH (this)-[this4:HAS_CONTENT]->(this5:\`Post\`)
-                    WHERE (this5.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this5)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this6 IN [(this5)<-[:HAS_CONTENT]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this)-[this4:\`HAS_CONTENT\`]->(this5:\`Post\`)
+                    WHERE (this5.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this5)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this6 IN [(this5)<-[:\`HAS_CONTENT\`]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     CALL {
                         WITH this5
-                        MATCH (this5)-[this7:HAS_COMMENT]->(this8:\`Comment\`)
-                        WHERE (this8.id = $param6 AND apoc.util.validatePredicate(NOT ((exists((this8)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this9 IN [(this8)<-[:HAS_CONTENT]-(this9:\`User\`) | this9] WHERE (this9.id IS NOT NULL AND this9.id = $param7)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                        MATCH (this5)-[this7:\`HAS_COMMENT\`]->(this8:\`Comment\`)
+                        WHERE (this8.id = $param6 AND apoc.util.validatePredicate(NOT ((exists((this8)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(this9 IN [(this8)<-[:\`HAS_CONTENT\`]-(this9:\`User\`) | this9] WHERE (this9.id IS NOT NULL AND this9.id = $param7)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                         WITH this8 { .content } AS this8
                         RETURN collect(this8) AS var10
                     }
@@ -231,21 +231,21 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Comment)
             	WITH this, this_content0
-            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
             	}
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_post_Post_unique:HAS_COMMENT]-(:Post)
+            		MATCH (this_content0)<-[this_content0_post_Post_unique:\`HAS_COMMENT\`]-(:Post)
             		WITH count(this_content0_post_Post_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
             		RETURN c AS this_content0_post_Post_unique_ignored
@@ -259,14 +259,14 @@ describe("@auth allow with interface relationships", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Post)
             	WITH this, this_content0
-            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -280,14 +280,14 @@ describe("@auth allow with interface relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:HAS_CONTENT]->(update_this1:\`Comment\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this1)<-[:HAS_CONTENT]-(:\`User\`)) AND any(update_this2 IN [(update_this1)<-[:HAS_CONTENT]-(update_this2:\`User\`) | update_this2] WHERE (update_this2.id IS NOT NULL AND update_this2.id = $update_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[update_this0:\`HAS_CONTENT\`]->(update_this1:\`Comment\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this1)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(update_this2 IN [(update_this1)<-[:\`HAS_CONTENT\`]-(update_this2:\`User\`) | update_this2] WHERE (update_this2.id IS NOT NULL AND update_this2.id = $update_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH update_this1 { __resolveType: \\"Comment\\", __id: id(this), .id } AS update_this1
                     RETURN update_this1 AS update_var3
                     UNION
                     WITH *
-                    MATCH (this)-[update_this4:HAS_CONTENT]->(update_this5:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this5)<-[:HAS_CONTENT]-(:\`User\`)) AND any(update_this6 IN [(update_this5)<-[:HAS_CONTENT]-(update_this6:\`User\`) | update_this6] WHERE (update_this6.id IS NOT NULL AND update_this6.id = $update_param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[update_this4:\`HAS_CONTENT\`]->(update_this5:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this5)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(update_this6 IN [(update_this5)<-[:\`HAS_CONTENT\`]-(update_this6:\`User\`) | update_this6] WHERE (update_this6.id IS NOT NULL AND update_this6.id = $update_param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH update_this5 { __resolveType: \\"Post\\", __id: id(this), .id } AS update_this5
                     RETURN update_this5 AS update_var3
                 }
@@ -333,11 +333,11 @@ describe("@auth allow with interface relationships", () => {
             "MATCH (this:\`Post\`)
             WHERE this.id = $param0
             WITH this
-            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_content0_relationship:HAS_CONTENT]-(this_creator0:User)
+            	MATCH (this)<-[this_has_content0_relationship:\`HAS_CONTENT\`]-(this_creator0:User)
             	WITH this, this_creator0
             	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0) AND (this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.password = $this_update_creator0_password
@@ -346,7 +346,7 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -383,10 +383,10 @@ describe("@auth allow with interface relationships", () => {
             "MATCH (this:\`User\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:\`HAS_CONTENT\`]->(this_content_Comment0:Comment)
             WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_this_content_Comment0param0
             WITH this, this_content_Comment0
-            CALL apoc.util.validate(NOT ((exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_content_Comment0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Comment0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
             CALL {
             	WITH this_content_Comment0_to_delete
@@ -395,10 +395,10 @@ describe("@auth allow with interface relationships", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:\`HAS_CONTENT\`]->(this_content_Post0:Post)
             WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0
             WITH this, this_content_Post0
-            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -460,10 +460,10 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -475,10 +475,10 @@ describe("@auth allow with interface relationships", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -551,10 +551,10 @@ describe("@auth allow with interface relationships", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -566,10 +566,10 @@ describe("@auth allow with interface relationships", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
-            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -579,10 +579,10 @@ describe("@auth allow with interface relationships", () => {
             }
             CALL {
             WITH this, this_disconnect_content0
-            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
+            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:\`HAS_COMMENT\`]->(this_disconnect_content0_comments0:Comment)
             WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0
             WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0))) AND (exists((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0_comments0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0))) AND (exists((this_disconnect_content0_comments0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0_comments0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0_comments0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
             	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
@@ -669,7 +669,7 @@ describe("@auth allow with interface relationships", () => {
             	OPTIONAL MATCH (this_connect_content0_node:Comment)
             	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
             	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
@@ -677,7 +677,7 @@ describe("@auth allow with interface relationships", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -690,7 +690,7 @@ describe("@auth allow with interface relationships", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0
             	WITH this, this_connect_content1_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -698,7 +698,7 @@ describe("@auth allow with interface relationships", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/bind.test.ts
@@ -149,7 +149,7 @@ describe("Cypher Auth Allow", () => {
                     CREATE (create_this5:\`Post\`)
                     SET
                         create_this5.id = create_var3.id
-                    MERGE (create_this1)-[create_this6:HAS_POST]->(create_this5)
+                    MERGE (create_this1)-[create_this6:\`HAS_POST\`]->(create_this5)
                     WITH create_this5, create_var3
                     CALL {
                         WITH create_this5, create_var3
@@ -158,17 +158,17 @@ describe("Cypher Auth Allow", () => {
                         CREATE (create_this10:\`User\`)
                         SET
                             create_this10.id = create_var8.id
-                        MERGE (create_this5)<-[create_this11:HAS_POST]-(create_this10)
+                        MERGE (create_this5)<-[create_this11:\`HAS_POST\`]-(create_this10)
                         WITH *
                         CALL apoc.util.validate(NOT ((create_this10.id IS NOT NULL AND create_this10.id = $create_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                         RETURN collect(NULL) AS create_var12
                     }
                     WITH *
-                    CALL apoc.util.validate(NOT ((exists((create_this5)<-[:HAS_POST]-(:\`User\`)) AND all(create_this13 IN [(create_this5)<-[:HAS_POST]-(create_this13:\`User\`) | create_this13] WHERE (create_this13.id IS NOT NULL AND create_this13.id = $create_param2)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    CALL apoc.util.validate(NOT ((exists((create_this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(create_this13 IN [(create_this5)<-[:\`HAS_POST\`]-(create_this13:\`User\`) | create_this13] WHERE (create_this13.id IS NOT NULL AND create_this13.id = $create_param2)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH create_this5
                     CALL {
                     	WITH create_this5
-                    	MATCH (create_this5)<-[create_this5_creator_User_unique:HAS_POST]-(:User)
+                    	MATCH (create_this5)<-[create_this5_creator_User_unique:\`HAS_POST\`]-(:User)
                     	WITH count(create_this5_creator_User_unique) as c
                     	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
                     	RETURN c AS create_this5_creator_User_unique_ignored
@@ -279,12 +279,12 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
+            	MATCH (this)-[this_has_post0_relationship:\`HAS_POST\`]->(this_posts0:Post)
             	WHERE this_posts0.id = $updateUsers_args_update_posts0_where_this_posts0param0
             	WITH this, this_posts0
             	CALL {
             		WITH this, this_posts0
-            		MATCH (this_posts0)<-[this_posts0_has_post0_relationship:HAS_POST]-(this_posts0_creator0:User)
+            		MATCH (this_posts0)<-[this_posts0_has_post0_relationship:\`HAS_POST\`]-(this_posts0_creator0:User)
             		SET this_posts0_creator0.id = $this_update_posts0_creator0_id
             		WITH this, this_posts0, this_posts0_creator0
             		CALL apoc.util.validate(NOT ((this_posts0_creator0.id IS NOT NULL AND this_posts0_creator0.id = $this_posts0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -293,7 +293,7 @@ describe("Cypher Auth Allow", () => {
             	WITH this, this_posts0
             	CALL {
             		WITH this_posts0
-            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:HAS_POST]-(:User)
+            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:\`HAS_POST\`]-(:User)
             		WITH count(this_posts0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_posts0_creator_User_unique_ignored
@@ -374,21 +374,21 @@ describe("Cypher Auth Allow", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_creator0_node
-            			MERGE (this)<-[:HAS_POST]-(this_connect_creator0_node)
+            			MERGE (this)<-[:\`HAS_POST\`]-(this_connect_creator0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
             	}
             WITH this, this_connect_creator0_node
             	WITH this, this_connect_creator0_node
-            	CALL apoc.util.validate(NOT ((exists((this_connect_creator0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_creator0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_creator0_nodeauth_param0))) AND (this_connect_creator0_node.id IS NOT NULL AND this_connect_creator0_node.id = $this_connect_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_connect_creator0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_creator0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_creator0_nodeauth_param0))) AND (this_connect_creator0_node.id IS NOT NULL AND this_connect_creator0_node.id = $this_connect_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	RETURN count(*) AS connect_this_connect_creator_User
             }
             WITH *
             WITH *
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_POST\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -428,7 +428,7 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_creator0_rel:HAS_POST]-(this_disconnect_creator0:User)
+            OPTIONAL MATCH (this)<-[this_disconnect_creator0_rel:\`HAS_POST\`]-(this_disconnect_creator0:User)
             WHERE this_disconnect_creator0.id = $updatePosts_args_disconnect_creator_where_User_this_disconnect_creator0param0
             CALL {
             	WITH this_disconnect_creator0, this_disconnect_creator0_rel, this
@@ -438,14 +438,14 @@ describe("Cypher Auth Allow", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_creator0
-            CALL apoc.util.validate(NOT ((exists((this_disconnect_creator0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_creator0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_creator0auth_param0))) AND (this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_creator0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_creator0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_creator0auth_param0))) AND (this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN count(*) AS disconnect_this_disconnect_creator_User
             }
             WITH *
             WITH *
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_POST\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -120,14 +120,14 @@ describe("Cypher Auth Allow", () => {
             SET this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_node_id
             WITH this0, this0_contentPost0_node, this0_contentPost0_node_creator0_node
             CALL apoc.util.validate(NOT ((this0_contentPost0_node_creator0_node.id IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            MERGE (this0_contentPost0_node)<-[:HAS_CONTENT]-(this0_contentPost0_node_creator0_node)
+            MERGE (this0_contentPost0_node)<-[:\`HAS_CONTENT\`]-(this0_contentPost0_node_creator0_node)
             WITH this0, this0_contentPost0_node
-            CALL apoc.util.validate(NOT ((exists((this0_contentPost0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_contentPost0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_contentPost0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            MERGE (this0)-[:HAS_CONTENT]->(this0_contentPost0_node)
+            CALL apoc.util.validate(NOT ((exists((this0_contentPost0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_contentPost0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_contentPost0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_contentPost0_node)
             WITH this0, this0_contentPost0_node
             CALL {
             	WITH this0_contentPost0_node
-            	MATCH (this0_contentPost0_node)<-[this0_contentPost0_node_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this0_contentPost0_node)<-[this0_contentPost0_node_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this0_contentPost0_node_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
@@ -201,12 +201,12 @@ describe("Cypher Auth Allow", () => {
             SET this0_contentComment0_node_creator0_node.id = $this0_contentComment0_node_creator0_node_id
             WITH this0, this0_contentComment0_node, this0_contentComment0_node_creator0_node
             CALL apoc.util.validate(NOT ((this0_contentComment0_node_creator0_node.id IS NOT NULL AND this0_contentComment0_node_creator0_node.id = $this0_contentComment0_node_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            MERGE (this0_contentComment0_node)<-[:HAS_CONTENT]-(this0_contentComment0_node_creator0_node)
-            MERGE (this0)-[:HAS_CONTENT]->(this0_contentComment0_node)
+            MERGE (this0_contentComment0_node)<-[:\`HAS_CONTENT\`]-(this0_contentComment0_node_creator0_node)
+            MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_contentComment0_node)
             WITH this0, this0_contentComment0_node
             CALL {
             	WITH this0_contentComment0_node
-            	MATCH (this0_contentComment0_node)<-[this0_contentComment0_node_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this0_contentComment0_node)<-[this0_contentComment0_node_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this0_contentComment0_node_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             	RETURN c AS this0_contentComment0_node_creator_User_unique_ignored
@@ -264,12 +264,12 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Comment)
             	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
             	WITH this, this_content0
             	CALL {
             		WITH this, this_content0
-            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:\`HAS_CONTENT\`]-(this_content0_creator0:User)
             		SET this_content0_creator0.id = $this_update_content0_creator0_id
             		WITH this, this_content0, this_content0_creator0
             		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -278,7 +278,7 @@ describe("Cypher Auth Allow", () => {
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -292,23 +292,23 @@ describe("Cypher Auth Allow", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Post)
             	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
             	WITH this, this_content0
             	CALL {
             		WITH this, this_content0
-            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:\`HAS_CONTENT\`]-(this_content0_creator0:User)
             		SET this_content0_creator0.id = $this_update_content0_creator0_id
             		WITH this, this_content0, this_content0_creator0
             		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             		RETURN count(*) AS update_this_content0_creator0
             	}
             	WITH this, this_content0
-            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -392,7 +392,7 @@ describe("Cypher Auth Allow", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -413,14 +413,14 @@ describe("Cypher Auth Allow", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
             	}
             WITH this, this_connect_content1_node
             	WITH this, this_connect_content1_node
-            	CALL apoc.util.validate(NOT ((this_connect_content1_node.id IS NOT NULL AND this_connect_content1_node.id = $this_connect_content1_nodeauth_param0) AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((this_connect_content1_node.id IS NOT NULL AND this_connect_content1_node.id = $this_connect_content1_nodeauth_param0) AND (exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	RETURN count(*) AS connect_this_connect_content_Post
             }
             WITH *
@@ -464,7 +464,7 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -479,7 +479,7 @@ describe("Cypher Auth Allow", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -489,7 +489,7 @@ describe("Cypher Auth Allow", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN count(*) AS disconnect_this_disconnect_content_Post
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/bind/interface-relationships/interface-bind.test.ts
@@ -116,14 +116,14 @@ describe("Cypher Auth Allow", () => {
             SET this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_node_id
             WITH this0, this0_contentPost0_node, this0_contentPost0_node_creator0_node
             CALL apoc.util.validate(NOT ((this0_contentPost0_node_creator0_node.id IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            MERGE (this0_contentPost0_node)<-[:HAS_CONTENT]-(this0_contentPost0_node_creator0_node)
+            MERGE (this0_contentPost0_node)<-[:\`HAS_CONTENT\`]-(this0_contentPost0_node_creator0_node)
             WITH this0, this0_contentPost0_node
-            CALL apoc.util.validate(NOT ((exists((this0_contentPost0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_contentPost0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_contentPost0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-            MERGE (this0)-[:HAS_CONTENT]->(this0_contentPost0_node)
+            CALL apoc.util.validate(NOT ((exists((this0_contentPost0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_contentPost0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_contentPost0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_contentPost0_node)
             WITH this0, this0_contentPost0_node
             CALL {
             	WITH this0_contentPost0_node
-            	MATCH (this0_contentPost0_node)<-[this0_contentPost0_node_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this0_contentPost0_node)<-[this0_contentPost0_node_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this0_contentPost0_node_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
@@ -182,12 +182,12 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Comment)
             	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
             	WITH this, this_content0
             	CALL {
             		WITH this, this_content0
-            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:\`HAS_CONTENT\`]-(this_content0_creator0:User)
             		SET this_content0_creator0.id = $this_update_content0_creator0_id
             		WITH this, this_content0, this_content0_creator0
             		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -196,7 +196,7 @@ describe("Cypher Auth Allow", () => {
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -210,12 +210,12 @@ describe("Cypher Auth Allow", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Post)
             	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
             	WITH this, this_content0
             	CALL {
             		WITH this, this_content0
-            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:\`HAS_CONTENT\`]-(this_content0_creator0:User)
             		SET this_content0_creator0.id = $this_update_content0_creator0_id
             		WITH this, this_content0, this_content0_creator0
             		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -224,7 +224,7 @@ describe("Cypher Auth Allow", () => {
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -307,14 +307,14 @@ describe("Cypher Auth Allow", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
             	}
             WITH this, this_connect_content0_node
             	WITH this, this_connect_content0_node
-            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	RETURN count(*) AS connect_this_connect_content_Comment
             }
             CALL {
@@ -328,14 +328,14 @@ describe("Cypher Auth Allow", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
             	}
             WITH this, this_connect_content1_node
             	WITH this, this_connect_content1_node
-            	CALL apoc.util.validate(NOT ((this_connect_content1_node.id IS NOT NULL AND this_connect_content1_node.id = $this_connect_content1_nodeauth_param0) AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL apoc.util.validate(NOT ((this_connect_content1_node.id IS NOT NULL AND this_connect_content1_node.id = $this_connect_content1_nodeauth_param0) AND (exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	RETURN count(*) AS connect_this_connect_content_Post
             }
             WITH *
@@ -379,7 +379,7 @@ describe("Cypher Auth Allow", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -389,12 +389,12 @@ describe("Cypher Auth Allow", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN count(*) AS disconnect_this_disconnect_content_Comment
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -404,7 +404,7 @@ describe("Cypher Auth Allow", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_content0
-            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN count(*) AS disconnect_this_disconnect_content_Post
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
@@ -277,7 +277,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -297,7 +297,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -349,7 +349,7 @@ describe("Cypher Auth isAuthenticated", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -361,7 +361,7 @@ describe("Cypher Auth isAuthenticated", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -483,7 +483,7 @@ describe("Cypher Auth isAuthenticated", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:\`HAS_CONTENT\`]->(this_content_Comment0:Comment)
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
             CALL {
             	WITH this_content_Comment0_to_delete
@@ -492,7 +492,7 @@ describe("Cypher Auth isAuthenticated", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:\`HAS_CONTENT\`]->(this_content_Post0:Post)
             WITH this, this_content_Post0
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete

--- a/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
@@ -220,7 +220,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -240,7 +240,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -292,7 +292,7 @@ describe("Cypher Auth isAuthenticated", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -306,7 +306,7 @@ describe("Cypher Auth isAuthenticated", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
             WITH this, this_disconnect_content0, this_disconnect_content0_rel
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -406,7 +406,7 @@ describe("Cypher Auth isAuthenticated", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:\`HAS_CONTENT\`]->(this_content_Comment0:Comment)
             WITH this, this_content_Comment0
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
@@ -417,7 +417,7 @@ describe("Cypher Auth isAuthenticated", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:\`HAS_CONTENT\`]->(this_content_Post0:Post)
             WITH this, this_content_Post0
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete

--- a/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/is-authenticated/is-authenticated.test.ts
@@ -442,7 +442,7 @@ describe("Cypher Auth isAuthenticated", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -494,7 +494,7 @@ describe("Cypher Auth isAuthenticated", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -594,7 +594,7 @@ describe("Cypher Auth isAuthenticated", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            OPTIONAL MATCH (this)-[this_posts0_relationship:\`HAS_POST\`]->(this_posts0:Post)
             WITH this, this_posts0
             CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete

--- a/packages/graphql/tests/tck/directives/auth/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/roles-where.test.ts
@@ -191,8 +191,8 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this5 { .content } AS this5
                 RETURN collect(this5) AS var15
             }
@@ -245,8 +245,8 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH { node: { content: this5.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -301,8 +301,8 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                WHERE (this5.id = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                WHERE (this5.id = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH { node: { content: this5.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -354,8 +354,8 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                WHERE (this5.content = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                WHERE (this5.content = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this5 { .content } AS this5
                 RETURN collect(this5) AS var15
             }
@@ -409,8 +409,8 @@ describe("Cypher Auth Where with Roles", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                    WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                    WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this5 { __resolveType: \\"Post\\", __id: id(this), .id } AS this5
                     RETURN this5 AS var15
                 }
@@ -470,8 +470,8 @@ describe("Cypher Auth Where with Roles", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                    WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                    WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this5), id: this5.id } } AS edge
                     RETURN edge
                 }
@@ -532,8 +532,8 @@ describe("Cypher Auth Where with Roles", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
-                    WHERE (this5.id = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    MATCH (this)-[this4:\`HAS_POST\`]->(this5:\`Post\`)
+                    WHERE (this5.id = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this8 IN [(this5)<-[:\`HAS_POST\`]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this5), id: this5.id } } AS edge
                     RETURN edge
                 }
@@ -685,15 +685,15 @@ describe("Cypher Auth Where with Roles", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	MATCH (this)-[this_has_post0_relationship:\`HAS_POST\`]->(this_posts0:Post)
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this, this_posts0
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
             	CALL {
             		WITH this_posts0
-            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:HAS_POST]-(:User)
+            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:\`HAS_POST\`]-(:User)
             		WITH count(this_posts0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator must be less than or equal to one', [0])
             		RETURN c AS this_posts0_creator_User_unique_ignored
@@ -703,8 +703,8 @@ describe("Cypher Auth Where with Roles", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:HAS_POST]->(update_this1:\`Post\`)
-                WHERE (((any(update_var3 IN [\\"user\\"] WHERE any(update_var2 IN $auth.roles WHERE update_var2 = update_var3)) AND (exists((update_this1)<-[:HAS_POST]-(:\`User\`)) AND all(update_this4 IN [(update_this1)<-[:HAS_POST]-(update_this4:\`User\`) | update_this4] WHERE (update_this4.id IS NOT NULL AND update_this4.id = $update_param1)))) OR any(update_var6 IN [\\"admin\\"] WHERE any(update_var5 IN $auth.roles WHERE update_var5 = update_var6))) AND apoc.util.validatePredicate(NOT ((any(update_var8 IN [\\"user\\"] WHERE any(update_var7 IN $auth.roles WHERE update_var7 = update_var8)) OR any(update_var10 IN [\\"admin\\"] WHERE any(update_var9 IN $auth.roles WHERE update_var9 = update_var10)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                MATCH (this)-[update_this0:\`HAS_POST\`]->(update_this1:\`Post\`)
+                WHERE (((any(update_var3 IN [\\"user\\"] WHERE any(update_var2 IN $auth.roles WHERE update_var2 = update_var3)) AND (exists((update_this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(update_this4 IN [(update_this1)<-[:\`HAS_POST\`]-(update_this4:\`User\`) | update_this4] WHERE (update_this4.id IS NOT NULL AND update_this4.id = $update_param1)))) OR any(update_var6 IN [\\"admin\\"] WHERE any(update_var5 IN $auth.roles WHERE update_var5 = update_var6))) AND apoc.util.validatePredicate(NOT ((any(update_var8 IN [\\"user\\"] WHERE any(update_var7 IN $auth.roles WHERE update_var7 = update_var8)) OR any(update_var10 IN [\\"admin\\"] WHERE any(update_var9 IN $auth.roles WHERE update_var9 = update_var10)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH update_this1 { .id } AS update_this1
                 RETURN collect(update_this1) AS update_var11
             }
@@ -793,8 +793,8 @@ describe("Cypher Auth Where with Roles", () => {
             "MATCH (this:\`User\`)
             WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            OPTIONAL MATCH (this)-[this_posts0_relationship:\`HAS_POST\`]->(this_posts0:Post)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             WITH this, this_posts0
             CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
@@ -859,7 +859,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this0, this0_posts_connect0_node
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
@@ -869,7 +869,7 @@ describe("Cypher Auth Where with Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_posts_connect0_node
-            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			MERGE (this0)-[:\`HAS_POST\`]->(this0_posts_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -940,7 +940,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this0, this0_posts_connect0_node
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
@@ -950,7 +950,7 @@ describe("Cypher Auth Where with Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_posts_connect0_node
-            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			MERGE (this0)-[:\`HAS_POST\`]->(this0_posts_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1014,7 +1014,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this, this_posts0_connect0_node
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
@@ -1024,7 +1024,7 @@ describe("Cypher Auth Where with Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_posts0_connect0_node
-            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_posts0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1084,7 +1084,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this, this_posts0_connect0_node
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
@@ -1094,7 +1094,7 @@ describe("Cypher Auth Where with Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_posts0_connect0_node
-            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_posts0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1153,7 +1153,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this, this_connect_posts0_node
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
@@ -1163,7 +1163,7 @@ describe("Cypher Auth Where with Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1222,7 +1222,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             	WITH this, this_connect_posts0_node
             	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
@@ -1232,7 +1232,7 @@ describe("Cypher Auth Where with Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1293,8 +1293,8 @@ describe("Cypher Auth Where with Roles", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:\`HAS_POST\`]->(this_posts0_disconnect0:Post)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
             CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -1357,8 +1357,8 @@ describe("Cypher Auth Where with Roles", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:\`HAS_POST\`]->(this_posts0_disconnect0:Post)
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
             CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -1439,8 +1439,8 @@ describe("Cypher Auth Where with Roles", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
             CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -1513,8 +1513,8 @@ describe("Cypher Auth Where with Roles", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:\`HAS_POST\`]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
             CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {

--- a/packages/graphql/tests/tck/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/roles/roles.test.ts
@@ -448,7 +448,7 @@ describe("Cypher Auth Roles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -504,7 +504,7 @@ describe("Cypher Auth Roles", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+            	MATCH (this)<-[this_has_comment0_relationship:\`HAS_COMMENT\`]-(this_post0:Post)
             	WITH this, this_post0
             	CALL {
             		WITH this, this_post0
@@ -519,7 +519,7 @@ describe("Cypher Auth Roles", () => {
             				WITH connectedNodes, parentNodes
             				UNWIND parentNodes as this_post0
             				UNWIND connectedNodes as this_post0_creator0_connect0_node
-            				MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
+            				MERGE (this_post0)-[:\`HAS_POST\`]->(this_post0_creator0_connect0_node)
             				RETURN count(*) AS _
             			}
             			RETURN count(*) AS _
@@ -530,7 +530,7 @@ describe("Cypher Auth Roles", () => {
             	WITH this, this_post0
             	CALL {
             		WITH this_post0
-            		MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+            		MATCH (this_post0)-[this_post0_creator_User_unique:\`HAS_POST\`]->(:User)
             		WITH count(this_post0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_post0_creator_User_unique_ignored
@@ -540,7 +540,7 @@ describe("Cypher Auth Roles", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	MATCH (this)<-[this_post_Post_unique:\`HAS_COMMENT\`]-(:Post)
             	WITH count(this_post_Post_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
             	RETURN c AS this_post_Post_unique_ignored
@@ -589,7 +589,7 @@ describe("Cypher Auth Roles", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
             WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
             CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
@@ -658,11 +658,11 @@ describe("Cypher Auth Roles", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+            	MATCH (this)<-[this_has_comment0_relationship:\`HAS_COMMENT\`]-(this_post0:Post)
             	WITH this, this_post0
             	CALL {
             	WITH this, this_post0
-            	OPTIONAL MATCH (this_post0)-[this_post0_creator0_disconnect0_rel:HAS_POST]->(this_post0_creator0_disconnect0:User)
+            	OPTIONAL MATCH (this_post0)-[this_post0_creator0_disconnect0_rel:\`HAS_POST\`]->(this_post0_creator0_disconnect0:User)
             	WHERE this_post0_creator0_disconnect0.id = $updateComments_args_update_post_update_node_creator_disconnect_where_User_this_post0_creator0_disconnect0param0
             	WITH this, this_post0, this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
             	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
@@ -678,7 +678,7 @@ describe("Cypher Auth Roles", () => {
             	WITH this, this_post0
             	CALL {
             		WITH this_post0
-            		MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+            		MATCH (this_post0)-[this_post0_creator_User_unique:\`HAS_POST\`]->(:User)
             		WITH count(this_post0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_post0_creator_User_unique_ignored
@@ -688,7 +688,7 @@ describe("Cypher Auth Roles", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	MATCH (this)<-[this_post_Post_unique:\`HAS_COMMENT\`]-(:Post)
             	WITH count(this_post_Post_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
             	RETURN c AS this_post_Post_unique_ignored
@@ -793,7 +793,7 @@ describe("Cypher Auth Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            OPTIONAL MATCH (this)-[this_posts0_relationship:\`HAS_POST\`]->(this_posts0:Post)
             WITH this, this_posts0
             CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -102,7 +102,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            WHERE (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             RETURN this { .id } AS this"
         `);
 
@@ -129,7 +129,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (this.content = $param0 AND (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             RETURN this { .id } AS this"
         `);
 
@@ -167,13 +167,13 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
                     WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
-                    WHERE (exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param1)))
+                    MATCH (this)-[this3:\`HAS_CONTENT\`]->(this4:\`Post\`)
+                    WHERE (exists((this4)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this5 IN [(this4)<-[:\`HAS_CONTENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param1)))
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS this4
                     RETURN this4 AS var2
                 }
@@ -221,13 +221,13 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
                     WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:HAS_CONTENT]->(this3:\`Post\`)
-                    WHERE (exists((this3)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this4 IN [(this3)<-[:HAS_CONTENT]-(this4:\`User\`) | this4] WHERE (this4.id IS NOT NULL AND this4.id = $param1)))
+                    MATCH (this)-[this2:\`HAS_CONTENT\`]->(this3:\`Post\`)
+                    WHERE (exists((this3)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this4 IN [(this3)<-[:\`HAS_CONTENT\`]-(this4:\`User\`) | this4] WHERE (this4.id IS NOT NULL AND this4.id = $param1)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
@@ -276,14 +276,14 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
                     WHERE this1.id = $param1
                     WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:HAS_CONTENT]->(this3:\`Post\`)
-                    WHERE (this3.id = $param2 AND (exists((this3)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this4 IN [(this3)<-[:HAS_CONTENT]-(this4:\`User\`) | this4] WHERE (this4.id IS NOT NULL AND this4.id = $param3))))
+                    MATCH (this)-[this2:\`HAS_CONTENT\`]->(this3:\`Post\`)
+                    WHERE (this3.id = $param2 AND (exists((this3)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this4 IN [(this3)<-[:\`HAS_CONTENT\`]-(this4:\`User\`) | this4] WHERE (this4.id IS NOT NULL AND this4.id = $param3))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
@@ -322,12 +322,12 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            WHERE (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             SET this.content = $this_update_content
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -362,12 +362,12 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (this.content = $param0 AND (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             SET this.content = $this_update_content
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -410,12 +410,12 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Comment)
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -429,13 +429,13 @@ describe("Cypher Auth Where", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
-            	WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Post)
+            	WHERE (exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -473,7 +473,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            WHERE (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             DETACH DELETE this"
         `);
 
@@ -500,7 +500,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (this.content = $param0 AND (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             DETACH DELETE this"
         `);
 
@@ -530,7 +530,7 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`User\`)
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:\`HAS_CONTENT\`]->(this_content_Comment0:Comment)
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
             CALL {
             	WITH this_content_Comment0_to_delete
@@ -539,8 +539,8 @@ describe("Cypher Auth Where", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:\`HAS_CONTENT\`]->(this_content_Post0:Post)
+            WHERE (exists((this_content_Post0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -596,7 +596,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect0_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -607,7 +607,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this0
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
-            	WHERE (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	WHERE (exists((this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -615,7 +615,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect1_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -682,7 +682,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect0_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -693,7 +693,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this0
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
-            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (exists((this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -701,7 +701,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect1_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -762,7 +762,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -780,7 +780,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	WHERE (exists((this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -788,7 +788,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -847,7 +847,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -865,7 +865,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -873,7 +873,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -929,7 +929,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -940,7 +940,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            	WHERE (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	WHERE (exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -948,7 +948,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1003,7 +1003,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1014,7 +1014,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1022,7 +1022,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1073,7 +1073,7 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Comment)
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1092,8 +1092,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Post)
+            WHERE (exists((this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1145,7 +1145,7 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Comment)
             WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1165,8 +1165,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Post)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1236,7 +1236,7 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1248,8 +1248,8 @@ describe("Cypher Auth Where", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
+            WHERE (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1308,7 +1308,7 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
             WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1321,8 +1321,8 @@ describe("Cypher Auth Where", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -102,7 +102,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            WHERE (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             RETURN this { .id } AS this"
         `);
 
@@ -129,7 +129,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (this.content = $param0 AND (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             RETURN this { .id } AS this"
         `);
 
@@ -167,14 +167,14 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
-                    WHERE (exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
+                    WHERE (exists((this1)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_CONTENT\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
                     WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
                     RETURN this1 AS var3
                     UNION
                     WITH *
-                    MATCH (this)-[this4:HAS_CONTENT]->(this5:\`Post\`)
-                    WHERE (exists((this5)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this6 IN [(this5)<-[:HAS_CONTENT]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param2)))
+                    MATCH (this)-[this4:\`HAS_CONTENT\`]->(this5:\`Post\`)
+                    WHERE (exists((this5)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this6 IN [(this5)<-[:\`HAS_CONTENT\`]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param2)))
                     WITH this5 { __resolveType: \\"Post\\", __id: id(this), .id } AS this5
                     RETURN this5 AS var3
                 }
@@ -223,14 +223,14 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
-                    WHERE (exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
+                    WHERE (exists((this1)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_CONTENT\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
                     WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
-                    WHERE (exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param2)))
+                    MATCH (this)-[this3:\`HAS_CONTENT\`]->(this4:\`Post\`)
+                    WHERE (exists((this4)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this5 IN [(this4)<-[:\`HAS_CONTENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param2)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this4), id: this4.id } } AS edge
                     RETURN edge
                 }
@@ -280,14 +280,14 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
-                    WHERE (this1.id = $param1 AND (exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]->(this1:\`Comment\`)
+                    WHERE (this1.id = $param1 AND (exists((this1)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_CONTENT\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
                     WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
-                    WHERE (this4.id = $param3 AND (exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param4))))
+                    MATCH (this)-[this3:\`HAS_CONTENT\`]->(this4:\`Post\`)
+                    WHERE (this4.id = $param3 AND (exists((this4)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(this5 IN [(this4)<-[:\`HAS_CONTENT\`]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param4))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this4), id: this4.id } } AS edge
                     RETURN edge
                 }
@@ -327,12 +327,12 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            WHERE (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             SET this.content = $this_update_content
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -367,12 +367,12 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (this.content = $param0 AND (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             SET this.content = $this_update_content
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	MATCH (this)<-[this_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             	WITH count(this_creator_User_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             	RETURN c AS this_creator_User_unique_ignored
@@ -415,13 +415,13 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
-            	WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Comment)
+            	WHERE (exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -435,13 +435,13 @@ describe("Cypher Auth Where", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
-            	WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
+            	MATCH (this)-[this_has_content0_relationship:\`HAS_CONTENT\`]->(this_content0:Post)
+            	WHERE (exists((this_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
-            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:\`HAS_CONTENT\`]-(:User)
             		WITH count(this_content0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_content0_creator_User_unique_ignored
@@ -479,7 +479,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            WHERE (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             DETACH DELETE this"
         `);
 
@@ -506,7 +506,7 @@ describe("Cypher Auth Where", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Post\`)
-            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (this.content = $param0 AND (exists((this)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             DETACH DELETE this"
         `);
 
@@ -536,8 +536,8 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`User\`)
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
-            WHERE (exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:\`HAS_CONTENT\`]->(this_content_Comment0:Comment)
+            WHERE (exists((this_content_Comment0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Comment0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
             CALL {
             	WITH this_content_Comment0_to_delete
@@ -546,8 +546,8 @@ describe("Cypher Auth Where", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:\`HAS_CONTENT\`]->(this_content_Post0:Post)
+            WHERE (exists((this_content_Post0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -597,7 +597,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+            	WHERE (exists((this0_content_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -605,7 +605,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect0_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -616,7 +616,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this0
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
-            	WHERE (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	WHERE (exists((this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -624,7 +624,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect1_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -684,7 +684,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -692,7 +692,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect0_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -703,7 +703,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this0
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
-            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (exists((this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -711,7 +711,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_content_connect1_node
-            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			MERGE (this0)-[:\`HAS_CONTENT\`]->(this0_content_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -766,7 +766,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	WHERE (exists((this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -774,7 +774,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -792,7 +792,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	WHERE (exists((this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -800,7 +800,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -851,7 +851,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -859,7 +859,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -877,7 +877,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -885,7 +885,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_content0_connect0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_content0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -934,7 +934,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+            	WHERE (exists((this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
@@ -942,7 +942,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -953,7 +953,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            	WHERE (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	WHERE (exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -961,7 +961,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1009,7 +1009,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
@@ -1017,7 +1017,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content0_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1028,7 +1028,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (exists((this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1036,7 +1036,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_content1_node
-            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			MERGE (this)-[:\`HAS_CONTENT\`]->(this_connect_content1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1088,8 +1088,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Comment)
+            WHERE (exists((this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1108,8 +1108,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Post)
+            WHERE (exists((this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1161,8 +1161,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Comment)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1181,8 +1181,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:\`HAS_CONTENT\`]->(this_content0_disconnect0:Post)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1252,8 +1252,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
+            WHERE (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1265,8 +1265,8 @@ describe("Cypher Auth Where", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
+            WHERE (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1325,8 +1325,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1338,8 +1338,8 @@ describe("Cypher Auth Where", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:\`HAS_CONTENT\`]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:\`HAS_CONTENT\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/where.test.ts
@@ -156,8 +156,8 @@ describe("Cypher Auth Where", () => {
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -198,8 +198,8 @@ describe("Cypher Auth Where", () => {
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -242,8 +242,8 @@ describe("Cypher Auth Where", () => {
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.id = $param1 AND (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE (this1.id = $param1 AND (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -283,8 +283,8 @@ describe("Cypher Auth Where", () => {
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.content = $param1 AND (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE (this1.content = $param1 AND (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -326,8 +326,8 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                    WHERE (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
                     WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var3
                 }
@@ -375,8 +375,8 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                    WHERE (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -425,8 +425,8 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE (this1.id = $param1 AND (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                    MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                    WHERE (this1.id = $param1 AND (exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -536,13 +536,13 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
-            	WHERE (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
+            	MATCH (this)-[this_has_post0_relationship:\`HAS_POST\`]->(this_posts0:Post)
+            	WHERE (exists((this_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
             	CALL {
             		WITH this_posts0
-            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:HAS_POST]-(:User)
+            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:\`HAS_POST\`]-(:User)
             		WITH count(this_posts0_creator_User_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
             		RETURN c AS this_posts0_creator_User_unique_ignored
@@ -552,8 +552,8 @@ describe("Cypher Auth Where", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:HAS_POST]->(update_this1:\`Post\`)
-                WHERE (exists((update_this1)<-[:HAS_POST]-(:\`User\`)) AND all(update_this2 IN [(update_this1)<-[:HAS_POST]-(update_this2:\`User\`) | update_this2] WHERE (update_this2.id IS NOT NULL AND update_this2.id = $update_param0)))
+                MATCH (this)-[update_this0:\`HAS_POST\`]->(update_this1:\`Post\`)
+                WHERE (exists((update_this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(update_this2 IN [(update_this1)<-[:\`HAS_POST\`]-(update_this2:\`User\`) | update_this2] WHERE (update_this2.id IS NOT NULL AND update_this2.id = $update_param0)))
                 WITH update_this1 { .id } AS update_this1
                 RETURN collect(update_this1) AS update_var3
             }
@@ -644,8 +644,8 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`User\`)
             WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
+            OPTIONAL MATCH (this)-[this_posts0_relationship:\`HAS_POST\`]->(this_posts0:Post)
+            WHERE (exists((this_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -694,7 +694,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
+            	WHERE (exists((this0_posts_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -702,7 +702,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_posts_connect0_node
-            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			MERGE (this0)-[:\`HAS_POST\`]->(this0_posts_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -761,7 +761,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (exists((this0_posts_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -769,7 +769,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_posts_connect0_node
-            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			MERGE (this0)-[:\`HAS_POST\`]->(this0_posts_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -819,7 +819,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
+            	WHERE (exists((this_posts0_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -827,7 +827,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_posts0_connect0_node
-            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_posts0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -873,7 +873,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (exists((this_posts0_connect0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -881,7 +881,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_posts0_connect0_node
-            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_posts0_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -928,7 +928,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
+            	WHERE (exists((this_connect_posts0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -936,7 +936,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -983,7 +983,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (exists((this_connect_posts0_node)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -991,7 +991,7 @@ describe("Cypher Auth Where", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_posts0_node
-            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			MERGE (this)-[:\`HAS_POST\`]->(this_connect_posts0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -1038,8 +1038,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:\`HAS_POST\`]->(this_posts0_disconnect0:Post)
+            WHERE (exists((this_posts0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1086,8 +1086,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:\`HAS_POST\`]->(this_posts0_disconnect0:Post)
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (exists((this_posts0_disconnect0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1154,8 +1154,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
+            WHERE (exists((this_disconnect_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1214,8 +1214,8 @@ describe("Cypher Auth Where", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:\`HAS_POST\`]->(this_disconnect_posts0:Post)
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (exists((this_disconnect_posts0)<-[:\`HAS_POST\`]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:\`HAS_POST\`]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this

--- a/packages/graphql/tests/tck/directives/auth/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/projection-connection-union.test.ts
@@ -95,11 +95,11 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:PUBLISHED]->(this1:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    MATCH (this)-[this0:\`PUBLISHED\`]->(this1:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     CALL {
                         WITH this1
-                        MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)
+                        MATCH (this1:\`Post\`)<-[this3:\`HAS_POST\`]-(this4:\`User\`)
                         WHERE apoc.util.validatePredicate(NOT ((this4.id IS NOT NULL AND this4.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                         WITH { node: { name: this4.name } } AS edge
                         WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/directives/auth/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/projection-connection.test.ts
@@ -83,8 +83,8 @@ describe("Cypher Auth Projection On Connections", () => {
             WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -134,11 +134,11 @@ describe("Cypher Auth Projection On Connections", () => {
             WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`User\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)
+                    MATCH (this1:\`Post\`)<-[this3:\`HAS_POST\`]-(this4:\`User\`)
                     WHERE apoc.util.validatePredicate(NOT ((this4.id IS NOT NULL AND this4.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { node: { name: this4.name } } AS edge
                     WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/directives/auth/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/projection-interface-relationships.test.ts
@@ -96,12 +96,12 @@ describe("Auth projections for interface relationship fields", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
+                    MATCH (this)-[this3:\`ACTED_IN\`]->(this4:\`Series\`)
                     WHERE apoc.util.validatePredicate(NOT ((this4.episodes IS NOT NULL AND this4.episodes = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
                     RETURN this4 AS var2

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -213,7 +213,7 @@ describe("Cypher coalesce()", () => {
             "MATCH (this:\`Actor\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                 WHERE coalesce(this1.status, \\"ACTIVE\\") = $param0
                 WITH { node: { id: this1.id, status: this1.status } } AS edge
                 WITH collect(edge) AS edges
@@ -274,7 +274,7 @@ describe("Cypher coalesce()", () => {
             "MATCH (this:\`Actor\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                 WHERE coalesce(this1.statuses, [ \\"ACTIVE\\", \\"INACTIVE\\" ]) = $param0
                 WITH { node: { id: this1.id, statuses: this1.statuses } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/directives/customResolver.test.ts
+++ b/packages/graphql/tests/tck/directives/customResolver.test.ts
@@ -273,10 +273,10 @@ describe("@customResolver directive", () => {
                 "MATCH (this:\`User\`)
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:LIVES_AT]->(this1:\`Address\`)
+                    MATCH (this)-[this0:\`LIVES_AT\`]->(this1:\`Address\`)
                     CALL {
                         WITH this1
-                        MATCH (this1)-[this2:IN_CITY]->(this3:\`City\`)
+                        MATCH (this1)-[this2:\`IN_CITY\`]->(this3:\`City\`)
                         WITH this3 { .name, .population } AS this3
                         RETURN head(collect(this3)) AS var4
                     }
@@ -335,10 +335,10 @@ describe("@customResolver directive", () => {
                 "MATCH (this:\`User\`)
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:LIVES_AT]->(this1:\`Address\`)
+                    MATCH (this)-[this0:\`LIVES_AT\`]->(this1:\`Address\`)
                     CALL {
                         WITH this1
-                        MATCH (this1)-[this2:IN_CITY]->(this3:\`City\`)
+                        MATCH (this1)-[this2:\`IN_CITY\`]->(this3:\`City\`)
                         WITH this3 { .population, .name } AS this3
                         RETURN head(collect(this3)) AS var4
                     }
@@ -369,10 +369,10 @@ describe("@customResolver directive", () => {
                 "MATCH (this:\`User\`)
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:LIVES_AT]->(this1:\`Address\`)
+                    MATCH (this)-[this0:\`LIVES_AT\`]->(this1:\`Address\`)
                     CALL {
                         WITH this1
-                        MATCH (this1)-[this2:IN_CITY]->(this3:\`City\`)
+                        MATCH (this1)-[this2:\`IN_CITY\`]->(this3:\`City\`)
                         WITH this3 { .name, .population } AS this3
                         RETURN head(collect(this3)) AS var4
                     }
@@ -453,12 +453,12 @@ describe("@customResolver directive", () => {
                     WITH this
                     CALL {
                         WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                        MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                         WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:\`Journal\`)
+                        MATCH (this)-[this3:\`WROTE\`]->(this4:\`Journal\`)
                         WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject } AS this4
                         RETURN this4 AS var2
                     }
@@ -518,12 +518,12 @@ describe("@customResolver directive", () => {
                     WITH this
                     CALL {
                         WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                        MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                         WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:\`Journal\`)
+                        MATCH (this)-[this3:\`WROTE\`]->(this4:\`Journal\`)
                         WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject } AS this4
                         RETURN this4 AS var2
                     }
@@ -556,12 +556,12 @@ describe("@customResolver directive", () => {
                     WITH this
                     CALL {
                         WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                        MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                         WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:\`Journal\`)
+                        MATCH (this)-[this3:\`WROTE\`]->(this4:\`Journal\`)
                         WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject } AS this4
                         RETURN this4 AS var2
                     }
@@ -647,12 +647,12 @@ describe("@customResolver directive", () => {
                     WITH this
                     CALL {
                         WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                        MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                         WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title, .publicationYear } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:\`Journal\`)
+                        MATCH (this)-[this3:\`WROTE\`]->(this4:\`Journal\`)
                         WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject, .publicationYear } AS this4
                         RETURN this4 AS var2
                     }
@@ -712,12 +712,12 @@ describe("@customResolver directive", () => {
                     WITH this
                     CALL {
                         WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                        MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                         WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title, .publicationYear } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:\`Journal\`)
+                        MATCH (this)-[this3:\`WROTE\`]->(this4:\`Journal\`)
                         WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject, .publicationYear } AS this4
                         RETURN this4 AS var2
                     }
@@ -750,12 +750,12 @@ describe("@customResolver directive", () => {
                     WITH this
                     CALL {
                         WITH *
-                        MATCH (this)-[this0:WROTE]->(this1:\`Book\`)
+                        MATCH (this)-[this0:\`WROTE\`]->(this1:\`Book\`)
                         WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title, .publicationYear } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
-                        MATCH (this)-[this3:WROTE]->(this4:\`Journal\`)
+                        MATCH (this)-[this3:\`WROTE\`]->(this4:\`Journal\`)
                         WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject, .publicationYear } AS this4
                         RETURN this4 AS var2
                     }

--- a/packages/graphql/tests/tck/directives/cypher.test.ts
+++ b/packages/graphql/tests/tck/directives/cypher.test.ts
@@ -656,7 +656,7 @@ describe("Cypher directive", () => {
                 WITH m as this
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                     WITH this1 { .name } AS this1
                     RETURN collect(this1) AS var2
                 }
@@ -724,7 +724,7 @@ describe("Cypher directive", () => {
                 WITH m as this
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                     WITH this1 { .name } AS this1
                     RETURN collect(this1) AS var2
                 }
@@ -796,7 +796,7 @@ describe("Cypher directive", () => {
                     WITH m AS this0
                     CALL {
                         WITH this0
-                        MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
+                        MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
                         WITH this2 { .name } AS this2
                         RETURN collect(this2) AS var3
                     }

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/connect.test.ts
@@ -109,7 +109,7 @@ describe("Interface Relationships - Create connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_actedIn_connect0_node
-            			MERGE (this0)-[this0_actedIn_connect0_relationship:ACTED_IN]->(this0_actedIn_connect0_node)
+            			MERGE (this0)-[this0_actedIn_connect0_relationship:\`ACTED_IN\`]->(this0_actedIn_connect0_node)
             			SET this0_actedIn_connect0_relationship.screenTime = $this0_actedIn_connect0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -129,7 +129,7 @@ describe("Interface Relationships - Create connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_actedIn_connect1_node
-            			MERGE (this0)-[this0_actedIn_connect1_relationship:ACTED_IN]->(this0_actedIn_connect1_node)
+            			MERGE (this0)-[this0_actedIn_connect1_relationship:\`ACTED_IN\`]->(this0_actedIn_connect1_node)
             			SET this0_actedIn_connect1_relationship.screenTime = $this0_actedIn_connect1_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -144,12 +144,12 @@ describe("Interface Relationships - Create connect", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)-[create_this0:ACTED_IN]->(create_this1:\`Movie\`)
+                    MATCH (this0)-[create_this0:\`ACTED_IN\`]->(create_this1:\`Movie\`)
                     WITH create_this1 { __resolveType: \\"Movie\\", __id: id(this0), .runtime, .title } AS create_this1
                     RETURN create_this1 AS create_var2
                     UNION
                     WITH *
-                    MATCH (this0)-[create_this3:ACTED_IN]->(create_this4:\`Series\`)
+                    MATCH (this0)-[create_this3:\`ACTED_IN\`]->(create_this4:\`Series\`)
                     WITH create_this4 { __resolveType: \\"Series\\", __id: id(this0), .episodes, .title } AS create_this4
                     RETURN create_this4 AS create_var2
                 }

--- a/packages/graphql/tests/tck/directives/interface-relationships/create/create.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/create/create.test.ts
@@ -104,7 +104,7 @@ describe("Interface Relationships - Create create", () => {
             CREATE (this0_actedInMovie0_node:Movie)
             SET this0_actedInMovie0_node.title = $this0_actedInMovie0_node_title
             SET this0_actedInMovie0_node.runtime = $this0_actedInMovie0_node_runtime
-            MERGE (this0)-[this0_actedInMovie0_relationship:ACTED_IN]->(this0_actedInMovie0_node)
+            MERGE (this0)-[this0_actedInMovie0_relationship:\`ACTED_IN\`]->(this0_actedInMovie0_node)
             SET this0_actedInMovie0_relationship.screenTime = $this0_actedInMovie0_relationship_screenTime
             RETURN this0
             }
@@ -112,12 +112,12 @@ describe("Interface Relationships - Create create", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)-[create_this0:ACTED_IN]->(create_this1:\`Movie\`)
+                    MATCH (this0)-[create_this0:\`ACTED_IN\`]->(create_this1:\`Movie\`)
                     WITH create_this1 { __resolveType: \\"Movie\\", __id: id(this0), .runtime, .title } AS create_this1
                     RETURN create_this1 AS create_var2
                     UNION
                     WITH *
-                    MATCH (this0)-[create_this3:ACTED_IN]->(create_this4:\`Series\`)
+                    MATCH (this0)-[create_this3:\`ACTED_IN\`]->(create_this4:\`Series\`)
                     WITH create_this4 { __resolveType: \\"Series\\", __id: id(this0), .episodes, .title } AS create_this4
                     RETURN create_this4 AS create_var2
                 }

--- a/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/delete/delete.test.ts
@@ -80,7 +80,7 @@ describe("Interface Relationships - Delete delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_actedIn_Movie0:Movie)
             WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Movie0param0
             WITH this, collect(DISTINCT this_actedIn_Movie0) AS this_actedIn_Movie0_to_delete
             CALL {
@@ -90,7 +90,7 @@ describe("Interface Relationships - Delete delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_actedIn_Series0:Series)
             WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Series0param0
             WITH this, collect(DISTINCT this_actedIn_Series0) AS this_actedIn_Series0_to_delete
             CALL {
@@ -150,10 +150,10 @@ describe("Interface Relationships - Delete delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_actedIn_Movie0:Movie)
             WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Movie0param0
             WITH this, this_actedIn_Movie0
-            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
+            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_actedIn_Movie0_actors0:Actor)
             WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_this_actedIn_Movie0_actors0param0
             WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) AS this_actedIn_Movie0_actors0_to_delete
             CALL {
@@ -170,10 +170,10 @@ describe("Interface Relationships - Delete delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_actedIn_Series0:Series)
             WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Series0param0
             WITH this, this_actedIn_Series0
-            OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_actedIn_Series0_actors0:Actor)
+            OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:\`ACTED_IN\`]-(this_actedIn_Series0_actors0:Actor)
             WHERE this_actedIn_Series0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_this_actedIn_Series0_actors0param0
             WITH this, this_actedIn_Series0, collect(DISTINCT this_actedIn_Series0_actors0) AS this_actedIn_Series0_actors0_to_delete
             CALL {
@@ -253,10 +253,10 @@ describe("Interface Relationships - Delete delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_actedIn_Movie0:Movie)
             WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Movie0param0
             WITH this, this_actedIn_Movie0
-            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
+            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_actedIn_Movie0_actors0:Actor)
             WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_this_actedIn_Movie0_actors0param0
             WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) AS this_actedIn_Movie0_actors0_to_delete
             CALL {
@@ -273,7 +273,7 @@ describe("Interface Relationships - Delete delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_actedIn_Series0:Series)
             WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Series0param0
             WITH this, collect(DISTINCT this_actedIn_Series0) AS this_actedIn_Series0_to_delete
             CALL {
@@ -354,10 +354,10 @@ describe("Interface Relationships - Delete delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:ACTED_IN]->(this_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_actedIn_Movie0:Movie)
             WHERE this_actedIn_Movie0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Movie0param0
             WITH this, this_actedIn_Movie0
-            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_actedIn_Movie0_actors0:Actor)
+            OPTIONAL MATCH (this_actedIn_Movie0)<-[this_actedIn_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_actedIn_Movie0_actors0:Actor)
             WHERE this_actedIn_Movie0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_this_actedIn_Movie0_actors0param0
             WITH this, this_actedIn_Movie0, collect(DISTINCT this_actedIn_Movie0_actors0) AS this_actedIn_Movie0_actors0_to_delete
             CALL {
@@ -374,10 +374,10 @@ describe("Interface Relationships - Delete delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:ACTED_IN]->(this_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_actedIn_Series0:Series)
             WHERE this_actedIn_Series0.title STARTS WITH $this_deleteActors_args_delete_actedIn0_where_this_actedIn_Series0param0
             WITH this, this_actedIn_Series0
-            OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_actedIn_Series0_actors0:Actor)
+            OPTIONAL MATCH (this_actedIn_Series0)<-[this_actedIn_Series0_actors0_relationship:\`ACTED_IN\`]-(this_actedIn_Series0_actors0:Actor)
             WHERE this_actedIn_Series0_actors0.name = $this_deleteActors_args_delete_actedIn0_delete_actors0_where_this_actedIn_Series0_actors0param0
             WITH this, this_actedIn_Series0, collect(DISTINCT this_actedIn_Series0_actors0) AS this_actedIn_Series0_actors0_to_delete
             CALL {

--- a/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
@@ -88,12 +88,12 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
+                    MATCH (this)-[this3:\`ACTED_IN\`]->(this4:\`Series\`)
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
                     RETURN this4 AS var2
                 }
@@ -134,12 +134,12 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:CURRENTLY_ACTING_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`CURRENTLY_ACTING_IN\`]->(this1:\`Movie\`)
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:CURRENTLY_ACTING_IN]->(this4:\`Series\`)
+                    MATCH (this)-[this3:\`CURRENTLY_ACTING_IN\`]->(this4:\`Series\`)
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
                     RETURN this4 AS var2
                 }
@@ -180,12 +180,12 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
+                    MATCH (this)-[this3:\`ACTED_IN\`]->(this4:\`Series\`)
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
                     RETURN this4 AS var2
                 }
@@ -237,7 +237,7 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE this1.title STARTS WITH $param0
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
                     RETURN this1 AS var2
@@ -283,13 +283,13 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE this1.title STARTS WITH $param0
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
+                    MATCH (this)-[this3:\`ACTED_IN\`]->(this4:\`Series\`)
                     WHERE this4.title STARTS WITH $param1
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
                     RETURN this4 AS var2
@@ -341,12 +341,12 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
@@ -393,13 +393,13 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE (this0.screenTime > $param0 AND this1.title STARTS WITH $param1)
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WHERE (this2.screenTime > $param2 AND this3.title STARTS WITH $param3)
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
@@ -459,7 +459,7 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE (this0.screenTime > $param0 AND this1.title STARTS WITH $param1)
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
@@ -520,13 +520,13 @@ describe("Interface Relationships", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE (this0.screenTime > $param0 AND this1.title STARTS WITH $param1)
                     WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WHERE (this2.screenTime > $param2 AND this3.title STARTS WITH $param3)
                     WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/connect.test.ts
@@ -94,7 +94,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn0_node
-            			MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+            			MERGE (this)-[this_connect_actedIn0_relationship:\`ACTED_IN\`]->(this_connect_actedIn0_node)
             			SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -114,7 +114,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn1_node
-            			MERGE (this)-[this_connect_actedIn1_relationship:ACTED_IN]->(this_connect_actedIn1_node)
+            			MERGE (this)-[this_connect_actedIn1_relationship:\`ACTED_IN\`]->(this_connect_actedIn1_node)
             			SET this_connect_actedIn1_relationship.screenTime = $this_connect_actedIn1_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -182,7 +182,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn0_node
-            			MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+            			MERGE (this)-[this_connect_actedIn0_relationship:\`ACTED_IN\`]->(this_connect_actedIn0_node)
             			SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -200,7 +200,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this_connect_actedIn0_node
             			UNWIND connectedNodes as this_connect_actedIn0_node_actors0_node
-            			MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_actors0_node)
+            			MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_actors0_relationship:\`ACTED_IN\`]-(this_connect_actedIn0_node_actors0_node)
             			SET this_connect_actedIn0_node_actors0_relationship.screenTime = $this_connect_actedIn0_node_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -222,7 +222,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn1_node
-            			MERGE (this)-[this_connect_actedIn1_relationship:ACTED_IN]->(this_connect_actedIn1_node)
+            			MERGE (this)-[this_connect_actedIn1_relationship:\`ACTED_IN\`]->(this_connect_actedIn1_node)
             			SET this_connect_actedIn1_relationship.screenTime = $this_connect_actedIn1_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -240,7 +240,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this_connect_actedIn1_node
             			UNWIND connectedNodes as this_connect_actedIn1_node_actors0_node
-            			MERGE (this_connect_actedIn1_node)<-[this_connect_actedIn1_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn1_node_actors0_node)
+            			MERGE (this_connect_actedIn1_node)<-[this_connect_actedIn1_node_actors0_relationship:\`ACTED_IN\`]-(this_connect_actedIn1_node_actors0_node)
             			SET this_connect_actedIn1_node_actors0_relationship.screenTime = $this_connect_actedIn1_node_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -324,7 +324,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn0_node
-            			MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+            			MERGE (this)-[this_connect_actedIn0_relationship:\`ACTED_IN\`]->(this_connect_actedIn0_node)
             			SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -342,7 +342,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this_connect_actedIn0_node
             			UNWIND connectedNodes as this_connect_actedIn0_node_on_Movie0_actors0_node
-            			MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
+            			MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
             			SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -364,7 +364,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn1_node
-            			MERGE (this)-[this_connect_actedIn1_relationship:ACTED_IN]->(this_connect_actedIn1_node)
+            			MERGE (this)-[this_connect_actedIn1_relationship:\`ACTED_IN\`]->(this_connect_actedIn1_node)
             			SET this_connect_actedIn1_relationship.screenTime = $this_connect_actedIn1_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -447,7 +447,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn0_node
-            			MERGE (this)-[this_connect_actedIn0_relationship:ACTED_IN]->(this_connect_actedIn0_node)
+            			MERGE (this)-[this_connect_actedIn0_relationship:\`ACTED_IN\`]->(this_connect_actedIn0_node)
             			SET this_connect_actedIn0_relationship.screenTime = $this_connect_actedIn0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -465,7 +465,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this_connect_actedIn0_node
             			UNWIND connectedNodes as this_connect_actedIn0_node_on_Movie0_actors0_node
-            			MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:ACTED_IN]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
+            			MERGE (this_connect_actedIn0_node)<-[this_connect_actedIn0_node_on_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_connect_actedIn0_node_on_Movie0_actors0_node)
             			SET this_connect_actedIn0_node_on_Movie0_actors0_relationship.screenTime = $this_connect_actedIn0_node_on_Movie0_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -487,7 +487,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actedIn1_node
-            			MERGE (this)-[this_connect_actedIn1_relationship:ACTED_IN]->(this_connect_actedIn1_node)
+            			MERGE (this)-[this_connect_actedIn1_relationship:\`ACTED_IN\`]->(this_connect_actedIn1_node)
             			SET this_connect_actedIn1_relationship.screenTime = $this_connect_actedIn1_relationship_screenTime
             			RETURN count(*) AS _
             		}
@@ -505,7 +505,7 @@ describe("Interface Relationships - Update connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this_connect_actedIn1_node
             			UNWIND connectedNodes as this_connect_actedIn1_node_actors0_node
-            			MERGE (this_connect_actedIn1_node)<-[this_connect_actedIn1_node_actors0_relationship:ACTED_IN]-(this_connect_actedIn1_node_actors0_node)
+            			MERGE (this_connect_actedIn1_node)<-[this_connect_actedIn1_node_actors0_relationship:\`ACTED_IN\`]-(this_connect_actedIn1_node_actors0_node)
             			SET this_connect_actedIn1_node_actors0_relationship.screenTime = $this_connect_actedIn1_node_actors0_relationship_screenTime
             			RETURN count(*) AS _
             		}

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/create.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/create.test.ts
@@ -93,19 +93,19 @@ describe("Interface Relationships - Update create", () => {
             CREATE (this_create_actedIn_Movie0_node_Movie:Movie)
             SET this_create_actedIn_Movie0_node_Movie.title = $this_create_actedIn_Movie0_node_Movie_title
             SET this_create_actedIn_Movie0_node_Movie.runtime = $this_create_actedIn_Movie0_node_Movie_runtime
-            MERGE (this)-[this_create_actedIn_Movie0_relationship:ACTED_IN]->(this_create_actedIn_Movie0_node_Movie)
+            MERGE (this)-[this_create_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_create_actedIn_Movie0_node_Movie)
             SET this_create_actedIn_Movie0_relationship.screenTime = $this_create_actedIn_Movie0_relationship_screenTime
             WITH *
             CALL {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                    MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                     WITH update_this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS update_this1
                     RETURN update_this1 AS update_var2
                     UNION
                     WITH *
-                    MATCH (this)-[update_this3:ACTED_IN]->(update_this4:\`Series\`)
+                    MATCH (this)-[update_this3:\`ACTED_IN\`]->(update_this4:\`Series\`)
                     WITH update_this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS update_this4
                     RETURN update_this4 AS update_var2
                 }

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/delete.test.ts
@@ -81,7 +81,7 @@ describe("Interface Relationships - Update delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Movie0:Movie)
             WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Movie0param0
             WITH this, collect(DISTINCT this_delete_actedIn_Movie0) AS this_delete_actedIn_Movie0_to_delete
             CALL {
@@ -91,7 +91,7 @@ describe("Interface Relationships - Update delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Series0:Series)
             WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Series0param0
             WITH this, collect(DISTINCT this_delete_actedIn_Series0) AS this_delete_actedIn_Series0_to_delete
             CALL {
@@ -154,10 +154,10 @@ describe("Interface Relationships - Update delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Movie0:Movie)
             WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Movie0param0
             WITH this, this_delete_actedIn_Movie0
-            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
+            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_delete_actedIn_Movie0_actors0:Actor)
             WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_this_delete_actedIn_Movie0_actors0param0
             WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) AS this_delete_actedIn_Movie0_actors0_to_delete
             CALL {
@@ -174,10 +174,10 @@ describe("Interface Relationships - Update delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Series0:Series)
             WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Series0param0
             WITH this, this_delete_actedIn_Series0
-            OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Series0_actors0:Actor)
+            OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:\`ACTED_IN\`]-(this_delete_actedIn_Series0_actors0:Actor)
             WHERE this_delete_actedIn_Series0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_this_delete_actedIn_Series0_actors0param0
             WITH this, this_delete_actedIn_Series0, collect(DISTINCT this_delete_actedIn_Series0_actors0) AS this_delete_actedIn_Series0_actors0_to_delete
             CALL {
@@ -260,10 +260,10 @@ describe("Interface Relationships - Update delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Movie0:Movie)
             WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Movie0param0
             WITH this, this_delete_actedIn_Movie0
-            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
+            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_delete_actedIn_Movie0_actors0:Actor)
             WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_this_delete_actedIn_Movie0_actors0param0
             WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) AS this_delete_actedIn_Movie0_actors0_to_delete
             CALL {
@@ -280,7 +280,7 @@ describe("Interface Relationships - Update delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Series0:Series)
             WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Series0param0
             WITH this, collect(DISTINCT this_delete_actedIn_Series0) AS this_delete_actedIn_Series0_to_delete
             CALL {
@@ -364,10 +364,10 @@ describe("Interface Relationships - Update delete", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Actor\`)
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:ACTED_IN]->(this_delete_actedIn_Movie0:Movie)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Movie0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Movie0:Movie)
             WHERE this_delete_actedIn_Movie0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Movie0param0
             WITH this, this_delete_actedIn_Movie0
-            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Movie0_actors0:Actor)
+            OPTIONAL MATCH (this_delete_actedIn_Movie0)<-[this_delete_actedIn_Movie0_actors0_relationship:\`ACTED_IN\`]-(this_delete_actedIn_Movie0_actors0:Actor)
             WHERE this_delete_actedIn_Movie0_actors0.name = $updateActors_args_delete_actedIn0_delete__on_Movie0_actors0_where_this_delete_actedIn_Movie0_actors0param0
             WITH this, this_delete_actedIn_Movie0, collect(DISTINCT this_delete_actedIn_Movie0_actors0) AS this_delete_actedIn_Movie0_actors0_to_delete
             CALL {
@@ -384,10 +384,10 @@ describe("Interface Relationships - Update delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:ACTED_IN]->(this_delete_actedIn_Series0:Series)
+            OPTIONAL MATCH (this)-[this_delete_actedIn_Series0_relationship:\`ACTED_IN\`]->(this_delete_actedIn_Series0:Series)
             WHERE this_delete_actedIn_Series0.title STARTS WITH $updateActors_args_delete_actedIn0_where_this_delete_actedIn_Series0param0
             WITH this, this_delete_actedIn_Series0
-            OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:ACTED_IN]-(this_delete_actedIn_Series0_actors0:Actor)
+            OPTIONAL MATCH (this_delete_actedIn_Series0)<-[this_delete_actedIn_Series0_actors0_relationship:\`ACTED_IN\`]-(this_delete_actedIn_Series0_actors0:Actor)
             WHERE this_delete_actedIn_Series0_actors0.name = $updateActors_args_delete_actedIn0_delete_actors0_where_this_delete_actedIn_Series0_actors0param0
             WITH this, this_delete_actedIn_Series0, collect(DISTINCT this_delete_actedIn_Series0_actors0) AS this_delete_actedIn_Series0_actors0_to_delete
             CALL {

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/disconnect.test.ts
@@ -83,7 +83,7 @@ describe("Interface Relationships - Update disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Movie)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movie_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -96,7 +96,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Series)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Series_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -163,7 +163,7 @@ describe("Interface Relationships - Update disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Movie)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movie_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -174,7 +174,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actedIn0_actors0:Actor)
             WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actor_this_disconnect_actedIn0_actors0param0
             CALL {
             	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel, this_disconnect_actedIn0
@@ -189,7 +189,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Series)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Series_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -200,7 +200,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actedIn0_actors0:Actor)
             WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actor_this_disconnect_actedIn0_actors0param0
             CALL {
             	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel, this_disconnect_actedIn0
@@ -281,7 +281,7 @@ describe("Interface Relationships - Update disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Movie)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movie_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -292,7 +292,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actedIn0_actors0:Actor)
             WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect__on_Movie0_actors0_where_Actor_this_disconnect_actedIn0_actors0param0
             CALL {
             	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel, this_disconnect_actedIn0
@@ -307,7 +307,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Series)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Series_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -395,7 +395,7 @@ describe("Interface Relationships - Update disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Movie)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Movie)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Movie_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -406,7 +406,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actedIn0_actors0:Actor)
             WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect__on_Movie0_actors0_where_Actor_this_disconnect_actedIn0_actors0param0
             CALL {
             	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel, this_disconnect_actedIn0
@@ -421,7 +421,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             	WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:ACTED_IN]->(this_disconnect_actedIn0:Series)
+            OPTIONAL MATCH (this)-[this_disconnect_actedIn0_rel:\`ACTED_IN\`]->(this_disconnect_actedIn0:Series)
             WHERE this_disconnect_actedIn0.title STARTS WITH $updateActors_args_disconnect_actedIn0_where_Series_this_disconnect_actedIn0param0
             CALL {
             	WITH this_disconnect_actedIn0, this_disconnect_actedIn0_rel, this
@@ -432,7 +432,7 @@ describe("Interface Relationships - Update disconnect", () => {
             }
             CALL {
             WITH this, this_disconnect_actedIn0
-            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:ACTED_IN]-(this_disconnect_actedIn0_actors0:Actor)
+            OPTIONAL MATCH (this_disconnect_actedIn0)<-[this_disconnect_actedIn0_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actedIn0_actors0:Actor)
             WHERE this_disconnect_actedIn0_actors0.name = $updateActors_args_disconnect_actedIn0_disconnect_actors0_where_Actor_this_disconnect_actedIn0_actors0param0
             CALL {
             	WITH this_disconnect_actedIn0_actors0, this_disconnect_actedIn0_actors0_rel, this_disconnect_actedIn0

--- a/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/update/update.test.ts
@@ -90,7 +90,7 @@ describe("Interface Relationships - Update update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	SET this_actedIn0.title = $this_update_actedIn0_title
             	RETURN count(*) AS update_this_actedIn0
@@ -102,7 +102,7 @@ describe("Interface Relationships - Update update", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Series)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	SET this_actedIn0.title = $this_update_actedIn0_title
             	RETURN count(*) AS update_this_actedIn0
@@ -172,12 +172,12 @@ describe("Interface Relationships - Update update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	WITH this, this_actedIn0
             	CALL {
             		WITH this, this_actedIn0
-            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
+            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:\`ACTED_IN\`]-(this_actedIn0_actors0:Actor)
             		SET this_actedIn0_actors0.name = $this_update_actedIn0_actors0_name
             		RETURN count(*) AS update_this_actedIn0_actors0
             	}
@@ -190,12 +190,12 @@ describe("Interface Relationships - Update update", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Series)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	WITH this, this_actedIn0
             	CALL {
             		WITH this, this_actedIn0
-            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
+            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:\`ACTED_IN\`]-(this_actedIn0_actors0:Actor)
             		SET this_actedIn0_actors0.name = $this_update_actedIn0_actors0_name
             		RETURN count(*) AS update_this_actedIn0_actors0
             	}
@@ -276,12 +276,12 @@ describe("Interface Relationships - Update update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	WITH this, this_actedIn0
             	CALL {
             		WITH this, this_actedIn0
-            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
+            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:\`ACTED_IN\`]-(this_actedIn0_actors0:Actor)
             		SET this_actedIn0_actors0.name = $this_update_actedIn0_on_Movie_actors0_name
             		RETURN count(*) AS update_this_actedIn0_actors0
             	}
@@ -294,7 +294,7 @@ describe("Interface Relationships - Update update", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Series)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	RETURN count(*) AS update_this_actedIn0
             }
@@ -380,12 +380,12 @@ describe("Interface Relationships - Update update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	WITH this, this_actedIn0
             	CALL {
             		WITH this, this_actedIn0
-            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
+            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:\`ACTED_IN\`]-(this_actedIn0_actors0:Actor)
             		SET this_actedIn0_actors0.name = $this_update_actedIn0_on_Movie_actors0_name
             		RETURN count(*) AS update_this_actedIn0_actors0
             	}
@@ -398,12 +398,12 @@ describe("Interface Relationships - Update update", () => {
             	WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Series)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Series)
             	WHERE this_actedIn0.title = $updateActors_args_update_actedIn0_where_this_actedIn0param0
             	WITH this, this_actedIn0
             	CALL {
             		WITH this, this_actedIn0
-            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:ACTED_IN]-(this_actedIn0_actors0:Actor)
+            		MATCH (this_actedIn0)<-[this_actedIn0_acted_in0_relationship:\`ACTED_IN\`]-(this_actedIn0_actors0:Actor)
             		SET this_actedIn0_actors0.name = $this_update_actedIn0_actors0_name
             		RETURN count(*) AS update_this_actedIn0_actors0
             	}

--- a/packages/graphql/tests/tck/directives/node/node-additional-labels.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-additional-labels.test.ts
@@ -97,7 +97,7 @@ describe("Node directive with additionalLabels", () => {
             "MATCH (this:\`Film\`:\`Multimedia\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`:\`Person\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`:\`Person\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
@@ -143,7 +143,7 @@ describe("Node directive with additionalLabels", () => {
                     CREATE (create_this5:\`Actor\`:\`Person\`)
                     SET
                         create_this5.name = create_var3.name
-                    MERGE (create_this1)<-[create_this6:ACTED_IN]-(create_this5)
+                    MERGE (create_this1)<-[create_this6:\`ACTED_IN\`]-(create_this5)
                     RETURN collect(NULL) AS create_var7
                 }
                 RETURN create_this1

--- a/packages/graphql/tests/tck/directives/node/node-label-jwt.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-jwt.test.ts
@@ -99,7 +99,7 @@ describe("Label in Node directive", () => {
             WHERE this.age > $param0
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Film\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Film\`)
                 WHERE this1.title = $param1
                 WITH this1 { .title } AS this1
                 RETURN collect(this1) AS var2

--- a/packages/graphql/tests/tck/directives/node/node-label-union.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label-union.test.ts
@@ -85,13 +85,13 @@ describe("Node directive with unions", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:\`Category\`:\`ExtraLabel1\`:\`ExtraLabel2\`)
+                    MATCH (this)-[this0:\`SEARCH\`]->(this1:\`Category\`:\`ExtraLabel1\`:\`ExtraLabel2\`)
                     WHERE this1.name = $param1
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:\`Film\`)
+                    MATCH (this)-[this3:\`SEARCH\`]->(this4:\`Film\`)
                     WHERE this4.title = $param2
                     WITH this4 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this4
                     RETURN this4 AS var2

--- a/packages/graphql/tests/tck/directives/node/node-label.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-label.test.ts
@@ -97,7 +97,7 @@ describe("Label in Node directive", () => {
             "MATCH (this:\`Film\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
@@ -132,7 +132,7 @@ describe("Label in Node directive", () => {
             "MATCH (this:\`Film\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                 WITH { node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -220,7 +220,7 @@ describe("Label in Node directive", () => {
                     CREATE (create_this5:\`Person\`)
                     SET
                         create_this5.name = create_var3.name
-                    MERGE (create_this1)<-[create_this6:ACTED_IN]-(create_this5)
+                    MERGE (create_this1)<-[create_this6:\`ACTED_IN\`]-(create_this5)
                     RETURN collect(NULL) AS create_var7
                 }
                 RETURN create_this1
@@ -320,7 +320,7 @@ describe("Label in Node directive", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:\`Person\`)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:\`Person\`)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	SET this_actors0.name = $this_update_actors0_name
             	RETURN count(*) AS update_this_actors0
@@ -389,7 +389,7 @@ describe("Label in Node directive", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors0_node
-            			MERGE (this)<-[:ACTED_IN]-(this_connect_actors0_node)
+            			MERGE (this)<-[:\`ACTED_IN\`]-(this_connect_actors0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -432,7 +432,7 @@ describe("Label in Node directive", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:\`Person\`)
+            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actors0:\`Person\`)
             WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actor_this_disconnect_actors0param0
             CALL {
             	WITH this_disconnect_actors0, this_disconnect_actors0_rel, this
@@ -516,7 +516,7 @@ describe("Label in Node directive", () => {
             "MATCH (this:\`Film\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:\`Person\`)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:\`Person\`)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, collect(DISTINCT this_actors0) AS this_actors0_to_delete
             CALL {
@@ -568,7 +568,7 @@ describe("Label in Node directive", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
             WHERE EXISTS {
-                MATCH (this)<-[:ACTED_IN]-(this0:\`Person\`)
+                MATCH (this)<-[:\`ACTED_IN\`]-(this0:\`Person\`)
                 WHERE this0.name = $param0
             }
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -83,8 +83,8 @@ describe("Cypher Auth Projection On Connections", () => {
             WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_POST]->(this1:\`Comment\`)
-                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`Person\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`Person\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                MATCH (this)-[this0:\`HAS_POST\`]->(this1:\`Comment\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:\`HAS_POST\`]-(:\`Person\`)) AND any(this2 IN [(this1)<-[:\`HAS_POST\`]-(this2:\`Person\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
@@ -103,7 +103,7 @@ describe("Node Directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Comment\`)
-            WHERE single(this0 IN [(this)<-[:HAS_POST]-(this0:\`Person\`) WHERE this0.id = $param0 | 1] WHERE true)
+            WHERE single(this0 IN [(this)<-[:\`HAS_POST\`]-(this0:\`Person\`) WHERE this0.id = $param0 | 1] WHERE true)
             WITH this
             CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             DETACH DELETE this"

--- a/packages/graphql/tests/tck/directives/relationship.test.ts
+++ b/packages/graphql/tests/tck/directives/relationship.test.ts
@@ -75,7 +75,7 @@ describe("Cypher relationship", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:TOP_ACTOR]->(this1:\`Actor\`)
+                MATCH (this)-[this0:\`TOP_ACTOR\`]->(this1:\`Actor\`)
                 WITH this1 { .name } AS this1
                 RETURN head(collect(this1)) AS var2
             }
@@ -106,7 +106,7 @@ describe("Cypher relationship", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
@@ -140,10 +140,10 @@ describe("Cypher relationship", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:TOP_ACTOR]->(this1:\`Actor\`)
+                MATCH (this)-[this0:\`TOP_ACTOR\`]->(this1:\`Actor\`)
                 CALL {
                     WITH this1
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     WITH this3 { .title } AS this3
                     RETURN collect(this3) AS var4
                 }
@@ -181,11 +181,11 @@ describe("Cypher relationship", () => {
             WHERE this.title = $param0
             CALL {
                 WITH this
-                MATCH (this)-[this0:TOP_ACTOR]->(this1:\`Actor\`)
+                MATCH (this)-[this0:\`TOP_ACTOR\`]->(this1:\`Actor\`)
                 WHERE this1.name = $param1
                 CALL {
                     WITH this1
-                    MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
+                    MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
                     WHERE this3.title = $param2
                     WITH this3 { .title } AS this3
                     RETURN collect(this3) AS var4

--- a/packages/graphql/tests/tck/fragments.test.ts
+++ b/packages/graphql/tests/tck/fragments.test.ts
@@ -122,12 +122,12 @@ describe("Cypher Fragment", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:OWNS]->(this1:\`Tile\`)
+                    MATCH (this)-[this0:\`OWNS\`]->(this1:\`Tile\`)
                     WITH this1 { __resolveType: \\"Tile\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:OWNS]->(this4:\`Character\`)
+                    MATCH (this)-[this3:\`OWNS\`]->(this4:\`Character\`)
                     WITH this4 { __resolveType: \\"Character\\", __id: id(this), .id } AS this4
                     RETURN this4 AS var2
                 }

--- a/packages/graphql/tests/tck/fulltext/auth.test.ts
+++ b/packages/graphql/tests/tck/fulltext/auth.test.ts
@@ -65,7 +65,7 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
-            WHERE (\\"Movie\\" IN labels(this) AND (exists((this)<-[:DIRECTED]-(:\`Person\`)) AND all(auth_this0 IN [(this)<-[:DIRECTED]-(auth_this0:\`Person\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            WHERE (\\"Movie\\" IN labels(this) AND (exists((this)<-[:\`DIRECTED\`]-(:\`Person\`)) AND all(auth_this0 IN [(this)<-[:\`DIRECTED\`]-(auth_this0:\`Person\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             RETURN this { .title } AS this"
         `);
 
@@ -118,7 +118,7 @@ describe("Cypher -> fulltext -> Auth", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
-            WHERE (\\"Movie\\" IN labels(this) AND apoc.util.validatePredicate(NOT ((exists((this)<-[:DIRECTED]-(:\`Person\`)) AND any(this0 IN [(this)<-[:DIRECTED]-(this0:\`Person\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (\\"Movie\\" IN labels(this) AND apoc.util.validatePredicate(NOT ((exists((this)<-[:\`DIRECTED\`]-(:\`Person\`)) AND any(this0 IN [(this)<-[:\`DIRECTED\`]-(this0:\`Person\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN this { .title } AS this"
         `);
 

--- a/packages/graphql/tests/tck/interfaces.test.ts
+++ b/packages/graphql/tests/tck/interfaces.test.ts
@@ -90,19 +90,19 @@ describe("Interfaces tests", () => {
             WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_OTHER_NODES]->(this1:\`OtherNode\`)
+                MATCH (this)-[this0:\`HAS_OTHER_NODES\`]->(this1:\`OtherNode\`)
                 WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this1
                     CALL {
                         WITH *
-                        MATCH (this1)-[this2:HAS_INTERFACE_NODES]->(this3:\`SomeNode\`)
+                        MATCH (this1)-[this2:\`HAS_INTERFACE_NODES\`]->(this3:\`SomeNode\`)
                         WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                         WITH this3 { __resolveType: \\"SomeNode\\", __id: id(this1), .id } AS this3
                         RETURN this3 AS var4
                         UNION
                         WITH *
-                        MATCH (this1)-[this5:HAS_INTERFACE_NODES]->(this6:\`MyImplementation\`)
+                        MATCH (this1)-[this5:\`HAS_INTERFACE_NODES\`]->(this6:\`MyImplementation\`)
                         WITH this6 { __resolveType: \\"MyImplementation\\", __id: id(this1), .id } AS this6
                         RETURN this6 AS var4
                     }

--- a/packages/graphql/tests/tck/issues/1115.test.ts
+++ b/packages/graphql/tests/tck/issues/1115.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
                 MERGE (this_connectOrCreate_children0:\`Child\` { tcId: $this_connectOrCreate_children_param0 })
                 ON CREATE SET
                     this_connectOrCreate_children0.tcId = $this_connectOrCreate_children_param1
-                MERGE (this)<-[this_connectOrCreate_children_this0:HAS]-(this_connectOrCreate_children0)
+                MERGE (this)<-[this_connectOrCreate_children_this0:\`HAS\`]-(this_connectOrCreate_children0)
                 WITH *
                 CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"upstream\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN COUNT(*) AS _
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
                 MERGE (this_connectOrCreate_children1:\`Child\` { tcId: $this_connectOrCreate_children_param2 })
                 ON CREATE SET
                     this_connectOrCreate_children1.tcId = $this_connectOrCreate_children_param3
-                MERGE (this)<-[this_connectOrCreate_children_this1:HAS]-(this_connectOrCreate_children1)
+                MERGE (this)<-[this_connectOrCreate_children_this1:\`HAS\`]-(this_connectOrCreate_children1)
                 WITH *
                 CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"upstream\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN COUNT(*) AS _

--- a/packages/graphql/tests/tck/issues/1131.test.ts
+++ b/packages/graphql/tests/tck/issues/1131.test.ts
@@ -98,7 +98,7 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
                 ON CREATE SET
                     this_isInPublication0_connectOrCreate0.uri = $this_isInPublication0_connectOrCreate_param1,
                     this_isInPublication0_connectOrCreate0.prefLabel = $this_isInPublication0_connectOrCreate_param2
-                MERGE (this)-[this_isInPublication0_connectOrCreate_this0:isInPublication]->(this_isInPublication0_connectOrCreate0)
+                MERGE (this)-[this_isInPublication0_connectOrCreate_this0:\`isInPublication\`]->(this_isInPublication0_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             WITH this
@@ -108,13 +108,13 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
                 ON CREATE SET
                     this_isInPublication1_connectOrCreate0.uri = $this_isInPublication1_connectOrCreate_param1,
                     this_isInPublication1_connectOrCreate0.prefLabel = $this_isInPublication1_connectOrCreate_param2
-                MERGE (this)-[this_isInPublication1_connectOrCreate_this0:isInPublication]->(this_isInPublication1_connectOrCreate0)
+                MERGE (this)-[this_isInPublication1_connectOrCreate_this0:\`isInPublication\`]->(this_isInPublication1_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:isInPublication]->(update_this1:\`Concept\`:\`Resource\`)
+                MATCH (this)-[update_this0:\`isInPublication\`]->(update_this1:\`Concept\`:\`Resource\`)
                 WHERE update_this1.uri IN $update_param0
                 WITH update_this1 { iri: update_this1.uri, .prefLabel } AS update_this1
                 RETURN collect(update_this1) AS update_var2

--- a/packages/graphql/tests/tck/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/issues/1132.test.ts
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_targets0_node
-            			MERGE (this)-[:HAS_TARGET]->(this_connect_targets0_node)
+            			MERGE (this)-[:\`HAS_TARGET\`]->(this_connect_targets0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -132,7 +132,7 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_targets0_rel:HAS_TARGET]->(this_disconnect_targets0:Target)
+            OPTIONAL MATCH (this)-[this_disconnect_targets0_rel:\`HAS_TARGET\`]->(this_disconnect_targets0:Target)
             WHERE this_disconnect_targets0.id = $updateSources_args_disconnect_targets0_where_Target_this_disconnect_targets0param0
             WITH this, this_disconnect_targets0, this_disconnect_targets0_rel
             CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -113,19 +113,19 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
             WHERE this.current = $param0
             CALL {
                 WITH this
-                MATCH (this)-[this0:CONSISTS_OF]->(this1:\`DriveComposition\`)
+                MATCH (this)-[this0:\`CONSISTS_OF\`]->(this1:\`DriveComposition\`)
                 WHERE this0.current = $param1
                 CALL {
                     WITH this1
                     CALL {
                         WITH this1
-                        MATCH (this1:\`DriveComposition\`)-[this2:HAS]->(this3:\`Battery\`)
+                        MATCH (this1:\`DriveComposition\`)-[this2:\`HAS\`]->(this3:\`Battery\`)
                         WHERE (this2.current = $param2 AND apoc.util.validatePredicate(NOT ((any(var5 IN [\\"admin\\"] WHERE any(var4 IN $auth.roles WHERE var4 = var5)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                         WITH { current: this2.current, node: { __resolveType: \\"Battery\\", __id: id(this3), id: this3.id } } AS edge
                         RETURN edge
                         UNION
                         WITH this1
-                        MATCH (this1:\`DriveComposition\`)-[this6:HAS]->(this7:\`CombustionEngine\`)
+                        MATCH (this1:\`DriveComposition\`)-[this6:\`HAS\`]->(this7:\`CombustionEngine\`)
                         WHERE this6.current = $param4
                         WITH { current: this6.current, node: { __resolveType: \\"CombustionEngine\\", __id: id(this7), id: this7.id } } AS edge
                         RETURN edge

--- a/packages/graphql/tests/tck/issues/1182.test.ts
+++ b/packages/graphql/tests/tck/issues/1182.test.ts
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
                     this0_actors_connectOrCreate0.name = $this0_actors_connectOrCreate_param1,
                     this0_actors_connectOrCreate0.homeAddress = $this0_actors_connectOrCreate_param2,
                     this0_actors_connectOrCreate0.dob = $this0_actors_connectOrCreate_param3
-                MERGE (this0)<-[this0_actors_connectOrCreate_this0:ACTED_IN]-(this0_actors_connectOrCreate0)
+                MERGE (this0)<-[this0_actors_connectOrCreate_this0:\`ACTED_IN\`]-(this0_actors_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             RETURN this0

--- a/packages/graphql/tests/tck/issues/1221.test.ts
+++ b/packages/graphql/tests/tck/issues/1221.test.ts
@@ -86,14 +86,14 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Series\`)
-            WHERE (this.current = $param0 AND single(this1 IN [(this)-[this3:ARCHITECTURE]->(this1:\`MasterData\`) WHERE single(this0 IN [(this1)-[this2:HAS_NAME]->(this0:\`NameDetails\`) WHERE this0.fullName = $param1 | 1] WHERE true) | 1] WHERE true))
+            WHERE (this.current = $param0 AND single(this1 IN [(this)-[this3:\`ARCHITECTURE\`]->(this1:\`MasterData\`) WHERE single(this0 IN [(this1)-[this2:\`HAS_NAME\`]->(this0:\`NameDetails\`) WHERE this0.fullName = $param1 | 1] WHERE true) | 1] WHERE true))
             CALL {
                 WITH this
-                MATCH (this)-[this4:ARCHITECTURE]->(this5:\`MasterData\`)
+                MATCH (this)-[this4:\`ARCHITECTURE\`]->(this5:\`MasterData\`)
                 WHERE this4.current = $param2
                 CALL {
                     WITH this5
-                    MATCH (this5:\`MasterData\`)-[this6:HAS_NAME]->(this7:\`NameDetails\`)
+                    MATCH (this5:\`MasterData\`)-[this6:\`HAS_NAME\`]->(this7:\`NameDetails\`)
                     WHERE this6.current = $param3
                     WITH { node: { fullName: this7.fullName } } AS edge
                     WITH collect(edge) AS edges
@@ -194,21 +194,21 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Main\`)
-            WHERE (this.current = $param0 AND single(this0 IN [(this)-[this5:MAIN]->(this0:\`Series\`) WHERE EXISTS {
-                MATCH (this0)-[this1:ARCHITECTURE]->(this2:\`MasterData\`)
-                WHERE single(this3 IN [(this2)-[this4:HAS_NAME]->(this3:\`NameDetails\`) WHERE this3.fullName = $param1 | 1] WHERE true)
+            WHERE (this.current = $param0 AND single(this0 IN [(this)-[this5:\`MAIN\`]->(this0:\`Series\`) WHERE EXISTS {
+                MATCH (this0)-[this1:\`ARCHITECTURE\`]->(this2:\`MasterData\`)
+                WHERE single(this3 IN [(this2)-[this4:\`HAS_NAME\`]->(this3:\`NameDetails\`) WHERE this3.fullName = $param1 | 1] WHERE true)
             } | 1] WHERE true))
             CALL {
                 WITH this
-                MATCH (this)-[this6:MAIN]->(this7:\`Series\`)
+                MATCH (this)-[this6:\`MAIN\`]->(this7:\`Series\`)
                 WHERE this6.current = $param2
                 CALL {
                     WITH this7
-                    MATCH (this7:\`Series\`)-[this8:ARCHITECTURE]->(this9:\`MasterData\`)
+                    MATCH (this7:\`Series\`)-[this8:\`ARCHITECTURE\`]->(this9:\`MasterData\`)
                     WHERE this8.current = $param3
                     CALL {
                         WITH this9
-                        MATCH (this9:\`MasterData\`)-[this10:HAS_NAME]->(this11:\`NameDetails\`)
+                        MATCH (this9:\`MasterData\`)-[this10:\`HAS_NAME\`]->(this11:\`NameDetails\`)
                         WHERE this10.current = $param4
                         WITH { node: { fullName: this11.fullName } } AS edge
                         WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/1249.test.ts
+++ b/packages/graphql/tests/tck/issues/1249.test.ts
@@ -86,10 +86,10 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
             "MATCH (this:\`Bulk\`:\`BULK\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:MATERIAL_BULK]->(this1:\`Material\`)
+                MATCH (this)-[this0:\`MATERIAL_BULK\`]->(this1:\`Material\`)
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Material\`)-[this2:MATERIAL_SUPPLIER]->(this3:\`Supplier\`)
+                    MATCH (this1:\`Material\`)-[this2:\`MATERIAL_SUPPLIER\`]->(this3:\`Supplier\`)
                     WITH { supplierMaterialNumber: this2.supplierMaterialNumber, node: { supplierId: this3.supplierId } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/issues/1263.test.ts
+++ b/packages/graphql/tests/tck/issues/1263.test.ts
@@ -84,13 +84,13 @@ describe("https://github.com/neo4j/graphql/issues/1263", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WHERE (this1.title = $param0 AND this1.runtime > $param1)
                     WITH { node: { __resolveType: \\"Movie\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:ACTED_IN]->(this3:\`Series\`)
+                    MATCH (this)-[this2:\`ACTED_IN\`]->(this3:\`Series\`)
                     WHERE (this3.title = $param2 AND this3.episodes > $param3)
                     WITH { node: { __resolveType: \\"Series\\", __id: id(this3), title: this3.title } } AS edge
                     RETURN edge

--- a/packages/graphql/tests/tck/issues/1320.test.ts
+++ b/packages/graphql/tests/tck/issues/1320.test.ts
@@ -71,13 +71,13 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
             "MATCH (this:\`Team\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:OWNS_RISK]->(this1:\`Risk\`)
+                MATCH (this)-[this0:\`OWNS_RISK\`]->(this1:\`Risk\`)
                 WHERE $param0 IN this1.mitigationState
                 RETURN count(this1) AS var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[this3:OWNS_RISK]->(this4:\`Risk\`)
+                MATCH (this)-[this3:\`OWNS_RISK\`]->(this4:\`Risk\`)
                 WHERE $param1 IN this4.mitigationState
                 RETURN count(this4) AS var5
             }

--- a/packages/graphql/tests/tck/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/issues/1348.test.ts
@@ -86,17 +86,17 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:RELATES_TO]-(this1:\`Series\`)
+                    MATCH (this)-[this0:\`RELATES_TO\`]-(this1:\`Series\`)
                     WITH this1 { __resolveType: \\"Series\\", __id: id(this), .productTitle } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:RELATES_TO]-(this4:\`Season\`)
+                    MATCH (this)-[this3:\`RELATES_TO\`]-(this4:\`Season\`)
                     WITH this4 { __resolveType: \\"Season\\", __id: id(this), .productTitle } AS this4
                     RETURN this4 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this5:RELATES_TO]-(this6:\`ProgrammeItem\`)
+                    MATCH (this)-[this5:\`RELATES_TO\`]-(this6:\`ProgrammeItem\`)
                     WITH this6 { __resolveType: \\"ProgrammeItem\\", __id: id(this), .productTitle } AS this6
                     RETURN this6 AS var2
                 }
@@ -142,17 +142,17 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)-[this0:RELATES_TO]-(this1:\`Series\`)
+                    MATCH (this)-[this0:\`RELATES_TO\`]-(this1:\`Series\`)
                     WITH { node: { __resolveType: \\"Series\\", __id: id(this1), productTitle: this1.productTitle } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this2:RELATES_TO]-(this3:\`Season\`)
+                    MATCH (this)-[this2:\`RELATES_TO\`]-(this3:\`Season\`)
                     WITH { node: { __resolveType: \\"Season\\", __id: id(this3), productTitle: this3.productTitle } } AS edge
                     RETURN edge
                     UNION
                     WITH this
-                    MATCH (this)-[this4:RELATES_TO]-(this5:\`ProgrammeItem\`)
+                    MATCH (this)-[this4:\`RELATES_TO\`]-(this5:\`ProgrammeItem\`)
                     WITH { node: { __resolveType: \\"ProgrammeItem\\", __id: id(this5), productTitle: this5.productTitle } } AS edge
                     RETURN edge
                 }

--- a/packages/graphql/tests/tck/issues/1430.test.ts
+++ b/packages/graphql/tests/tck/issues/1430.test.ts
@@ -81,22 +81,22 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`ABCE\`)
             WHERE this.id = $param0
-            CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildOne)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
+            CALL apoc.util.validate(EXISTS((this)-[:\`HAS_INTERFACE\`]->(:ChildOne)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
             CREATE (this_create_interface_ChildOne0_node_ChildOne:ChildOne)
             SET this_create_interface_ChildOne0_node_ChildOne.id = randomUUID()
             SET this_create_interface_ChildOne0_node_ChildOne.name = $this_create_interface_ChildOne0_node_ChildOne_name
-            MERGE (this)-[:HAS_INTERFACE]->(this_create_interface_ChildOne0_node_ChildOne)
+            MERGE (this)-[:\`HAS_INTERFACE\`]->(this_create_interface_ChildOne0_node_ChildOne)
             WITH *
             CALL {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:HAS_INTERFACE]->(update_this1:\`ChildOne\`)
+                    MATCH (this)-[update_this0:\`HAS_INTERFACE\`]->(update_this1:\`ChildOne\`)
                     WITH update_this1 { __resolveType: \\"ChildOne\\", __id: id(this), .id, .name } AS update_this1
                     RETURN update_this1 AS update_var2
                     UNION
                     WITH *
-                    MATCH (this)-[update_this3:HAS_INTERFACE]->(update_this4:\`ChildTwo\`)
+                    MATCH (this)-[update_this3:\`HAS_INTERFACE\`]->(update_this4:\`ChildTwo\`)
                     WITH update_this4 { __resolveType: \\"ChildTwo\\", __id: id(this), .id, .name } AS update_this4
                     RETURN update_this4 AS update_var2
                 }
@@ -139,8 +139,8 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`ABCE\`)
             WHERE this.id = $param0
-            CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildOne)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
-            CALL apoc.util.validate(EXISTS((this)-[:HAS_INTERFACE]->(:ChildTwo)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
+            CALL apoc.util.validate(EXISTS((this)-[:\`HAS_INTERFACE\`]->(:ChildOne)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
+            CALL apoc.util.validate(EXISTS((this)-[:\`HAS_INTERFACE\`]->(:ChildTwo)),'Relationship field \\"%s.%s\\" cannot have more than one node linked',[\\"ABCE\\",\\"interface\\"])
             WITH this
             CALL {
             	WITH this
@@ -153,7 +153,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_interface0_node
-            			MERGE (this)-[:HAS_INTERFACE]->(this_connect_interface0_node)
+            			MERGE (this)-[:\`HAS_INTERFACE\`]->(this_connect_interface0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -172,7 +172,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_interface1_node
-            			MERGE (this)-[:HAS_INTERFACE]->(this_connect_interface1_node)
+            			MERGE (this)-[:\`HAS_INTERFACE\`]->(this_connect_interface1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -185,12 +185,12 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:HAS_INTERFACE]->(update_this1:\`ChildOne\`)
+                    MATCH (this)-[update_this0:\`HAS_INTERFACE\`]->(update_this1:\`ChildOne\`)
                     WITH update_this1 { __resolveType: \\"ChildOne\\", __id: id(this), .id, .name } AS update_this1
                     RETURN update_this1 AS update_var2
                     UNION
                     WITH *
-                    MATCH (this)-[update_this3:HAS_INTERFACE]->(update_this4:\`ChildTwo\`)
+                    MATCH (this)-[update_this3:\`HAS_INTERFACE\`]->(update_this4:\`ChildTwo\`)
                     WITH update_this4 { __resolveType: \\"ChildTwo\\", __id: id(this), .id, .name } AS update_this4
                     RETURN update_this4 AS update_var2
                 }

--- a/packages/graphql/tests/tck/issues/1528.test.ts
+++ b/packages/graphql/tests/tck/issues/1528.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             "MATCH (this:\`Genre\`)
             CALL {
                 WITH this
-                MATCH (this)<-[this0:IS_GENRE]-(this1:\`Movie\`)
+                MATCH (this)<-[this0:\`IS_GENRE\`]-(this1:\`Movie\`)
                 WITH this0, this1
                 ORDER BY this1.actorsCount DESC
                 CALL {

--- a/packages/graphql/tests/tck/issues/1535.test.ts
+++ b/packages/graphql/tests/tck/issues/1535.test.ts
@@ -85,12 +85,12 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)<-[this0:HOSTED_BY]-(this1:\`Screening\`)
+                    MATCH (this)<-[this0:\`HOSTED_BY\`]-(this1:\`Screening\`)
                     WITH this1 { __resolveType: \\"Screening\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)<-[this3:HOSTED_BY]-(this4:\`Booking\`)
+                    MATCH (this)<-[this3:\`HOSTED_BY\`]-(this4:\`Booking\`)
                     WITH this4 { __resolveType: \\"Booking\\", __id: id(this), .id } AS this4
                     RETURN this4 AS var2
                 }

--- a/packages/graphql/tests/tck/issues/1536.test.ts
+++ b/packages/graphql/tests/tck/issues/1536.test.ts
@@ -71,12 +71,12 @@ describe("https://github.com/neo4j/graphql/issues/1536", () => {
             "MATCH (this:\`SomeNode\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_OTHER_NODES]->(this1:\`OtherNode\`)
+                MATCH (this)-[this0:\`HAS_OTHER_NODES\`]->(this1:\`OtherNode\`)
                 CALL {
                     WITH this1
                     CALL {
                         WITH *
-                        MATCH (this1)-[this2:HAS_INTERFACE_NODES]->(this3:\`MyImplementation\`)
+                        MATCH (this1)-[this2:\`HAS_INTERFACE_NODES\`]->(this3:\`MyImplementation\`)
                         WITH this3 { __resolveType: \\"MyImplementation\\", __id: id(this1), .id } AS this3
                         RETURN this3 AS var4
                     }

--- a/packages/graphql/tests/tck/issues/1628.test.ts
+++ b/packages/graphql/tests/tck/issues/1628.test.ts
@@ -65,14 +65,14 @@ describe("https://github.com/neo4j/graphql/issues/1628", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`frbr__Work\`:\`Resource\`)
             WHERE EXISTS {
-                MATCH (this)-[:dcterms__title]->(this0:\`dcterms_title\`:\`property\`)
+                MATCH (this)-[:\`dcterms__title\`]->(this0:\`dcterms_title\`:\`property\`)
                 WHERE this0.value CONTAINS $param0
             }
             WITH *
             LIMIT $param1
             CALL {
                 WITH this
-                MATCH (this)-[this1:dcterms__title]->(this2:\`dcterms_title\`:\`property\`)
+                MATCH (this)-[this1:\`dcterms__title\`]->(this2:\`dcterms_title\`:\`property\`)
                 WHERE this2.value CONTAINS $param2
                 WITH this2 { .value } AS this2
                 RETURN collect(this2) AS var3

--- a/packages/graphql/tests/tck/issues/1685.test.ts
+++ b/packages/graphql/tests/tck/issues/1685.test.ts
@@ -73,9 +73,9 @@ describe("https://github.com/neo4j/graphql/issues/1685", () => {
                 WITH this
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:HAS_GENRE]-(this1:\`Movie\`)
+                    MATCH (this)<-[this0:\`HAS_GENRE\`]-(this1:\`Movie\`)
                     WHERE EXISTS {
-                        MATCH (this1)-[this2:HAS_GENRE]->(this3:\`Genre\`)
+                        MATCH (this1)-[this2:\`HAS_GENRE\`]->(this3:\`Genre\`)
                         WHERE this3.name = $param0
                     }
                     WITH { node: { __resolveType: \\"Movie\\", __id: id(this1) } } AS edge

--- a/packages/graphql/tests/tck/issues/1687.test.ts
+++ b/packages/graphql/tests/tck/issues/1687.test.ts
@@ -65,10 +65,10 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Genre\`)
             WHERE (EXISTS {
-                MATCH (this)<-[this0:HAS_GENRE]-(this1:\`Movie\`)
+                MATCH (this)<-[this0:\`HAS_GENRE\`]-(this1:\`Movie\`)
                 WHERE this1.title = $param0
             } AND NOT (EXISTS {
-                MATCH (this)<-[this0:HAS_GENRE]-(this1:\`Movie\`)
+                MATCH (this)<-[this0:\`HAS_GENRE\`]-(this1:\`Movie\`)
                 WHERE NOT (this1.title = $param0)
             }))
             RETURN this { .name } AS this"

--- a/packages/graphql/tests/tck/issues/1751.test.ts
+++ b/packages/graphql/tests/tck/issues/1751.test.ts
@@ -80,30 +80,30 @@ describe("https://github.com/neo4j/graphql/issues/1751", () => {
         const result = await translateQuery(neoSchema, query, { variableValues });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Organization\`)
-WHERE this.title = $param0
-WITH this
-OPTIONAL MATCH (this)-[this_admins0_relationship:HAS_ADMINISTRATOR]->(this_admins0:Admin)
-CALL {
-    WITH this_admins0
-    MATCH (this_admins0)<-[this_deleteOrganizations_args_delete_admins0_where_this_admins0this1:HAS_ADMINISTRATOR]-(this_deleteOrganizations_args_delete_admins0_where_this_admins0this2:\`Organization\`)
-    RETURN count(this_deleteOrganizations_args_delete_admins0_where_this_admins0this2) = $this_deleteOrganizations_args_delete_admins0_where_this_admins0param0 AS this_deleteOrganizations_args_delete_admins0_where_this_admins0var0
-}
-WITH *, CASE this_deleteOrganizations_args_delete_admins0_where_this_admins0var0 = true
-    WHEN true THEN [ this_admins0_relationship, this_admins0 ]
-    ELSE [ NULL, NULL ]
-END AS aggregateWhereFiltervar0
-WITH *, aggregateWhereFiltervar0[0] AS this_admins0_relationship, aggregateWhereFiltervar0[1] AS this_admins0
-WITH this, collect(DISTINCT this_admins0) AS this_admins0_to_delete
-ORDER BY this_admins0_to_delete DESC
-CALL {
-	WITH this_admins0_to_delete
-	UNWIND this_admins0_to_delete AS x
-	DETACH DELETE x
-	RETURN count(*) AS _
-}
-DETACH DELETE this"
-`);
+            "MATCH (this:\`Organization\`)
+            WHERE this.title = $param0
+            WITH this
+            OPTIONAL MATCH (this)-[this_admins0_relationship:\`HAS_ADMINISTRATOR\`]->(this_admins0:Admin)
+            CALL {
+                WITH this_admins0
+                MATCH (this_admins0)<-[this_deleteOrganizations_args_delete_admins0_where_this_admins0this1:\`HAS_ADMINISTRATOR\`]-(this_deleteOrganizations_args_delete_admins0_where_this_admins0this2:\`Organization\`)
+                RETURN count(this_deleteOrganizations_args_delete_admins0_where_this_admins0this2) = $this_deleteOrganizations_args_delete_admins0_where_this_admins0param0 AS this_deleteOrganizations_args_delete_admins0_where_this_admins0var0
+            }
+            WITH *, CASE this_deleteOrganizations_args_delete_admins0_where_this_admins0var0 = true
+                WHEN true THEN [ this_admins0_relationship, this_admins0 ]
+                ELSE [ NULL, NULL ]
+            END AS aggregateWhereFiltervar0
+            WITH *, aggregateWhereFiltervar0[0] AS this_admins0_relationship, aggregateWhereFiltervar0[1] AS this_admins0
+            WITH this, collect(DISTINCT this_admins0) AS this_admins0_to_delete
+            ORDER BY this_admins0_to_delete DESC
+            CALL {
+            	WITH this_admins0_to_delete
+            	UNWIND this_admins0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            DETACH DELETE this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/1756.test.ts
+++ b/packages/graphql/tests/tck/issues/1756.test.ts
@@ -93,14 +93,14 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
                 ON CREATE SET
                     this0_genre_connectOrCreate0.value = $this0_genre_connectOrCreate_param1,
                     this0_genre_connectOrCreate0.id = $resolvedCallbacks.this0_genre_connectOrCreate0_id_nanoid
-                MERGE (this0)-[this0_genre_connectOrCreate_this0:HAS_GENRE]->(this0_genre_connectOrCreate0)
+                MERGE (this0)-[this0_genre_connectOrCreate_this0:\`HAS_GENRE\`]->(this0_genre_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             RETURN this0
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:HAS_GENRE]->(create_this1:\`Genre\`)
+                MATCH (this0)-[create_this0:\`HAS_GENRE\`]->(create_this1:\`Genre\`)
                 WITH create_this1 { .id, .value } AS create_this1
                 RETURN collect(create_this1) AS create_var2
             }

--- a/packages/graphql/tests/tck/issues/1760.test.ts
+++ b/packages/graphql/tests/tck/issues/1760.test.ts
@@ -142,7 +142,7 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
             LIMIT $param3
             CALL {
                 WITH this
-                MATCH (this)-[this3:HAS_NAME]->(this4:\`NameDetails\`)
+                MATCH (this)-[this3:\`HAS_NAME\`]->(this4:\`NameDetails\`)
                 WHERE apoc.util.validatePredicate(NOT ((any(var6 IN [\\"ALL\\"] WHERE any(var5 IN $auth.roles WHERE var5 = var6)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { fullName: this4.fullName } } AS edge
                 WITH collect(edge) AS edges
@@ -151,11 +151,11 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
             }
             CALL {
                 WITH this
-                MATCH (this)-[this8:HAS_MARKETS]->(this9:\`Market\`)
+                MATCH (this)-[this8:\`HAS_MARKETS\`]->(this9:\`Market\`)
                 WHERE apoc.util.validatePredicate(NOT ((any(var11 IN [\\"ALL\\"] WHERE any(var10 IN $auth.roles WHERE var10 = var11)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this9
-                    MATCH (this9:\`Market\`)-[this12:HAS_NAME]->(this13:\`NameDetails\`)
+                    MATCH (this9:\`Market\`)-[this12:\`HAS_NAME\`]->(this13:\`NameDetails\`)
                     WHERE apoc.util.validatePredicate(NOT ((any(var15 IN [\\"ALL\\"] WHERE any(var14 IN $auth.roles WHERE var14 = var15)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { node: { fullName: this13.fullName } } AS edge
                     WITH collect(edge) AS edges
@@ -169,7 +169,7 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
             }
             CALL {
                 WITH this
-                MATCH (this)<-[this18:HAS_BASE]-(this19:\`BaseObject\`)
+                MATCH (this)<-[this18:\`HAS_BASE\`]-(this19:\`BaseObject\`)
                 WHERE apoc.util.validatePredicate(NOT ((any(var21 IN [\\"ALL\\"] WHERE any(var20 IN $auth.roles WHERE var20 = var21)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { id: this19.id } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/1779.test.ts
+++ b/packages/graphql/tests/tck/issues/1779.test.ts
@@ -63,12 +63,12 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
             "MATCH (this:\`Person\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:attends]->(this1:\`School\`)
+                MATCH (this)-[this0:\`attends\`]->(this1:\`School\`)
                 WHERE (EXISTS {
-                    MATCH (this1)<-[:attends]-(this2:\`Person\`)
+                    MATCH (this1)<-[:\`attends\`]-(this2:\`Person\`)
                     WHERE this2.age > $param0
                 } AND NOT (EXISTS {
-                    MATCH (this1)<-[:attends]-(this2:\`Person\`)
+                    MATCH (this1)<-[:\`attends\`]-(this2:\`Person\`)
                     WHERE NOT (this2.age > $param0)
                 }))
                 WITH this1 { .name } AS this1

--- a/packages/graphql/tests/tck/issues/1783.test.ts
+++ b/packages/graphql/tests/tck/issues/1783.test.ts
@@ -121,10 +121,10 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Series\`)
-            WHERE (this.current = $param0 AND single(this3 IN [(this)-[this0:ARCHITECTURE]->(this3:\`MasterData\`) WHERE (this0.current = $param1 AND single(this2 IN [(this3)-[this1:HAS_NAME]->(this2:\`NameDetails\`) WHERE (this1.current = $param2 AND this2.fullName = $param3) | 1] WHERE true)) | 1] WHERE true) AND single(this5 IN [(this)-[this4:HAS_NAME]->(this5:\`NameDetails\`) WHERE (this4.current = $param4 AND this5.fullName CONTAINS $param5) | 1] WHERE true))
+            WHERE (this.current = $param0 AND single(this3 IN [(this)-[this0:\`ARCHITECTURE\`]->(this3:\`MasterData\`) WHERE (this0.current = $param1 AND single(this2 IN [(this3)-[this1:\`HAS_NAME\`]->(this2:\`NameDetails\`) WHERE (this1.current = $param2 AND this2.fullName = $param3) | 1] WHERE true)) | 1] WHERE true) AND single(this5 IN [(this)-[this4:\`HAS_NAME\`]->(this5:\`NameDetails\`) WHERE (this4.current = $param4 AND this5.fullName CONTAINS $param5) | 1] WHERE true))
             CALL {
                 WITH this
-                MATCH (this)-[this6:HAS_NAME]->(this7:\`NameDetails\`)
+                MATCH (this)-[this6:\`HAS_NAME\`]->(this7:\`NameDetails\`)
                 WHERE this6.current = $param6
                 WITH { node: { fullName: this7.fullName } } AS edge
                 WITH collect(edge) AS edges
@@ -133,11 +133,11 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
             }
             CALL {
                 WITH this
-                MATCH (this)-[this9:ARCHITECTURE]->(this10:\`MasterData\`)
+                MATCH (this)-[this9:\`ARCHITECTURE\`]->(this10:\`MasterData\`)
                 WHERE this9.current = $param7
                 CALL {
                     WITH this10
-                    MATCH (this10:\`MasterData\`)-[this11:HAS_NAME]->(this12:\`NameDetails\`)
+                    MATCH (this10:\`MasterData\`)-[this11:\`HAS_NAME\`]->(this12:\`NameDetails\`)
                     WHERE this11.current = $param8
                     WITH { node: { fullName: this12.fullName } } AS edge
                     WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/190.test.ts
+++ b/packages/graphql/tests/tck/issues/190.test.ts
@@ -70,12 +70,12 @@ describe("#190", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WHERE EXISTS {
-                MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:\`UserDemographics\`)
+                MATCH (this)-[:\`HAS_DEMOGRAPHIC\`]->(this0:\`UserDemographics\`)
                 WHERE (this0.type = $param0 AND this0.value = $param1)
             }
             CALL {
                 WITH this
-                MATCH (this)-[this1:HAS_DEMOGRAPHIC]->(this2:\`UserDemographics\`)
+                MATCH (this)-[this1:\`HAS_DEMOGRAPHIC\`]->(this2:\`UserDemographics\`)
                 WITH this2 { .type, .value } AS this2
                 RETURN collect(this2) AS var3
             }
@@ -115,12 +115,12 @@ describe("#190", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WHERE EXISTS {
-                MATCH (this)-[:HAS_DEMOGRAPHIC]->(this0:\`UserDemographics\`)
+                MATCH (this)-[:\`HAS_DEMOGRAPHIC\`]->(this0:\`UserDemographics\`)
                 WHERE ((this0.type = $param0 AND this0.value = $param1) OR this0.type = $param2 OR this0.type = $param3)
             }
             CALL {
                 WITH this
-                MATCH (this)-[this1:HAS_DEMOGRAPHIC]->(this2:\`UserDemographics\`)
+                MATCH (this)-[this1:\`HAS_DEMOGRAPHIC\`]->(this2:\`UserDemographics\`)
                 WITH this2 { .type, .value } AS this2
                 RETURN collect(this2) AS var3
             }

--- a/packages/graphql/tests/tck/issues/1933.test.ts
+++ b/packages/graphql/tests/tck/issues/1933.test.ts
@@ -82,19 +82,19 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             "MATCH (this:\`Employee\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:PARTICIPATES]->(this1:\`Project\`)
+                MATCH (this)-[this0:\`PARTICIPATES\`]->(this1:\`Project\`)
                 RETURN sum(this0.allocation) <= $param0 AS var2
             }
             WITH *
             WHERE var2 = true
             CALL {
                 WITH this
-                MATCH (this)-[this3:PARTICIPATES]->(this4:\`Project\`)
+                MATCH (this)-[this3:\`PARTICIPATES\`]->(this4:\`Project\`)
                 RETURN count(this4) AS var5
             }
             CALL {
                 WITH this
-                MATCH (this)-[this3:PARTICIPATES]->(this4:\`Project\`)
+                MATCH (this)-[this3:\`PARTICIPATES\`]->(this4:\`Project\`)
                 RETURN { min: min(this3.allocation), max: max(this3.allocation), average: avg(this3.allocation), sum: sum(this3.allocation) }  AS var6
             }
             RETURN this { .employeeId, .firstName, .lastName, projectsAggregate: { count: var5, edge: { allocation: var6 } } } AS this"
@@ -135,19 +135,19 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             "MATCH (this:\`Employee\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:PARTICIPATES]->(this1:\`Project\`)
+                MATCH (this)-[this0:\`PARTICIPATES\`]->(this1:\`Project\`)
                 RETURN any(var2 IN collect(this0.allocation) WHERE var2 <= $param0) AS var3
             }
             WITH *
             WHERE var3 = true
             CALL {
                 WITH this
-                MATCH (this)-[this4:PARTICIPATES]->(this5:\`Project\`)
+                MATCH (this)-[this4:\`PARTICIPATES\`]->(this5:\`Project\`)
                 RETURN count(this5) AS var6
             }
             CALL {
                 WITH this
-                MATCH (this)-[this4:PARTICIPATES]->(this5:\`Project\`)
+                MATCH (this)-[this4:\`PARTICIPATES\`]->(this5:\`Project\`)
                 RETURN { min: min(this4.allocation), max: max(this4.allocation), average: avg(this4.allocation), sum: sum(this4.allocation) }  AS var7
             }
             RETURN this { .employeeId, .firstName, .lastName, projectsAggregate: { count: var6, edge: { allocation: var7 } } } AS this"

--- a/packages/graphql/tests/tck/issues/2022.test.ts
+++ b/packages/graphql/tests/tck/issues/2022.test.ts
@@ -97,10 +97,10 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
             WITH this, totalCount
             CALL {
                 WITH this
-                MATCH (this)-[this0:SOLD_AT_AUCTION_AS]->(this1:\`AuctionItem\`)
+                MATCH (this)-[this0:\`SOLD_AT_AUCTION_AS\`]->(this1:\`AuctionItem\`)
                 CALL {
                     WITH this1
-                    MATCH (this1)<-[this2:BOUGHT_ITEM_AT_AUCTION]-(this3:\`Organization\`)
+                    MATCH (this1)<-[this2:\`BOUGHT_ITEM_AT_AUCTION\`]-(this3:\`Organization\`)
                     WITH this3 { .name, dbId: this3.id } AS this3
                     RETURN head(collect(this3)) AS var4
                 }
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
             }
             CALL {
                 WITH this
-                MATCH (this)-[this6:OWNED_BY]->(this7:\`Organization\`)
+                MATCH (this)-[this6:\`OWNED_BY\`]->(this7:\`Organization\`)
                 WITH this7 { .name, dbId: this7.id } AS this7
                 RETURN head(collect(this7)) AS var8
             }

--- a/packages/graphql/tests/tck/issues/2100.test.ts
+++ b/packages/graphql/tests/tck/issues/2100.test.ts
@@ -139,7 +139,7 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
                 }
                 CALL {
                     WITH this0
-                    MATCH (this0)-[this2:BUSSED_ON]->(this3:\`TimeGraph\`)
+                    MATCH (this0)-[this2:\`BUSSED_ON\`]->(this3:\`TimeGraph\`)
                     WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this3 { .date } AS this3
                     RETURN head(collect(this3)) AS var4

--- a/packages/graphql/tests/tck/issues/2249.test.ts
+++ b/packages/graphql/tests/tck/issues/2249.test.ts
@@ -96,7 +96,7 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
             CREATE (this_reviewers0_create0_node:Person)
             SET this_reviewers0_create0_node.name = $this_reviewers0_create0_node_name
             SET this_reviewers0_create0_node.reputation = $this_reviewers0_create0_node_reputation
-            MERGE (this)<-[this_reviewers0_create0_relationship:REVIEWED]-(this_reviewers0_create0_node)
+            MERGE (this)<-[this_reviewers0_create0_relationship:\`REVIEWED\`]-(this_reviewers0_create0_node)
             SET this_reviewers0_create0_relationship.score = $updateMovies.args.update.reviewers[0].create[0].edge.score
             RETURN count(*) AS update_this_Person
             }
@@ -110,12 +110,12 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)<-[update_this0:REVIEWED]-(update_this1:\`Person\`)
+                    MATCH (this)<-[update_this0:\`REVIEWED\`]-(update_this1:\`Person\`)
                     WITH update_this1 { __resolveType: \\"Person\\", __id: id(this), .name, .reputation } AS update_this1
                     RETURN update_this1 AS update_var2
                     UNION
                     WITH *
-                    MATCH (this)<-[update_this3:REVIEWED]-(update_this4:\`Influencer\`)
+                    MATCH (this)<-[update_this3:\`REVIEWED\`]-(update_this4:\`Influencer\`)
                     WITH update_this4 { __resolveType: \\"Influencer\\", __id: id(this) } AS update_this4
                     RETURN update_this4 AS update_var2
                 }

--- a/packages/graphql/tests/tck/issues/2262.test.ts
+++ b/packages/graphql/tests/tck/issues/2262.test.ts
@@ -75,10 +75,10 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
             WHERE this.uuid = $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:OUTPUT]-(this1:\`Process\`)
+                MATCH (this)<-[this0:\`OUTPUT\`]-(this1:\`Process\`)
                 CALL {
                     WITH this1
-                    MATCH (this1:\`Process\`)<-[this2:INPUT]-(this3:\`Component\`)
+                    MATCH (this1:\`Process\`)<-[this2:\`INPUT\`]-(this3:\`Component\`)
                     WITH this2, this3
                     ORDER BY this3.uuid DESC
                     WITH { node: { uuid: this3.uuid } } AS edge

--- a/packages/graphql/tests/tck/issues/2267.test.ts
+++ b/packages/graphql/tests/tck/issues/2267.test.ts
@@ -76,12 +76,12 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)<-[this0:ACTIVITY]-(this1:\`Post\`)
+                    MATCH (this)<-[this0:\`ACTIVITY\`]-(this1:\`Post\`)
                     WITH this1 { __resolveType: \\"Post\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)<-[this3:ACTIVITY]-(this4:\`Story\`)
+                    MATCH (this)<-[this3:\`ACTIVITY\`]-(this4:\`Story\`)
                     WITH this4 { __resolveType: \\"Story\\", __id: id(this), .name } AS this4
                     RETURN this4 AS var2
                 }

--- a/packages/graphql/tests/tck/issues/2396.test.ts
+++ b/packages/graphql/tests/tck/issues/2396.test.ts
@@ -156,14 +156,14 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Mandate\`)
-            WHERE ((this.price >= $param0 AND single(this3 IN [(this)-[:HAS_VALUATION]->(this3:\`Valuation\`) WHERE single(this0 IN [(this3)-[:VALUATION_FOR]->(this0:\`Estate\`) WHERE (this0.area >= $param1 AND this0.floor >= $param2 AND this0.estateType IN $param3 AND single(this2 IN [(this0)-[:HAS_ADDRESS]->(this2:\`Address\`) WHERE single(this1 IN [(this2)-[:HAS_POSTAL_CODE]->(this1:\`PostalCode\`) WHERE this1.number IN $param4 | 1] WHERE true) | 1] WHERE true)) | 1] WHERE true) | 1] WHERE true)) AND this.archivedAt IS NULL)
+            WHERE ((this.price >= $param0 AND single(this3 IN [(this)-[:\`HAS_VALUATION\`]->(this3:\`Valuation\`) WHERE single(this0 IN [(this3)-[:\`VALUATION_FOR\`]->(this0:\`Estate\`) WHERE (this0.area >= $param1 AND this0.floor >= $param2 AND this0.estateType IN $param3 AND single(this2 IN [(this0)-[:\`HAS_ADDRESS\`]->(this2:\`Address\`) WHERE single(this1 IN [(this2)-[:\`HAS_POSTAL_CODE\`]->(this1:\`PostalCode\`) WHERE this1.number IN $param4 | 1] WHERE true) | 1] WHERE true)) | 1] WHERE true) | 1] WHERE true)) AND this.archivedAt IS NULL)
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_VALUATION]->(this5:\`Valuation\`)
+                MATCH (this)-[this4:\`HAS_VALUATION\`]->(this5:\`Valuation\`)
                 WHERE this5.archivedAt IS NULL
                 CALL {
                     WITH this5
-                    MATCH (this5)-[this6:VALUATION_FOR]->(this7:\`Estate\`)
+                    MATCH (this5)-[this6:\`VALUATION_FOR\`]->(this7:\`Estate\`)
                     WHERE this7.archivedAt IS NULL
                     WITH this7 { .uuid } AS this7
                     RETURN head(collect(this7)) AS var8
@@ -231,17 +231,17 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Mandate\`)
-            WHERE ((this.price >= $param0 AND single(this3 IN [(this)-[:HAS_VALUATION]->(this3:\`Valuation\`) WHERE single(this0 IN [(this3)-[:VALUATION_FOR]->(this0:\`Estate\`) WHERE (this0.area >= $param1 AND this0.floor >= $param2 AND this0.estateType IN $param3 AND single(this2 IN [(this0)-[:HAS_ADDRESS]->(this2:\`Address\`) WHERE single(this1 IN [(this2)-[:HAS_POSTAL_CODE]->(this1:\`PostalCode\`) WHERE this1.number IN $param4 | 1] WHERE true) | 1] WHERE true)) | 1] WHERE true) | 1] WHERE true)) AND this.archivedAt IS NULL)
+            WHERE ((this.price >= $param0 AND single(this3 IN [(this)-[:\`HAS_VALUATION\`]->(this3:\`Valuation\`) WHERE single(this0 IN [(this3)-[:\`VALUATION_FOR\`]->(this0:\`Estate\`) WHERE (this0.area >= $param1 AND this0.floor >= $param2 AND this0.estateType IN $param3 AND single(this2 IN [(this0)-[:\`HAS_ADDRESS\`]->(this2:\`Address\`) WHERE single(this1 IN [(this2)-[:\`HAS_POSTAL_CODE\`]->(this1:\`PostalCode\`) WHERE this1.number IN $param4 | 1] WHERE true) | 1] WHERE true)) | 1] WHERE true) | 1] WHERE true)) AND this.archivedAt IS NULL)
             WITH *
             SKIP $param5
             LIMIT $param6
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_VALUATION]->(this5:\`Valuation\`)
+                MATCH (this)-[this4:\`HAS_VALUATION\`]->(this5:\`Valuation\`)
                 WHERE this5.archivedAt IS NULL
                 CALL {
                     WITH this5
-                    MATCH (this5)-[this6:VALUATION_FOR]->(this7:\`Estate\`)
+                    MATCH (this5)-[this6:\`VALUATION_FOR\`]->(this7:\`Estate\`)
                     WHERE this7.archivedAt IS NULL
                     WITH this7 { .uuid } AS this7
                     RETURN head(collect(this7)) AS var8
@@ -317,17 +317,17 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Mandate\`)
-            WHERE ((this.price >= $param0 AND single(this3 IN [(this)-[:HAS_VALUATION]->(this3:\`Valuation\`) WHERE single(this0 IN [(this3)-[:VALUATION_FOR]->(this0:\`Estate\`) WHERE (this0.area >= $param1 AND this0.floor >= $param2 AND this0.estateType IN $param3 AND single(this2 IN [(this0)-[:HAS_ADDRESS]->(this2:\`Address\`) WHERE single(this1 IN [(this2)-[:HAS_POSTAL_CODE]->(this1:\`PostalCode\`) WHERE this1.number IN $param4 | 1] WHERE true) | 1] WHERE true)) | 1] WHERE true) | 1] WHERE true)) AND this.archivedAt IS NULL)
+            WHERE ((this.price >= $param0 AND single(this3 IN [(this)-[:\`HAS_VALUATION\`]->(this3:\`Valuation\`) WHERE single(this0 IN [(this3)-[:\`VALUATION_FOR\`]->(this0:\`Estate\`) WHERE (this0.area >= $param1 AND this0.floor >= $param2 AND this0.estateType IN $param3 AND single(this2 IN [(this0)-[:\`HAS_ADDRESS\`]->(this2:\`Address\`) WHERE single(this1 IN [(this2)-[:\`HAS_POSTAL_CODE\`]->(this1:\`PostalCode\`) WHERE this1.number IN $param4 | 1] WHERE true) | 1] WHERE true)) | 1] WHERE true) | 1] WHERE true)) AND this.archivedAt IS NULL)
             WITH *
             SKIP $param5
             LIMIT $param6
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_VALUATION]->(this5:\`Valuation\`)
+                MATCH (this)-[this4:\`HAS_VALUATION\`]->(this5:\`Valuation\`)
                 WHERE this5.archivedAt IS NULL
                 CALL {
                     WITH this5
-                    MATCH (this5)-[this6:VALUATION_FOR]->(this7:\`Estate\`)
+                    MATCH (this5)-[this6:\`VALUATION_FOR\`]->(this7:\`Estate\`)
                     WHERE this7.archivedAt IS NULL
                     WITH this7 { .uuid } AS this7
                     RETURN head(collect(this7)) AS var8

--- a/packages/graphql/tests/tck/issues/2437.test.ts
+++ b/packages/graphql/tests/tck/issues/2437.test.ts
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
             WHERE (this.uuid = $param0 AND this.archivedAt IS NULL)
             CALL {
                 WITH this
-                MATCH (this)-[this0:IS_VALUATION_AGENT]->(this1:\`Valuation\`)
+                MATCH (this)-[this0:\`IS_VALUATION_AGENT\`]->(this1:\`Valuation\`)
                 WHERE this1.archivedAt IS NULL
                 WITH { node: { uuid: this1.uuid } } AS edge
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/2614.test.ts
+++ b/packages/graphql/tests/tck/issues/2614.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/2614", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Film\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Film\`)
                     WHERE this1.title = $param0
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this1
                     RETURN this1 AS var2

--- a/packages/graphql/tests/tck/issues/2670.test.ts
+++ b/packages/graphql/tests/tck/issues/2670.test.ts
@@ -64,23 +64,23 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -104,23 +104,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) < $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) < $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -144,23 +144,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) > $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) > $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -186,23 +186,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN min(size(this3.title)) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN min(size(this3.title)) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -228,23 +228,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN avg(size(this3.title)) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN avg(size(this3.title)) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -265,23 +265,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN max(this2.intValue) < $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN max(this2.intValue) < $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -307,23 +307,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN min(this2.intValue) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN min(this2.intValue) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -347,23 +347,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -387,23 +387,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = false
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = false
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -427,35 +427,35 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this6:IN_GENRE]-(this7:\`Movie\`)
-        RETURN count(this7) = $param1 AS var8
-    }
-    WITH *
-    WHERE NOT (var8 = true)
-    RETURN count(this1) > 0 AS var9
-}
-WITH *
-WHERE (var9 = false AND var5 = true)
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this6:\`IN_GENRE\`]-(this7:\`Movie\`)
+                    RETURN count(this7) = $param1 AS var8
+                }
+                WITH *
+                WHERE NOT (var8 = true)
+                RETURN count(this1) > 0 AS var9
+            }
+            WITH *
+            WHERE (var9 = false AND var5 = true)
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -483,23 +483,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) = 1 AS var5
-}
-WITH *
-WHERE var5 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) = 1 AS var5
+            }
+            WITH *
+            WHERE var5 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -523,23 +523,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-WITH *
-WHERE var5 = false
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            WITH *
+            WHERE var5 = false
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -572,28 +572,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this5:IN_GENRE]-(this6:\`Series\`)
-        RETURN min(size(this6.name)) = $param1 AS var7
-    }
-    WITH *
-    WHERE (var4 = true AND var7 = true)
-    RETURN count(this1) > 0 AS var8
-}
-WITH *
-WHERE var8 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this5:\`IN_GENRE\`]-(this6:\`Series\`)
+                    RETURN min(size(this6.name)) = $param1 AS var7
+                }
+                WITH *
+                WHERE (var4 = true AND var7 = true)
+                RETURN count(this1) > 0 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -630,28 +630,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this5:IN_GENRE]-(this6:\`Series\`)
-        RETURN min(size(this6.name)) = $param1 AS var7
-    }
-    WITH *
-    WHERE (var4 = true OR var7 = true)
-    RETURN count(this1) > 0 AS var8
-}
-WITH *
-WHERE var8 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this5:\`IN_GENRE\`]-(this6:\`Series\`)
+                    RETURN min(size(this6.name)) = $param1 AS var7
+                }
+                WITH *
+                WHERE (var4 = true OR var7 = true)
+                RETURN count(this1) > 0 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -688,28 +688,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this5:IN_GENRE]-(this6:\`Series\`)
-        RETURN min(size(this6.name)) = $param1 AS var7
-    }
-    WITH *
-    WHERE (var4 = true AND var7 = true)
-    RETURN count(this1) > 0 AS var8
-}
-WITH *
-WHERE var8 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this5:\`IN_GENRE\`]-(this6:\`Series\`)
+                    RETURN min(size(this6.name)) = $param1 AS var7
+                }
+                WITH *
+                WHERE (var4 = true AND var7 = true)
+                RETURN count(this1) > 0 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -742,28 +742,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    RETURN count(this1) = $param0 AS var2
-}
-CALL {
-    WITH this
-    MATCH (this)-[this3:IN_GENRE]->(this4:\`Genre\`)
-    CALL {
-        WITH this4
-        MATCH (this4)<-[this5:IN_GENRE]-(this6:\`Movie\`)
-        RETURN count(this6) = $param1 AS var7
-    }
-    WITH *
-    WHERE var7 = true
-    RETURN count(this4) > 0 AS var8
-}
-WITH *
-WHERE (var2 = true AND var8 = true)
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                RETURN count(this1) = $param0 AS var2
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[this3:\`IN_GENRE\`]->(this4:\`Genre\`)
+                CALL {
+                    WITH this4
+                    MATCH (this4)<-[this5:\`IN_GENRE\`]-(this6:\`Movie\`)
+                    RETURN count(this6) = $param1 AS var7
+                }
+                WITH *
+                WHERE var7 = true
+                RETURN count(this4) > 0 AS var8
+            }
+            WITH *
+            WHERE (var2 = true AND var8 = true)
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/2708.test.ts
+++ b/packages/graphql/tests/tck/issues/2708.test.ts
@@ -64,23 +64,23 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -104,23 +104,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) < $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) < $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -144,23 +144,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) > $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) > $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -184,23 +184,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN min(size(this2.title)) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN min(size(this2.title)) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -224,23 +224,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN avg(size(this2.title)) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN avg(size(this2.title)) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -261,23 +261,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN max(this1.intValue) < $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN max(this1.intValue) < $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -301,23 +301,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN min(this1.intValue) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN min(this1.intValue) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -341,23 +341,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -381,23 +381,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = false
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = false
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -421,35 +421,35 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this5:IN_GENRE]-(this6:\`Movie\`)
-        RETURN count(this6) = $param1 AS var7
-    }
-    WITH *
-    WHERE NOT (var7 = true)
-    RETURN count(this0) > 0 AS var8
-}
-WITH *
-WHERE (var8 = false AND var4 = true)
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this5:\`IN_GENRE\`]-(this6:\`Movie\`)
+                    RETURN count(this6) = $param1 AS var7
+                }
+                WITH *
+                WHERE NOT (var7 = true)
+                RETURN count(this0) > 0 AS var8
+            }
+            WITH *
+            WHERE (var8 = false AND var4 = true)
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -477,23 +477,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) = 1 AS var4
-}
-WITH *
-WHERE var4 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) = 1 AS var4
+            }
+            WITH *
+            WHERE var4 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -517,23 +517,23 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-WITH *
-WHERE var4 = false
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            WITH *
+            WHERE var4 = false
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -557,35 +557,35 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this5:IN_GENRE]-(this6:\`Movie\`)
-        RETURN count(this6) = $param1 AS var7
-    }
-    WITH *
-    WHERE NOT (var7 = true)
-    RETURN count(this0) > 0 AS var8
-}
-WITH *
-WHERE (var8 = false AND var4 = true)
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this5:\`IN_GENRE\`]-(this6:\`Movie\`)
+                    RETURN count(this6) = $param1 AS var7
+                }
+                WITH *
+                WHERE NOT (var7 = true)
+                RETURN count(this0) > 0 AS var8
+            }
+            WITH *
+            WHERE (var8 = false AND var4 = true)
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -622,28 +622,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this4:IN_GENRE]-(this5:\`Series\`)
-        RETURN min(size(this5.name)) = $param1 AS var6
-    }
-    WITH *
-    WHERE (var3 = true AND var6 = true)
-    RETURN count(this0) > 0 AS var7
-}
-WITH *
-WHERE var7 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this4:\`IN_GENRE\`]-(this5:\`Series\`)
+                    RETURN min(size(this5.name)) = $param1 AS var6
+                }
+                WITH *
+                WHERE (var3 = true AND var6 = true)
+                RETURN count(this0) > 0 AS var7
+            }
+            WITH *
+            WHERE var7 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -680,28 +680,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this4:IN_GENRE]-(this5:\`Series\`)
-        RETURN min(size(this5.name)) = $param1 AS var6
-    }
-    WITH *
-    WHERE (var3 = true OR var6 = true)
-    RETURN count(this0) > 0 AS var7
-}
-WITH *
-WHERE var7 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this4:\`IN_GENRE\`]-(this5:\`Series\`)
+                    RETURN min(size(this5.name)) = $param1 AS var6
+                }
+                WITH *
+                WHERE (var3 = true OR var6 = true)
+                RETURN count(this0) > 0 AS var7
+            }
+            WITH *
+            WHERE var7 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -733,28 +733,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this4:IN_GENRE]-(this5:\`Series\`)
-        RETURN min(size(this5.name)) = $param1 AS var6
-    }
-    WITH *
-    WHERE (var3 = true AND var6 = true)
-    RETURN count(this0) > 0 AS var7
-}
-WITH *
-WHERE var7 = true
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this4:\`IN_GENRE\`]-(this5:\`Series\`)
+                    RETURN min(size(this5.name)) = $param1 AS var6
+                }
+                WITH *
+                WHERE (var3 = true AND var6 = true)
+                RETURN count(this0) > 0 AS var7
+            }
+            WITH *
+            WHERE var7 = true
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -782,28 +782,28 @@ RETURN this { .title } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[:IN_GENRE]->(this0:\`Genre\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:IN_GENRE]-(this2:\`Movie\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    WITH *
-    WHERE var3 = true
-    RETURN count(this0) > 0 AS var4
-}
-CALL {
-    WITH this
-    MATCH (this)-[this5:IN_GENRE]->(this6:\`Genre\`)
-    RETURN count(this6) = $param1 AS var7
-}
-WITH *
-WHERE (var4 = true AND var7 = true)
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`IN_GENRE\`]->(this0:\`Genre\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`IN_GENRE\`]-(this2:\`Movie\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                WITH *
+                WHERE var3 = true
+                RETURN count(this0) > 0 AS var4
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[this5:\`IN_GENRE\`]->(this6:\`Genre\`)
+                RETURN count(this6) = $param1 AS var7
+            }
+            WITH *
+            WHERE (var4 = true AND var7 = true)
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/2709.test.ts
+++ b/packages/graphql/tests/tck/issues/2709.test.ts
@@ -107,7 +107,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:\`Netflix\`)
+                MATCH (this)<-[this0:\`DISTRIBUTED_BY\`]-(this1:\`Netflix\`)
                 WHERE this1.name = $param0
             }
             RETURN this { .title } AS this"
@@ -135,7 +135,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:\`Dishney\`)
+                MATCH (this)<-[this0:\`DISTRIBUTED_BY\`]-(this1:\`Dishney\`)
                 WHERE this1.name = $param0
             }
             RETURN this { .title } AS this"
@@ -161,7 +161,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1:\`Dishney\`)
+                MATCH (this)<-[this0:\`DISTRIBUTED_BY\`]-(this1:\`Dishney\`)
                 WHERE this1.name = $param0
             }
             RETURN this { .title } AS this"
@@ -187,7 +187,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Film\`)
             WHERE EXISTS {
-                MATCH (this)<-[this0:DISTRIBUTED_BY]-(this1)
+                MATCH (this)<-[this0:\`DISTRIBUTED_BY\`]-(this1)
                 WHERE (this1.name = $param0 AND (this1:\`Dishney\` OR this1:\`Prime\` OR this1:\`Netflix\`))
             }
             RETURN this { .title } AS this"

--- a/packages/graphql/tests/tck/issues/2713.test.ts
+++ b/packages/graphql/tests/tck/issues/2713.test.ts
@@ -64,35 +64,35 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:IN_GENRE]-(this3:\`Movie\`)
-        RETURN count(this3) = $param0 AS var4
-    }
-    WITH *
-    WHERE var4 = true
-    RETURN count(this1) > 0 AS var5
-}
-CALL {
-    WITH this
-    MATCH (this)-[this0:IN_GENRE]->(this1:\`Genre\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this6:IN_GENRE]-(this7:\`Movie\`)
-        RETURN count(this7) = $param1 AS var8
-    }
-    WITH *
-    WHERE NOT (var8 = true)
-    RETURN count(this1) > 0 AS var9
-}
-WITH *
-WHERE (var9 = false AND var5 = true)
-RETURN this { .title } AS this"
-`);
+            "MATCH (this:\`Movie\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`IN_GENRE\`]-(this3:\`Movie\`)
+                    RETURN count(this3) = $param0 AS var4
+                }
+                WITH *
+                WHERE var4 = true
+                RETURN count(this1) > 0 AS var5
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`IN_GENRE\`]->(this1:\`Genre\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this6:\`IN_GENRE\`]-(this7:\`Movie\`)
+                    RETURN count(this7) = $param1 AS var8
+                }
+                WITH *
+                WHERE NOT (var8 = true)
+                RETURN count(this1) > 0 AS var9
+            }
+            WITH *
+            WHERE (var9 = false AND var5 = true)
+            RETURN this { .title } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/2782.test.ts
+++ b/packages/graphql/tests/tck/issues/2782.test.ts
@@ -102,7 +102,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_colors0_disconnect0_rel:HAS_COLOR]->(this_colors0_disconnect0:Color)
+            OPTIONAL MATCH (this)-[this_colors0_disconnect0_rel:\`HAS_COLOR\`]->(this_colors0_disconnect0:Color)
             WHERE this_colors0_disconnect0.name = $updateProducts_args_update_colors0_disconnect0_where_Color_this_colors0_disconnect0param0
             CALL {
             	WITH this_colors0_disconnect0, this_colors0_disconnect0_rel, this
@@ -113,7 +113,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
             CALL {
             WITH this, this_colors0_disconnect0
-            OPTIONAL MATCH (this_colors0_disconnect0)<-[this_colors0_disconnect0_photos0_rel:OF_COLOR]-(this_colors0_disconnect0_photos0:Photo)
+            OPTIONAL MATCH (this_colors0_disconnect0)<-[this_colors0_disconnect0_photos0_rel:\`OF_COLOR\`]-(this_colors0_disconnect0_photos0:Photo)
             WHERE this_colors0_disconnect0_photos0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos0_where_Photo_this_colors0_disconnect0_photos0param0
             CALL {
             	WITH this_colors0_disconnect0_photos0, this_colors0_disconnect0_photos0_rel, this_colors0_disconnect0
@@ -124,7 +124,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
             CALL {
             WITH this, this_colors0_disconnect0, this_colors0_disconnect0_photos0
-            OPTIONAL MATCH (this_colors0_disconnect0_photos0)-[this_colors0_disconnect0_photos0_color0_rel:OF_COLOR]->(this_colors0_disconnect0_photos0_color0:Color)
+            OPTIONAL MATCH (this_colors0_disconnect0_photos0)-[this_colors0_disconnect0_photos0_color0_rel:\`OF_COLOR\`]->(this_colors0_disconnect0_photos0_color0:Color)
             WHERE this_colors0_disconnect0_photos0_color0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos_disconnect_color_where_Color_this_colors0_disconnect0_photos0_color0param0
             CALL {
             	WITH this_colors0_disconnect0_photos0_color0, this_colors0_disconnect0_photos0_color0_rel, this_colors0_disconnect0_photos0
@@ -142,7 +142,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_photos0_disconnect0_rel:HAS_PHOTO]->(this_photos0_disconnect0:Photo)
+            OPTIONAL MATCH (this)-[this_photos0_disconnect0_rel:\`HAS_PHOTO\`]->(this_photos0_disconnect0:Photo)
             WHERE this_photos0_disconnect0.id = $updateProducts_args_update_photos0_disconnect0_where_Photo_this_photos0_disconnect0param0
             CALL {
             	WITH this_photos0_disconnect0, this_photos0_disconnect0_rel, this
@@ -153,7 +153,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
             CALL {
             WITH this, this_photos0_disconnect0
-            OPTIONAL MATCH (this_photos0_disconnect0)-[this_photos0_disconnect0_color0_rel:OF_COLOR]->(this_photos0_disconnect0_color0:Color)
+            OPTIONAL MATCH (this_photos0_disconnect0)-[this_photos0_disconnect0_color0_rel:\`OF_COLOR\`]->(this_photos0_disconnect0_color0:Color)
             WHERE this_photos0_disconnect0_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Color_this_photos0_disconnect0_color0param0
             CALL {
             	WITH this_photos0_disconnect0_color0, this_photos0_disconnect0_color0_rel, this_photos0_disconnect0
@@ -169,7 +169,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_photos0_disconnect1_rel:HAS_PHOTO]->(this_photos0_disconnect1:Photo)
+            OPTIONAL MATCH (this)-[this_photos0_disconnect1_rel:\`HAS_PHOTO\`]->(this_photos0_disconnect1:Photo)
             WHERE this_photos0_disconnect1.id = $updateProducts_args_update_photos0_disconnect1_where_Photo_this_photos0_disconnect1param0
             CALL {
             	WITH this_photos0_disconnect1, this_photos0_disconnect1_rel, this
@@ -180,7 +180,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
             CALL {
             WITH this, this_photos0_disconnect1
-            OPTIONAL MATCH (this_photos0_disconnect1)-[this_photos0_disconnect1_color0_rel:OF_COLOR]->(this_photos0_disconnect1_color0:Color)
+            OPTIONAL MATCH (this_photos0_disconnect1)-[this_photos0_disconnect1_color0_rel:\`OF_COLOR\`]->(this_photos0_disconnect1_color0:Color)
             WHERE this_photos0_disconnect1_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Color_this_photos0_disconnect1_color0param0
             CALL {
             	WITH this_photos0_disconnect1_color0, this_photos0_disconnect1_color0_rel, this_photos0_disconnect1

--- a/packages/graphql/tests/tck/issues/2803.test.ts
+++ b/packages/graphql/tests/tck/issues/2803.test.ts
@@ -59,42 +59,42 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this1:\`Actor\`)
-        CALL {
-            WITH this1
-            MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
-            RETURN count(this3) > $param0 AS var4
-        }
-        WITH *
-        WHERE var4 = true
-        RETURN count(this1) > 0 AS var5
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this1:\`Actor\`)
-        CALL {
-            WITH this1
-            MATCH (this1)-[this6:ACTED_IN]->(this7:\`Movie\`)
-            RETURN count(this7) > $param1 AS var8
-        }
-        WITH *
-        WHERE NOT (var8 = true)
-        RETURN count(this1) > 0 AS var9
-    }
-    WITH *
-    WHERE (var9 = false AND var5 = true)
-    RETURN count(this0) > 0 AS var10
-}
-WITH *
-WHERE var10 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this1:\`Actor\`)
+                    CALL {
+                        WITH this1
+                        MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
+                        RETURN count(this3) > $param0 AS var4
+                    }
+                    WITH *
+                    WHERE var4 = true
+                    RETURN count(this1) > 0 AS var5
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this1:\`Actor\`)
+                    CALL {
+                        WITH this1
+                        MATCH (this1)-[this6:\`ACTED_IN\`]->(this7:\`Movie\`)
+                        RETURN count(this7) > $param1 AS var8
+                    }
+                    WITH *
+                    WHERE NOT (var8 = true)
+                    RETURN count(this1) > 0 AS var9
+                }
+                WITH *
+                WHERE (var9 = false AND var5 = true)
+                RETURN count(this0) > 0 AS var10
+            }
+            WITH *
+            WHERE var10 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -126,47 +126,47 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this4:\`Actor\`)
-        CALL {
-            WITH this4
-            MATCH (this4)-[this5:ACTED_IN]->(this6:\`Movie\`)
-            RETURN count(this6) > $param1 AS var7
-        }
-        WITH *
-        WHERE var7 = true
-        RETURN count(this4) > 0 AS var8
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this4:\`Actor\`)
-        CALL {
-            WITH this4
-            MATCH (this4)-[this9:ACTED_IN]->(this10:\`Movie\`)
-            RETURN count(this10) > $param2 AS var11
-        }
-        WITH *
-        WHERE NOT (var11 = true)
-        RETURN count(this4) > 0 AS var12
-    }
-    WITH *
-    WHERE (var3 = true AND (var12 = false AND var8 = true))
-    RETURN count(this0) > 0 AS var13
-}
-WITH *
-WHERE var13 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this4:\`Actor\`)
+                    CALL {
+                        WITH this4
+                        MATCH (this4)-[this5:\`ACTED_IN\`]->(this6:\`Movie\`)
+                        RETURN count(this6) > $param1 AS var7
+                    }
+                    WITH *
+                    WHERE var7 = true
+                    RETURN count(this4) > 0 AS var8
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this4:\`Actor\`)
+                    CALL {
+                        WITH this4
+                        MATCH (this4)-[this9:\`ACTED_IN\`]->(this10:\`Movie\`)
+                        RETURN count(this10) > $param2 AS var11
+                    }
+                    WITH *
+                    WHERE NOT (var11 = true)
+                    RETURN count(this4) > 0 AS var12
+                }
+                WITH *
+                WHERE (var3 = true AND (var12 = false AND var8 = true))
+                RETURN count(this0) > 0 AS var13
+            }
+            WITH *
+            WHERE var13 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -198,49 +198,49 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)<-[:ACTED_IN]-(this0:\`Actor\`)
-    CALL {
-        WITH this0
-        MATCH (this0)-[:ACTED_IN]->(this1:\`Movie\`)
-        CALL {
-            WITH this1
-            MATCH (this1)<-[:ACTED_IN]-(this2:\`Actor\`)
+            "MATCH (this:\`Movie\`)
             CALL {
-                WITH this2
-                MATCH (this2)-[this3:ACTED_IN]->(this4:\`Movie\`)
-                RETURN count(this4) > $param0 AS var5
+                WITH this
+                MATCH (this)<-[:\`ACTED_IN\`]-(this0:\`Actor\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)-[:\`ACTED_IN\`]->(this1:\`Movie\`)
+                    CALL {
+                        WITH this1
+                        MATCH (this1)<-[:\`ACTED_IN\`]-(this2:\`Actor\`)
+                        CALL {
+                            WITH this2
+                            MATCH (this2)-[this3:\`ACTED_IN\`]->(this4:\`Movie\`)
+                            RETURN count(this4) > $param0 AS var5
+                        }
+                        WITH *
+                        WHERE var5 = true
+                        RETURN count(this2) > 0 AS var6
+                    }
+                    CALL {
+                        WITH this1
+                        MATCH (this1)<-[:\`ACTED_IN\`]-(this2:\`Actor\`)
+                        CALL {
+                            WITH this2
+                            MATCH (this2)-[this7:\`ACTED_IN\`]->(this8:\`Movie\`)
+                            RETURN count(this8) > $param1 AS var9
+                        }
+                        WITH *
+                        WHERE NOT (var9 = true)
+                        RETURN count(this2) > 0 AS var10
+                    }
+                    WITH *
+                    WHERE (var10 = false AND var6 = true)
+                    RETURN count(this1) > 0 AS var11
+                }
+                WITH *
+                WHERE var11 = true
+                RETURN count(this0) > 0 AS var12
             }
             WITH *
-            WHERE var5 = true
-            RETURN count(this2) > 0 AS var6
-        }
-        CALL {
-            WITH this1
-            MATCH (this1)<-[:ACTED_IN]-(this2:\`Actor\`)
-            CALL {
-                WITH this2
-                MATCH (this2)-[this7:ACTED_IN]->(this8:\`Movie\`)
-                RETURN count(this8) > $param1 AS var9
-            }
-            WITH *
-            WHERE NOT (var9 = true)
-            RETURN count(this2) > 0 AS var10
-        }
-        WITH *
-        WHERE (var10 = false AND var6 = true)
-        RETURN count(this1) > 0 AS var11
-    }
-    WITH *
-    WHERE var11 = true
-    RETURN count(this0) > 0 AS var12
-}
-WITH *
-WHERE var12 = true
-RETURN this { .released } AS this"
-`);
+            WHERE var12 = true
+            RETURN this { .released } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -279,64 +279,64 @@ RETURN this { .released } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
-    RETURN avg(size(this1.name)) >= $param0 AS var2
-}
-CALL {
-    WITH this
-    MATCH (this)<-[:ACTED_IN]-(this3:\`Actor\`)
-    CALL {
-        WITH this3
-        MATCH (this3)-[this4:ACTED_IN]->(this5:\`Movie\`)
-        RETURN avg(this5.released) = $param1 AS var6
-    }
-    CALL {
-        WITH this3
-        MATCH (this3)-[:ACTED_IN]->(this7:\`Movie\`)
-        CALL {
-            WITH this7
-            MATCH (this7)<-[this8:ACTED_IN]-(this9:\`Actor\`)
-            RETURN avg(size(this9.name)) < $param2 AS var10
-        }
-        CALL {
-            WITH this7
-            MATCH (this7)<-[:ACTED_IN]-(this11:\`Actor\`)
+            "MATCH (this:\`Movie\`)
             CALL {
-                WITH this11
-                MATCH (this11)-[this12:ACTED_IN]->(this13:\`Movie\`)
-                RETURN count(this13) > $param3 AS var14
+                WITH this
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
+                RETURN avg(size(this1.name)) >= $param0 AS var2
+            }
+            CALL {
+                WITH this
+                MATCH (this)<-[:\`ACTED_IN\`]-(this3:\`Actor\`)
+                CALL {
+                    WITH this3
+                    MATCH (this3)-[this4:\`ACTED_IN\`]->(this5:\`Movie\`)
+                    RETURN avg(this5.released) = $param1 AS var6
+                }
+                CALL {
+                    WITH this3
+                    MATCH (this3)-[:\`ACTED_IN\`]->(this7:\`Movie\`)
+                    CALL {
+                        WITH this7
+                        MATCH (this7)<-[this8:\`ACTED_IN\`]-(this9:\`Actor\`)
+                        RETURN avg(size(this9.name)) < $param2 AS var10
+                    }
+                    CALL {
+                        WITH this7
+                        MATCH (this7)<-[:\`ACTED_IN\`]-(this11:\`Actor\`)
+                        CALL {
+                            WITH this11
+                            MATCH (this11)-[this12:\`ACTED_IN\`]->(this13:\`Movie\`)
+                            RETURN count(this13) > $param3 AS var14
+                        }
+                        WITH *
+                        WHERE var14 = true
+                        RETURN count(this11) > 0 AS var15
+                    }
+                    CALL {
+                        WITH this7
+                        MATCH (this7)<-[:\`ACTED_IN\`]-(this11:\`Actor\`)
+                        CALL {
+                            WITH this11
+                            MATCH (this11)-[this16:\`ACTED_IN\`]->(this17:\`Movie\`)
+                            RETURN count(this17) > $param4 AS var18
+                        }
+                        WITH *
+                        WHERE NOT (var18 = true)
+                        RETURN count(this11) > 0 AS var19
+                    }
+                    WITH *
+                    WHERE (var10 = true AND (var19 = false AND var15 = true))
+                    RETURN count(this7) > 0 AS var20
+                }
+                WITH *
+                WHERE (var6 = true AND var20 = true)
+                RETURN count(this3) = 1 AS var21
             }
             WITH *
-            WHERE var14 = true
-            RETURN count(this11) > 0 AS var15
-        }
-        CALL {
-            WITH this7
-            MATCH (this7)<-[:ACTED_IN]-(this11:\`Actor\`)
-            CALL {
-                WITH this11
-                MATCH (this11)-[this16:ACTED_IN]->(this17:\`Movie\`)
-                RETURN count(this17) > $param4 AS var18
-            }
-            WITH *
-            WHERE NOT (var18 = true)
-            RETURN count(this11) > 0 AS var19
-        }
-        WITH *
-        WHERE (var10 = true AND (var19 = false AND var15 = true))
-        RETURN count(this7) > 0 AS var20
-    }
-    WITH *
-    WHERE (var6 = true AND var20 = true)
-    RETURN count(this3) = 1 AS var21
-}
-WITH *
-WHERE (var2 = true AND var21 = true)
-RETURN this { .released } AS this"
-`);
+            WHERE (var2 = true AND var21 = true)
+            RETURN this { .released } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -373,42 +373,42 @@ RETURN this { .released } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:ACTED_IN]-(this3:\`Actor\`)
-        CALL {
-            WITH this3
-            MATCH (this3)-[this4:ACTED_IN]->(this5:\`Movie\`)
-            RETURN count(this5) > $param0 AS var6
-        }
-        WITH *
-        WHERE var6 = true
-        RETURN count(this3) > 0 AS var7
-    }
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:ACTED_IN]-(this3:\`Actor\`)
-        CALL {
-            WITH this3
-            MATCH (this3)-[this8:ACTED_IN]->(this9:\`Movie\`)
-            RETURN count(this9) > $param1 AS var10
-        }
-        WITH *
-        WHERE NOT (var10 = true)
-        RETURN count(this3) > 0 AS var11
-    }
-    WITH *
-    WHERE (var11 = false AND var7 = true)
-    RETURN count(this1) > 0 AS var12
-}
-WITH *
-WHERE var12 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`ACTED_IN\`]-(this3:\`Actor\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)-[this4:\`ACTED_IN\`]->(this5:\`Movie\`)
+                        RETURN count(this5) > $param0 AS var6
+                    }
+                    WITH *
+                    WHERE var6 = true
+                    RETURN count(this3) > 0 AS var7
+                }
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`ACTED_IN\`]-(this3:\`Actor\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)-[this8:\`ACTED_IN\`]->(this9:\`Movie\`)
+                        RETURN count(this9) > $param1 AS var10
+                    }
+                    WITH *
+                    WHERE NOT (var10 = true)
+                    RETURN count(this3) > 0 AS var11
+                }
+                WITH *
+                WHERE (var11 = false AND var7 = true)
+                RETURN count(this1) > 0 AS var12
+            }
+            WITH *
+            WHERE var12 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -443,47 +443,47 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
-        RETURN count(this2) = $param0 AS var3
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this4:ACTED_IN]-(this5:\`Actor\`)
-        CALL {
-            WITH this5
-            MATCH (this5)-[this6:ACTED_IN]->(this7:\`Movie\`)
-            RETURN count(this7) > $param1 AS var8
-        }
-        WITH *
-        WHERE var8 = true
-        RETURN count(this5) > 0 AS var9
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this4:ACTED_IN]-(this5:\`Actor\`)
-        CALL {
-            WITH this5
-            MATCH (this5)-[this10:ACTED_IN]->(this11:\`Movie\`)
-            RETURN count(this11) > $param2 AS var12
-        }
-        WITH *
-        WHERE NOT (var12 = true)
-        RETURN count(this5) > 0 AS var13
-    }
-    WITH *
-    WHERE (var3 = true AND (var13 = false AND var9 = true))
-    RETURN count(this0) > 0 AS var14
-}
-WITH *
-WHERE var14 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    RETURN count(this2) = $param0 AS var3
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this4:\`ACTED_IN\`]-(this5:\`Actor\`)
+                    CALL {
+                        WITH this5
+                        MATCH (this5)-[this6:\`ACTED_IN\`]->(this7:\`Movie\`)
+                        RETURN count(this7) > $param1 AS var8
+                    }
+                    WITH *
+                    WHERE var8 = true
+                    RETURN count(this5) > 0 AS var9
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this4:\`ACTED_IN\`]-(this5:\`Actor\`)
+                    CALL {
+                        WITH this5
+                        MATCH (this5)-[this10:\`ACTED_IN\`]->(this11:\`Movie\`)
+                        RETURN count(this11) > $param2 AS var12
+                    }
+                    WITH *
+                    WHERE NOT (var12 = true)
+                    RETURN count(this5) > 0 AS var13
+                }
+                WITH *
+                WHERE (var3 = true AND (var13 = false AND var9 = true))
+                RETURN count(this0) > 0 AS var14
+            }
+            WITH *
+            WHERE var14 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -525,49 +525,49 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
-    CALL {
-        WITH this1
-        MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
-        CALL {
-            WITH this3
-            MATCH (this3)<-[this4:ACTED_IN]-(this5:\`Actor\`)
+            "MATCH (this:\`Movie\`)
             CALL {
-                WITH this5
-                MATCH (this5)-[this6:ACTED_IN]->(this7:\`Movie\`)
-                RETURN count(this7) > $param0 AS var8
+                WITH this
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)<-[this4:\`ACTED_IN\`]-(this5:\`Actor\`)
+                        CALL {
+                            WITH this5
+                            MATCH (this5)-[this6:\`ACTED_IN\`]->(this7:\`Movie\`)
+                            RETURN count(this7) > $param0 AS var8
+                        }
+                        WITH *
+                        WHERE var8 = true
+                        RETURN count(this5) > 0 AS var9
+                    }
+                    CALL {
+                        WITH this3
+                        MATCH (this3)<-[this4:\`ACTED_IN\`]-(this5:\`Actor\`)
+                        CALL {
+                            WITH this5
+                            MATCH (this5)-[this10:\`ACTED_IN\`]->(this11:\`Movie\`)
+                            RETURN count(this11) > $param1 AS var12
+                        }
+                        WITH *
+                        WHERE NOT (var12 = true)
+                        RETURN count(this5) > 0 AS var13
+                    }
+                    WITH *
+                    WHERE (var13 = false AND var9 = true)
+                    RETURN count(this3) > 0 AS var14
+                }
+                WITH *
+                WHERE var14 = true
+                RETURN count(this1) > 0 AS var15
             }
             WITH *
-            WHERE var8 = true
-            RETURN count(this5) > 0 AS var9
-        }
-        CALL {
-            WITH this3
-            MATCH (this3)<-[this4:ACTED_IN]-(this5:\`Actor\`)
-            CALL {
-                WITH this5
-                MATCH (this5)-[this10:ACTED_IN]->(this11:\`Movie\`)
-                RETURN count(this11) > $param1 AS var12
-            }
-            WITH *
-            WHERE NOT (var12 = true)
-            RETURN count(this5) > 0 AS var13
-        }
-        WITH *
-        WHERE (var13 = false AND var9 = true)
-        RETURN count(this3) > 0 AS var14
-    }
-    WITH *
-    WHERE var14 = true
-    RETURN count(this1) > 0 AS var15
-}
-WITH *
-WHERE var15 = true
-RETURN this { .released } AS this"
-`);
+            WHERE var15 = true
+            RETURN this { .released } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -610,64 +610,64 @@ RETURN this { .released } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
-    RETURN avg(size(this1.name)) >= $param0 AS var2
-}
-CALL {
-    WITH this
-    MATCH (this)<-[this3:ACTED_IN]-(this4:\`Actor\`)
-    CALL {
-        WITH this4
-        MATCH (this4)-[this5:ACTED_IN]->(this6:\`Movie\`)
-        RETURN avg(this6.released) = $param1 AS var7
-    }
-    CALL {
-        WITH this4
-        MATCH (this4)-[this8:ACTED_IN]->(this9:\`Movie\`)
-        CALL {
-            WITH this9
-            MATCH (this9)<-[this10:ACTED_IN]-(this11:\`Actor\`)
-            RETURN avg(size(this11.name)) < $param2 AS var12
-        }
-        CALL {
-            WITH this9
-            MATCH (this9)<-[this13:ACTED_IN]-(this14:\`Actor\`)
+            "MATCH (this:\`Movie\`)
             CALL {
-                WITH this14
-                MATCH (this14)-[this15:ACTED_IN]->(this16:\`Movie\`)
-                RETURN count(this16) > $param3 AS var17
+                WITH this
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
+                RETURN avg(size(this1.name)) >= $param0 AS var2
+            }
+            CALL {
+                WITH this
+                MATCH (this)<-[this3:\`ACTED_IN\`]-(this4:\`Actor\`)
+                CALL {
+                    WITH this4
+                    MATCH (this4)-[this5:\`ACTED_IN\`]->(this6:\`Movie\`)
+                    RETURN avg(this6.released) = $param1 AS var7
+                }
+                CALL {
+                    WITH this4
+                    MATCH (this4)-[this8:\`ACTED_IN\`]->(this9:\`Movie\`)
+                    CALL {
+                        WITH this9
+                        MATCH (this9)<-[this10:\`ACTED_IN\`]-(this11:\`Actor\`)
+                        RETURN avg(size(this11.name)) < $param2 AS var12
+                    }
+                    CALL {
+                        WITH this9
+                        MATCH (this9)<-[this13:\`ACTED_IN\`]-(this14:\`Actor\`)
+                        CALL {
+                            WITH this14
+                            MATCH (this14)-[this15:\`ACTED_IN\`]->(this16:\`Movie\`)
+                            RETURN count(this16) > $param3 AS var17
+                        }
+                        WITH *
+                        WHERE var17 = true
+                        RETURN count(this14) > 0 AS var18
+                    }
+                    CALL {
+                        WITH this9
+                        MATCH (this9)<-[this13:\`ACTED_IN\`]-(this14:\`Actor\`)
+                        CALL {
+                            WITH this14
+                            MATCH (this14)-[this19:\`ACTED_IN\`]->(this20:\`Movie\`)
+                            RETURN count(this20) > $param4 AS var21
+                        }
+                        WITH *
+                        WHERE NOT (var21 = true)
+                        RETURN count(this14) > 0 AS var22
+                    }
+                    WITH *
+                    WHERE (var12 = true AND (var22 = false AND var18 = true))
+                    RETURN count(this9) > 0 AS var23
+                }
+                WITH *
+                WHERE (var7 = true AND var23 = true)
+                RETURN count(this4) > 0 AS var24
             }
             WITH *
-            WHERE var17 = true
-            RETURN count(this14) > 0 AS var18
-        }
-        CALL {
-            WITH this9
-            MATCH (this9)<-[this13:ACTED_IN]-(this14:\`Actor\`)
-            CALL {
-                WITH this14
-                MATCH (this14)-[this19:ACTED_IN]->(this20:\`Movie\`)
-                RETURN count(this20) > $param4 AS var21
-            }
-            WITH *
-            WHERE NOT (var21 = true)
-            RETURN count(this14) > 0 AS var22
-        }
-        WITH *
-        WHERE (var12 = true AND (var22 = false AND var18 = true))
-        RETURN count(this9) > 0 AS var23
-    }
-    WITH *
-    WHERE (var7 = true AND var23 = true)
-    RETURN count(this4) > 0 AS var24
-}
-WITH *
-WHERE (var2 = true AND var24 = true)
-RETURN this { .released } AS this"
-`);
+            WHERE (var2 = true AND var24 = true)
+            RETURN this { .released } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -700,42 +700,42 @@ RETURN this { .released } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
-        CALL {
-            WITH this2
-            MATCH (this2)-[this3:ACTED_IN]->(this4:\`Movie\`)
-            RETURN count(this4) > $param0 AS var5
-        }
-        WITH *
-        WHERE var5 = true
-        RETURN count(this2) > 0 AS var6
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
-        CALL {
-            WITH this2
-            MATCH (this2)-[this7:ACTED_IN]->(this8:\`Movie\`)
-            RETURN count(this8) > $param1 AS var9
-        }
-        WITH *
-        WHERE NOT (var9 = true)
-        RETURN count(this2) > 0 AS var10
-    }
-    WITH *
-    WHERE (var10 = false AND var6 = true)
-    RETURN count(this0) > 0 AS var11
-}
-WITH *
-WHERE var11 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    CALL {
+                        WITH this2
+                        MATCH (this2)-[this3:\`ACTED_IN\`]->(this4:\`Movie\`)
+                        RETURN count(this4) > $param0 AS var5
+                    }
+                    WITH *
+                    WHERE var5 = true
+                    RETURN count(this2) > 0 AS var6
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    CALL {
+                        WITH this2
+                        MATCH (this2)-[this7:\`ACTED_IN\`]->(this8:\`Movie\`)
+                        RETURN count(this8) > $param1 AS var9
+                    }
+                    WITH *
+                    WHERE NOT (var9 = true)
+                    RETURN count(this2) > 0 AS var10
+                }
+                WITH *
+                WHERE (var10 = false AND var6 = true)
+                RETURN count(this0) > 0 AS var11
+            }
+            WITH *
+            WHERE var11 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -765,42 +765,42 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[:ACTED_IN]-(this2:\`Actor\`)
-        CALL {
-            WITH this2
-            MATCH (this2)-[this3:ACTED_IN]->(this4:\`Movie\`)
-            RETURN count(this4) > $param0 AS var5
-        }
-        WITH *
-        WHERE var5 = true
-        RETURN count(this2) > 0 AS var6
-    }
-    CALL {
-        WITH this1
-        MATCH (this1)<-[:ACTED_IN]-(this2:\`Actor\`)
-        CALL {
-            WITH this2
-            MATCH (this2)-[this7:ACTED_IN]->(this8:\`Movie\`)
-            RETURN count(this8) > $param1 AS var9
-        }
-        WITH *
-        WHERE NOT (var9 = true)
-        RETURN count(this2) > 0 AS var10
-    }
-    WITH *
-    WHERE (var10 = false AND var6 = true)
-    RETURN count(this1) > 0 AS var11
-}
-WITH *
-WHERE var11 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    CALL {
+                        WITH this2
+                        MATCH (this2)-[this3:\`ACTED_IN\`]->(this4:\`Movie\`)
+                        RETURN count(this4) > $param0 AS var5
+                    }
+                    WITH *
+                    WHERE var5 = true
+                    RETURN count(this2) > 0 AS var6
+                }
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    CALL {
+                        WITH this2
+                        MATCH (this2)-[this7:\`ACTED_IN\`]->(this8:\`Movie\`)
+                        RETURN count(this8) > $param1 AS var9
+                    }
+                    WITH *
+                    WHERE NOT (var9 = true)
+                    RETURN count(this2) > 0 AS var10
+                }
+                WITH *
+                WHERE (var10 = false AND var6 = true)
+                RETURN count(this1) > 0 AS var11
+            }
+            WITH *
+            WHERE var11 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -836,37 +836,37 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Movie\`)
-CALL {
-    WITH this
-    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
-    CALL {
-        WITH this1
-        MATCH (this1)-[:ACTED_IN]->(this2:\`Movie\`)
-        CALL {
-            WITH this2
-            MATCH (this2)<-[this3:ACTED_IN]-(this4:\`Actor\`)
+            "MATCH (this:\`Movie\`)
             CALL {
-                WITH this4
-                MATCH (this4)-[this5:ACTED_IN]->(this6:\`Movie\`)
-                RETURN count(this6) > $param0 AS var7
+                WITH this
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)-[:\`ACTED_IN\`]->(this2:\`Movie\`)
+                    CALL {
+                        WITH this2
+                        MATCH (this2)<-[this3:\`ACTED_IN\`]-(this4:\`Actor\`)
+                        CALL {
+                            WITH this4
+                            MATCH (this4)-[this5:\`ACTED_IN\`]->(this6:\`Movie\`)
+                            RETURN count(this6) > $param0 AS var7
+                        }
+                        WITH *
+                        WHERE var7 = true
+                        RETURN count(this4) > 0 AS var8
+                    }
+                    WITH *
+                    WHERE var8 = false
+                    RETURN count(this2) = 1 AS var9
+                }
+                WITH *
+                WHERE var9 = true
+                RETURN count(this1) > 0 AS var10
             }
             WITH *
-            WHERE var7 = true
-            RETURN count(this4) > 0 AS var8
-        }
-        WITH *
-        WHERE var8 = false
-        RETURN count(this2) = 1 AS var9
-    }
-    WITH *
-    WHERE var9 = true
-    RETURN count(this1) > 0 AS var10
-}
-WITH *
-WHERE var10 = true
-RETURN this { .released } AS this"
-`);
+            WHERE var10 = true
+            RETURN this { .released } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -897,35 +897,35 @@ RETURN this { .released } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
-        RETURN avg(this1.screenTime) <= $param0 AS var3
-    }
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this4:\`Actor\`)
-        CALL {
-            WITH this4
-            MATCH (this4)-[this5:ACTED_IN]->(this6:\`Movie\`)
-            RETURN avg(this5.screenTime) <= $param1 AS var7
-        }
-        WITH *
-        WHERE var7 = true
-        RETURN count(this4) > 0 AS var8
-    }
-    WITH *
-    WHERE (var3 = true AND var8 = false)
-    RETURN count(this0) = 1 AS var9
-}
-WITH *
-WHERE var9 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
+                    RETURN avg(this1.screenTime) <= $param0 AS var3
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this4:\`Actor\`)
+                    CALL {
+                        WITH this4
+                        MATCH (this4)-[this5:\`ACTED_IN\`]->(this6:\`Movie\`)
+                        RETURN avg(this5.screenTime) <= $param1 AS var7
+                    }
+                    WITH *
+                    WHERE var7 = true
+                    RETURN count(this4) > 0 AS var8
+                }
+                WITH *
+                WHERE (var3 = true AND var8 = false)
+                RETURN count(this0) = 1 AS var9
+            }
+            WITH *
+            WHERE var9 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -959,30 +959,30 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:ACTED_IN]-(this3:\`Actor\`)
-        CALL {
-            WITH this3
-            MATCH (this3)-[this4:ACTED_IN]->(this5:\`Movie\`)
-            RETURN count(this5) > $param0 AS var6
-        }
-        WITH *
-        WHERE ($param1 IN this2.roles AND var6 = true)
-        RETURN count(this3) > 0 AS var7
-    }
-    WITH *
-    WHERE ($param2 IN this0.roles AND var7 = false)
-    RETURN count(this1) = 1 AS var8
-}
-WITH *
-WHERE var8 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`ACTED_IN\`]-(this3:\`Actor\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)-[this4:\`ACTED_IN\`]->(this5:\`Movie\`)
+                        RETURN count(this5) > $param0 AS var6
+                    }
+                    WITH *
+                    WHERE ($param1 IN this2.roles AND var6 = true)
+                    RETURN count(this3) > 0 AS var7
+                }
+                WITH *
+                WHERE ($param2 IN this0.roles AND var7 = false)
+                RETURN count(this1) = 1 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1019,30 +1019,30 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:ACTED_IN]-(this3:\`Actor\`)
-        CALL {
-            WITH this3
-            MATCH (this3)-[this4:ACTED_IN]->(this5:\`Movie\`)
-            RETURN count(this5) > $param0 AS var6
-        }
-        WITH *
-        WHERE ($param1 IN this2.roles AND (this3.name = $param2 AND var6 = true))
-        RETURN count(this3) > 0 AS var7
-    }
-    WITH *
-    WHERE var7 = true
-    RETURN count(this1) = 1 AS var8
-}
-WITH *
-WHERE var8 = true
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`ACTED_IN\`]-(this3:\`Actor\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)-[this4:\`ACTED_IN\`]->(this5:\`Movie\`)
+                        RETURN count(this5) > $param0 AS var6
+                    }
+                    WITH *
+                    WHERE ($param1 IN this2.roles AND (this3.name = $param2 AND var6 = true))
+                    RETURN count(this3) > 0 AS var7
+                }
+                WITH *
+                WHERE var7 = true
+                RETURN count(this1) = 1 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1068,49 +1068,49 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this1:\`Actor\`)
-        CALL {
-            WITH this1
-            MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
-            RETURN count(this3) > $param0 AS var4
-        }
-        WITH *
-        WHERE (this1.name = $param1 AND var4 = true)
-        RETURN count(this1) > 0 AS var5
-    }
-    WITH *
-    WHERE var5 = true
-    RETURN count(this0) > 0 AS var6
-}
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this7:\`Actor\`)
-        CALL {
-            WITH this7
-            MATCH (this7)-[this8:ACTED_IN]->(this9:\`Movie\`)
-            RETURN count(this9) > $param2 AS var10
-        }
-        WITH *
-        WHERE (this7.name = $param3 AND var10 = true)
-        RETURN count(this7) > 0 AS var11
-    }
-    WITH *
-    WHERE NOT (var11 = true)
-    RETURN count(this0) > 0 AS var12
-}
-WITH *
-WHERE (var12 = false AND var6 = true)
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this1:\`Actor\`)
+                    CALL {
+                        WITH this1
+                        MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
+                        RETURN count(this3) > $param0 AS var4
+                    }
+                    WITH *
+                    WHERE (this1.name = $param1 AND var4 = true)
+                    RETURN count(this1) > 0 AS var5
+                }
+                WITH *
+                WHERE var5 = true
+                RETURN count(this0) > 0 AS var6
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this7:\`Actor\`)
+                    CALL {
+                        WITH this7
+                        MATCH (this7)-[this8:\`ACTED_IN\`]->(this9:\`Movie\`)
+                        RETURN count(this9) > $param2 AS var10
+                    }
+                    WITH *
+                    WHERE (this7.name = $param3 AND var10 = true)
+                    RETURN count(this7) > 0 AS var11
+                }
+                WITH *
+                WHERE NOT (var11 = true)
+                RETURN count(this0) > 0 AS var12
+            }
+            WITH *
+            WHERE (var12 = false AND var6 = true)
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1146,49 +1146,49 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this1:\`Actor\`)
-        CALL {
-            WITH this1
-            MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
-            RETURN count(this3) > $param0 AS var4
-        }
-        WITH *
-        WHERE (this1.name = $param1 OR var4 = true)
-        RETURN count(this1) > 0 AS var5
-    }
-    WITH *
-    WHERE var5 = true
-    RETURN count(this0) > 0 AS var6
-}
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this7:\`Actor\`)
-        CALL {
-            WITH this7
-            MATCH (this7)-[this8:ACTED_IN]->(this9:\`Movie\`)
-            RETURN count(this9) > $param2 AS var10
-        }
-        WITH *
-        WHERE (this7.name = $param3 OR var10 = true)
-        RETURN count(this7) > 0 AS var11
-    }
-    WITH *
-    WHERE NOT (var11 = true)
-    RETURN count(this0) > 0 AS var12
-}
-WITH *
-WHERE (var12 = false AND var6 = true)
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this1:\`Actor\`)
+                    CALL {
+                        WITH this1
+                        MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
+                        RETURN count(this3) > $param0 AS var4
+                    }
+                    WITH *
+                    WHERE (this1.name = $param1 OR var4 = true)
+                    RETURN count(this1) > 0 AS var5
+                }
+                WITH *
+                WHERE var5 = true
+                RETURN count(this0) > 0 AS var6
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this7:\`Actor\`)
+                    CALL {
+                        WITH this7
+                        MATCH (this7)-[this8:\`ACTED_IN\`]->(this9:\`Movie\`)
+                        RETURN count(this9) > $param2 AS var10
+                    }
+                    WITH *
+                    WHERE (this7.name = $param3 OR var10 = true)
+                    RETURN count(this7) > 0 AS var11
+                }
+                WITH *
+                WHERE NOT (var11 = true)
+                RETURN count(this0) > 0 AS var12
+            }
+            WITH *
+            WHERE (var12 = false AND var6 = true)
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1224,49 +1224,49 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this1:\`Actor\`)
-        CALL {
-            WITH this1
-            MATCH (this1)-[this2:ACTED_IN]->(this3:\`Movie\`)
-            RETURN count(this3) > $param0 AS var4
-        }
-        WITH *
-        WHERE (this1.name = $param1 AND var4 = true)
-        RETURN count(this1) > 0 AS var5
-    }
-    WITH *
-    WHERE var5 = true
-    RETURN count(this0) > 0 AS var6
-}
-CALL {
-    WITH this
-    MATCH (this)-[:ACTED_IN]->(this0:\`Movie\`)
-    CALL {
-        WITH this0
-        MATCH (this0)<-[:ACTED_IN]-(this7:\`Actor\`)
-        CALL {
-            WITH this7
-            MATCH (this7)-[this8:ACTED_IN]->(this9:\`Movie\`)
-            RETURN count(this9) > $param2 AS var10
-        }
-        WITH *
-        WHERE (this7.name = $param3 AND var10 = true)
-        RETURN count(this7) > 0 AS var11
-    }
-    WITH *
-    WHERE NOT (var11 = true)
-    RETURN count(this0) > 0 AS var12
-}
-WITH *
-WHERE (var12 = false AND var6 = true)
-RETURN this { .name } AS this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this1:\`Actor\`)
+                    CALL {
+                        WITH this1
+                        MATCH (this1)-[this2:\`ACTED_IN\`]->(this3:\`Movie\`)
+                        RETURN count(this3) > $param0 AS var4
+                    }
+                    WITH *
+                    WHERE (this1.name = $param1 AND var4 = true)
+                    RETURN count(this1) > 0 AS var5
+                }
+                WITH *
+                WHERE var5 = true
+                RETURN count(this0) > 0 AS var6
+            }
+            CALL {
+                WITH this
+                MATCH (this)-[:\`ACTED_IN\`]->(this0:\`Movie\`)
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[:\`ACTED_IN\`]-(this7:\`Actor\`)
+                    CALL {
+                        WITH this7
+                        MATCH (this7)-[this8:\`ACTED_IN\`]->(this9:\`Movie\`)
+                        RETURN count(this9) > $param2 AS var10
+                    }
+                    WITH *
+                    WHERE (this7.name = $param3 AND var10 = true)
+                    RETURN count(this7) > 0 AS var11
+                }
+                WITH *
+                WHERE NOT (var11 = true)
+                RETURN count(this0) > 0 AS var12
+            }
+            WITH *
+            WHERE (var12 = false AND var6 = true)
+            RETURN this { .name } AS this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1311,31 +1311,31 @@ RETURN this { .name } AS this"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:ACTED_IN]-(this3:\`Actor\`)
-        CALL {
-            WITH this3
-            MATCH (this3)-[this4:ACTED_IN]->(this5:\`Movie\`)
-            RETURN count(this5) > $param0 AS var6
-        }
-        WITH *
-        WHERE ($param1 IN this2.roles AND var6 = true)
-        RETURN count(this3) > 0 AS var7
-    }
-    WITH *
-    WHERE ($param2 IN this0.roles AND var7 = false)
-    RETURN count(this1) = 1 AS var8
-}
-WITH *
-WHERE var8 = true
-SET this.name = $this_update_name
-RETURN collect(DISTINCT this { .name }) AS data"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`ACTED_IN\`]-(this3:\`Actor\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)-[this4:\`ACTED_IN\`]->(this5:\`Movie\`)
+                        RETURN count(this5) > $param0 AS var6
+                    }
+                    WITH *
+                    WHERE ($param1 IN this2.roles AND var6 = true)
+                    RETURN count(this3) > 0 AS var7
+                }
+                WITH *
+                WHERE ($param2 IN this0.roles AND var7 = false)
+                RETURN count(this1) = 1 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            SET this.name = $this_update_name
+            RETURN collect(DISTINCT this { .name }) AS data"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
@@ -1374,30 +1374,30 @@ RETURN collect(DISTINCT this { .name }) AS data"
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-"MATCH (this:\`Actor\`)
-CALL {
-    WITH this
-    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
-    CALL {
-        WITH this1
-        MATCH (this1)<-[this2:ACTED_IN]-(this3:\`Actor\`)
-        CALL {
-            WITH this3
-            MATCH (this3)-[this4:ACTED_IN]->(this5:\`Movie\`)
-            RETURN count(this5) > $param0 AS var6
-        }
-        WITH *
-        WHERE ($param1 IN this2.roles AND (this3.name = $param2 AND var6 = true))
-        RETURN count(this3) > 0 AS var7
-    }
-    WITH *
-    WHERE var7 = true
-    RETURN count(this1) = 1 AS var8
-}
-WITH *
-WHERE var8 = true
-DETACH DELETE this"
-`);
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
+                CALL {
+                    WITH this1
+                    MATCH (this1)<-[this2:\`ACTED_IN\`]-(this3:\`Actor\`)
+                    CALL {
+                        WITH this3
+                        MATCH (this3)-[this4:\`ACTED_IN\`]->(this5:\`Movie\`)
+                        RETURN count(this5) > $param0 AS var6
+                    }
+                    WITH *
+                    WHERE ($param1 IN this2.roles AND (this3.name = $param2 AND var6 = true))
+                    RETURN count(this3) > 0 AS var7
+                }
+                WITH *
+                WHERE var7 = true
+                RETURN count(this1) = 1 AS var8
+            }
+            WITH *
+            WHERE var8 = true
+            DETACH DELETE this"
+        `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{

--- a/packages/graphql/tests/tck/issues/2812.test.ts
+++ b/packages/graphql/tests/tck/issues/2812.test.ts
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         create_this8.fieldA = create_var6.fieldA,
                         create_this8.fieldB = create_var6.fieldB,
                         create_this8.id = randomUUID()
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     WITH *
                     CALL apoc.util.validate(NOT ((create_var6.fieldA IS NULL OR any(create_var11 IN [\\"role-A\\"] WHERE any(create_var10 IN $auth.roles WHERE create_var10 = create_var11))) AND (create_var6.fieldB IS NULL OR any(create_var13 IN [\\"role-B\\"] WHERE any(create_var12 IN $auth.roles WHERE create_var12 = create_var13)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN collect(NULL) AS create_var14
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this2.nodeCreatedBy IS NOT NULL AND create_this2.nodeCreatedBy = $create_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
@@ -209,7 +209,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         create_this8.fieldA = create_var6.fieldA,
                         create_this8.fieldB = create_var6.fieldB,
                         create_this8.id = randomUUID()
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     WITH *
                     CALL apoc.util.validate(NOT ((create_var6.fieldA IS NULL OR any(create_var11 IN [\\"role-A\\"] WHERE any(create_var10 IN $auth.roles WHERE create_var10 = create_var11))) AND (create_var6.fieldB IS NULL OR any(create_var13 IN [\\"role-B\\"] WHERE any(create_var12 IN $auth.roles WHERE create_var12 = create_var13)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     RETURN collect(NULL) AS create_var14
@@ -220,7 +220,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this2.nodeCreatedBy IS NOT NULL AND create_this2.nodeCreatedBy = $create_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
@@ -322,7 +322,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         create_this8.name = create_var6.name,
                         create_this8.nodeCreatedBy = create_var6.nodeCreatedBy,
                         create_this8.id = randomUUID()
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     RETURN collect(NULL) AS create_var10
                 }
                 WITH *
@@ -331,7 +331,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this2.nodeCreatedBy IS NOT NULL AND create_this2.nodeCreatedBy = $create_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3

--- a/packages/graphql/tests/tck/issues/2871.test.ts
+++ b/packages/graphql/tests/tck/issues/2871.test.ts
@@ -63,8 +63,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`FirstLevel\`)
-            WHERE single(this0 IN [(this)-[:HAS_SECOND_LEVEL]->(this0:\`SecondLevel\`) WHERE EXISTS {
-                MATCH (this0)-[:HAS_THIRD_LEVEL]->(this1:\`ThirdLevel\`)
+            WHERE single(this0 IN [(this)-[:\`HAS_SECOND_LEVEL\`]->(this0:\`SecondLevel\`) WHERE EXISTS {
+                MATCH (this0)-[:\`HAS_THIRD_LEVEL\`]->(this1:\`ThirdLevel\`)
                 WHERE this1.id = $param0
             } | 1] WHERE true)
             RETURN this { .id, createdAt: apoc.date.convertFormat(toString(this.createdAt), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
@@ -91,11 +91,11 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`FirstLevel\`)
-            WHERE single(this0 IN [(this)-[:HAS_SECOND_LEVEL]->(this0:\`SecondLevel\`) WHERE (EXISTS {
-                MATCH (this0)-[:HAS_THIRD_LEVEL]->(this1:\`ThirdLevel\`)
+            WHERE single(this0 IN [(this)-[:\`HAS_SECOND_LEVEL\`]->(this0:\`SecondLevel\`) WHERE (EXISTS {
+                MATCH (this0)-[:\`HAS_THIRD_LEVEL\`]->(this1:\`ThirdLevel\`)
                 WHERE this1.id = $param0
             } AND NOT (EXISTS {
-                MATCH (this0)-[:HAS_THIRD_LEVEL]->(this1:\`ThirdLevel\`)
+                MATCH (this0)-[:\`HAS_THIRD_LEVEL\`]->(this1:\`ThirdLevel\`)
                 WHERE NOT (this1.id = $param0)
             })) | 1] WHERE true)
             RETURN this { .id, createdAt: apoc.date.convertFormat(toString(this.createdAt), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"
@@ -122,8 +122,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`FirstLevel\`)
-            WHERE single(this0 IN [(this)-[:HAS_SECOND_LEVEL]->(this0:\`SecondLevel\`) WHERE NOT (EXISTS {
-                MATCH (this0)-[:HAS_THIRD_LEVEL]->(this1:\`ThirdLevel\`)
+            WHERE single(this0 IN [(this)-[:\`HAS_SECOND_LEVEL\`]->(this0:\`SecondLevel\`) WHERE NOT (EXISTS {
+                MATCH (this0)-[:\`HAS_THIRD_LEVEL\`]->(this1:\`ThirdLevel\`)
                 WHERE this1.id = $param0
             }) | 1] WHERE true)
             RETURN this { .id, createdAt: apoc.date.convertFormat(toString(this.createdAt), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS this"

--- a/packages/graphql/tests/tck/issues/324.test.ts
+++ b/packages/graphql/tests/tck/issues/324.test.ts
@@ -98,11 +98,11 @@ describe("#324", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_car0_relationship:CAR]->(this_car0:Car)
+            	MATCH (this)-[this_car0_relationship:\`CAR\`]->(this_car0:Car)
             	WITH this, this_car0
             	CALL {
             		WITH this, this_car0
-            		MATCH (this_car0)-[this_car0_manufacturer0_relationship:MANUFACTURER]->(this_car0_manufacturer0:Manufacturer)
+            		MATCH (this_car0)-[this_car0_manufacturer0_relationship:\`MANUFACTURER\`]->(this_car0_manufacturer0:Manufacturer)
             		SET this_car0_manufacturer0.name = $this_update_car0_manufacturer0_name
             		WITH this, this_car0, this_car0_manufacturer0
             		CALL {
@@ -116,7 +116,7 @@ describe("#324", () => {
             					WITH connectedNodes, parentNodes
             					UNWIND parentNodes as this_car0_manufacturer0
             					UNWIND connectedNodes as this_car0_manufacturer0_logo0_connect0_node
-            					MERGE (this_car0_manufacturer0)-[:LOGO]->(this_car0_manufacturer0_logo0_connect0_node)
+            					MERGE (this_car0_manufacturer0)-[:\`LOGO\`]->(this_car0_manufacturer0_logo0_connect0_node)
             					RETURN count(*) AS _
             				}
             				RETURN count(*) AS _
@@ -127,7 +127,7 @@ describe("#324", () => {
             		WITH this, this_car0, this_car0_manufacturer0
             		CALL {
             			WITH this_car0_manufacturer0
-            			MATCH (this_car0_manufacturer0)-[this_car0_manufacturer0_logo_Logo_unique:LOGO]->(:Logo)
+            			MATCH (this_car0_manufacturer0)-[this_car0_manufacturer0_logo_Logo_unique:\`LOGO\`]->(:Logo)
             			WITH count(this_car0_manufacturer0_logo_Logo_unique) as c
             			CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDManufacturer.logo required exactly once', [0])
             			RETURN c AS this_car0_manufacturer0_logo_Logo_unique_ignored
@@ -137,7 +137,7 @@ describe("#324", () => {
             	WITH this, this_car0
             	CALL {
             		WITH this_car0
-            		MATCH (this_car0)-[this_car0_manufacturer_Manufacturer_unique:MANUFACTURER]->(:Manufacturer)
+            		MATCH (this_car0)-[this_car0_manufacturer_Manufacturer_unique:\`MANUFACTURER\`]->(:Manufacturer)
             		WITH count(this_car0_manufacturer_Manufacturer_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDCar.manufacturer required exactly once', [0])
             		RETURN c AS this_car0_manufacturer_Manufacturer_unique_ignored
@@ -147,7 +147,7 @@ describe("#324", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_car_Car_unique:CAR]->(:Car)
+            	MATCH (this)-[this_car_Car_unique:\`CAR\`]->(:Car)
             	WITH count(this_car_Car_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPerson.car required exactly once', [0])
             	RETURN c AS this_car_Car_unique_ignored

--- a/packages/graphql/tests/tck/issues/402.test.ts
+++ b/packages/graphql/tests/tck/issues/402.test.ts
@@ -66,7 +66,7 @@ describe("#402", () => {
             "MATCH (this:\`Event\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAPPENS_IN]->(this1:\`Area\`)
+                MATCH (this)-[this0:\`HAPPENS_IN\`]->(this1:\`Area\`)
                 WITH this1 { .id } AS this1
                 RETURN head(collect(this1)) AS var2
             }

--- a/packages/graphql/tests/tck/issues/433.test.ts
+++ b/packages/graphql/tests/tck/issues/433.test.ts
@@ -71,7 +71,7 @@ describe("#413", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:ACTED_IN]->(this1:\`Person\`)
+                MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Person\`)
                 WITH { node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/issues/488.test.ts
+++ b/packages/graphql/tests/tck/issues/488.test.ts
@@ -81,24 +81,24 @@ describe("#488", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Journalist\`)
             WHERE EXISTS {
-                MATCH (this)-[this0:HAS_KEYWORD]->(this1:\`Emoji\`)
+                MATCH (this)-[this0:\`HAS_KEYWORD\`]->(this1:\`Emoji\`)
                 WHERE this1.type = $param0
             }
             CALL {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this2:HAS_KEYWORD]->(this3:\`Emoji\`)
+                    MATCH (this)-[this2:\`HAS_KEYWORD\`]->(this3:\`Emoji\`)
                     WITH this3 { __resolveType: \\"Emoji\\", __id: id(this), .id, .type } AS this3
                     RETURN this3 AS var4
                     UNION
                     WITH *
-                    MATCH (this)-[this5:HAS_KEYWORD]->(this6:\`Hashtag\`)
+                    MATCH (this)-[this5:\`HAS_KEYWORD\`]->(this6:\`Hashtag\`)
                     WITH this6 { __resolveType: \\"Hashtag\\", __id: id(this) } AS this6
                     RETURN this6 AS var4
                     UNION
                     WITH *
-                    MATCH (this)-[this7:HAS_KEYWORD]->(this8:\`Text\`)
+                    MATCH (this)-[this7:\`HAS_KEYWORD\`]->(this8:\`Text\`)
                     WITH this8 { __resolveType: \\"Text\\", __id: id(this) } AS this8
                     RETURN this8 AS var4
                 }
@@ -138,24 +138,24 @@ describe("#488", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Journalist\`)
             WHERE NOT (EXISTS {
-                MATCH (this)-[this0:HAS_KEYWORD]->(this1:\`Emoji\`)
+                MATCH (this)-[this0:\`HAS_KEYWORD\`]->(this1:\`Emoji\`)
                 WHERE this1.type = $param0
             })
             CALL {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this2:HAS_KEYWORD]->(this3:\`Emoji\`)
+                    MATCH (this)-[this2:\`HAS_KEYWORD\`]->(this3:\`Emoji\`)
                     WITH this3 { __resolveType: \\"Emoji\\", __id: id(this), .id, .type } AS this3
                     RETURN this3 AS var4
                     UNION
                     WITH *
-                    MATCH (this)-[this5:HAS_KEYWORD]->(this6:\`Hashtag\`)
+                    MATCH (this)-[this5:\`HAS_KEYWORD\`]->(this6:\`Hashtag\`)
                     WITH this6 { __resolveType: \\"Hashtag\\", __id: id(this) } AS this6
                     RETURN this6 AS var4
                     UNION
                     WITH *
-                    MATCH (this)-[this7:HAS_KEYWORD]->(this8:\`Text\`)
+                    MATCH (this)-[this7:\`HAS_KEYWORD\`]->(this8:\`Text\`)
                     WITH this8 { __resolveType: \\"Text\\", __id: id(this) } AS this8
                     RETURN this8 AS var4
                 }

--- a/packages/graphql/tests/tck/issues/582.test.ts
+++ b/packages/graphql/tests/tck/issues/582.test.ts
@@ -74,9 +74,9 @@ describe("#582", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Entity\`)
             WHERE (this.type = $param0 AND EXISTS {
-                MATCH (this)-[this0:EDGE]->(this1:\`Entity\`)
+                MATCH (this)-[this0:\`EDGE\`]->(this1:\`Entity\`)
                 WHERE (this1.type = $param1 AND EXISTS {
-                    MATCH (this1)<-[this2:EDGE]-(this3:\`Entity\`)
+                    MATCH (this1)<-[this2:\`EDGE\`]-(this3:\`Entity\`)
                     WHERE this3.type = $param2
                 })
             })
@@ -127,11 +127,11 @@ describe("#582", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Entity\`)
             WHERE (this.type = $param0 AND EXISTS {
-                MATCH (this)-[this0:EDGE]->(this1:\`Entity\`)
+                MATCH (this)-[this0:\`EDGE\`]->(this1:\`Entity\`)
                 WHERE (this1.type = $param1 AND EXISTS {
-                    MATCH (this1)<-[this2:EDGE]-(this3:\`Entity\`)
+                    MATCH (this1)<-[this2:\`EDGE\`]-(this3:\`Entity\`)
                     WHERE (this3.type = $param2 AND EXISTS {
-                        MATCH (this3)-[this4:EDGE]->(this5:\`Entity\`)
+                        MATCH (this3)-[this4:\`EDGE\`]->(this5:\`Entity\`)
                         WHERE this5.type = $param3
                     })
                 })

--- a/packages/graphql/tests/tck/issues/583.test.ts
+++ b/packages/graphql/tests/tck/issues/583.test.ts
@@ -91,17 +91,17 @@ describe("#583", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]->(this1:\`Movie\`)
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .title, .awardsGiven } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
+                    MATCH (this)-[this3:\`ACTED_IN\`]->(this4:\`Series\`)
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .title, .awardsGiven } AS this4
                     RETURN this4 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:\`ShortFilm\`)
+                    MATCH (this)-[this5:\`ACTED_IN\`]->(this6:\`ShortFilm\`)
                     WITH this6 { __resolveType: \\"ShortFilm\\", __id: id(this), .title } AS this6
                     RETURN this6 AS var2
                 }

--- a/packages/graphql/tests/tck/issues/601.test.ts
+++ b/packages/graphql/tests/tck/issues/601.test.ts
@@ -94,11 +94,11 @@ describe("#601", () => {
             WHERE apoc.util.validatePredicate(NOT (any(var1 IN [\\"view\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
-                MATCH (this)-[this2:REQUIRES]->(this3:\`Document\`)
+                MATCH (this)-[this2:\`REQUIRES\`]->(this3:\`Document\`)
                 WHERE apoc.util.validatePredicate(NOT (any(var5 IN [\\"view\\"] WHERE any(var4 IN $auth.roles WHERE var4 = var5))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this3
-                    MATCH (this3:\`Document\`)<-[this6:UPLOADED]-(this7:\`CustomerContact\`)
+                    MATCH (this3:\`Document\`)<-[this6:\`UPLOADED\`]-(this7:\`CustomerContact\`)
                     WHERE apoc.util.validatePredicate(NOT (any(var9 IN [\\"view\\"] WHERE any(var8 IN $auth.roles WHERE var8 = var9))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { fileId: this6.fileId, uploadedAt: apoc.date.convertFormat(toString(this6.uploadedAt), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } AS edge
                     WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/630.test.ts
+++ b/packages/graphql/tests/tck/issues/630.test.ts
@@ -85,7 +85,7 @@ describe("Cypher directive", () => {
                 WITH m AS this0
                 CALL {
                     WITH this0
-                    MATCH (this0)<-[this1:ACTED_IN]-(this2:\`Actor\`)
+                    MATCH (this0)<-[this1:\`ACTED_IN\`]-(this2:\`Actor\`)
                     WITH { node: { __resolveType: \\"Actor\\", __id: id(this2) } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/issues/832.test.ts
+++ b/packages/graphql/tests/tck/issues/832.test.ts
@@ -101,7 +101,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect0_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -120,7 +120,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect1_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect1_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -140,7 +140,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect0_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -159,7 +159,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect1_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect1_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -185,7 +185,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_subjects_connect0_node
-            			MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
+            			MERGE (this1)<-[:\`ACTED_IN\`]-(this1_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -204,7 +204,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_subjects_connect1_node
-            			MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect1_node)
+            			MERGE (this1)<-[:\`ACTED_IN\`]-(this1_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -224,7 +224,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_objects_connect0_node
-            			MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
+            			MERGE (this1)-[:\`ACTED_IN\`]->(this1_objects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -243,7 +243,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_objects_connect1_node
-            			MERGE (this1)-[:ACTED_IN]->(this1_objects_connect1_node)
+            			MERGE (this1)-[:\`ACTED_IN\`]->(this1_objects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -334,7 +334,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect0_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -353,7 +353,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect1_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect1_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -373,7 +373,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect0_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -392,7 +392,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect1_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect1_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -468,7 +468,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect0_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -487,7 +487,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect1_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect1_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -507,7 +507,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect0_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -526,7 +526,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect1_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect1_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -613,7 +613,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect0_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -632,7 +632,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect1_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect1_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -652,7 +652,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect0_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect0_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -671,7 +671,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_objects_connect1_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_objects_connect1_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_objects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -697,7 +697,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_subjects_connect0_node
-            			MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect0_node)
+            			MERGE (this1)<-[:\`ACTED_IN\`]-(this1_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -716,7 +716,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_subjects_connect1_node
-            			MERGE (this1)<-[:ACTED_IN]-(this1_subjects_connect1_node)
+            			MERGE (this1)<-[:\`ACTED_IN\`]-(this1_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -736,7 +736,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_objects_connect0_node
-            			MERGE (this1)-[:ACTED_IN]->(this1_objects_connect0_node)
+            			MERGE (this1)-[:\`ACTED_IN\`]->(this1_objects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -755,7 +755,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_objects_connect1_node
-            			MERGE (this1)-[:ACTED_IN]->(this1_objects_connect1_node)
+            			MERGE (this1)-[:\`ACTED_IN\`]->(this1_objects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -769,12 +769,12 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Person\`)
+                    MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Person\`)
                     WITH create_this1 { __resolveType: \\"Person\\", __id: id(this0), .id } AS create_this1
                     RETURN create_this1 AS create_var2
                     UNION
                     WITH *
-                    MATCH (this0)<-[create_this3:ACTED_IN]-(create_this4:\`Place\`)
+                    MATCH (this0)<-[create_this3:\`ACTED_IN\`]-(create_this4:\`Place\`)
                     WITH create_this4 { __resolveType: \\"Place\\", __id: id(this0), .id } AS create_this4
                     RETURN create_this4 AS create_var2
                 }
@@ -785,12 +785,12 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)-[create_this5:ACTED_IN]->(create_this6:\`Person\`)
+                    MATCH (this0)-[create_this5:\`ACTED_IN\`]->(create_this6:\`Person\`)
                     WITH create_this6 { __resolveType: \\"Person\\", __id: id(this0), .id } AS create_this6
                     RETURN create_this6 AS create_var7
                     UNION
                     WITH *
-                    MATCH (this0)-[create_this8:ACTED_IN]->(create_this9:\`Place\`)
+                    MATCH (this0)-[create_this8:\`ACTED_IN\`]->(create_this9:\`Place\`)
                     WITH create_this9 { __resolveType: \\"Place\\", __id: id(this0), .id } AS create_this9
                     RETURN create_this9 AS create_var7
                 }
@@ -801,12 +801,12 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
                 WITH this1
                 CALL {
                     WITH *
-                    MATCH (this1)<-[create_this10:ACTED_IN]-(create_this11:\`Person\`)
+                    MATCH (this1)<-[create_this10:\`ACTED_IN\`]-(create_this11:\`Person\`)
                     WITH create_this11 { __resolveType: \\"Person\\", __id: id(this1), .id } AS create_this11
                     RETURN create_this11 AS create_var12
                     UNION
                     WITH *
-                    MATCH (this1)<-[create_this13:ACTED_IN]-(create_this14:\`Place\`)
+                    MATCH (this1)<-[create_this13:\`ACTED_IN\`]-(create_this14:\`Place\`)
                     WITH create_this14 { __resolveType: \\"Place\\", __id: id(this1), .id } AS create_this14
                     RETURN create_this14 AS create_var12
                 }
@@ -817,12 +817,12 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
                 WITH this1
                 CALL {
                     WITH *
-                    MATCH (this1)-[create_this15:ACTED_IN]->(create_this16:\`Person\`)
+                    MATCH (this1)-[create_this15:\`ACTED_IN\`]->(create_this16:\`Person\`)
                     WITH create_this16 { __resolveType: \\"Person\\", __id: id(this1), .id } AS create_this16
                     RETURN create_this16 AS create_var17
                     UNION
                     WITH *
-                    MATCH (this1)-[create_this18:ACTED_IN]->(create_this19:\`Place\`)
+                    MATCH (this1)-[create_this18:\`ACTED_IN\`]->(create_this19:\`Place\`)
                     WITH create_this19 { __resolveType: \\"Place\\", __id: id(this1), .id } AS create_this19
                     RETURN create_this19 AS create_var17
                 }
@@ -907,7 +907,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect0_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect0_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -926,7 +926,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_subjects_connect1_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_subjects_connect1_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_subjects_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _

--- a/packages/graphql/tests/tck/issues/847.test.ts
+++ b/packages/graphql/tests/tck/issues/847.test.ts
@@ -73,12 +73,12 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WITH this1 { __resolveType: \\"Person\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)<-[this3:ACTED_IN]-(this4:\`Place\`)
+                    MATCH (this)<-[this3:\`ACTED_IN\`]-(this4:\`Place\`)
                     WITH this4 { __resolveType: \\"Place\\", __id: id(this), .id } AS this4
                     RETURN this4 AS var2
                 }
@@ -89,12 +89,12 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this5:ACTED_IN]->(this6:\`Person\`)
+                    MATCH (this)-[this5:\`ACTED_IN\`]->(this6:\`Person\`)
                     WITH this6 { __resolveType: \\"Person\\", __id: id(this), .id } AS this6
                     RETURN this6 AS var7
                     UNION
                     WITH *
-                    MATCH (this)-[this8:ACTED_IN]->(this9:\`Place\`)
+                    MATCH (this)-[this8:\`ACTED_IN\`]->(this9:\`Place\`)
                     WITH this9 { __resolveType: \\"Place\\", __id: id(this), .id } AS this9
                     RETURN this9 AS var7
                 }

--- a/packages/graphql/tests/tck/issues/894.test.ts
+++ b/packages/graphql/tests/tck/issues/894.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_activeOrganization0_node
-            			MERGE (this)-[:ACTIVELY_MANAGING]->(this_connect_activeOrganization0_node)
+            			MERGE (this)-[:\`ACTIVELY_MANAGING\`]->(this_connect_activeOrganization0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_activeOrganization0_rel:ACTIVELY_MANAGING]->(this_disconnect_activeOrganization0:Organization)
+            OPTIONAL MATCH (this)-[this_disconnect_activeOrganization0_rel:\`ACTIVELY_MANAGING\`]->(this_disconnect_activeOrganization0:Organization)
             WHERE NOT (this_disconnect_activeOrganization0._id = $updateUsers_args_disconnect_activeOrganization_where_Organization_this_disconnect_activeOrganization0param0)
             CALL {
             	WITH this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel, this
@@ -108,7 +108,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             WITH *
             CALL {
             	WITH this
-            	MATCH (this)-[this_activeOrganization_Organization_unique:ACTIVELY_MANAGING]->(:Organization)
+            	MATCH (this)-[this_activeOrganization_Organization_unique:\`ACTIVELY_MANAGING\`]->(:Organization)
             	WITH count(this_activeOrganization_Organization_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDUser.activeOrganization must be less than or equal to one', [0])
             	RETURN c AS this_activeOrganization_Organization_unique_ignored

--- a/packages/graphql/tests/tck/issues/901.test.ts
+++ b/packages/graphql/tests/tck/issues/901.test.ts
@@ -95,16 +95,16 @@ describe("https://github.com/neo4j/graphql/issues/901", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Series\`)
-            WHERE (single(this1 IN [(this)-[this0:HAS_MANUFACTURER]->(this1:\`Series\`) WHERE (this0.current = $param0 AND this1.name = $param1) | 1] WHERE true) OR single(this3 IN [(this)-[this2:HAS_BRAND]->(this3:\`Series\`) WHERE (this2.current = $param2 AND this3.name = $param3) | 1] WHERE true))
+            WHERE (single(this1 IN [(this)-[this0:\`HAS_MANUFACTURER\`]->(this1:\`Series\`) WHERE (this0.current = $param0 AND this1.name = $param1) | 1] WHERE true) OR single(this3 IN [(this)-[this2:\`HAS_BRAND\`]->(this3:\`Series\`) WHERE (this2.current = $param2 AND this3.name = $param3) | 1] WHERE true))
             CALL {
                 WITH this
-                MATCH (this)-[this4:HAS_BRAND]->(this5:\`Series\`)
+                MATCH (this)-[this4:\`HAS_BRAND\`]->(this5:\`Series\`)
                 WITH this5 { .name } AS this5
                 RETURN head(collect(this5)) AS var6
             }
             CALL {
                 WITH this
-                MATCH (this)-[this7:HAS_MANUFACTURER]->(this8:\`Series\`)
+                MATCH (this)-[this7:\`HAS_MANUFACTURER\`]->(this8:\`Series\`)
                 WITH this8 { .name } AS this8
                 RETURN head(collect(this8)) AS var9
             }

--- a/packages/graphql/tests/tck/issues/988.test.ts
+++ b/packages/graphql/tests/tck/issues/988.test.ts
@@ -137,18 +137,18 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Series\`)
             WHERE (((EXISTS {
-                MATCH (this)-[this0:MANUFACTURER]->(this1:\`Manufacturer\`)
+                MATCH (this)-[this0:\`MANUFACTURER\`]->(this1:\`Manufacturer\`)
                 WHERE (this0.current = $param0 AND this1.name = $param1)
             } OR EXISTS {
-                MATCH (this)-[this2:MANUFACTURER]->(this3:\`Manufacturer\`)
+                MATCH (this)-[this2:\`MANUFACTURER\`]->(this3:\`Manufacturer\`)
                 WHERE (this2.current = $param2 AND this3.name = $param3)
             }) AND EXISTS {
-                MATCH (this)-[this4:BRAND]->(this5:\`Brand\`)
+                MATCH (this)-[this4:\`BRAND\`]->(this5:\`Brand\`)
                 WHERE (this4.current = $param4 AND this5.name = $param5)
             }) AND this.current = $param6)
             CALL {
                 WITH this
-                MATCH (this)-[this6:MANUFACTURER]->(this7:\`Manufacturer\`)
+                MATCH (this)-[this6:\`MANUFACTURER\`]->(this7:\`Manufacturer\`)
                 WITH { current: this6.current, node: { name: this7.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -156,7 +156,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
             }
             CALL {
                 WITH this
-                MATCH (this)-[this9:BRAND]->(this10:\`Brand\`)
+                MATCH (this)-[this9:\`BRAND\`]->(this10:\`Brand\`)
                 WITH { current: this9.current, node: { name: this10.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/math.test.ts
+++ b/packages/graphql/tests/tck/math.test.ts
@@ -165,7 +165,7 @@ describe("Math operators", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	WITH this_actedIn0, this
             	CALL {
             	WITH this_actedIn0
@@ -180,7 +180,7 @@ describe("Math operators", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .viewers } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
@@ -226,7 +226,7 @@ describe("Math operators", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_acted_in0_relationship:ACTED_IN]->(this_actedIn0:Movie)
+            	MATCH (this)-[this_acted_in0_relationship:\`ACTED_IN\`]->(this_actedIn0:Movie)
             	WITH this_acted_in0_relationship, this
             	CALL {
             	WITH this_acted_in0_relationship
@@ -240,13 +240,13 @@ describe("Math operators", () => {
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .title } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[update_this3:ACTED_IN]->(update_this4:\`Movie\`)
+                MATCH (this)-[update_this3:\`ACTED_IN\`]->(update_this4:\`Movie\`)
                 WITH { pay: update_this3.pay } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -303,7 +303,7 @@ describe("Math operators", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_married_with0_relationship:MARRIED_WITH]->(this_marriedWith0:Star)
+            	MATCH (this)-[this_married_with0_relationship:\`MARRIED_WITH\`]->(this_marriedWith0:Star)
             	WITH this_marriedWith0, this
             	CALL {
             	WITH this_marriedWith0
@@ -316,7 +316,7 @@ describe("Math operators", () => {
             	WITH this, this_marriedWith0
             	CALL {
             		WITH this_marriedWith0
-            		MATCH (this_marriedWith0)<-[this_marriedWith0_marriedWith_Actor_unique:MARRIED_WITH]-(:Actor)
+            		MATCH (this_marriedWith0)<-[this_marriedWith0_marriedWith_Actor_unique:\`MARRIED_WITH\`]-(:Actor)
             		WITH count(this_marriedWith0_marriedWith_Actor_unique) as c
             		CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDStar.marriedWith must be less than or equal to one', [0])
             		RETURN c AS this_marriedWith0_marriedWith_Actor_unique_ignored
@@ -330,7 +330,7 @@ describe("Math operators", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:MARRIED_WITH]->(update_this1:\`Star\`)
+                    MATCH (this)-[update_this0:\`MARRIED_WITH\`]->(update_this1:\`Star\`)
                     WITH update_this1 { __resolveType: \\"Star\\", __id: id(this), .marriageLength } AS update_this1
                     RETURN update_this1 AS update_var2
                 }
@@ -379,11 +379,11 @@ describe("Math operators", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_married_with0_relationship:MARRIED_WITH]->(this_marriedWith0:Star)
+            	MATCH (this)-[this_married_with0_relationship:\`MARRIED_WITH\`]->(this_marriedWith0:Star)
             	WITH this, this_marriedWith0
             	CALL {
             		WITH this_marriedWith0
-            		MATCH (this_marriedWith0)<-[this_marriedWith0_marriedWith_Actor_unique:MARRIED_WITH]-(:Actor)
+            		MATCH (this_marriedWith0)<-[this_marriedWith0_marriedWith_Actor_unique:\`MARRIED_WITH\`]-(:Actor)
             		WITH count(this_marriedWith0_marriedWith_Actor_unique) as c
             		CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDStar.marriedWith must be less than or equal to one', [0])
             		RETURN c AS this_marriedWith0_marriedWith_Actor_unique_ignored
@@ -406,7 +406,7 @@ describe("Math operators", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[update_this0:MARRIED_WITH]->(update_this1:\`Star\`)
+                    MATCH (this)-[update_this0:\`MARRIED_WITH\`]->(update_this1:\`Star\`)
                     WITH update_this1 { __resolveType: \\"Star\\", __id: id(this), .marriageLength } AS update_this1
                     RETURN update_this1 AS update_var2
                 }

--- a/packages/graphql/tests/tck/nested-unions.test.ts
+++ b/packages/graphql/tests/tck/nested-unions.test.ts
@@ -117,7 +117,7 @@ describe("Nested Unions", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors_LeadActor0_node
-            			MERGE (this)<-[:ACTED_IN]-(this_connect_actors_LeadActor0_node)
+            			MERGE (this)<-[:\`ACTED_IN\`]-(this_connect_actors_LeadActor0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -134,7 +134,7 @@ describe("Nested Unions", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this_connect_actors_LeadActor0_node
             			UNWIND connectedNodes as this_connect_actors_LeadActor0_node_actedIn_Series0_node
-            			MERGE (this_connect_actors_LeadActor0_node)-[:ACTED_IN]->(this_connect_actors_LeadActor0_node_actedIn_Series0_node)
+            			MERGE (this_connect_actors_LeadActor0_node)-[:\`ACTED_IN\`]->(this_connect_actors_LeadActor0_node_actedIn_Series0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -149,17 +149,17 @@ describe("Nested Unions", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:\`LeadActor\`)
+                    MATCH (this)<-[update_this0:\`ACTED_IN\`]-(update_this1:\`LeadActor\`)
                     CALL {
                         WITH update_this1
                         CALL {
                             WITH *
-                            MATCH (update_this1)-[update_this2:ACTED_IN]->(update_this3:\`Movie\`)
+                            MATCH (update_this1)-[update_this2:\`ACTED_IN\`]->(update_this3:\`Movie\`)
                             WITH update_this3 { __resolveType: \\"Movie\\", __id: id(update_this1) } AS update_this3
                             RETURN update_this3 AS update_var4
                             UNION
                             WITH *
-                            MATCH (update_this1)-[update_this5:ACTED_IN]->(update_this6:\`Series\`)
+                            MATCH (update_this1)-[update_this5:\`ACTED_IN\`]->(update_this6:\`Series\`)
                             WITH update_this6 { __resolveType: \\"Series\\", __id: id(update_this1), .name } AS update_this6
                             RETURN update_this6 AS update_var4
                         }
@@ -170,7 +170,7 @@ describe("Nested Unions", () => {
                     RETURN update_this1 AS update_var7
                     UNION
                     WITH *
-                    MATCH (this)<-[update_this8:ACTED_IN]-(update_this9:\`Extra\`)
+                    MATCH (this)<-[update_this8:\`ACTED_IN\`]-(update_this9:\`Extra\`)
                     WITH update_this9 { __resolveType: \\"Extra\\", __id: id(this) } AS update_this9
                     RETURN update_this9 AS update_var7
                 }
@@ -232,7 +232,7 @@ describe("Nested Unions", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors_LeadActor0_rel:ACTED_IN]-(this_disconnect_actors_LeadActor0:LeadActor)
+            OPTIONAL MATCH (this)<-[this_disconnect_actors_LeadActor0_rel:\`ACTED_IN\`]-(this_disconnect_actors_LeadActor0:LeadActor)
             WHERE this_disconnect_actors_LeadActor0.name = $updateMovies_args_disconnect_actors_LeadActor0_where_LeadActor_this_disconnect_actors_LeadActor0param0
             CALL {
             	WITH this_disconnect_actors_LeadActor0, this_disconnect_actors_LeadActor0_rel, this
@@ -243,7 +243,7 @@ describe("Nested Unions", () => {
             }
             CALL {
             WITH this, this_disconnect_actors_LeadActor0
-            OPTIONAL MATCH (this_disconnect_actors_LeadActor0)-[this_disconnect_actors_LeadActor0_actedIn_Series0_rel:ACTED_IN]->(this_disconnect_actors_LeadActor0_actedIn_Series0:Series)
+            OPTIONAL MATCH (this_disconnect_actors_LeadActor0)-[this_disconnect_actors_LeadActor0_actedIn_Series0_rel:\`ACTED_IN\`]->(this_disconnect_actors_LeadActor0_actedIn_Series0:Series)
             WHERE this_disconnect_actors_LeadActor0_actedIn_Series0.name = $updateMovies_args_disconnect_actors_LeadActor0_disconnect_actedIn_Series0_where_Series_this_disconnect_actors_LeadActor0_actedIn_Series0param0
             CALL {
             	WITH this_disconnect_actors_LeadActor0_actedIn_Series0, this_disconnect_actors_LeadActor0_actedIn_Series0_rel, this_disconnect_actors_LeadActor0
@@ -261,17 +261,17 @@ describe("Nested Unions", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:\`LeadActor\`)
+                    MATCH (this)<-[update_this0:\`ACTED_IN\`]-(update_this1:\`LeadActor\`)
                     CALL {
                         WITH update_this1
                         CALL {
                             WITH *
-                            MATCH (update_this1)-[update_this2:ACTED_IN]->(update_this3:\`Movie\`)
+                            MATCH (update_this1)-[update_this2:\`ACTED_IN\`]->(update_this3:\`Movie\`)
                             WITH update_this3 { __resolveType: \\"Movie\\", __id: id(update_this1) } AS update_this3
                             RETURN update_this3 AS update_var4
                             UNION
                             WITH *
-                            MATCH (update_this1)-[update_this5:ACTED_IN]->(update_this6:\`Series\`)
+                            MATCH (update_this1)-[update_this5:\`ACTED_IN\`]->(update_this6:\`Series\`)
                             WITH update_this6 { __resolveType: \\"Series\\", __id: id(update_this1), .name } AS update_this6
                             RETURN update_this6 AS update_var4
                         }
@@ -282,7 +282,7 @@ describe("Nested Unions", () => {
                     RETURN update_this1 AS update_var7
                     UNION
                     WITH *
-                    MATCH (this)<-[update_this8:ACTED_IN]-(update_this9:\`Extra\`)
+                    MATCH (this)<-[update_this8:\`ACTED_IN\`]-(update_this9:\`Extra\`)
                     WITH update_this9 { __resolveType: \\"Extra\\", __id: id(this) } AS update_this9
                     RETURN update_this9 AS update_var7
                 }

--- a/packages/graphql/tests/tck/null.test.ts
+++ b/packages/graphql/tests/tck/null.test.ts
@@ -117,7 +117,7 @@ describe("Cypher NULL", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
             WHERE NOT (EXISTS {
-                MATCH (this)<-[:ACTED_IN]-(this0:\`Actor\`)
+                MATCH (this)<-[:\`ACTED_IN\`]-(this0:\`Actor\`)
             })
             RETURN this { .title } AS this"
         `);
@@ -142,7 +142,7 @@ describe("Cypher NULL", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
             WHERE EXISTS {
-                MATCH (this)<-[:ACTED_IN]-(this0:\`Actor\`)
+                MATCH (this)<-[:\`ACTED_IN\`]-(this0:\`Actor\`)
             }
             RETURN this { .title } AS this"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
@@ -93,7 +93,7 @@ describe("Batch Create, Auth", () => {
                 WITH create_this1
                 CALL {
                 	WITH create_this1
-                	MATCH (create_this1)-[create_this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this1)-[create_this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this1_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this1_website_Website_unique_ignored
@@ -166,13 +166,13 @@ describe("Batch Create, Auth", () => {
                     SET
                         create_this8.name = create_var6.name,
                         create_this8.id = randomUUID()
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     SET
                         create_this9.year = create_var7.year
                     WITH create_this8
                     CALL {
                     	WITH create_this8
-                    	MATCH (create_this8)-[create_this8_website_Website_unique:HAS_WEBSITE]->(:Website)
+                    	MATCH (create_this8)-[create_this8_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                     	WITH count(create_this8_website_Website_unique) as c
                     	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
                     	RETURN c AS create_this8_website_Website_unique_ignored
@@ -184,7 +184,7 @@ describe("Batch Create, Auth", () => {
                 WITH create_this0
                 CALL {
                 	WITH create_this0
-                	MATCH (create_this0)-[create_this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this0)-[create_this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this0_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this0_website_Website_unique_ignored
@@ -193,7 +193,7 @@ describe("Batch Create, Auth", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this2.id IS NOT NULL AND create_this2.id = $create_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
@@ -301,12 +301,12 @@ describe("Batch Create, Auth", () => {
             CREATE (this0_actors0_node:Actor)
             SET this0_actors0_node.id = randomUUID()
             SET this0_actors0_node.name = $this0_actors0_node_name
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             SET this0_actors0_relationship.year = $this0_actors0_relationship_year
             WITH this0, this0_actors0_node
             CALL {
             	WITH this0_actors0_node
-            	MATCH (this0_actors0_node)-[this0_actors0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0_actors0_node)-[this0_actors0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_actors0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this0_actors0_node_website_Website_unique_ignored
@@ -316,7 +316,7 @@ describe("Batch Create, Auth", () => {
             WITH this0
             CALL {
             	WITH this0
-            	MATCH (this0)-[this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0)-[this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this0_website_Website_unique_ignored
@@ -330,12 +330,12 @@ describe("Batch Create, Auth", () => {
             CREATE (this1_actors0_node:Actor)
             SET this1_actors0_node.id = randomUUID()
             SET this1_actors0_node.name = $this1_actors0_node_name
-            MERGE (this1)<-[this1_actors0_relationship:ACTED_IN]-(this1_actors0_node)
+            MERGE (this1)<-[this1_actors0_relationship:\`ACTED_IN\`]-(this1_actors0_node)
             SET this1_actors0_relationship.year = $this1_actors0_relationship_year
             WITH this1, this1_actors0_node
             CALL {
             	WITH this1_actors0_node
-            	MATCH (this1_actors0_node)-[this1_actors0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1_actors0_node)-[this1_actors0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_actors0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this1_actors0_node_website_Website_unique_ignored
@@ -345,7 +345,7 @@ describe("Batch Create, Auth", () => {
             WITH this1
             CALL {
             	WITH this1
-            	MATCH (this1)-[this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1)-[this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this1_website_Website_unique_ignored
@@ -358,13 +358,13 @@ describe("Batch Create, Auth", () => {
             WITH this2
             CREATE (this2_website0_node:Website)
             SET this2_website0_node.address = $this2_website0_node_address
-            MERGE (this2)-[:HAS_WEBSITE]->(this2_website0_node)
+            MERGE (this2)-[:\`HAS_WEBSITE\`]->(this2_website0_node)
             WITH this2
             CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this2
             CALL {
             	WITH this2
-            	MATCH (this2)-[this2_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this2)-[this2_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this2_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this2_website_Website_unique_ignored
@@ -388,7 +388,7 @@ describe("Batch Create, Auth", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this3
             			UNWIND connectedNodes as this3_actors_connect0_node
-            			MERGE (this3)<-[this3_actors_connect0_relationship:ACTED_IN]-(this3_actors_connect0_node)
+            			MERGE (this3)<-[this3_actors_connect0_relationship:\`ACTED_IN\`]-(this3_actors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -401,7 +401,7 @@ describe("Batch Create, Auth", () => {
             WITH this3
             CALL {
             	WITH this3
-            	MATCH (this3)-[this3_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this3)-[this3_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this3_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this3_website_Website_unique_ignored
@@ -417,7 +417,7 @@ describe("Batch Create, Auth", () => {
                 MERGE (this4_actors_connectOrCreate0:\`Actor\` { id: $this4_actors_connectOrCreate_param0 })
                 ON CREATE SET
                     this4_actors_connectOrCreate0.name = $this4_actors_connectOrCreate_param1
-                MERGE (this4)<-[this4_actors_connectOrCreate_this0:ACTED_IN]-(this4_actors_connectOrCreate0)
+                MERGE (this4)<-[this4_actors_connectOrCreate_this0:\`ACTED_IN\`]-(this4_actors_connectOrCreate0)
                 WITH *
                 CALL apoc.util.validate(NOT ((this4_actors_connectOrCreate0.id IS NOT NULL AND this4_actors_connectOrCreate0.id = $this4_actors_connectOrCreate0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN COUNT(*) AS _
@@ -427,7 +427,7 @@ describe("Batch Create, Auth", () => {
             WITH this4
             CALL {
             	WITH this4
-            	MATCH (this4)-[this4_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this4)-[this4_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this4_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this4_website_Website_unique_ignored
@@ -436,65 +436,65 @@ describe("Batch Create, Auth", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:HAS_WEBSITE]->(create_this1:\`Website\`)
+                MATCH (this0)-[create_this0:\`HAS_WEBSITE\`]->(create_this1:\`Website\`)
                 WITH create_this1 { .address } AS create_this1
                 RETURN head(collect(create_this1)) AS create_var2
             }
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this3:ACTED_IN]-(create_this4:\`Actor\`)
+                MATCH (this0)<-[create_this3:\`ACTED_IN\`]-(create_this4:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this4.id IS NOT NULL AND create_this4.id = $create_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this4 { .name } AS create_this4
                 RETURN collect(create_this4) AS create_var5
             }
             CALL {
                 WITH this1
-                MATCH (this1)-[create_this6:HAS_WEBSITE]->(create_this7:\`Website\`)
+                MATCH (this1)-[create_this6:\`HAS_WEBSITE\`]->(create_this7:\`Website\`)
                 WITH create_this7 { .address } AS create_this7
                 RETURN head(collect(create_this7)) AS create_var8
             }
             CALL {
                 WITH this1
-                MATCH (this1)<-[create_this9:ACTED_IN]-(create_this10:\`Actor\`)
+                MATCH (this1)<-[create_this9:\`ACTED_IN\`]-(create_this10:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this10.id IS NOT NULL AND create_this10.id = $create_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this10 { .name } AS create_this10
                 RETURN collect(create_this10) AS create_var11
             }
             CALL {
                 WITH this2
-                MATCH (this2)-[create_this12:HAS_WEBSITE]->(create_this13:\`Website\`)
+                MATCH (this2)-[create_this12:\`HAS_WEBSITE\`]->(create_this13:\`Website\`)
                 WITH create_this13 { .address } AS create_this13
                 RETURN head(collect(create_this13)) AS create_var14
             }
             CALL {
                 WITH this2
-                MATCH (this2)<-[create_this15:ACTED_IN]-(create_this16:\`Actor\`)
+                MATCH (this2)<-[create_this15:\`ACTED_IN\`]-(create_this16:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this16.id IS NOT NULL AND create_this16.id = $create_param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this16 { .name } AS create_this16
                 RETURN collect(create_this16) AS create_var17
             }
             CALL {
                 WITH this3
-                MATCH (this3)-[create_this18:HAS_WEBSITE]->(create_this19:\`Website\`)
+                MATCH (this3)-[create_this18:\`HAS_WEBSITE\`]->(create_this19:\`Website\`)
                 WITH create_this19 { .address } AS create_this19
                 RETURN head(collect(create_this19)) AS create_var20
             }
             CALL {
                 WITH this3
-                MATCH (this3)<-[create_this21:ACTED_IN]-(create_this22:\`Actor\`)
+                MATCH (this3)<-[create_this21:\`ACTED_IN\`]-(create_this22:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this22.id IS NOT NULL AND create_this22.id = $create_param3)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this22 { .name } AS create_this22
                 RETURN collect(create_this22) AS create_var23
             }
             CALL {
                 WITH this4
-                MATCH (this4)-[create_this24:HAS_WEBSITE]->(create_this25:\`Website\`)
+                MATCH (this4)-[create_this24:\`HAS_WEBSITE\`]->(create_this25:\`Website\`)
                 WITH create_this25 { .address } AS create_this25
                 RETURN head(collect(create_this25)) AS create_var26
             }
             CALL {
                 WITH this4
-                MATCH (this4)<-[create_this27:ACTED_IN]-(create_this28:\`Actor\`)
+                MATCH (this4)<-[create_this27:\`ACTED_IN\`]-(create_this28:\`Actor\`)
                 WHERE apoc.util.validatePredicate(NOT ((create_this28.id IS NOT NULL AND create_this28.id = $create_param4)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this28 { .name } AS create_this28
                 RETURN collect(create_this28) AS create_var29

--- a/packages/graphql/tests/tck/operations/batch/batch-create-fields.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-fields.test.ts
@@ -97,7 +97,7 @@ describe("Batch Create, Scalar types", () => {
                 WITH create_this1
                 CALL {
                 	WITH create_this1
-                	MATCH (create_this1)-[create_this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this1)-[create_this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this1_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this1_website_Website_unique_ignored
@@ -191,7 +191,7 @@ describe("Batch Create, Scalar types", () => {
                         create_this5.name = create_var3.name,
                         create_this5.createdAt = datetime(),
                         create_this5.id = randomUUID()
-                    MERGE (create_this1)<-[create_this6:ACTED_IN]-(create_this5)
+                    MERGE (create_this1)<-[create_this6:\`ACTED_IN\`]-(create_this5)
                     SET
                         create_this6.year = create_var4.year
                     WITH create_this5, create_var3
@@ -202,13 +202,13 @@ describe("Batch Create, Scalar types", () => {
                         CREATE (create_this10:\`Website\`)
                         SET
                             create_this10.address = create_var8.address
-                        MERGE (create_this5)-[create_this11:HAS_WEBSITE]->(create_this10)
+                        MERGE (create_this5)-[create_this11:\`HAS_WEBSITE\`]->(create_this10)
                         RETURN collect(NULL) AS create_var12
                     }
                     WITH create_this5
                     CALL {
                     	WITH create_this5
-                    	MATCH (create_this5)-[create_this5_website_Website_unique:HAS_WEBSITE]->(:Website)
+                    	MATCH (create_this5)-[create_this5_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                     	WITH count(create_this5_website_Website_unique) as c
                     	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
                     	RETURN c AS create_this5_website_Website_unique_ignored
@@ -223,13 +223,13 @@ describe("Batch Create, Scalar types", () => {
                     CREATE (create_this17:\`Website\`)
                     SET
                         create_this17.address = create_var15.address
-                    MERGE (create_this1)-[create_this18:HAS_WEBSITE]->(create_this17)
+                    MERGE (create_this1)-[create_this18:\`HAS_WEBSITE\`]->(create_this17)
                     RETURN collect(NULL) AS create_var19
                 }
                 WITH create_this1
                 CALL {
                 	WITH create_this1
-                	MATCH (create_this1)-[create_this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this1)-[create_this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this1_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this1_website_Website_unique_ignored
@@ -325,13 +325,13 @@ describe("Batch Create, Scalar types", () => {
                         create_this8.name = create_var6.name,
                         create_this8.createdAt = datetime(),
                         create_this8.id = randomUUID()
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     SET
                         create_this9.year = create_var7.year
                     WITH create_this8
                     CALL {
                     	WITH create_this8
-                    	MATCH (create_this8)-[create_this8_website_Website_unique:HAS_WEBSITE]->(:Website)
+                    	MATCH (create_this8)-[create_this8_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                     	WITH count(create_this8_website_Website_unique) as c
                     	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
                     	RETURN c AS create_this8_website_Website_unique_ignored
@@ -341,7 +341,7 @@ describe("Batch Create, Scalar types", () => {
                 WITH create_this0
                 CALL {
                 	WITH create_this0
-                	MATCH (create_this0)-[create_this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this0)-[create_this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this0_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this0_website_Website_unique_ignored
@@ -350,7 +350,7 @@ describe("Batch Create, Scalar types", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
@@ -450,12 +450,12 @@ describe("Batch Create, Scalar types", () => {
             SET this0_actors0_node.createdAt = datetime()
             SET this0_actors0_node.id = randomUUID()
             SET this0_actors0_node.name = $this0_actors0_node_name
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             SET this0_actors0_relationship.year = $this0_actors0_relationship_year
             WITH this0, this0_actors0_node
             CALL {
             	WITH this0_actors0_node
-            	MATCH (this0_actors0_node)-[this0_actors0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0_actors0_node)-[this0_actors0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_actors0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this0_actors0_node_website_Website_unique_ignored
@@ -463,7 +463,7 @@ describe("Batch Create, Scalar types", () => {
             WITH this0
             CALL {
             	WITH this0
-            	MATCH (this0)-[this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0)-[this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this0_website_Website_unique_ignored
@@ -479,12 +479,12 @@ describe("Batch Create, Scalar types", () => {
             SET this1_actors0_node.createdAt = datetime()
             SET this1_actors0_node.id = randomUUID()
             SET this1_actors0_node.name = $this1_actors0_node_name
-            MERGE (this1)<-[this1_actors0_relationship:ACTED_IN]-(this1_actors0_node)
+            MERGE (this1)<-[this1_actors0_relationship:\`ACTED_IN\`]-(this1_actors0_node)
             SET this1_actors0_relationship.year = $this1_actors0_relationship_year
             WITH this1, this1_actors0_node
             CALL {
             	WITH this1_actors0_node
-            	MATCH (this1_actors0_node)-[this1_actors0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1_actors0_node)-[this1_actors0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_actors0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this1_actors0_node_website_Website_unique_ignored
@@ -492,7 +492,7 @@ describe("Batch Create, Scalar types", () => {
             WITH this1
             CALL {
             	WITH this1
-            	MATCH (this1)-[this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1)-[this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this1_website_Website_unique_ignored
@@ -506,11 +506,11 @@ describe("Batch Create, Scalar types", () => {
             WITH this2
             CREATE (this2_website0_node:Website)
             SET this2_website0_node.address = $this2_website0_node_address
-            MERGE (this2)-[:HAS_WEBSITE]->(this2_website0_node)
+            MERGE (this2)-[:\`HAS_WEBSITE\`]->(this2_website0_node)
             WITH this2
             CALL {
             	WITH this2
-            	MATCH (this2)-[this2_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this2)-[this2_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this2_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this2_website_Website_unique_ignored
@@ -533,7 +533,7 @@ describe("Batch Create, Scalar types", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this3
             			UNWIND connectedNodes as this3_actors_connect0_node
-            			MERGE (this3)<-[this3_actors_connect0_relationship:ACTED_IN]-(this3_actors_connect0_node)
+            			MERGE (this3)<-[this3_actors_connect0_relationship:\`ACTED_IN\`]-(this3_actors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -544,7 +544,7 @@ describe("Batch Create, Scalar types", () => {
             WITH this3
             CALL {
             	WITH this3
-            	MATCH (this3)-[this3_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this3)-[this3_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this3_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this3_website_Website_unique_ignored
@@ -562,13 +562,13 @@ describe("Batch Create, Scalar types", () => {
                 ON CREATE SET
                     this4_actors_connectOrCreate0.createdAt = datetime(),
                     this4_actors_connectOrCreate0.name = $this4_actors_connectOrCreate_param1
-                MERGE (this4)<-[this4_actors_connectOrCreate_this0:ACTED_IN]-(this4_actors_connectOrCreate0)
+                MERGE (this4)<-[this4_actors_connectOrCreate_this0:\`ACTED_IN\`]-(this4_actors_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             WITH this4
             CALL {
             	WITH this4
-            	MATCH (this4)-[this4_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this4)-[this4_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this4_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this4_website_Website_unique_ignored
@@ -577,61 +577,61 @@ describe("Batch Create, Scalar types", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:HAS_WEBSITE]->(create_this1:\`Website\`)
+                MATCH (this0)-[create_this0:\`HAS_WEBSITE\`]->(create_this1:\`Website\`)
                 WITH create_this1 { .address } AS create_this1
                 RETURN head(collect(create_this1)) AS create_var2
             }
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this3:ACTED_IN]-(create_this4:\`Actor\`)
+                MATCH (this0)<-[create_this3:\`ACTED_IN\`]-(create_this4:\`Actor\`)
                 WITH create_this4 { .name } AS create_this4
                 RETURN collect(create_this4) AS create_var5
             }
             CALL {
                 WITH this1
-                MATCH (this1)-[create_this6:HAS_WEBSITE]->(create_this7:\`Website\`)
+                MATCH (this1)-[create_this6:\`HAS_WEBSITE\`]->(create_this7:\`Website\`)
                 WITH create_this7 { .address } AS create_this7
                 RETURN head(collect(create_this7)) AS create_var8
             }
             CALL {
                 WITH this1
-                MATCH (this1)<-[create_this9:ACTED_IN]-(create_this10:\`Actor\`)
+                MATCH (this1)<-[create_this9:\`ACTED_IN\`]-(create_this10:\`Actor\`)
                 WITH create_this10 { .name } AS create_this10
                 RETURN collect(create_this10) AS create_var11
             }
             CALL {
                 WITH this2
-                MATCH (this2)-[create_this12:HAS_WEBSITE]->(create_this13:\`Website\`)
+                MATCH (this2)-[create_this12:\`HAS_WEBSITE\`]->(create_this13:\`Website\`)
                 WITH create_this13 { .address } AS create_this13
                 RETURN head(collect(create_this13)) AS create_var14
             }
             CALL {
                 WITH this2
-                MATCH (this2)<-[create_this15:ACTED_IN]-(create_this16:\`Actor\`)
+                MATCH (this2)<-[create_this15:\`ACTED_IN\`]-(create_this16:\`Actor\`)
                 WITH create_this16 { .name } AS create_this16
                 RETURN collect(create_this16) AS create_var17
             }
             CALL {
                 WITH this3
-                MATCH (this3)-[create_this18:HAS_WEBSITE]->(create_this19:\`Website\`)
+                MATCH (this3)-[create_this18:\`HAS_WEBSITE\`]->(create_this19:\`Website\`)
                 WITH create_this19 { .address } AS create_this19
                 RETURN head(collect(create_this19)) AS create_var20
             }
             CALL {
                 WITH this3
-                MATCH (this3)<-[create_this21:ACTED_IN]-(create_this22:\`Actor\`)
+                MATCH (this3)<-[create_this21:\`ACTED_IN\`]-(create_this22:\`Actor\`)
                 WITH create_this22 { .name } AS create_this22
                 RETURN collect(create_this22) AS create_var23
             }
             CALL {
                 WITH this4
-                MATCH (this4)-[create_this24:HAS_WEBSITE]->(create_this25:\`Website\`)
+                MATCH (this4)-[create_this24:\`HAS_WEBSITE\`]->(create_this25:\`Website\`)
                 WITH create_this25 { .address } AS create_this25
                 RETURN head(collect(create_this25)) AS create_var26
             }
             CALL {
                 WITH this4
-                MATCH (this4)<-[create_this27:ACTED_IN]-(create_this28:\`Actor\`)
+                MATCH (this4)<-[create_this27:\`ACTED_IN\`]-(create_this28:\`Actor\`)
                 WITH create_this28 { .name } AS create_this28
                 RETURN collect(create_this28) AS create_var29
             }

--- a/packages/graphql/tests/tck/operations/batch/batch-create-interface.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-interface.test.ts
@@ -96,7 +96,7 @@ describe("Batch Create, Interface", () => {
                 WITH create_this1
                 CALL {
                 	WITH create_this1
-                	MATCH (create_this1)-[create_this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this1)-[create_this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this1_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this1_website_Website_unique_ignored
@@ -163,12 +163,12 @@ describe("Batch Create, Interface", () => {
             CREATE (this0_workersActor0_node:Actor)
             SET this0_workersActor0_node.id = $this0_workersActor0_node_id
             SET this0_workersActor0_node.name = $this0_workersActor0_node_name
-            MERGE (this0)<-[this0_workersActor0_relationship:EMPLOYED]-(this0_workersActor0_node)
+            MERGE (this0)<-[this0_workersActor0_relationship:\`EMPLOYED\`]-(this0_workersActor0_node)
             SET this0_workersActor0_relationship.year = $this0_workersActor0_relationship_year
             WITH this0, this0_workersActor0_node
             CALL {
             	WITH this0_workersActor0_node
-            	MATCH (this0_workersActor0_node)-[this0_workersActor0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0_workersActor0_node)-[this0_workersActor0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_workersActor0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this0_workersActor0_node_website_Website_unique_ignored
@@ -176,7 +176,7 @@ describe("Batch Create, Interface", () => {
             WITH this0
             CALL {
             	WITH this0
-            	MATCH (this0)-[this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0)-[this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this0_website_Website_unique_ignored
@@ -190,12 +190,12 @@ describe("Batch Create, Interface", () => {
             CREATE (this1_workersModeler0_node:Modeler)
             SET this1_workersModeler0_node.id = $this1_workersModeler0_node_id
             SET this1_workersModeler0_node.name = $this1_workersModeler0_node_name
-            MERGE (this1)<-[this1_workersModeler0_relationship:EMPLOYED]-(this1_workersModeler0_node)
+            MERGE (this1)<-[this1_workersModeler0_relationship:\`EMPLOYED\`]-(this1_workersModeler0_node)
             SET this1_workersModeler0_relationship.year = $this1_workersModeler0_relationship_year
             WITH this1, this1_workersModeler0_node
             CALL {
             	WITH this1_workersModeler0_node
-            	MATCH (this1_workersModeler0_node)-[this1_workersModeler0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1_workersModeler0_node)-[this1_workersModeler0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_workersModeler0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDModeler.website must be less than or equal to one', [0])
             	RETURN c AS this1_workersModeler0_node_website_Website_unique_ignored
@@ -203,7 +203,7 @@ describe("Batch Create, Interface", () => {
             WITH this1
             CALL {
             	WITH this1
-            	MATCH (this1)-[this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1)-[this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this1_website_Website_unique_ignored
@@ -214,12 +214,12 @@ describe("Batch Create, Interface", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)<-[create_this0:EMPLOYED]-(create_this1:\`Actor\`)
+                    MATCH (this0)<-[create_this0:\`EMPLOYED\`]-(create_this1:\`Actor\`)
                     WITH create_this1 { __resolveType: \\"Actor\\", __id: id(this0), .name } AS create_this1
                     RETURN create_this1 AS create_var2
                     UNION
                     WITH *
-                    MATCH (this0)<-[create_this3:EMPLOYED]-(create_this4:\`Modeler\`)
+                    MATCH (this0)<-[create_this3:\`EMPLOYED\`]-(create_this4:\`Modeler\`)
                     WITH create_this4 { __resolveType: \\"Modeler\\", __id: id(this0), .name } AS create_this4
                     RETURN create_this4 AS create_var2
                 }
@@ -230,12 +230,12 @@ describe("Batch Create, Interface", () => {
                 WITH this1
                 CALL {
                     WITH *
-                    MATCH (this1)<-[create_this5:EMPLOYED]-(create_this6:\`Actor\`)
+                    MATCH (this1)<-[create_this5:\`EMPLOYED\`]-(create_this6:\`Actor\`)
                     WITH create_this6 { __resolveType: \\"Actor\\", __id: id(this1), .name } AS create_this6
                     RETURN create_this6 AS create_var7
                     UNION
                     WITH *
-                    MATCH (this1)<-[create_this8:EMPLOYED]-(create_this9:\`Modeler\`)
+                    MATCH (this1)<-[create_this8:\`EMPLOYED\`]-(create_this9:\`Modeler\`)
                     WITH create_this9 { __resolveType: \\"Modeler\\", __id: id(this1), .name } AS create_this9
                     RETURN create_this9 AS create_var7
                 }
@@ -313,12 +313,12 @@ describe("Batch Create, Interface", () => {
             CREATE (this0_workersActor0_node:Actor)
             SET this0_workersActor0_node.id = $this0_workersActor0_node_id
             SET this0_workersActor0_node.name = $this0_workersActor0_node_name
-            MERGE (this0)<-[this0_workersActor0_relationship:EMPLOYED]-(this0_workersActor0_node)
+            MERGE (this0)<-[this0_workersActor0_relationship:\`EMPLOYED\`]-(this0_workersActor0_node)
             SET this0_workersActor0_relationship.year = $this0_workersActor0_relationship_year
             WITH this0, this0_workersActor0_node
             CALL {
             	WITH this0_workersActor0_node
-            	MATCH (this0_workersActor0_node)-[this0_workersActor0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0_workersActor0_node)-[this0_workersActor0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_workersActor0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this0_workersActor0_node_website_Website_unique_ignored
@@ -326,7 +326,7 @@ describe("Batch Create, Interface", () => {
             WITH this0
             CALL {
             	WITH this0
-            	MATCH (this0)-[this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0)-[this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this0_website_Website_unique_ignored
@@ -340,12 +340,12 @@ describe("Batch Create, Interface", () => {
             CREATE (this1_workersActor0_node:Actor)
             SET this1_workersActor0_node.id = $this1_workersActor0_node_id
             SET this1_workersActor0_node.name = $this1_workersActor0_node_name
-            MERGE (this1)<-[this1_workersActor0_relationship:EMPLOYED]-(this1_workersActor0_node)
+            MERGE (this1)<-[this1_workersActor0_relationship:\`EMPLOYED\`]-(this1_workersActor0_node)
             SET this1_workersActor0_relationship.year = $this1_workersActor0_relationship_year
             WITH this1, this1_workersActor0_node
             CALL {
             	WITH this1_workersActor0_node
-            	MATCH (this1_workersActor0_node)-[this1_workersActor0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1_workersActor0_node)-[this1_workersActor0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_workersActor0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this1_workersActor0_node_website_Website_unique_ignored
@@ -353,7 +353,7 @@ describe("Batch Create, Interface", () => {
             WITH this1
             CALL {
             	WITH this1
-            	MATCH (this1)-[this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1)-[this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this1_website_Website_unique_ignored
@@ -366,11 +366,11 @@ describe("Batch Create, Interface", () => {
             WITH this2
             CREATE (this2_website0_node:Website)
             SET this2_website0_node.address = $this2_website0_node_address
-            MERGE (this2)-[:HAS_WEBSITE]->(this2_website0_node)
+            MERGE (this2)-[:\`HAS_WEBSITE\`]->(this2_website0_node)
             WITH this2
             CALL {
             	WITH this2
-            	MATCH (this2)-[this2_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this2)-[this2_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this2_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this2_website_Website_unique_ignored
@@ -392,7 +392,7 @@ describe("Batch Create, Interface", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this3
             			UNWIND connectedNodes as this3_workers_connect0_node
-            			MERGE (this3)<-[this3_workers_connect0_relationship:EMPLOYED]-(this3_workers_connect0_node)
+            			MERGE (this3)<-[this3_workers_connect0_relationship:\`EMPLOYED\`]-(this3_workers_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -411,7 +411,7 @@ describe("Batch Create, Interface", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this3
             			UNWIND connectedNodes as this3_workers_connect1_node
-            			MERGE (this3)<-[this3_workers_connect1_relationship:EMPLOYED]-(this3_workers_connect1_node)
+            			MERGE (this3)<-[this3_workers_connect1_relationship:\`EMPLOYED\`]-(this3_workers_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -422,7 +422,7 @@ describe("Batch Create, Interface", () => {
             WITH this3
             CALL {
             	WITH this3
-            	MATCH (this3)-[this3_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this3)-[this3_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this3_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this3_website_Website_unique_ignored
@@ -431,7 +431,7 @@ describe("Batch Create, Interface", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:HAS_WEBSITE]->(create_this1:\`Website\`)
+                MATCH (this0)-[create_this0:\`HAS_WEBSITE\`]->(create_this1:\`Website\`)
                 WITH create_this1 { .address } AS create_this1
                 RETURN head(collect(create_this1)) AS create_var2
             }
@@ -439,12 +439,12 @@ describe("Batch Create, Interface", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)<-[create_this3:EMPLOYED]-(create_this4:\`Actor\`)
+                    MATCH (this0)<-[create_this3:\`EMPLOYED\`]-(create_this4:\`Actor\`)
                     WITH create_this4 { __resolveType: \\"Actor\\", __id: id(this0), .name } AS create_this4
                     RETURN create_this4 AS create_var5
                     UNION
                     WITH *
-                    MATCH (this0)<-[create_this6:EMPLOYED]-(create_this7:\`Modeler\`)
+                    MATCH (this0)<-[create_this6:\`EMPLOYED\`]-(create_this7:\`Modeler\`)
                     WITH create_this7 { __resolveType: \\"Modeler\\", __id: id(this0), .name } AS create_this7
                     RETURN create_this7 AS create_var5
                 }
@@ -453,7 +453,7 @@ describe("Batch Create, Interface", () => {
             }
             CALL {
                 WITH this1
-                MATCH (this1)-[create_this8:HAS_WEBSITE]->(create_this9:\`Website\`)
+                MATCH (this1)-[create_this8:\`HAS_WEBSITE\`]->(create_this9:\`Website\`)
                 WITH create_this9 { .address } AS create_this9
                 RETURN head(collect(create_this9)) AS create_var10
             }
@@ -461,12 +461,12 @@ describe("Batch Create, Interface", () => {
                 WITH this1
                 CALL {
                     WITH *
-                    MATCH (this1)<-[create_this11:EMPLOYED]-(create_this12:\`Actor\`)
+                    MATCH (this1)<-[create_this11:\`EMPLOYED\`]-(create_this12:\`Actor\`)
                     WITH create_this12 { __resolveType: \\"Actor\\", __id: id(this1), .name } AS create_this12
                     RETURN create_this12 AS create_var13
                     UNION
                     WITH *
-                    MATCH (this1)<-[create_this14:EMPLOYED]-(create_this15:\`Modeler\`)
+                    MATCH (this1)<-[create_this14:\`EMPLOYED\`]-(create_this15:\`Modeler\`)
                     WITH create_this15 { __resolveType: \\"Modeler\\", __id: id(this1), .name } AS create_this15
                     RETURN create_this15 AS create_var13
                 }
@@ -475,7 +475,7 @@ describe("Batch Create, Interface", () => {
             }
             CALL {
                 WITH this2
-                MATCH (this2)-[create_this16:HAS_WEBSITE]->(create_this17:\`Website\`)
+                MATCH (this2)-[create_this16:\`HAS_WEBSITE\`]->(create_this17:\`Website\`)
                 WITH create_this17 { .address } AS create_this17
                 RETURN head(collect(create_this17)) AS create_var18
             }
@@ -483,12 +483,12 @@ describe("Batch Create, Interface", () => {
                 WITH this2
                 CALL {
                     WITH *
-                    MATCH (this2)<-[create_this19:EMPLOYED]-(create_this20:\`Actor\`)
+                    MATCH (this2)<-[create_this19:\`EMPLOYED\`]-(create_this20:\`Actor\`)
                     WITH create_this20 { __resolveType: \\"Actor\\", __id: id(this2), .name } AS create_this20
                     RETURN create_this20 AS create_var21
                     UNION
                     WITH *
-                    MATCH (this2)<-[create_this22:EMPLOYED]-(create_this23:\`Modeler\`)
+                    MATCH (this2)<-[create_this22:\`EMPLOYED\`]-(create_this23:\`Modeler\`)
                     WITH create_this23 { __resolveType: \\"Modeler\\", __id: id(this2), .name } AS create_this23
                     RETURN create_this23 AS create_var21
                 }
@@ -497,7 +497,7 @@ describe("Batch Create, Interface", () => {
             }
             CALL {
                 WITH this3
-                MATCH (this3)-[create_this24:HAS_WEBSITE]->(create_this25:\`Website\`)
+                MATCH (this3)-[create_this24:\`HAS_WEBSITE\`]->(create_this25:\`Website\`)
                 WITH create_this25 { .address } AS create_this25
                 RETURN head(collect(create_this25)) AS create_var26
             }
@@ -505,12 +505,12 @@ describe("Batch Create, Interface", () => {
                 WITH this3
                 CALL {
                     WITH *
-                    MATCH (this3)<-[create_this27:EMPLOYED]-(create_this28:\`Actor\`)
+                    MATCH (this3)<-[create_this27:\`EMPLOYED\`]-(create_this28:\`Actor\`)
                     WITH create_this28 { __resolveType: \\"Actor\\", __id: id(this3), .name } AS create_this28
                     RETURN create_this28 AS create_var29
                     UNION
                     WITH *
-                    MATCH (this3)<-[create_this30:EMPLOYED]-(create_this31:\`Modeler\`)
+                    MATCH (this3)<-[create_this30:\`EMPLOYED\`]-(create_this31:\`Modeler\`)
                     WITH create_this31 { __resolveType: \\"Modeler\\", __id: id(this3), .name } AS create_this31
                     RETURN create_this31 AS create_var29
                 }

--- a/packages/graphql/tests/tck/operations/batch/batch-create.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create.test.ts
@@ -84,7 +84,7 @@ describe("Batch Create", () => {
                 WITH create_this1
                 CALL {
                 	WITH create_this1
-                	MATCH (create_this1)-[create_this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this1)-[create_this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this1_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this1_website_Website_unique_ignored
@@ -160,7 +160,7 @@ describe("Batch Create", () => {
                     SET
                         create_this5.name = create_var3.name,
                         create_this5.id = randomUUID()
-                    MERGE (create_this1)<-[create_this6:ACTED_IN]-(create_this5)
+                    MERGE (create_this1)<-[create_this6:\`ACTED_IN\`]-(create_this5)
                     SET
                         create_this6.year = create_var4.year
                     WITH create_this5, create_var3
@@ -171,13 +171,13 @@ describe("Batch Create", () => {
                         CREATE (create_this10:\`Website\`)
                         SET
                             create_this10.address = create_var8.address
-                        MERGE (create_this5)-[create_this11:HAS_WEBSITE]->(create_this10)
+                        MERGE (create_this5)-[create_this11:\`HAS_WEBSITE\`]->(create_this10)
                         RETURN collect(NULL) AS create_var12
                     }
                     WITH create_this5
                     CALL {
                     	WITH create_this5
-                    	MATCH (create_this5)-[create_this5_website_Website_unique:HAS_WEBSITE]->(:Website)
+                    	MATCH (create_this5)-[create_this5_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                     	WITH count(create_this5_website_Website_unique) as c
                     	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
                     	RETURN c AS create_this5_website_Website_unique_ignored
@@ -192,13 +192,13 @@ describe("Batch Create", () => {
                     CREATE (create_this17:\`Website\`)
                     SET
                         create_this17.address = create_var15.address
-                    MERGE (create_this1)-[create_this18:HAS_WEBSITE]->(create_this17)
+                    MERGE (create_this1)-[create_this18:\`HAS_WEBSITE\`]->(create_this17)
                     RETURN collect(NULL) AS create_var19
                 }
                 WITH create_this1
                 CALL {
                 	WITH create_this1
-                	MATCH (create_this1)-[create_this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this1)-[create_this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this1_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this1_website_Website_unique_ignored
@@ -292,13 +292,13 @@ describe("Batch Create", () => {
                     SET
                         create_this8.name = create_var6.name,
                         create_this8.id = randomUUID()
-                    MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
+                    MERGE (create_this0)<-[create_this9:\`ACTED_IN\`]-(create_this8)
                     SET
                         create_this9.year = create_var7.year
                     WITH create_this8
                     CALL {
                     	WITH create_this8
-                    	MATCH (create_this8)-[create_this8_website_Website_unique:HAS_WEBSITE]->(:Website)
+                    	MATCH (create_this8)-[create_this8_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                     	WITH count(create_this8_website_Website_unique) as c
                     	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
                     	RETURN c AS create_this8_website_Website_unique_ignored
@@ -308,7 +308,7 @@ describe("Batch Create", () => {
                 WITH create_this0
                 CALL {
                 	WITH create_this0
-                	MATCH (create_this0)-[create_this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+                	MATCH (create_this0)-[create_this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
                 	WITH count(create_this0_website_Website_unique) as c
                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
                 	RETURN c AS create_this0_website_Website_unique_ignored
@@ -317,7 +317,7 @@ describe("Batch Create", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
+                MATCH (create_this0)<-[create_this1:\`ACTED_IN\`]-(create_this2:\`Actor\`)
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
@@ -409,7 +409,7 @@ describe("Batch Create", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_actors_connect0_node
-            			MERGE (this0)<-[this0_actors_connect0_relationship:ACTED_IN]-(this0_actors_connect0_node)
+            			MERGE (this0)<-[this0_actors_connect0_relationship:\`ACTED_IN\`]-(this0_actors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -420,7 +420,7 @@ describe("Batch Create", () => {
             WITH this0
             CALL {
             	WITH this0
-            	MATCH (this0)-[this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0)-[this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this0_website_Website_unique_ignored
@@ -442,7 +442,7 @@ describe("Batch Create", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this1
             			UNWIND connectedNodes as this1_actors_connect0_node
-            			MERGE (this1)<-[this1_actors_connect0_relationship:ACTED_IN]-(this1_actors_connect0_node)
+            			MERGE (this1)<-[this1_actors_connect0_relationship:\`ACTED_IN\`]-(this1_actors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -453,7 +453,7 @@ describe("Batch Create", () => {
             WITH this1
             CALL {
             	WITH this1
-            	MATCH (this1)-[this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1)-[this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this1_website_Website_unique_ignored
@@ -462,13 +462,13 @@ describe("Batch Create", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH create_this1 { .name } AS create_this1
                 RETURN collect(create_this1) AS create_var2
             }
             CALL {
                 WITH this1
-                MATCH (this1)<-[create_this3:ACTED_IN]-(create_this4:\`Actor\`)
+                MATCH (this1)<-[create_this3:\`ACTED_IN\`]-(create_this4:\`Actor\`)
                 WITH create_this4 { .name } AS create_this4
                 RETURN collect(create_this4) AS create_var5
             }
@@ -532,12 +532,12 @@ describe("Batch Create", () => {
             CREATE (this0_actors0_node:Actor)
             SET this0_actors0_node.id = randomUUID()
             SET this0_actors0_node.name = $this0_actors0_node_name
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             SET this0_actors0_relationship.year = $this0_actors0_relationship_year
             WITH this0, this0_actors0_node
             CALL {
             	WITH this0_actors0_node
-            	MATCH (this0_actors0_node)-[this0_actors0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0_actors0_node)-[this0_actors0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_actors0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this0_actors0_node_website_Website_unique_ignored
@@ -545,7 +545,7 @@ describe("Batch Create", () => {
             WITH this0
             CALL {
             	WITH this0
-            	MATCH (this0)-[this0_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this0)-[this0_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this0_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this0_website_Website_unique_ignored
@@ -559,12 +559,12 @@ describe("Batch Create", () => {
             CREATE (this1_actors0_node:Actor)
             SET this1_actors0_node.id = randomUUID()
             SET this1_actors0_node.name = $this1_actors0_node_name
-            MERGE (this1)<-[this1_actors0_relationship:ACTED_IN]-(this1_actors0_node)
+            MERGE (this1)<-[this1_actors0_relationship:\`ACTED_IN\`]-(this1_actors0_node)
             SET this1_actors0_relationship.year = $this1_actors0_relationship_year
             WITH this1, this1_actors0_node
             CALL {
             	WITH this1_actors0_node
-            	MATCH (this1_actors0_node)-[this1_actors0_node_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1_actors0_node)-[this1_actors0_node_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_actors0_node_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDActor.website must be less than or equal to one', [0])
             	RETURN c AS this1_actors0_node_website_Website_unique_ignored
@@ -572,7 +572,7 @@ describe("Batch Create", () => {
             WITH this1
             CALL {
             	WITH this1
-            	MATCH (this1)-[this1_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this1)-[this1_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this1_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this1_website_Website_unique_ignored
@@ -585,11 +585,11 @@ describe("Batch Create", () => {
             WITH this2
             CREATE (this2_website0_node:Website)
             SET this2_website0_node.address = $this2_website0_node_address
-            MERGE (this2)-[:HAS_WEBSITE]->(this2_website0_node)
+            MERGE (this2)-[:\`HAS_WEBSITE\`]->(this2_website0_node)
             WITH this2
             CALL {
             	WITH this2
-            	MATCH (this2)-[this2_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this2)-[this2_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this2_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this2_website_Website_unique_ignored
@@ -611,7 +611,7 @@ describe("Batch Create", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this3
             			UNWIND connectedNodes as this3_actors_connect0_node
-            			MERGE (this3)<-[this3_actors_connect0_relationship:ACTED_IN]-(this3_actors_connect0_node)
+            			MERGE (this3)<-[this3_actors_connect0_relationship:\`ACTED_IN\`]-(this3_actors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -622,7 +622,7 @@ describe("Batch Create", () => {
             WITH this3
             CALL {
             	WITH this3
-            	MATCH (this3)-[this3_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this3)-[this3_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this3_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this3_website_Website_unique_ignored
@@ -638,13 +638,13 @@ describe("Batch Create", () => {
                 MERGE (this4_actors_connectOrCreate0:\`Actor\` { id: $this4_actors_connectOrCreate_param0 })
                 ON CREATE SET
                     this4_actors_connectOrCreate0.name = $this4_actors_connectOrCreate_param1
-                MERGE (this4)<-[this4_actors_connectOrCreate_this0:ACTED_IN]-(this4_actors_connectOrCreate0)
+                MERGE (this4)<-[this4_actors_connectOrCreate_this0:\`ACTED_IN\`]-(this4_actors_connectOrCreate0)
                 RETURN COUNT(*) AS _
             }
             WITH this4
             CALL {
             	WITH this4
-            	MATCH (this4)-[this4_website_Website_unique:HAS_WEBSITE]->(:Website)
+            	MATCH (this4)-[this4_website_Website_unique:\`HAS_WEBSITE\`]->(:Website)
             	WITH count(this4_website_Website_unique) as c
             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.website must be less than or equal to one', [0])
             	RETURN c AS this4_website_Website_unique_ignored
@@ -653,61 +653,61 @@ describe("Batch Create", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:HAS_WEBSITE]->(create_this1:\`Website\`)
+                MATCH (this0)-[create_this0:\`HAS_WEBSITE\`]->(create_this1:\`Website\`)
                 WITH create_this1 { .address } AS create_this1
                 RETURN head(collect(create_this1)) AS create_var2
             }
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this3:ACTED_IN]-(create_this4:\`Actor\`)
+                MATCH (this0)<-[create_this3:\`ACTED_IN\`]-(create_this4:\`Actor\`)
                 WITH create_this4 { .name } AS create_this4
                 RETURN collect(create_this4) AS create_var5
             }
             CALL {
                 WITH this1
-                MATCH (this1)-[create_this6:HAS_WEBSITE]->(create_this7:\`Website\`)
+                MATCH (this1)-[create_this6:\`HAS_WEBSITE\`]->(create_this7:\`Website\`)
                 WITH create_this7 { .address } AS create_this7
                 RETURN head(collect(create_this7)) AS create_var8
             }
             CALL {
                 WITH this1
-                MATCH (this1)<-[create_this9:ACTED_IN]-(create_this10:\`Actor\`)
+                MATCH (this1)<-[create_this9:\`ACTED_IN\`]-(create_this10:\`Actor\`)
                 WITH create_this10 { .name } AS create_this10
                 RETURN collect(create_this10) AS create_var11
             }
             CALL {
                 WITH this2
-                MATCH (this2)-[create_this12:HAS_WEBSITE]->(create_this13:\`Website\`)
+                MATCH (this2)-[create_this12:\`HAS_WEBSITE\`]->(create_this13:\`Website\`)
                 WITH create_this13 { .address } AS create_this13
                 RETURN head(collect(create_this13)) AS create_var14
             }
             CALL {
                 WITH this2
-                MATCH (this2)<-[create_this15:ACTED_IN]-(create_this16:\`Actor\`)
+                MATCH (this2)<-[create_this15:\`ACTED_IN\`]-(create_this16:\`Actor\`)
                 WITH create_this16 { .name } AS create_this16
                 RETURN collect(create_this16) AS create_var17
             }
             CALL {
                 WITH this3
-                MATCH (this3)-[create_this18:HAS_WEBSITE]->(create_this19:\`Website\`)
+                MATCH (this3)-[create_this18:\`HAS_WEBSITE\`]->(create_this19:\`Website\`)
                 WITH create_this19 { .address } AS create_this19
                 RETURN head(collect(create_this19)) AS create_var20
             }
             CALL {
                 WITH this3
-                MATCH (this3)<-[create_this21:ACTED_IN]-(create_this22:\`Actor\`)
+                MATCH (this3)<-[create_this21:\`ACTED_IN\`]-(create_this22:\`Actor\`)
                 WITH create_this22 { .name } AS create_this22
                 RETURN collect(create_this22) AS create_var23
             }
             CALL {
                 WITH this4
-                MATCH (this4)-[create_this24:HAS_WEBSITE]->(create_this25:\`Website\`)
+                MATCH (this4)-[create_this24:\`HAS_WEBSITE\`]->(create_this25:\`Website\`)
                 WITH create_this25 { .address } AS create_this25
                 RETURN head(collect(create_this25)) AS create_var26
             }
             CALL {
                 WITH this4
-                MATCH (this4)<-[create_this27:ACTED_IN]-(create_this28:\`Actor\`)
+                MATCH (this4)<-[create_this27:\`ACTED_IN\`]-(create_this28:\`Actor\`)
                 WITH create_this28 { .name } AS create_this28
                 RETURN collect(create_this28) AS create_var29
             }

--- a/packages/graphql/tests/tck/operations/connect.test.ts
+++ b/packages/graphql/tests/tck/operations/connect.test.ts
@@ -129,7 +129,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_colors_connect0_node
-            			MERGE (this0)-[:HAS_COLOR]->(this0_colors_connect0_node)
+            			MERGE (this0)-[:\`HAS_COLOR\`]->(this0_colors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -146,7 +146,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_colors_connect0_node
             			UNWIND connectedNodes as this0_colors_connect0_node_photos0_node
-            			MERGE (this0_colors_connect0_node)<-[:OF_COLOR]-(this0_colors_connect0_node_photos0_node)
+            			MERGE (this0_colors_connect0_node)<-[:\`OF_COLOR\`]-(this0_colors_connect0_node_photos0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -154,7 +154,7 @@ describe("Cypher Connect", () => {
             	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node
             CALL {
             	WITH this0_colors_connect0_node_photos0_node
-            	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_colors_connect0_node_photos0_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
@@ -171,7 +171,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_colors_connect0_node_photos0_node
             			UNWIND connectedNodes as this0_colors_connect0_node_photos0_node_color0_node
-            			MERGE (this0_colors_connect0_node_photos0_node)-[:OF_COLOR]->(this0_colors_connect0_node_photos0_node_color0_node)
+            			MERGE (this0_colors_connect0_node_photos0_node)-[:\`OF_COLOR\`]->(this0_colors_connect0_node_photos0_node_color0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -179,7 +179,7 @@ describe("Cypher Connect", () => {
             	WITH this0, this0_colors_connect0_node, this0_colors_connect0_node_photos0_node, this0_colors_connect0_node_photos0_node_color0_node
             CALL {
             	WITH this0_colors_connect0_node_photos0_node
-            	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_colors_connect0_node_photos0_node)-[this0_colors_connect0_node_photos0_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_colors_connect0_node_photos0_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_colors_connect0_node_photos0_node_color_Color_unique_ignored
@@ -203,7 +203,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_photos_connect0_node
-            			MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect0_node)
+            			MERGE (this0)-[:\`HAS_PHOTO\`]->(this0_photos_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -220,7 +220,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_photos_connect0_node
             			UNWIND connectedNodes as this0_photos_connect0_node_color0_node
-            			MERGE (this0_photos_connect0_node)-[:OF_COLOR]->(this0_photos_connect0_node_color0_node)
+            			MERGE (this0_photos_connect0_node)-[:\`OF_COLOR\`]->(this0_photos_connect0_node_color0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -228,7 +228,7 @@ describe("Cypher Connect", () => {
             	WITH this0, this0_photos_connect0_node, this0_photos_connect0_node_color0_node
             CALL {
             	WITH this0_photos_connect0_node
-            	MATCH (this0_photos_connect0_node)-[this0_photos_connect0_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_photos_connect0_node)-[this0_photos_connect0_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_photos_connect0_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_photos_connect0_node_color_Color_unique_ignored
@@ -250,7 +250,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_photos_connect1_node
-            			MERGE (this0)-[:HAS_PHOTO]->(this0_photos_connect1_node)
+            			MERGE (this0)-[:\`HAS_PHOTO\`]->(this0_photos_connect1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -267,7 +267,7 @@ describe("Cypher Connect", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_photos_connect1_node
             			UNWIND connectedNodes as this0_photos_connect1_node_color0_node
-            			MERGE (this0_photos_connect1_node)-[:OF_COLOR]->(this0_photos_connect1_node_color0_node)
+            			MERGE (this0_photos_connect1_node)-[:\`OF_COLOR\`]->(this0_photos_connect1_node_color0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -275,7 +275,7 @@ describe("Cypher Connect", () => {
             	WITH this0, this0_photos_connect1_node, this0_photos_connect1_node_color0_node
             CALL {
             	WITH this0_photos_connect1_node
-            	MATCH (this0_photos_connect1_node)-[this0_photos_connect1_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_photos_connect1_node)-[this0_photos_connect1_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_photos_connect1_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_photos_connect1_node_color_Color_unique_ignored

--- a/packages/graphql/tests/tck/operations/create.test.ts
+++ b/packages/graphql/tests/tck/operations/create.test.ts
@@ -165,7 +165,7 @@ describe("Cypher Create", () => {
                     CREATE (create_this5:\`Actor\`)
                     SET
                         create_this5.name = create_var3.name
-                    MERGE (create_this1)<-[create_this6:ACTED_IN]-(create_this5)
+                    MERGE (create_this1)<-[create_this6:\`ACTED_IN\`]-(create_this5)
                     RETURN collect(NULL) AS create_var7
                 }
                 RETURN create_this1
@@ -252,7 +252,7 @@ describe("Cypher Create", () => {
                     CREATE (create_this5:\`Actor\`)
                     SET
                         create_this5.name = create_var3.name
-                    MERGE (create_this1)<-[create_this6:ACTED_IN]-(create_this5)
+                    MERGE (create_this1)<-[create_this6:\`ACTED_IN\`]-(create_this5)
                     WITH create_this5, create_var3
                     CALL {
                         WITH create_this5, create_var3
@@ -261,7 +261,7 @@ describe("Cypher Create", () => {
                         CREATE (create_this10:\`Movie\`)
                         SET
                             create_this10.id = create_var8.id
-                        MERGE (create_this5)-[create_this11:ACTED_IN]->(create_this10)
+                        MERGE (create_this5)-[create_this11:\`ACTED_IN\`]->(create_this10)
                         RETURN collect(NULL) AS create_var12
                     }
                     RETURN collect(NULL) AS create_var13
@@ -354,7 +354,7 @@ describe("Cypher Create", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_actors_connect0_node
-            			MERGE (this0)<-[:ACTED_IN]-(this0_actors_connect0_node)
+            			MERGE (this0)<-[:\`ACTED_IN\`]-(this0_actors_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -418,7 +418,7 @@ describe("Cypher Create", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_movies_connect0_node
-            			MERGE (this0)-[:ACTED_IN]->(this0_movies_connect0_node)
+            			MERGE (this0)-[:\`ACTED_IN\`]->(this0_movies_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -430,10 +430,10 @@ describe("Cypher Create", () => {
             }
             CALL {
                 WITH this0
-                MATCH (this0)-[create_this0:ACTED_IN]->(create_this1:\`Movie\`)
+                MATCH (this0)-[create_this0:\`ACTED_IN\`]->(create_this1:\`Movie\`)
                 CALL {
                     WITH create_this1
-                    MATCH (create_this1:\`Movie\`)<-[create_this2:ACTED_IN]-(create_this3:\`Actor\`)
+                    MATCH (create_this1:\`Movie\`)<-[create_this2:\`ACTED_IN\`]-(create_this3:\`Actor\`)
                     WHERE create_this3.name = $create_param0
                     WITH { node: { name: create_this3.name } } AS edge
                     WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/operations/delete.test.ts
+++ b/packages/graphql/tests/tck/operations/delete.test.ts
@@ -92,7 +92,7 @@ describe("Cypher Delete", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, collect(DISTINCT this_actors0) AS this_actors0_to_delete
             CALL {
@@ -153,7 +153,7 @@ describe("Cypher Delete", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, collect(DISTINCT this_actors0) AS this_actors0_to_delete
             CALL {
@@ -163,7 +163,7 @@ describe("Cypher Delete", () => {
             	RETURN count(*) AS _
             }
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors1_relationship:ACTED_IN]-(this_actors1:Actor)
+            OPTIONAL MATCH (this)<-[this_actors1_relationship:\`ACTED_IN\`]-(this_actors1:Actor)
             WHERE this_actors1.name = $this_deleteMovies_args_delete_actors1_where_this_actors1param0
             WITH this, collect(DISTINCT this_actors1) AS this_actors1_to_delete
             CALL {
@@ -232,10 +232,10 @@ describe("Cypher Delete", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, this_actors0
-            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:\`ACTED_IN\`]->(this_actors0_movies0:Movie)
             WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_this_actors0_movies0param0
             WITH this, this_actors0, collect(DISTINCT this_actors0_movies0) AS this_actors0_movies0_to_delete
             CALL {
@@ -320,13 +320,13 @@ describe("Cypher Delete", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, this_actors0
-            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:\`ACTED_IN\`]->(this_actors0_movies0:Movie)
             WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_this_actors0_movies0param0
             WITH this, this_actors0, this_actors0_movies0
-            OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:ACTED_IN]-(this_actors0_movies0_actors0:Actor)
+            OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:\`ACTED_IN\`]-(this_actors0_movies0_actors0:Actor)
             WHERE this_actors0_movies0_actors0.name = $this_deleteMovies_args_delete_actors0_delete_movies0_delete_actors0_where_this_actors0_movies0_actors0param0
             WITH this, this_actors0, this_actors0_movies0, collect(DISTINCT this_actors0_movies0_actors0) AS this_actors0_movies0_actors0_to_delete
             CALL {

--- a/packages/graphql/tests/tck/operations/disconnect.test.ts
+++ b/packages/graphql/tests/tck/operations/disconnect.test.ts
@@ -117,7 +117,7 @@ describe("Cypher Disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_colors0_disconnect0_rel:HAS_COLOR]->(this_colors0_disconnect0:Color)
+            OPTIONAL MATCH (this)-[this_colors0_disconnect0_rel:\`HAS_COLOR\`]->(this_colors0_disconnect0:Color)
             WHERE this_colors0_disconnect0.name = $updateProducts_args_update_colors0_disconnect0_where_Color_this_colors0_disconnect0param0
             CALL {
             	WITH this_colors0_disconnect0, this_colors0_disconnect0_rel, this
@@ -128,7 +128,7 @@ describe("Cypher Disconnect", () => {
             }
             CALL {
             WITH this, this_colors0_disconnect0
-            OPTIONAL MATCH (this_colors0_disconnect0)<-[this_colors0_disconnect0_photos0_rel:OF_COLOR]-(this_colors0_disconnect0_photos0:Photo)
+            OPTIONAL MATCH (this_colors0_disconnect0)<-[this_colors0_disconnect0_photos0_rel:\`OF_COLOR\`]-(this_colors0_disconnect0_photos0:Photo)
             WHERE this_colors0_disconnect0_photos0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos0_where_Photo_this_colors0_disconnect0_photos0param0
             CALL {
             	WITH this_colors0_disconnect0_photos0, this_colors0_disconnect0_photos0_rel, this_colors0_disconnect0
@@ -139,7 +139,7 @@ describe("Cypher Disconnect", () => {
             }
             CALL {
             WITH this, this_colors0_disconnect0, this_colors0_disconnect0_photos0
-            OPTIONAL MATCH (this_colors0_disconnect0_photos0)-[this_colors0_disconnect0_photos0_color0_rel:OF_COLOR]->(this_colors0_disconnect0_photos0_color0:Color)
+            OPTIONAL MATCH (this_colors0_disconnect0_photos0)-[this_colors0_disconnect0_photos0_color0_rel:\`OF_COLOR\`]->(this_colors0_disconnect0_photos0_color0:Color)
             WHERE this_colors0_disconnect0_photos0_color0.id = $updateProducts_args_update_colors0_disconnect0_disconnect_photos_disconnect_color_where_Color_this_colors0_disconnect0_photos0_color0param0
             CALL {
             	WITH this_colors0_disconnect0_photos0_color0, this_colors0_disconnect0_photos0_color0_rel, this_colors0_disconnect0_photos0
@@ -157,7 +157,7 @@ describe("Cypher Disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_photos0_disconnect0_rel:HAS_PHOTO]->(this_photos0_disconnect0:Photo)
+            OPTIONAL MATCH (this)-[this_photos0_disconnect0_rel:\`HAS_PHOTO\`]->(this_photos0_disconnect0:Photo)
             WHERE this_photos0_disconnect0.id = $updateProducts_args_update_photos0_disconnect0_where_Photo_this_photos0_disconnect0param0
             CALL {
             	WITH this_photos0_disconnect0, this_photos0_disconnect0_rel, this
@@ -168,7 +168,7 @@ describe("Cypher Disconnect", () => {
             }
             CALL {
             WITH this, this_photos0_disconnect0
-            OPTIONAL MATCH (this_photos0_disconnect0)-[this_photos0_disconnect0_color0_rel:OF_COLOR]->(this_photos0_disconnect0_color0:Color)
+            OPTIONAL MATCH (this_photos0_disconnect0)-[this_photos0_disconnect0_color0_rel:\`OF_COLOR\`]->(this_photos0_disconnect0_color0:Color)
             WHERE this_photos0_disconnect0_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Color_this_photos0_disconnect0_color0param0
             CALL {
             	WITH this_photos0_disconnect0_color0, this_photos0_disconnect0_color0_rel, this_photos0_disconnect0
@@ -184,7 +184,7 @@ describe("Cypher Disconnect", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_photos0_disconnect1_rel:HAS_PHOTO]->(this_photos0_disconnect1:Photo)
+            OPTIONAL MATCH (this)-[this_photos0_disconnect1_rel:\`HAS_PHOTO\`]->(this_photos0_disconnect1:Photo)
             WHERE this_photos0_disconnect1.id = $updateProducts_args_update_photos0_disconnect1_where_Photo_this_photos0_disconnect1param0
             CALL {
             	WITH this_photos0_disconnect1, this_photos0_disconnect1_rel, this
@@ -195,7 +195,7 @@ describe("Cypher Disconnect", () => {
             }
             CALL {
             WITH this, this_photos0_disconnect1
-            OPTIONAL MATCH (this_photos0_disconnect1)-[this_photos0_disconnect1_color0_rel:OF_COLOR]->(this_photos0_disconnect1_color0:Color)
+            OPTIONAL MATCH (this_photos0_disconnect1)-[this_photos0_disconnect1_color0_rel:\`OF_COLOR\`]->(this_photos0_disconnect1_color0:Color)
             WHERE this_photos0_disconnect1_color0.name = $updateProducts_args_update_photos0_disconnect_disconnect_color_where_Color_this_photos0_disconnect1_color0param0
             CALL {
             	WITH this_photos0_disconnect1_color0, this_photos0_disconnect1_color0_rel, this_photos0_disconnect1

--- a/packages/graphql/tests/tck/operations/update.test.ts
+++ b/packages/graphql/tests/tck/operations/update.test.ts
@@ -110,7 +110,7 @@ describe("Cypher Update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	SET this_actors0.name = $this_update_actors0_name
             	RETURN count(*) AS update_this_actors0
@@ -190,13 +190,13 @@ describe("Cypher Update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	SET this_actors0.name = $this_update_actors0_name
             	WITH this, this_actors0
             	CALL {
             		WITH this, this_actors0
-            		MATCH (this_actors0)-[this_actors0_acted_in0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+            		MATCH (this_actors0)-[this_actors0_acted_in0_relationship:\`ACTED_IN\`]->(this_actors0_movies0:Movie)
             		WHERE this_actors0_movies0.id = $updateMovies_args_update_actors0_update_node_movies0_where_this_actors0_movies0param0
             		SET this_actors0_movies0.title = $this_update_actors0_movies0_title
             		RETURN count(*) AS update_this_actors0_movies0
@@ -283,7 +283,7 @@ describe("Cypher Update", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors0_node
-            			MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+            			MERGE (this)<-[this_connect_actors0_relationship:\`ACTED_IN\`]-(this_connect_actors0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -340,7 +340,7 @@ describe("Cypher Update", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors0_node
-            			MERGE (this)<-[this_connect_actors0_relationship:ACTED_IN]-(this_connect_actors0_node)
+            			MERGE (this)<-[this_connect_actors0_relationship:\`ACTED_IN\`]-(this_connect_actors0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -360,7 +360,7 @@ describe("Cypher Update", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_actors1_node
-            			MERGE (this)<-[this_connect_actors1_relationship:ACTED_IN]-(this_connect_actors1_node)
+            			MERGE (this)<-[this_connect_actors1_relationship:\`ACTED_IN\`]-(this_connect_actors1_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -404,7 +404,7 @@ describe("Cypher Update", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actors0:Actor)
             WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actor_this_disconnect_actors0param0
             CALL {
             	WITH this_disconnect_actors0, this_disconnect_actors0_rel, this
@@ -470,7 +470,7 @@ describe("Cypher Update", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:ACTED_IN]-(this_disconnect_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_disconnect_actors0_rel:\`ACTED_IN\`]-(this_disconnect_actors0:Actor)
             WHERE this_disconnect_actors0.name = $updateMovies_args_disconnect_actors0_where_Actor_this_disconnect_actors0param0
             CALL {
             	WITH this_disconnect_actors0, this_disconnect_actors0_rel, this
@@ -484,7 +484,7 @@ describe("Cypher Update", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)<-[this_disconnect_actors1_rel:ACTED_IN]-(this_disconnect_actors1:Actor)
+            OPTIONAL MATCH (this)<-[this_disconnect_actors1_rel:\`ACTED_IN\`]-(this_disconnect_actors1:Actor)
             WHERE this_disconnect_actors1.name = $updateMovies_args_disconnect_actors1_where_Actor_this_disconnect_actors1param0
             CALL {
             	WITH this_disconnect_actors1, this_disconnect_actors1_rel, this
@@ -561,11 +561,11 @@ describe("Cypher Update", () => {
             CREATE (this_movies0_create0_node:Movie)
             SET this_movies0_create0_node.id = $this_movies0_create0_node_id
             SET this_movies0_create0_node.title = $this_movies0_create0_node_title
-            MERGE (this)-[:ACTED_IN]->(this_movies0_create0_node)
+            MERGE (this)-[:\`ACTED_IN\`]->(this_movies0_create0_node)
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .id, .title } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
@@ -611,11 +611,11 @@ describe("Cypher Update", () => {
             CREATE (this_create_movies0_node:Movie)
             SET this_create_movies0_node.id = $this_create_movies0_node_id
             SET this_create_movies0_node.title = $this_create_movies0_node_title
-            MERGE (this)-[this_create_movies0_relationship:ACTED_IN]->(this_create_movies0_node)
+            MERGE (this)-[this_create_movies0_relationship:\`ACTED_IN\`]->(this_create_movies0_node)
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .id, .title } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
@@ -666,15 +666,15 @@ describe("Cypher Update", () => {
             CREATE (this_create_movies0_node:Movie)
             SET this_create_movies0_node.id = $this_create_movies0_node_id
             SET this_create_movies0_node.title = $this_create_movies0_node_title
-            MERGE (this)-[this_create_movies0_relationship:ACTED_IN]->(this_create_movies0_node)
+            MERGE (this)-[this_create_movies0_relationship:\`ACTED_IN\`]->(this_create_movies0_node)
             CREATE (this_create_movies1_node:Movie)
             SET this_create_movies1_node.id = $this_create_movies1_node_id
             SET this_create_movies1_node.title = $this_create_movies1_node_title
-            MERGE (this)-[this_create_movies1_relationship:ACTED_IN]->(this_create_movies1_node)
+            MERGE (this)-[this_create_movies1_relationship:\`ACTED_IN\`]->(this_create_movies1_node)
             WITH *
             CALL {
                 WITH this
-                MATCH (this)-[update_this0:ACTED_IN]->(update_this1:\`Movie\`)
+                MATCH (this)-[update_this0:\`ACTED_IN\`]->(update_this1:\`Movie\`)
                 WITH update_this1 { .id, .title } AS update_this1
                 RETURN collect(update_this1) AS update_var2
             }
@@ -716,7 +716,7 @@ describe("Cypher Update", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:\`ACTED_IN\`]-(this_delete_actors0:Actor)
             WHERE (this_delete_actors0_relationship.screenTime = $updateMovies_args_delete_actors0_where_this_delete_actors0param0 AND this_delete_actors0.name = $updateMovies_args_delete_actors0_where_this_delete_actors0param1)
             WITH this, collect(DISTINCT this_delete_actors0) AS this_delete_actors0_to_delete
             CALL {
@@ -794,13 +794,13 @@ describe("Cypher Update", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	SET this_actors0.name = $this_update_actors0_name
             	RETURN count(*) AS update_this_actors0
             }
             WITH this
-            OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:\`ACTED_IN\`]-(this_delete_actors0:Actor)
             WHERE this_delete_actors0.name = $updateMovies_args_delete_actors0_where_this_delete_actors0param0
             WITH this, collect(DISTINCT this_delete_actors0) AS this_delete_actors0_to_delete
             CALL {
@@ -878,7 +878,7 @@ describe("Cypher Update", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:ACTED_IN]-(this_actors0_delete0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:\`ACTED_IN\`]-(this_actors0_delete0:Actor)
             WHERE this_actors0_delete0.name = $updateMovies_args_update_actors0_delete0_where_this_actors0_delete0param0
             WITH this, collect(DISTINCT this_actors0_delete0) AS this_actors0_delete0_to_delete
             CALL {
@@ -948,10 +948,10 @@ describe("Cypher Update", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:ACTED_IN]-(this_actors0_delete0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_delete0_relationship:\`ACTED_IN\`]-(this_actors0_delete0:Actor)
             WHERE this_actors0_delete0.name = $updateMovies_args_update_actors0_delete0_where_this_actors0_delete0param0
             WITH this, this_actors0_delete0
-            OPTIONAL MATCH (this_actors0_delete0)-[this_actors0_delete0_movies0_relationship:ACTED_IN]->(this_actors0_delete0_movies0:Movie)
+            OPTIONAL MATCH (this_actors0_delete0)-[this_actors0_delete0_movies0_relationship:\`ACTED_IN\`]->(this_actors0_delete0_movies0:Movie)
             WHERE this_actors0_delete0_movies0.id = $updateMovies_args_update_actors0_delete0_delete_movies0_where_this_actors0_delete0_movies0param0
             WITH this, this_actors0_delete0, collect(DISTINCT this_actors0_delete0_movies0) AS this_actors0_delete0_movies0_to_delete
             CALL {

--- a/packages/graphql/tests/tck/pringles.test.ts
+++ b/packages/graphql/tests/tck/pringles.test.ts
@@ -127,32 +127,32 @@ describe("Cypher Create Pringles", () => {
             CREATE (this0_sizes0_node:Size)
             SET this0_sizes0_node.id = $this0_sizes0_node_id
             SET this0_sizes0_node.name = $this0_sizes0_node_name
-            MERGE (this0)-[:HAS_SIZE]->(this0_sizes0_node)
+            MERGE (this0)-[:\`HAS_SIZE\`]->(this0_sizes0_node)
             WITH this0
             CREATE (this0_sizes1_node:Size)
             SET this0_sizes1_node.id = $this0_sizes1_node_id
             SET this0_sizes1_node.name = $this0_sizes1_node_name
-            MERGE (this0)-[:HAS_SIZE]->(this0_sizes1_node)
+            MERGE (this0)-[:\`HAS_SIZE\`]->(this0_sizes1_node)
             WITH this0
             CREATE (this0_colors0_node:Color)
             SET this0_colors0_node.id = $this0_colors0_node_id
             SET this0_colors0_node.name = $this0_colors0_node_name
-            MERGE (this0)-[:HAS_COLOR]->(this0_colors0_node)
+            MERGE (this0)-[:\`HAS_COLOR\`]->(this0_colors0_node)
             WITH this0
             CREATE (this0_colors1_node:Color)
             SET this0_colors1_node.id = $this0_colors1_node_id
             SET this0_colors1_node.name = $this0_colors1_node_name
-            MERGE (this0)-[:HAS_COLOR]->(this0_colors1_node)
+            MERGE (this0)-[:\`HAS_COLOR\`]->(this0_colors1_node)
             WITH this0
             CREATE (this0_photos0_node:Photo)
             SET this0_photos0_node.id = $this0_photos0_node_id
             SET this0_photos0_node.description = $this0_photos0_node_description
             SET this0_photos0_node.url = $this0_photos0_node_url
-            MERGE (this0)-[:HAS_PHOTO]->(this0_photos0_node)
+            MERGE (this0)-[:\`HAS_PHOTO\`]->(this0_photos0_node)
             WITH this0, this0_photos0_node
             CALL {
             	WITH this0_photos0_node
-            	MATCH (this0_photos0_node)-[this0_photos0_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_photos0_node)-[this0_photos0_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_photos0_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_photos0_node_color_Color_unique_ignored
@@ -174,7 +174,7 @@ describe("Cypher Create Pringles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_photos1_node
             			UNWIND connectedNodes as this0_photos1_node_color_connect0_node
-            			MERGE (this0_photos1_node)-[:OF_COLOR]->(this0_photos1_node_color_connect0_node)
+            			MERGE (this0_photos1_node)-[:\`OF_COLOR\`]->(this0_photos1_node_color_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -182,11 +182,11 @@ describe("Cypher Create Pringles", () => {
             WITH this0, this0_photos1_node, this0_photos1_node_color_connect0_node
             	RETURN count(*) AS connect_this0_photos1_node_color_connect_Color
             }
-            MERGE (this0)-[:HAS_PHOTO]->(this0_photos1_node)
+            MERGE (this0)-[:\`HAS_PHOTO\`]->(this0_photos1_node)
             WITH this0, this0_photos1_node
             CALL {
             	WITH this0_photos1_node
-            	MATCH (this0_photos1_node)-[this0_photos1_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_photos1_node)-[this0_photos1_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_photos1_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_photos1_node_color_Color_unique_ignored
@@ -208,7 +208,7 @@ describe("Cypher Create Pringles", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0_photos2_node
             			UNWIND connectedNodes as this0_photos2_node_color_connect0_node
-            			MERGE (this0_photos2_node)-[:OF_COLOR]->(this0_photos2_node_color_connect0_node)
+            			MERGE (this0_photos2_node)-[:\`OF_COLOR\`]->(this0_photos2_node_color_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -216,11 +216,11 @@ describe("Cypher Create Pringles", () => {
             WITH this0, this0_photos2_node, this0_photos2_node_color_connect0_node
             	RETURN count(*) AS connect_this0_photos2_node_color_connect_Color
             }
-            MERGE (this0)-[:HAS_PHOTO]->(this0_photos2_node)
+            MERGE (this0)-[:\`HAS_PHOTO\`]->(this0_photos2_node)
             WITH this0, this0_photos2_node
             CALL {
             	WITH this0_photos2_node
-            	MATCH (this0_photos2_node)-[this0_photos2_node_color_Color_unique:OF_COLOR]->(:Color)
+            	MATCH (this0_photos2_node)-[this0_photos2_node_color_Color_unique:\`OF_COLOR\`]->(:Color)
             	WITH count(this0_photos2_node_color_Color_unique) as c
             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             	RETURN c AS this0_photos2_node_color_Color_unique_ignored
@@ -298,13 +298,13 @@ describe("Cypher Create Pringles", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_has_photo0_relationship:HAS_PHOTO]->(this_photos0:Photo)
+            	MATCH (this)-[this_has_photo0_relationship:\`HAS_PHOTO\`]->(this_photos0:Photo)
             	WHERE this_photos0.description = $updateProducts_args_update_photos0_where_this_photos0param0
             	SET this_photos0.description = $this_update_photos0_description
             	WITH this, this_photos0
             	CALL {
             	WITH this, this_photos0
-            	OPTIONAL MATCH (this_photos0)-[this_photos0_color0_disconnect0_rel:OF_COLOR]->(this_photos0_color0_disconnect0:Color)
+            	OPTIONAL MATCH (this_photos0)-[this_photos0_color0_disconnect0_rel:\`OF_COLOR\`]->(this_photos0_color0_disconnect0:Color)
             	WHERE this_photos0_color0_disconnect0.name = $updateProducts_args_update_photos0_update_node_color_disconnect_where_Color_this_photos0_color0_disconnect0param0
             	CALL {
             		WITH this_photos0_color0_disconnect0, this_photos0_color0_disconnect0_rel, this_photos0
@@ -327,7 +327,7 @@ describe("Cypher Create Pringles", () => {
             				WITH connectedNodes, parentNodes
             				UNWIND parentNodes as this_photos0
             				UNWIND connectedNodes as this_photos0_color0_connect0_node
-            				MERGE (this_photos0)-[:OF_COLOR]->(this_photos0_color0_connect0_node)
+            				MERGE (this_photos0)-[:\`OF_COLOR\`]->(this_photos0_color0_connect0_node)
             				RETURN count(*) AS _
             			}
             			RETURN count(*) AS _
@@ -338,7 +338,7 @@ describe("Cypher Create Pringles", () => {
             	WITH this, this_photos0
             	CALL {
             		WITH this_photos0
-            		MATCH (this_photos0)-[this_photos0_color_Color_unique:OF_COLOR]->(:Color)
+            		MATCH (this_photos0)-[this_photos0_color_Color_unique:\`OF_COLOR\`]->(:Color)
             		WITH count(this_photos0_color_Color_unique) as c
             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPhoto.color required exactly once', [0])
             		RETURN c AS this_photos0_color_Color_unique_ignored

--- a/packages/graphql/tests/tck/projection.test.ts
+++ b/packages/graphql/tests/tck/projection.test.ts
@@ -110,7 +110,7 @@ describe("Cypher Projection", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)-[create_this1:HAS_PHOTO]->(create_this2:\`Photo\`)
+                MATCH (create_this0)-[create_this1:\`HAS_PHOTO\`]->(create_this2:\`Photo\`)
                 WHERE create_this2.url = $create_param0
                 WITH create_this2 { .url, location: CASE
                     WHEN create_this2.location IS NOT NULL THEN { point: create_this2.location }
@@ -120,14 +120,14 @@ describe("Cypher Projection", () => {
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)-[create_this4:HAS_COLOR]->(create_this5:\`Color\`)
+                MATCH (create_this0)-[create_this4:\`HAS_COLOR\`]->(create_this5:\`Color\`)
                 WHERE create_this5.id = $create_param1
                 WITH create_this5 { .id } AS create_this5
                 RETURN collect(create_this5) AS create_var6
             }
             CALL {
                 WITH create_this0
-                MATCH (create_this0)-[create_this7:HAS_SIZE]->(create_this8:\`Size\`)
+                MATCH (create_this0)-[create_this7:\`HAS_SIZE\`]->(create_this8:\`Size\`)
                 WHERE create_this8.name = $create_param2
                 WITH create_this8 { .name } AS create_this8
                 RETURN collect(create_this8) AS create_var9

--- a/packages/graphql/tests/tck/rfcs/query-limits.test.ts
+++ b/packages/graphql/tests/tck/rfcs/query-limits.test.ts
@@ -173,7 +173,7 @@ describe("tck/rfcs/query-limits", () => {
                 LIMIT $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WITH this1 { .id } AS this1
                     LIMIT $param1
                     RETURN collect(this1) AS var2
@@ -222,7 +222,7 @@ describe("tck/rfcs/query-limits", () => {
                 LIMIT $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WITH { node: { id: this1.id } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount
@@ -280,7 +280,7 @@ describe("tck/rfcs/query-limits", () => {
                 LIMIT $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WITH { node: { id: this1.id } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount
@@ -336,7 +336,7 @@ describe("tck/rfcs/query-limits", () => {
                 "MATCH (this:\`Festival\`)
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:PART_OF]-(this1:\`Show\`)
+                    MATCH (this)<-[this0:\`PART_OF\`]-(this1:\`Show\`)
                     WITH { node: { id: this1.id } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount
@@ -386,7 +386,7 @@ describe("tck/rfcs/query-limits", () => {
                 LIMIT $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WITH this1 { .id } AS this1
                     LIMIT $param1
                     RETURN collect(this1) AS var2

--- a/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
@@ -65,7 +65,7 @@ describe("tck/rfs/003", () => {
                         WITH create_this1
                         CALL {
                         	WITH create_this1
-                        	MATCH (create_this1)<-[create_this1_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (create_this1)<-[create_this1_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(create_this1_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                         	RETURN c AS create_this1_director_Director_unique_ignored
@@ -127,7 +127,7 @@ describe("tck/rfs/003", () => {
                         WITH create_this1
                         CALL {
                         	WITH create_this1
-                        	MATCH (create_this1)<-[create_this1_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (create_this1)<-[create_this1_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(create_this1_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                         	RETURN c AS create_this1_director_Director_unique_ignored
@@ -201,11 +201,11 @@ describe("tck/rfs/003", () => {
                                 CREATE (create_this5:\`Director\`)
                                 SET
                                     create_this5.id = create_var3.id
-                                MERGE (create_this1)<-[create_this6:DIRECTED]-(create_this5)
+                                MERGE (create_this1)<-[create_this6:\`DIRECTED\`]-(create_this5)
                                 WITH create_this5
                                 CALL {
                                 	WITH create_this5
-                                	MATCH (create_this5)-[create_this5_address_Address_unique:HAS_ADDRESS]->(:Address)
+                                	MATCH (create_this5)-[create_this5_address_Address_unique:\`HAS_ADDRESS\`]->(:Address)
                                 	WITH count(create_this5_address_Address_unique) as c
                                 	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required exactly once', [0])
                                 	RETURN c AS create_this5_address_Address_unique_ignored
@@ -215,7 +215,7 @@ describe("tck/rfs/003", () => {
                             WITH create_this1
                             CALL {
                             	WITH create_this1
-                            	MATCH (create_this1)<-[create_this1_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (create_this1)<-[create_this1_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(create_this1_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                             	RETURN c AS create_this1_director_Director_unique_ignored
@@ -295,11 +295,11 @@ describe("tck/rfs/003", () => {
                                 CREATE (create_this5:\`Director\`)
                                 SET
                                     create_this5.id = create_var3.id
-                                MERGE (create_this1)<-[create_this6:DIRECTED]-(create_this5)
+                                MERGE (create_this1)<-[create_this6:\`DIRECTED\`]-(create_this5)
                                 WITH create_this5
                                 CALL {
                                 	WITH create_this5
-                                	MATCH (create_this5)-[create_this5_address_Address_unique:HAS_ADDRESS]->(:Address)
+                                	MATCH (create_this5)-[create_this5_address_Address_unique:\`HAS_ADDRESS\`]->(:Address)
                                 	WITH count(create_this5_address_Address_unique) as c
                                 	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address must be less than or equal to one', [0])
                                 	RETURN c AS create_this5_address_Address_unique_ignored
@@ -309,7 +309,7 @@ describe("tck/rfs/003", () => {
                             WITH create_this1
                             CALL {
                             	WITH create_this1
-                            	MATCH (create_this1)<-[create_this1_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (create_this1)<-[create_this1_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(create_this1_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                             	RETURN c AS create_this1_director_Director_unique_ignored
@@ -377,7 +377,7 @@ describe("tck/rfs/003", () => {
                         WITH this
                         CALL {
                         	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                         	RETURN c AS this_director_Director_unique_ignored
@@ -431,7 +431,7 @@ describe("tck/rfs/003", () => {
                         WITH this
                         CALL {
                         	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                         	RETURN c AS this_director_Director_unique_ignored
@@ -494,12 +494,12 @@ describe("tck/rfs/003", () => {
                             WITH this
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_directed0_relationship:DIRECTED]-(this_director0:Director)
+                            	MATCH (this)<-[this_directed0_relationship:\`DIRECTED\`]-(this_director0:Director)
                             	SET this_director0.id = $this_update_director0_id
                             	WITH this, this_director0
                             	CALL {
                             		WITH this_director0
-                            		MATCH (this_director0)-[this_director0_address_Address_unique:HAS_ADDRESS]->(:Address)
+                            		MATCH (this_director0)-[this_director0_address_Address_unique:\`HAS_ADDRESS\`]->(:Address)
                             		WITH count(this_director0_address_Address_unique) as c
                             		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required exactly once', [0])
                             		RETURN c AS this_director0_address_Address_unique_ignored
@@ -509,7 +509,7 @@ describe("tck/rfs/003", () => {
                             WITH this
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(this_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                             	RETURN c AS this_director_Director_unique_ignored
@@ -571,12 +571,12 @@ describe("tck/rfs/003", () => {
                             WITH this
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_directed0_relationship:DIRECTED]-(this_director0:Director)
+                            	MATCH (this)<-[this_directed0_relationship:\`DIRECTED\`]-(this_director0:Director)
                             	SET this_director0.id = $this_update_director0_id
                             	WITH this, this_director0
                             	CALL {
                             		WITH this_director0
-                            		MATCH (this_director0)-[this_director0_address_Address_unique:HAS_ADDRESS]->(:Address)
+                            		MATCH (this_director0)-[this_director0_address_Address_unique:\`HAS_ADDRESS\`]->(:Address)
                             		WITH count(this_director0_address_Address_unique) as c
                             		CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address must be less than or equal to one', [0])
                             		RETURN c AS this_director0_address_Address_unique_ignored
@@ -586,7 +586,7 @@ describe("tck/rfs/003", () => {
                             WITH this
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(this_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                             	RETURN c AS this_director_Director_unique_ignored
@@ -648,11 +648,11 @@ describe("tck/rfs/003", () => {
                             WITH this
                             CREATE (this_director0_create0_node:Director)
                             SET this_director0_create0_node.id = $this_director0_create0_node_id
-                            MERGE (this)<-[:DIRECTED]-(this_director0_create0_node)
+                            MERGE (this)<-[:\`DIRECTED\`]-(this_director0_create0_node)
                             WITH this, this_director0_create0_node
                             CALL {
                             	WITH this_director0_create0_node
-                            	MATCH (this_director0_create0_node)-[this_director0_create0_node_address_Address_unique:HAS_ADDRESS]->(:Address)
+                            	MATCH (this_director0_create0_node)-[this_director0_create0_node_address_Address_unique:\`HAS_ADDRESS\`]->(:Address)
                             	WITH count(this_director0_create0_node_address_Address_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required exactly once', [0])
                             	RETURN c AS this_director0_create0_node_address_Address_unique_ignored
@@ -660,7 +660,7 @@ describe("tck/rfs/003", () => {
                             WITH this
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(this_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                             	RETURN c AS this_director_Director_unique_ignored
@@ -734,10 +734,10 @@ describe("tck/rfs/003", () => {
                             "MATCH (this:\`Movie\`)
                             WHERE this.id = $param0
                             WITH this
-                            OPTIONAL MATCH (this)<-[this_delete_director0_relationship:DIRECTED]-(this_delete_director0:Director)
+                            OPTIONAL MATCH (this)<-[this_delete_director0_relationship:\`DIRECTED\`]-(this_delete_director0:Director)
                             WHERE this_delete_director0.id = $updateMovies_args_delete_director_where_this_delete_director0param0
                             WITH this, this_delete_director0
-                            OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:HAS_ADDRESS]->(this_delete_director0_address0:Address)
+                            OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:\`HAS_ADDRESS\`]->(this_delete_director0_address0:Address)
                             WHERE this_delete_director0_address0.id = $updateMovies_args_delete_director_delete_address_where_this_delete_director0_address0param0
                             WITH this, this_delete_director0, collect(DISTINCT this_delete_director0_address0) AS this_delete_director0_address0_to_delete
                             CALL {
@@ -757,14 +757,14 @@ describe("tck/rfs/003", () => {
                             WITH *
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(this_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                             	RETURN c AS this_director_Director_unique_ignored
                             }
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_coDirector_CoDirector_unique:CO_DIRECTED]-(:CoDirector)
+                            	MATCH (this)<-[this_coDirector_CoDirector_unique:\`CO_DIRECTED\`]-(:CoDirector)
                             	WITH count(this_coDirector_CoDirector_unique) as c
                             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.coDirector must be less than or equal to one', [0])
                             	RETURN c AS this_coDirector_CoDirector_unique_ignored
@@ -857,10 +857,10 @@ describe("tck/rfs/003", () => {
                             "MATCH (this:\`Movie\`)
                             WHERE this.id = $param0
                             WITH this
-                            OPTIONAL MATCH (this)<-[this_delete_director0_relationship:DIRECTED]-(this_delete_director0:Director)
+                            OPTIONAL MATCH (this)<-[this_delete_director0_relationship:\`DIRECTED\`]-(this_delete_director0:Director)
                             WHERE this_delete_director0.id = $updateMovies_args_delete_director_where_this_delete_director0param0
                             WITH this, this_delete_director0
-                            OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:HAS_ADDRESS]->(this_delete_director0_address0:Address)
+                            OPTIONAL MATCH (this_delete_director0)-[this_delete_director0_address0_relationship:\`HAS_ADDRESS\`]->(this_delete_director0_address0:Address)
                             WHERE this_delete_director0_address0.id = $updateMovies_args_delete_director_delete_address_where_this_delete_director0_address0param0
                             WITH this, this_delete_director0, collect(DISTINCT this_delete_director0_address0) AS this_delete_director0_address0_to_delete
                             CALL {
@@ -880,14 +880,14 @@ describe("tck/rfs/003", () => {
                             WITH *
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(this_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                             	RETURN c AS this_director_Director_unique_ignored
                             }
                             CALL {
                             	WITH this
-                            	MATCH (this)<-[this_coDirector_CoDirector_unique:CO_DIRECTED]-(:CoDirector)
+                            	MATCH (this)<-[this_coDirector_CoDirector_unique:\`CO_DIRECTED\`]-(:CoDirector)
                             	WITH count(this_coDirector_CoDirector_unique) as c
                             	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.coDirector must be less than or equal to one', [0])
                             	RETURN c AS this_coDirector_CoDirector_unique_ignored
@@ -977,7 +977,7 @@ describe("tck/rfs/003", () => {
                         			WITH connectedNodes, parentNodes
                         			UNWIND parentNodes as this0
                         			UNWIND connectedNodes as this0_director_connect0_node
-                        			MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
+                        			MERGE (this0)<-[:\`DIRECTED\`]-(this0_director_connect0_node)
                         			RETURN count(*) AS _
                         		}
                         		RETURN count(*) AS _
@@ -988,7 +988,7 @@ describe("tck/rfs/003", () => {
                         WITH this0
                         CALL {
                         	WITH this0
-                        	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this0)<-[this0_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this0_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                         	RETURN c AS this0_director_Director_unique_ignored
@@ -1054,7 +1054,7 @@ describe("tck/rfs/003", () => {
                         			WITH connectedNodes, parentNodes
                         			UNWIND parentNodes as this0
                         			UNWIND connectedNodes as this0_director_connect0_node
-                        			MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
+                        			MERGE (this0)<-[:\`DIRECTED\`]-(this0_director_connect0_node)
                         			RETURN count(*) AS _
                         		}
                         		RETURN count(*) AS _
@@ -1065,7 +1065,7 @@ describe("tck/rfs/003", () => {
                         WITH this0
                         CALL {
                         	WITH this0
-                        	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this0)<-[this0_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this0_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                         	RETURN c AS this0_director_Director_unique_ignored
@@ -1149,7 +1149,7 @@ describe("tck/rfs/003", () => {
                             			WITH connectedNodes, parentNodes
                             			UNWIND parentNodes as this0
                             			UNWIND connectedNodes as this0_director_connect0_node
-                            			MERGE (this0)<-[:DIRECTED]-(this0_director_connect0_node)
+                            			MERGE (this0)<-[:\`DIRECTED\`]-(this0_director_connect0_node)
                             			RETURN count(*) AS _
                             		}
                             		RETURN count(*) AS _
@@ -1166,7 +1166,7 @@ describe("tck/rfs/003", () => {
                             			WITH connectedNodes, parentNodes
                             			UNWIND parentNodes as this0_director_connect0_node
                             			UNWIND connectedNodes as this0_director_connect0_node_address0_node
-                            			MERGE (this0_director_connect0_node)-[:HAS_ADDRESS]->(this0_director_connect0_node_address0_node)
+                            			MERGE (this0_director_connect0_node)-[:\`HAS_ADDRESS\`]->(this0_director_connect0_node_address0_node)
                             			RETURN count(*) AS _
                             		}
                             		RETURN count(*) AS _
@@ -1174,7 +1174,7 @@ describe("tck/rfs/003", () => {
                             	WITH this0, this0_director_connect0_node, this0_director_connect0_node_address0_node
                             CALL {
                             	WITH this0_director_connect0_node
-                            	MATCH (this0_director_connect0_node)-[this0_director_connect0_node_address_Address_unique:HAS_ADDRESS]->(:Address)
+                            	MATCH (this0_director_connect0_node)-[this0_director_connect0_node_address_Address_unique:\`HAS_ADDRESS\`]->(:Address)
                             	WITH count(this0_director_connect0_node_address_Address_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required exactly once', [0])
                             	RETURN c AS this0_director_connect0_node_address_Address_unique_ignored
@@ -1187,7 +1187,7 @@ describe("tck/rfs/003", () => {
                             WITH this0
                             CALL {
                             	WITH this0
-                            	MATCH (this0)<-[this0_director_Director_unique:DIRECTED]-(:Director)
+                            	MATCH (this0)<-[this0_director_Director_unique:\`DIRECTED\`]-(:Director)
                             	WITH count(this0_director_Director_unique) as c
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                             	RETURN c AS this0_director_Director_unique_ignored
@@ -1247,7 +1247,7 @@ describe("tck/rfs/003", () => {
                         WITH this
                         CALL {
                         WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:\`DIRECTED\`]-(this_disconnect_director0:Director)
                         WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
                         CALL {
                         	WITH this_disconnect_director0, this_disconnect_director0_rel, this
@@ -1262,7 +1262,7 @@ describe("tck/rfs/003", () => {
                         WITH *
                         CALL {
                         	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                         	RETURN c AS this_director_Director_unique_ignored
@@ -1352,7 +1352,7 @@ describe("tck/rfs/003", () => {
                         			WITH connectedNodes, parentNodes
                         			UNWIND parentNodes as this
                         			UNWIND connectedNodes as this_connect_director0_node
-                        			MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
+                        			MERGE (this)<-[:\`DIRECTED\`]-(this_connect_director0_node)
                         			RETURN count(*) AS _
                         		}
                         		RETURN count(*) AS _
@@ -1363,7 +1363,7 @@ describe("tck/rfs/003", () => {
                         WITH this
                         CALL {
                         WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:\`DIRECTED\`]-(this_disconnect_director0:Director)
                         WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
                         CALL {
                         	WITH this_disconnect_director0, this_disconnect_director0_rel, this
@@ -1377,14 +1377,14 @@ describe("tck/rfs/003", () => {
                         WITH *
                         CALL {
                             WITH this
-                            MATCH (this)<-[update_this0:DIRECTED]-(update_this1:\`Director\`)
+                            MATCH (this)<-[update_this0:\`DIRECTED\`]-(update_this1:\`Director\`)
                             WITH update_this1 { .id } AS update_this1
                             RETURN head(collect(update_this1)) AS update_var2
                         }
                         WITH *
                         CALL {
                         	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director required exactly once', [0])
                         	RETURN c AS this_director_Director_unique_ignored
@@ -1473,7 +1473,7 @@ describe("tck/rfs/003", () => {
                         			WITH connectedNodes, parentNodes
                         			UNWIND parentNodes as this
                         			UNWIND connectedNodes as this_connect_director0_node
-                        			MERGE (this)<-[:DIRECTED]-(this_connect_director0_node)
+                        			MERGE (this)<-[:\`DIRECTED\`]-(this_connect_director0_node)
                         			RETURN count(*) AS _
                         		}
                         		RETURN count(*) AS _
@@ -1484,7 +1484,7 @@ describe("tck/rfs/003", () => {
                         WITH this
                         CALL {
                         WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:\`DIRECTED\`]-(this_disconnect_director0:Director)
                         WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
                         CALL {
                         	WITH this_disconnect_director0, this_disconnect_director0_rel, this
@@ -1498,14 +1498,14 @@ describe("tck/rfs/003", () => {
                         WITH *
                         CALL {
                             WITH this
-                            MATCH (this)<-[update_this0:DIRECTED]-(update_this1:\`Director\`)
+                            MATCH (this)<-[update_this0:\`DIRECTED\`]-(update_this1:\`Director\`)
                             WITH update_this1 { .id } AS update_this1
                             RETURN head(collect(update_this1)) AS update_var2
                         }
                         WITH *
                         CALL {
                         	WITH this
-                        	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
+                        	MATCH (this)<-[this_director_Director_unique:\`DIRECTED\`]-(:Director)
                         	WITH count(this_director_Director_unique) as c
                         	CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.director must be less than or equal to one', [0])
                         	RETURN c AS this_director_Director_unique_ignored

--- a/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
@@ -82,7 +82,7 @@ describe("tck/rfs/022 subquery projection", () => {
                 WHERE this.released = $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WHERE this1.name = $param1
                     WITH this1 { .name } AS this1
                     RETURN collect(this1) AS var2
@@ -127,11 +127,11 @@ describe("tck/rfs/022 subquery projection", () => {
                 WHERE this.released = $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WHERE this1.name = $param1
                     CALL {
                         WITH this1
-                        MATCH (this1)-[this2:DIRECTED]->(this3:\`Movie\`)
+                        MATCH (this1)-[this2:\`DIRECTED\`]->(this3:\`Movie\`)
                         WITH this3 { .title, .released } AS this3
                         RETURN collect(this3) AS var4
                     }
@@ -217,7 +217,7 @@ describe("tck/rfs/022 subquery projection", () => {
                 WHERE this.released = $param0
                 CALL {
                     WITH this
-                    MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
+                    MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Person\`)
                     WHERE (this1.name = $param1 AND (any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND (this1.name IS NOT NULL AND this1.name = $param3)) AND apoc.util.validatePredicate(NOT ((any(var5 IN [\\"admin\\"] WHERE any(var4 IN $auth.roles WHERE var4 = var5)) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND (this1.name IS NOT NULL AND this1.name = $param5))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this1 { .name } AS this1
                     RETURN collect(this1) AS var6

--- a/packages/graphql/tests/tck/root-connection.test.ts
+++ b/packages/graphql/tests/tck/root-connection.test.ts
@@ -194,7 +194,7 @@ describe("Root Connection Query tests", () => {
             LIMIT $param0
             CALL {
                 WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:\`Actor\`)
+                MATCH (this)<-[this0:\`ACTED_IN\`]-(this1:\`Actor\`)
                 WITH { node: { name: this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/sort.test.ts
+++ b/packages/graphql/tests/tck/sort.test.ts
@@ -270,7 +270,7 @@ describe("Cypher sort tests", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_GENRE]->(this1:\`Genre\`)
+                MATCH (this)-[this0:\`HAS_GENRE\`]->(this1:\`Genre\`)
                 WITH this1 { .name } AS this1
                 ORDER BY this1.name DESC
                 RETURN collect(this1) AS var2
@@ -301,7 +301,7 @@ describe("Cypher sort tests", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_GENRE]->(this1:\`Genre\`)
+                MATCH (this)-[this0:\`HAS_GENRE\`]->(this1:\`Genre\`)
                 WITH this1 { .name } AS this1
                 ORDER BY this1.name ASC
                 RETURN collect(this1) AS var2
@@ -333,7 +333,7 @@ describe("Cypher sort tests", () => {
             "MATCH (this:\`Movie\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:HAS_GENRE]->(this1:\`Genre\`)
+                MATCH (this)-[this0:\`HAS_GENRE\`]->(this1:\`Genre\`)
                 CALL {
                     WITH this1
                     CALL {

--- a/packages/graphql/tests/tck/subscriptions/create.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create.test.ts
@@ -117,7 +117,7 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node:Actor)
             SET this0_actors0_node.name = $this0_actors0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             SET this0_actors0_relationship.screenTime = $this0_actors0_relationship_screenTime
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
@@ -126,7 +126,7 @@ describe("Subscriptions metadata on create", () => {
             WITH this0, this0_meta AS meta
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH { screenTime: create_this0.screenTime, node: { name: create_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -202,7 +202,7 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node:Actor)
             SET this0_actors0_node.name = $this0_actors0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
             RETURN this0, meta AS this0_meta
@@ -210,7 +210,7 @@ describe("Subscriptions metadata on create", () => {
             WITH this0, this0_meta AS meta
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH { node: { name: create_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -306,11 +306,11 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node_movies0_node:Movie)
             SET this0_actors0_node_movies0_node.title = $this0_actors0_node_movies0_node_title
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node_movies0_node), properties: { old: null, new: this0_actors0_node_movies0_node { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
-            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:ACTED_IN]->(this0_actors0_node_movies0_node)
+            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:\`ACTED_IN\`]->(this0_actors0_node_movies0_node)
             SET this0_actors0_node_movies0_relationship.screenTime = $this0_actors0_node_movies0_relationship_screenTime
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0_actors0_node_movies0_node), id: id(this0_actors0_node_movies0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0_actors0_node_movies0_node { .* }, relationship: this0_actors0_node_movies0_relationship { .* } } } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             SET this0_actors0_relationship.screenTime = $this0_actors0_relationship_screenTime
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
@@ -319,7 +319,7 @@ describe("Subscriptions metadata on create", () => {
             WITH this0, this0_meta AS meta
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH { screenTime: create_this0.screenTime, node: { name: create_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -424,13 +424,13 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_directors_Actor0_node:Actor)
             SET this0_directors_Actor0_node.name = $this0_directors_Actor0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_directors_Actor0_node), properties: { old: null, new: this0_directors_Actor0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_directors_Actor0_node
-            MERGE (this0)<-[this0_directors_Actor0_relationship:DIRECTED]-(this0_directors_Actor0_node)
+            MERGE (this0)<-[this0_directors_Actor0_relationship:\`DIRECTED\`]-(this0_directors_Actor0_node)
             SET this0_directors_Actor0_relationship.year = $this0_directors_Actor0_relationship_year
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_directors_Actor0_node), id_to: id(this0), id: id(this0_directors_Actor0_relationship), relationshipName: \\"DIRECTED\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_directors_Actor0_node { .* }, to: this0 { .* }, relationship: this0_directors_Actor0_relationship { .* } } } AS meta, this0, this0_directors_Actor0_node
             CREATE (this0_directors_Person0_node:Person)
             SET this0_directors_Person0_node.name = $this0_directors_Person0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_directors_Person0_node), properties: { old: null, new: this0_directors_Person0_node { .* } }, timestamp: timestamp(), typename: \\"Person\\" } AS meta, this0, this0_directors_Person0_node
-            MERGE (this0)<-[this0_directors_Person0_relationship:DIRECTED]-(this0_directors_Person0_node)
+            MERGE (this0)<-[this0_directors_Person0_relationship:\`DIRECTED\`]-(this0_directors_Person0_node)
             SET this0_directors_Person0_relationship.year = $this0_directors_Person0_relationship_year
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_directors_Person0_node), id_to: id(this0), id: id(this0_directors_Person0_relationship), relationshipName: \\"DIRECTED\\", fromTypename: \\"Person\\", toTypename: \\"Movie\\", properties: { from: this0_directors_Person0_node { .* }, to: this0 { .* }, relationship: this0_directors_Person0_relationship { .* } } } AS meta, this0, this0_directors_Person0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
@@ -441,12 +441,12 @@ describe("Subscriptions metadata on create", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)<-[create_this0:DIRECTED]-(create_this1:\`Actor\`)
+                    MATCH (this0)<-[create_this0:\`DIRECTED\`]-(create_this1:\`Actor\`)
                     WITH create_this1 { __resolveType: \\"Actor\\", __id: id(this0), .name } AS create_this1
                     RETURN create_this1 AS create_var2
                     UNION
                     WITH *
-                    MATCH (this0)<-[create_this3:DIRECTED]-(create_this4:\`Person\`)
+                    MATCH (this0)<-[create_this3:\`DIRECTED\`]-(create_this4:\`Person\`)
                     WITH create_this4 { __resolveType: \\"Person\\", __id: id(this0), .name } AS create_this4
                     RETURN create_this4 AS create_var2
                 }
@@ -571,17 +571,17 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_directors_Actor0_node_movies0_node:Movie)
             SET this0_directors_Actor0_node_movies0_node.title = $this0_directors_Actor0_node_movies0_node_title
             WITH meta + { event: \\"create\\", id: id(this0_directors_Actor0_node_movies0_node), properties: { old: null, new: this0_directors_Actor0_node_movies0_node { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0, this0_directors_Actor0_node, this0_directors_Actor0_node_movies0_node
-            MERGE (this0_directors_Actor0_node)-[this0_directors_Actor0_node_movies0_relationship:ACTED_IN]->(this0_directors_Actor0_node_movies0_node)
+            MERGE (this0_directors_Actor0_node)-[this0_directors_Actor0_node_movies0_relationship:\`ACTED_IN\`]->(this0_directors_Actor0_node_movies0_node)
             SET this0_directors_Actor0_node_movies0_relationship.screenTime = $this0_directors_Actor0_node_movies0_relationship_screenTime
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_directors_Actor0_node), id_to: id(this0_directors_Actor0_node_movies0_node), id: id(this0_directors_Actor0_node_movies0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_directors_Actor0_node { .* }, to: this0_directors_Actor0_node_movies0_node { .* }, relationship: this0_directors_Actor0_node_movies0_relationship { .* } } } AS meta, this0, this0_directors_Actor0_node, this0_directors_Actor0_node_movies0_node
             WITH meta + { event: \\"create\\", id: id(this0_directors_Actor0_node), properties: { old: null, new: this0_directors_Actor0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_directors_Actor0_node
-            MERGE (this0)<-[this0_directors_Actor0_relationship:DIRECTED]-(this0_directors_Actor0_node)
+            MERGE (this0)<-[this0_directors_Actor0_relationship:\`DIRECTED\`]-(this0_directors_Actor0_node)
             SET this0_directors_Actor0_relationship.year = $this0_directors_Actor0_relationship_year
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_directors_Actor0_node), id_to: id(this0), id: id(this0_directors_Actor0_relationship), relationshipName: \\"DIRECTED\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_directors_Actor0_node { .* }, to: this0 { .* }, relationship: this0_directors_Actor0_relationship { .* } } } AS meta, this0, this0_directors_Actor0_node
             CREATE (this0_directors_Person0_node:Person)
             SET this0_directors_Person0_node.name = $this0_directors_Person0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_directors_Person0_node), properties: { old: null, new: this0_directors_Person0_node { .* } }, timestamp: timestamp(), typename: \\"Person\\" } AS meta, this0, this0_directors_Person0_node
-            MERGE (this0)<-[this0_directors_Person0_relationship:DIRECTED]-(this0_directors_Person0_node)
+            MERGE (this0)<-[this0_directors_Person0_relationship:\`DIRECTED\`]-(this0_directors_Person0_node)
             SET this0_directors_Person0_relationship.year = $this0_directors_Person0_relationship_year
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_directors_Person0_node), id_to: id(this0), id: id(this0_directors_Person0_relationship), relationshipName: \\"DIRECTED\\", fromTypename: \\"Person\\", toTypename: \\"Movie\\", properties: { from: this0_directors_Person0_node { .* }, to: this0 { .* }, relationship: this0_directors_Person0_relationship { .* } } } AS meta, this0, this0_directors_Person0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
@@ -592,10 +592,10 @@ describe("Subscriptions metadata on create", () => {
                 WITH this0
                 CALL {
                     WITH *
-                    MATCH (this0)<-[create_this0:DIRECTED]-(create_this1:\`Actor\`)
+                    MATCH (this0)<-[create_this0:\`DIRECTED\`]-(create_this1:\`Actor\`)
                     CALL {
                         WITH create_this1
-                        MATCH (create_this1)-[create_this2:ACTED_IN]->(create_this3:\`Movie\`)
+                        MATCH (create_this1)-[create_this2:\`ACTED_IN\`]->(create_this3:\`Movie\`)
                         WITH create_this3 { .title } AS create_this3
                         RETURN collect(create_this3) AS create_var4
                     }
@@ -603,7 +603,7 @@ describe("Subscriptions metadata on create", () => {
                     RETURN create_this1 AS create_var5
                     UNION
                     WITH *
-                    MATCH (this0)<-[create_this6:DIRECTED]-(create_this7:\`Person\`)
+                    MATCH (this0)<-[create_this6:\`DIRECTED\`]-(create_this7:\`Person\`)
                     WITH create_this7 { __resolveType: \\"Person\\", __id: id(this0), .name } AS create_this7
                     RETURN create_this7 AS create_var5
                 }
@@ -742,7 +742,7 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node:Actor)
             SET this0_actors0_node.name = $this0_actors0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
             RETURN this0, meta AS this0_meta
@@ -750,7 +750,7 @@ describe("Subscriptions metadata on create", () => {
             WITH this0, this0_meta AS meta
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH create_this1 { .name } AS create_this1
                 RETURN collect(create_this1) AS create_var2
             }
@@ -802,10 +802,10 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node_movies0_node:Movie)
             SET this0_actors0_node_movies0_node.id = $this0_actors0_node_movies0_node_id
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node_movies0_node), properties: { old: null, new: this0_actors0_node_movies0_node { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
-            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:ACTED_IN]->(this0_actors0_node_movies0_node)
+            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:\`ACTED_IN\`]->(this0_actors0_node_movies0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0_actors0_node_movies0_node), id: id(this0_actors0_node_movies0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0_actors0_node_movies0_node { .* }, relationship: this0_actors0_node_movies0_relationship { .* } } } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
             RETURN this0, meta AS this0_meta
@@ -813,7 +813,7 @@ describe("Subscriptions metadata on create", () => {
             WITH this0, this0_meta AS meta
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 WITH create_this1 { .name } AS create_this1
                 RETURN collect(create_this1) AS create_var2
             }
@@ -885,13 +885,13 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node_movies0_node_actors0_node:Actor)
             SET this0_actors0_node_movies0_node_actors0_node.name = $this0_actors0_node_movies0_node_actors0_node_name
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node_movies0_node_actors0_node), properties: { old: null, new: this0_actors0_node_movies0_node_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node, this0_actors0_node_movies0_node_actors0_node
-            MERGE (this0_actors0_node_movies0_node)<-[this0_actors0_node_movies0_node_actors0_relationship:ACTED_IN]-(this0_actors0_node_movies0_node_actors0_node)
+            MERGE (this0_actors0_node_movies0_node)<-[this0_actors0_node_movies0_node_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node_movies0_node_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node_movies0_node_actors0_node), id_to: id(this0_actors0_node_movies0_node), id: id(this0_actors0_node_movies0_node_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node_movies0_node_actors0_node { .* }, to: this0_actors0_node_movies0_node { .* }, relationship: this0_actors0_node_movies0_node_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node, this0_actors0_node_movies0_node_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node_movies0_node), properties: { old: null, new: this0_actors0_node_movies0_node { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
-            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:ACTED_IN]->(this0_actors0_node_movies0_node)
+            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:\`ACTED_IN\`]->(this0_actors0_node_movies0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0_actors0_node_movies0_node), id: id(this0_actors0_node_movies0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0_actors0_node_movies0_node { .* }, relationship: this0_actors0_node_movies0_relationship { .* } } } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
             RETURN this0, meta AS this0_meta
@@ -899,13 +899,13 @@ describe("Subscriptions metadata on create", () => {
             WITH this0, this0_meta AS meta
             CALL {
                 WITH this0
-                MATCH (this0)<-[create_this0:ACTED_IN]-(create_this1:\`Actor\`)
+                MATCH (this0)<-[create_this0:\`ACTED_IN\`]-(create_this1:\`Actor\`)
                 CALL {
                     WITH create_this1
-                    MATCH (create_this1)-[create_this2:ACTED_IN]->(create_this3:\`Movie\`)
+                    MATCH (create_this1)-[create_this2:\`ACTED_IN\`]->(create_this3:\`Movie\`)
                     CALL {
                         WITH create_this3
-                        MATCH (create_this3)<-[create_this4:ACTED_IN]-(create_this5:\`Actor\`)
+                        MATCH (create_this3)<-[create_this4:\`ACTED_IN\`]-(create_this5:\`Actor\`)
                         WITH create_this5 { .name } AS create_this5
                         RETURN collect(create_this5) AS create_var6
                     }
@@ -966,10 +966,10 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this0_actors0_node_movies0_node:Movie)
             SET this0_actors0_node_movies0_node.id = $this0_actors0_node_movies0_node_id
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node_movies0_node), properties: { old: null, new: this0_actors0_node_movies0_node { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
-            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:ACTED_IN]->(this0_actors0_node_movies0_node)
+            MERGE (this0_actors0_node)-[this0_actors0_node_movies0_relationship:\`ACTED_IN\`]->(this0_actors0_node_movies0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0_actors0_node_movies0_node), id: id(this0_actors0_node_movies0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0_actors0_node_movies0_node { .* }, relationship: this0_actors0_node_movies0_relationship { .* } } } AS meta, this0, this0_actors0_node, this0_actors0_node_movies0_node
             WITH meta + { event: \\"create\\", id: id(this0_actors0_node), properties: { old: null, new: this0_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0, this0_actors0_node
-            MERGE (this0)<-[this0_actors0_relationship:ACTED_IN]-(this0_actors0_node)
+            MERGE (this0)<-[this0_actors0_relationship:\`ACTED_IN\`]-(this0_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this0_actors0_node), id_to: id(this0), id: id(this0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this0_actors0_node { .* }, to: this0 { .* }, relationship: this0_actors0_relationship { .* } } } AS meta, this0, this0_actors0_node
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this0
             RETURN this0, meta AS this0_meta
@@ -983,10 +983,10 @@ describe("Subscriptions metadata on create", () => {
             CREATE (this1_actors0_node_movies0_node:Movie)
             SET this1_actors0_node_movies0_node.id = $this1_actors0_node_movies0_node_id
             WITH meta + { event: \\"create\\", id: id(this1_actors0_node_movies0_node), properties: { old: null, new: this1_actors0_node_movies0_node { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this1, this1_actors0_node, this1_actors0_node_movies0_node
-            MERGE (this1_actors0_node)-[this1_actors0_node_movies0_relationship:ACTED_IN]->(this1_actors0_node_movies0_node)
+            MERGE (this1_actors0_node)-[this1_actors0_node_movies0_relationship:\`ACTED_IN\`]->(this1_actors0_node_movies0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this1_actors0_node), id_to: id(this1_actors0_node_movies0_node), id: id(this1_actors0_node_movies0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this1_actors0_node { .* }, to: this1_actors0_node_movies0_node { .* }, relationship: this1_actors0_node_movies0_relationship { .* } } } AS meta, this1, this1_actors0_node, this1_actors0_node_movies0_node
             WITH meta + { event: \\"create\\", id: id(this1_actors0_node), properties: { old: null, new: this1_actors0_node { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this1, this1_actors0_node
-            MERGE (this1)<-[this1_actors0_relationship:ACTED_IN]-(this1_actors0_node)
+            MERGE (this1)<-[this1_actors0_relationship:\`ACTED_IN\`]-(this1_actors0_node)
             WITH meta + { event: \\"create_relationship\\", timestamp: timestamp(), id_from: id(this1_actors0_node), id_to: id(this1), id: id(this1_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: this1_actors0_node { .* }, to: this1 { .* }, relationship: this1_actors0_relationship { .* } } } AS meta, this1, this1_actors0_node
             WITH meta + { event: \\"create\\", id: id(this1), properties: { old: null, new: this1 { .* } }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta, this1
             RETURN this1, meta AS this1_meta

--- a/packages/graphql/tests/tck/subscriptions/delete.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/delete.test.ts
@@ -116,7 +116,7 @@ describe("Subscriptions metadata on delete", () => {
             WHERE this.id = $param0
             WITH this, meta + { event: \\"delete\\", id: id(this), properties: { old: this { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
             WITH this, meta
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, meta, collect(DISTINCT this_actors0) AS this_actors0_to_delete, this_actors0_relationship
             WITH this, this_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" } + { event: \\"delete_relationship\\", timestamp: timestamp(), id_from: id(n), id_to: id(this), id: id(this_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: n { .* }, to: this { .* }, relationship: this_actors0_relationship { .* } } }) AS meta
@@ -189,13 +189,13 @@ describe("Subscriptions metadata on delete", () => {
             WHERE this.id = $param0
             WITH this, meta + { event: \\"delete\\", id: id(this), properties: { old: this { .* }, new: null }, timestamp: timestamp(), typename: \\"Movie\\" } AS meta
             WITH this, meta
-            OPTIONAL MATCH (this)<-[this_actors0_relationship:ACTED_IN]-(this_actors0:Actor)
+            OPTIONAL MATCH (this)<-[this_actors0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             WHERE this_actors0.name = $this_deleteMovies_args_delete_actors0_where_this_actors0param0
             WITH this, meta, this_actors0, this_actors0_relationship
-            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:ACTED_IN]->(this_actors0_movies0:Movie)
+            OPTIONAL MATCH (this_actors0)-[this_actors0_movies0_relationship:\`ACTED_IN\`]->(this_actors0_movies0:Movie)
             WHERE this_actors0_movies0.id = $this_deleteMovies_args_delete_actors0_delete_movies0_where_this_actors0_movies0param0
             WITH this, meta, this_actors0, this_actors0_relationship, this_actors0_movies0, this_actors0_movies0_relationship
-            OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:ACTED_IN]-(this_actors0_movies0_actors0:Actor)
+            OPTIONAL MATCH (this_actors0_movies0)<-[this_actors0_movies0_actors0_relationship:\`ACTED_IN\`]-(this_actors0_movies0_actors0:Actor)
             WHERE this_actors0_movies0_actors0.name = $this_deleteMovies_args_delete_actors0_delete_movies0_delete_actors0_where_this_actors0_movies0_actors0param0
             WITH this, meta, this_actors0, this_actors0_relationship, this_actors0_movies0, this_actors0_movies0_relationship, collect(DISTINCT this_actors0_movies0_actors0) AS this_actors0_movies0_actors0_to_delete, this_actors0_movies0_actors0_relationship
             WITH this, this_actors0, this_actors0_relationship, this_actors0_movies0, this_actors0_movies0_relationship, this_actors0_movies0_actors0_to_delete, REDUCE(m=meta, n IN this_actors0_movies0_actors0_to_delete | m + { event: \\"delete\\", id: id(n), properties: { old: n { .* }, new: null }, timestamp: timestamp(), typename: \\"Actor\\" } + { event: \\"delete_relationship\\", timestamp: timestamp(), id_from: id(n), id_to: id(this_actors0_movies0), id: id(this_actors0_movies0_actors0_relationship), relationshipName: \\"ACTED_IN\\", fromTypename: \\"Actor\\", toTypename: \\"Movie\\", properties: { from: n { .* }, to: this_actors0_movies0 { .* }, relationship: this_actors0_movies0_actors0_relationship { .* } } }) AS meta

--- a/packages/graphql/tests/tck/subscriptions/update.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/update.test.ts
@@ -128,7 +128,7 @@ describe("Subscriptions metadata on update", () => {
             	WITH this, meta
             CALL {
             	WITH this, meta
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	MATCH (this)<-[this_acted_in0_relationship:\`ACTED_IN\`]-(this_actors0:Actor)
             	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
             	WITH this_actors0 { .* } AS oldProps, this, meta, this_actors0
             	CALL {

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-aggregations.test.ts
@@ -65,7 +65,7 @@ describe("QueryDirection in relationships aggregations", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 RETURN count(this1) AS var2
             }
             RETURN this { friendsAggregate: { count: var2 } } AS this"
@@ -108,7 +108,7 @@ describe("QueryDirection in relationships aggregations", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]->(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]->(this1:\`User\`)
                 RETURN count(this1) AS var2
             }
             RETURN this { friendsAggregate: { count: var2 } } AS this"
@@ -151,7 +151,7 @@ describe("QueryDirection in relationships aggregations", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 RETURN count(this1) AS var2
             }
             RETURN this { friendsAggregate: { count: var2 } } AS this"

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction-connection.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction-connection.test.ts
@@ -65,7 +65,7 @@ describe("QueryDirection in relationships connection", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 WITH { node: { __resolveType: \\"User\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -112,7 +112,7 @@ describe("QueryDirection in relationships connection", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]->(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]->(this1:\`User\`)
                 WITH { node: { __resolveType: \\"User\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -158,7 +158,7 @@ describe("QueryDirection in relationships connection", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 WITH { node: { __resolveType: \\"User\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/undirected-relationships/query-direction.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/query-direction.test.ts
@@ -69,13 +69,13 @@ describe("QueryDirection in relationships", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[this3:FRIENDS_WITH]->(this4:\`User\`)
+                MATCH (this)-[this3:\`FRIENDS_WITH\`]->(this4:\`User\`)
                 WITH this4 { .name } AS this4
                 RETURN collect(this4) AS var5
             }
@@ -124,13 +124,13 @@ describe("QueryDirection in relationships", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]->(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]->(this1:\`User\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[this3:FRIENDS_WITH]-(this4:\`User\`)
+                MATCH (this)-[this3:\`FRIENDS_WITH\`]-(this4:\`User\`)
                 WITH this4 { .name } AS this4
                 RETURN collect(this4) AS var5
             }
@@ -176,7 +176,7 @@ describe("QueryDirection in relationships", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]->(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]->(this1:\`User\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
@@ -221,7 +221,7 @@ describe("QueryDirection in relationships", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-aggregations.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-aggregations.test.ts
@@ -64,7 +64,7 @@ describe("Undirected Aggregations", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 RETURN count(this1) AS var2
             }
             RETURN this { friendsAggregate: { count: var2 } } AS this"

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-connection.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-connection.test.ts
@@ -64,7 +64,7 @@ describe("Undirected connections", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 WITH { node: { __resolveType: \\"User\\", __id: id(this1) } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-relationships.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-relationships.test.ts
@@ -68,13 +68,13 @@ describe("Undirected relationships", () => {
             "MATCH (this:\`User\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:FRIENDS_WITH]-(this1:\`User\`)
+                MATCH (this)-[this0:\`FRIENDS_WITH\`]-(this1:\`User\`)
                 WITH this1 { .name } AS this1
                 RETURN collect(this1) AS var2
             }
             CALL {
                 WITH this
-                MATCH (this)-[this3:FRIENDS_WITH]->(this4:\`User\`)
+                MATCH (this)-[this3:\`FRIENDS_WITH\`]->(this4:\`User\`)
                 WITH this4 { .name } AS this4
                 RETURN collect(this4) AS var5
             }
@@ -137,12 +137,12 @@ describe("Undirected relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:HAS_CONTENT]-(this1:\`Blog\`)
+                    MATCH (this)-[this0:\`HAS_CONTENT\`]-(this1:\`Blog\`)
                     WITH this1 { __resolveType: \\"Blog\\", __id: id(this), .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:HAS_CONTENT]-(this4:\`Post\`)
+                    MATCH (this)-[this3:\`HAS_CONTENT\`]-(this4:\`Post\`)
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .content } AS this4
                     RETURN this4 AS var2
                 }
@@ -213,12 +213,12 @@ describe("Undirected relationships", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:ACTED_IN]-(this1:\`Movie\`)
+                    MATCH (this)-[this0:\`ACTED_IN\`]-(this1:\`Movie\`)
                     WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:ACTED_IN]-(this4:\`Series\`)
+                    MATCH (this)-[this3:\`ACTED_IN\`]-(this4:\`Series\`)
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .title } AS this4
                     RETURN this4 AS var2
                 }
@@ -277,10 +277,10 @@ describe("Undirected relationships", () => {
             "MATCH (this:\`Foo\`)
             CALL {
                 WITH this
-                MATCH (this)-[this0:DRINKS_AT]->(this1:\`Bar\`)
+                MATCH (this)-[this0:\`DRINKS_AT\`]->(this1:\`Bar\`)
                 CALL {
                     WITH this1
-                    MATCH (this1)-[this2:DRINKS_AT]-(this3:\`Foo\`)
+                    MATCH (this1)-[this2:\`DRINKS_AT\`]-(this3:\`Foo\`)
                     WITH this3 { .Name } AS this3
                     RETURN collect(this3) AS var4
                 }

--- a/packages/graphql/tests/tck/union.test.ts
+++ b/packages/graphql/tests/tck/union.test.ts
@@ -81,13 +81,13 @@ describe("Cypher Union", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:\`Genre\`)
+                    MATCH (this)-[this0:\`SEARCH\`]->(this1:\`Genre\`)
                     WHERE apoc.util.validatePredicate(NOT ((this1.name IS NOT NULL AND this1.name = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:\`Movie\`)
+                    MATCH (this)-[this3:\`SEARCH\`]->(this4:\`Movie\`)
                     WITH this4 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this4
                     RETURN this4 AS var2
                 }
@@ -128,13 +128,13 @@ describe("Cypher Union", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:\`Genre\`)
+                    MATCH (this)-[this0:\`SEARCH\`]->(this1:\`Genre\`)
                     WHERE apoc.util.validatePredicate(NOT ((this1.name IS NOT NULL AND this1.name = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:\`Movie\`)
+                    MATCH (this)-[this3:\`SEARCH\`]->(this4:\`Movie\`)
                     WITH this4 { __resolveType: \\"Movie\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
@@ -182,13 +182,13 @@ describe("Cypher Union", () => {
                 WITH this
                 CALL {
                     WITH *
-                    MATCH (this)-[this0:SEARCH]->(this1:\`Genre\`)
+                    MATCH (this)-[this0:\`SEARCH\`]->(this1:\`Genre\`)
                     WHERE (this1.name = $param1 AND apoc.util.validatePredicate(NOT ((this1.name IS NOT NULL AND this1.name = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
-                    MATCH (this)-[this3:SEARCH]->(this4:\`Movie\`)
+                    MATCH (this)-[this3:\`SEARCH\`]->(this4:\`Movie\`)
                     WHERE this4.title = $param3
                     WITH this4 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this4
                     RETURN this4 AS var2
@@ -244,7 +244,7 @@ describe("Cypher Union", () => {
             WITH this0
             CREATE (this0_search_Genre0_node:Genre)
             SET this0_search_Genre0_node.name = $this0_search_Genre0_node_name
-            MERGE (this0)-[:SEARCH]->(this0_search_Genre0_node)
+            MERGE (this0)-[:\`SEARCH\`]->(this0_search_Genre0_node)
             RETURN this0
             }
             RETURN [ this0 { .title } ] AS data"
@@ -279,7 +279,7 @@ describe("Cypher Union", () => {
             "MATCH (this:\`Movie\`)
             CREATE (this_create_search_Genre0_node:Genre)
             SET this_create_search_Genre0_node.name = $this_create_search_Genre0_node_name
-            MERGE (this)-[:SEARCH]->(this_create_search_Genre0_node)
+            MERGE (this)-[:\`SEARCH\`]->(this_create_search_Genre0_node)
             WITH *
             RETURN collect(DISTINCT this { .title }) AS data"
         `);
@@ -331,7 +331,7 @@ describe("Cypher Union", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this0
             			UNWIND connectedNodes as this0_search_Genre_connect0_node
-            			MERGE (this0)-[:SEARCH]->(this0_search_Genre_connect0_node)
+            			MERGE (this0)-[:\`SEARCH\`]->(this0_search_Genre_connect0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -385,7 +385,7 @@ describe("Cypher Union", () => {
             WITH this
             CALL {
             	WITH this
-            	MATCH (this)-[this_search0_relationship:SEARCH]->(this_search_Genre0:Genre)
+            	MATCH (this)-[this_search0_relationship:\`SEARCH\`]->(this_search_Genre0:Genre)
             	WHERE this_search_Genre0.name = $updateMovies_args_update_search_Genre0_where_this_search_Genre0param0
             	SET this_search_Genre0.name = $this_update_search_Genre0_name
             	RETURN count(*) AS update_this_search_Genre0
@@ -450,7 +450,7 @@ describe("Cypher Union", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_search_Genre0_disconnect0_rel:SEARCH]->(this_search_Genre0_disconnect0:Genre)
+            OPTIONAL MATCH (this)-[this_search_Genre0_disconnect0_rel:\`SEARCH\`]->(this_search_Genre0_disconnect0:Genre)
             WHERE this_search_Genre0_disconnect0.name = $updateMovies_args_update_search_Genre0_disconnect0_where_Genre_this_search_Genre0_disconnect0param0
             CALL {
             	WITH this_search_Genre0_disconnect0, this_search_Genre0_disconnect0_rel, this
@@ -519,7 +519,7 @@ describe("Cypher Union", () => {
             WITH this
             CALL {
             WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_search_Genre0_rel:SEARCH]->(this_disconnect_search_Genre0:Genre)
+            OPTIONAL MATCH (this)-[this_disconnect_search_Genre0_rel:\`SEARCH\`]->(this_disconnect_search_Genre0:Genre)
             WHERE this_disconnect_search_Genre0.name = $updateMovies_args_disconnect_search_Genre0_where_Genre_this_disconnect_search_Genre0param0
             CALL {
             	WITH this_disconnect_search_Genre0, this_disconnect_search_Genre0_rel, this
@@ -594,7 +594,7 @@ describe("Cypher Union", () => {
             			WITH connectedNodes, parentNodes
             			UNWIND parentNodes as this
             			UNWIND connectedNodes as this_connect_search_Genre0_node
-            			MERGE (this)-[:SEARCH]->(this_connect_search_Genre0_node)
+            			MERGE (this)-[:\`SEARCH\`]->(this_connect_search_Genre0_node)
             			RETURN count(*) AS _
             		}
             		RETURN count(*) AS _
@@ -638,7 +638,7 @@ describe("Cypher Union", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.title = $param0
             WITH this
-            OPTIONAL MATCH (this)-[this_delete_search_Genre0_relationship:SEARCH]->(this_delete_search_Genre0:Genre)
+            OPTIONAL MATCH (this)-[this_delete_search_Genre0_relationship:\`SEARCH\`]->(this_delete_search_Genre0:Genre)
             WHERE this_delete_search_Genre0.name = $updateMovies_args_delete_search_Genre0_where_this_delete_search_Genre0param0
             WITH this, collect(DISTINCT this_delete_search_Genre0) AS this_delete_search_Genre0_to_delete
             CALL {

--- a/packages/graphql/tests/utils/builders/relation-field-builder.ts
+++ b/packages/graphql/tests/utils/builders/relation-field-builder.ts
@@ -26,6 +26,7 @@ export class RelationFieldBuilder extends Builder<RelationField, RelationField> 
         super({
             direction: "OUT",
             type: "",
+            typeUnescaped: "",
             fieldName: "",
             typeMeta: {
                 name: "",


### PR DESCRIPTION
# Description

This PR adds escaping to relationship type strings.

There is a need for an unescaped version of the relationship type string so this is added as a new property `typeUnescaped`

This PR also includes some small type and typo fixes that were in the periphery :)

## Complexity

Low