### PR TITLE
[cypher-builder] Add and export all math operators

### DIFF
--- a/.changeset/spotty-rockets-hope.md
+++ b/.changeset/spotty-rockets-hope.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/cypher-builder": patch
+---
+
+Export MathOp and add all math operators

--- a/packages/cypher-builder/src/Cypher.ts
+++ b/packages/cypher-builder/src/Cypher.ts
@@ -77,7 +77,7 @@ export {
     endsWith,
     matches,
 } from "./expressions/operations/comparison";
-export { plus, minus } from "./expressions/operations/math";
+export { MathOp as Math, plus, minus } from "./expressions/operations/math";
 
 // --Functions
 export { CypherFunction as Function } from "./expressions/functions/CypherFunctions";

--- a/packages/cypher-builder/src/Cypher.ts
+++ b/packages/cypher-builder/src/Cypher.ts
@@ -77,7 +77,7 @@ export {
     endsWith,
     matches,
 } from "./expressions/operations/comparison";
-export { MathOp as Math, plus, minus } from "./expressions/operations/math";
+export { plus, minus, multiplication, division, modulo, exponentiation } from "./expressions/operations/math";
 
 // --Functions
 export { CypherFunction as Function } from "./expressions/functions/CypherFunctions";

--- a/packages/cypher-builder/src/expressions/operations/math.ts
+++ b/packages/cypher-builder/src/expressions/operations/math.ts
@@ -64,6 +64,52 @@ export function plus(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function minus(leftExpr: Expr, rightExpr: Expr): MathOp {
+export function minus(leftExpr: Expr, rightExpr: Expr): MathOp
+export function minus(...exprs: Expr[]): MathOp;
+export function minus(...exprs: Expr[]): MathOp {
     return createOp("-", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function multiplication(leftExpr: Expr, rightExpr: Expr): MathOp
+export function multiplication(...exprs: Expr[]): MathOp;
+export function multiplication(...exprs: Expr[]): MathOp {
+    return createOp("*", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function division(leftExpr: Expr, rightExpr: Expr): MathOp
+export function division(...exprs: Expr[]): MathOp;
+export function division(...exprs: Expr[]): MathOp {
+    return createOp("/", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function modulo(leftExpr: Expr, rightExpr: Expr): MathOp
+export function modulo(...exprs: Expr[]): MathOp;
+export function modulo(...exprs: Expr[]): MathOp {
+    return createOp("%", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function exponentiation(leftExpr: Expr, rightExpr: Expr): MathOp
+export function exponentiation(...exprs: Expr[]): MathOp;
+export function exponentiation(...exprs: Expr[]): MathOp {
+    return createOp("^", [leftExpr, rightExpr]);
 }

--- a/packages/cypher-builder/src/expressions/operations/math.ts
+++ b/packages/cypher-builder/src/expressions/operations/math.ts
@@ -64,7 +64,7 @@ export function plus(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function minus(leftExpr: Expr, rightExpr: Expr): MathOp
+export function minus(leftExpr: Expr, rightExpr: Expr): MathOp;
 export function minus(...exprs: Expr[]): MathOp;
 export function minus(...exprs: Expr[]): MathOp {
     return createOp("-", [leftExpr, rightExpr]);
@@ -75,7 +75,7 @@ export function minus(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function multiplication(leftExpr: Expr, rightExpr: Expr): MathOp
+export function multiplication(leftExpr: Expr, rightExpr: Expr): MathOp;
 export function multiplication(...exprs: Expr[]): MathOp;
 export function multiplication(...exprs: Expr[]): MathOp {
     return createOp("*", [leftExpr, rightExpr]);
@@ -86,7 +86,7 @@ export function multiplication(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function division(leftExpr: Expr, rightExpr: Expr): MathOp
+export function division(leftExpr: Expr, rightExpr: Expr): MathOp;
 export function division(...exprs: Expr[]): MathOp;
 export function division(...exprs: Expr[]): MathOp {
     return createOp("/", [leftExpr, rightExpr]);
@@ -97,7 +97,7 @@ export function division(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function modulo(leftExpr: Expr, rightExpr: Expr): MathOp
+export function modulo(leftExpr: Expr, rightExpr: Expr): MathOp;
 export function modulo(...exprs: Expr[]): MathOp;
 export function modulo(...exprs: Expr[]): MathOp {
     return createOp("%", [leftExpr, rightExpr]);
@@ -108,7 +108,7 @@ export function modulo(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function exponentiation(leftExpr: Expr, rightExpr: Expr): MathOp
+export function exponentiation(leftExpr: Expr, rightExpr: Expr): MathOp;
 export function exponentiation(...exprs: Expr[]): MathOp;
 export function exponentiation(...exprs: Expr[]): MathOp {
     return createOp("^", [leftExpr, rightExpr]);

--- a/packages/cypher-builder/src/expressions/operations/math.ts
+++ b/packages/cypher-builder/src/expressions/operations/math.ts
@@ -21,7 +21,7 @@ import type { Expr } from "../../types";
 import type { CypherEnvironment } from "../../Environment";
 import { CypherASTNode } from "../../CypherASTNode";
 
-type MathOperator = "+" | "-";
+type MathOperator = "+" | "-" | "*", "/", "%", "^";
 
 export class MathOp extends CypherASTNode {
     private operator: MathOperator;

--- a/packages/cypher-builder/src/expressions/operations/math.ts
+++ b/packages/cypher-builder/src/expressions/operations/math.ts
@@ -21,7 +21,7 @@ import type { Expr } from "../../types";
 import type { CypherEnvironment } from "../../Environment";
 import { CypherASTNode } from "../../CypherASTNode";
 
-type MathOperator = "+" | "-" | "*", "/", "%", "^";
+type MathOperator = "+" | "-" | "*" | "/" | "%" | "^";
 
 export class MathOp extends CypherASTNode {
     private operator: MathOperator;


### PR DESCRIPTION
# Description

Exports `MathOp` as `Math` in the entry point and add all math operators to the type `MathOperator`.

## Complexity

Complexity: Low

# Issue

N/A

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [X] CLA (https://neo4j.com/developer/cla/) has been signed
