### PR TITLE
change Math operator to support unary operations, move outside string…

### DIFF
--- a/packages/cypher-builder/src/Cypher.ts
+++ b/packages/cypher-builder/src/Cypher.ts
@@ -77,7 +77,9 @@ export {
     endsWith,
     matches,
 } from "./expressions/operations/comparison";
-export { plus, minus } from "./expressions/operations/math";
+export { plus, minus, add, divide, multiply, subtract, remainder, pow } from "./expressions/operations/math";
+// Concat exported as append as concat is colliding with the Composite Clause concat
+export { concat as append } from "./expressions/operations/string";
 
 // --Functions
 export { CypherFunction as Function } from "./expressions/functions/CypherFunctions";

--- a/packages/cypher-builder/src/clauses/With.test.ts
+++ b/packages/cypher-builder/src/clauses/With.test.ts
@@ -71,7 +71,7 @@ describe("CypherBuilder With", () => {
         });
 
         test("With expression aliased", () => {
-            const expr = Cypher.plus(new Cypher.Param("The "), new Cypher.Param("Matrix"));
+            const expr = Cypher.append(new Cypher.Param("The "), new Cypher.Param("Matrix"));
             const alias = new Cypher.Variable();
             const withQuery = new Cypher.With([expr, alias]);
 

--- a/packages/cypher-builder/src/expressions/functions/ListFunctions.test.ts
+++ b/packages/cypher-builder/src/expressions/functions/ListFunctions.test.ts
@@ -37,7 +37,7 @@ describe("List Functions", () => {
 
         const listExpr = new Cypher.List([new Cypher.Param(2), new Cypher.Param(3)]);
 
-        const reduceFn = Cypher.reduce(acc, new Cypher.Param(0), listElement, listExpr, Cypher.plus(acc, listElement));
+        const reduceFn = Cypher.reduce(acc, new Cypher.Param(0), listElement, listExpr, Cypher.add(acc, listElement));
 
         const queryResult = new TestClause(reduceFn).build();
         expect(queryResult.cypher).toMatchInlineSnapshot(

--- a/packages/cypher-builder/src/expressions/operations/math.test.ts
+++ b/packages/cypher-builder/src/expressions/operations/math.test.ts
@@ -18,28 +18,57 @@
  */
 
 import Cypher from "../..";
+import { TestClause } from "../../utils/TestClause";
 
-test("Match node with mathematical operator", () => {
-    const yearParam = new Cypher.Param(2000);
+describe("math operators", () => {
+    const literal1 = new Cypher.Literal(4);
+    const literal2 = new Cypher.Literal(3);
 
-    const movieNode = new Cypher.Node({
-        labels: ["Movie"],
+    test("unary plus", () => {
+        const plus = Cypher.plus(literal1);
+        const { cypher } = new TestClause(plus).build();
+        expect(cypher).toMatchInlineSnapshot(`"+4"`);
     });
 
-    const matchQuery = new Cypher.Match(movieNode)
-        .where(Cypher.eq(movieNode.property("released"), Cypher.plus(new Cypher.Literal(10), yearParam)))
-        .return(movieNode);
+    test("unary minus", () => {
+        const minus = Cypher.minus(literal1);
+        const { cypher } = new TestClause(minus).build();
+        expect(cypher).toMatchInlineSnapshot(`"-4"`);
+    });
 
-    const queryResult = matchQuery.build();
-    expect(queryResult.cypher).toMatchInlineSnapshot(`
-        "MATCH (this0:\`Movie\`)
-        WHERE this0.released = 10 + $param0
-        RETURN this0"
-    `);
+    test("add", () => {
+        const add = Cypher.add(literal1, literal2);
+        const { cypher } = new TestClause(add).build();
+        expect(cypher).toMatchInlineSnapshot(`"4 + 3"`);
+    });
 
-    expect(queryResult.params).toMatchInlineSnapshot(`
-        Object {
-          "param0": 2000,
-        }
-    `);
+    test("subtract", () => {
+        const subtract = Cypher.subtract(literal1, literal2);
+        const { cypher } = new TestClause(subtract).build();
+        expect(cypher).toMatchInlineSnapshot(`"4 - 3"`);
+    });
+
+    test("divide", () => {
+        const divide = Cypher.divide(literal1, literal2);
+        const { cypher } = new TestClause(divide).build();
+        expect(cypher).toMatchInlineSnapshot(`"4 / 3"`);
+    });
+
+    test("multiply", () => {
+        const multiply = Cypher.multiply(literal1, literal2);
+        const { cypher } = new TestClause(multiply).build();
+        expect(cypher).toMatchInlineSnapshot(`"4 * 3"`);
+    });
+
+    test("remainder", () => {
+        const remainder = Cypher.remainder(literal1, literal2);
+        const { cypher } = new TestClause(remainder).build();
+        expect(cypher).toMatchInlineSnapshot(`"4 % 3"`);
+    });
+
+    test("pow", () => {
+        const pow = Cypher.pow(literal1, literal2);
+        const { cypher } = new TestClause(pow).build();
+        expect(cypher).toMatchInlineSnapshot(`"4 ^ 3"`);
+    });
 });

--- a/packages/cypher-builder/src/expressions/operations/math.ts
+++ b/packages/cypher-builder/src/expressions/operations/math.ts
@@ -21,7 +21,7 @@ import type { Expr } from "../../types";
 import type { CypherEnvironment } from "../../Environment";
 import { CypherASTNode } from "../../CypherASTNode";
 
-type MathOperator = "+" | "-";
+type MathOperator = "+" | "-" | "*" | "/" | "%" | "^";
 
 export class MathOp extends CypherASTNode {
     private operator: MathOperator;
@@ -39,6 +39,10 @@ export class MathOp extends CypherASTNode {
     public getCypher(env: CypherEnvironment): string {
         const exprs = this.exprs.map((e) => e.getCypher(env));
 
+        if (exprs.length === 1) {
+            return `${this.operator}${exprs}`
+        }
+
         return exprs.join(` ${this.operator} `);
     }
 }
@@ -49,14 +53,11 @@ function createOp(op: MathOperator, exprs: Expr[]): MathOp {
 
 /**
  * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
- * @see [String Concatenation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-strings)
  * @group Expressions
  * @category Operators
  */
-export function plus(leftExpr: Expr, rightExpr: Expr): MathOp;
-export function plus(...exprs: Expr[]): MathOp;
-export function plus(...exprs: Expr[]): MathOp {
-    return createOp("+", exprs);
+export function plus(expr: Expr): MathOp {
+    return createOp("+", [expr]);
 }
 
 /**
@@ -64,6 +65,60 @@ export function plus(...exprs: Expr[]): MathOp {
  * @group Expressions
  * @category Operators
  */
-export function minus(leftExpr: Expr, rightExpr: Expr): MathOp {
+export function minus(expr: Expr): MathOp {
+    return createOp("-", [expr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function add(leftExpr: Expr, rightExpr: Expr): MathOp {
+    return createOp("+", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function subtract(leftExpr: Expr, rightExpr: Expr): MathOp {
     return createOp("-", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function multiply(leftExpr: Expr, rightExpr: Expr): MathOp {
+    return createOp("*", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function divide(leftExpr: Expr, rightExpr: Expr): MathOp {
+    return createOp("/", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function remainder(leftExpr: Expr, rightExpr: Expr): MathOp {
+    return createOp("%", [leftExpr, rightExpr]);
+}
+
+/**
+ * @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#query-operators-mathematical)
+ * @group Expressions
+ * @category Operators
+ */
+export function pow(leftExpr: Expr, rightExpr: Expr): MathOp {
+    return createOp("^", [leftExpr, rightExpr]);
 }

--- a/packages/cypher-builder/src/expressions/operations/string.test.ts
+++ b/packages/cypher-builder/src/expressions/operations/string.test.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "../..";
+import { TestClause } from "../../utils/TestClause";
+
+describe("string operators", () => {
+    const im = new Cypher.Literal("I'm");
+    const space = new Cypher.Literal(" ");
+    const batman = new Cypher.Literal("Batman");
+
+    test("append two strings", () => {
+        const append = Cypher.append(im, space);
+        const { cypher } = new TestClause(append).build();
+        expect(cypher).toMatchInlineSnapshot(`"\\"I'm\\" + \\" \\""`);
+    });
+
+    test("append more than two strings", () => {
+        const append = Cypher.append(im, space, batman);
+        const { cypher } = new TestClause(append).build();
+        expect(cypher).toMatchInlineSnapshot(`"\\"I'm\\" + \\" \\" + \\"Batman\\""`);
+    });
+});

--- a/packages/cypher-builder/src/expressions/operations/string.ts
+++ b/packages/cypher-builder/src/expressions/operations/string.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Expr } from "../../types";
+import type { CypherEnvironment } from "../../Environment";
+import { CypherASTNode } from "../../CypherASTNode";
+
+type StringOperator = "+";
+
+export class StringOp extends CypherASTNode {
+    private operator: StringOperator;
+    private exprs: Expr[];
+
+    constructor(operator: StringOperator, exprs: Expr[] = []) {
+        super();
+        this.operator = operator;
+        this.exprs = exprs;
+    }
+
+    /**
+     * @hidden
+     */
+    public getCypher(env: CypherEnvironment): string {
+        const exprs = this.exprs.map((e) => e.getCypher(env));
+        return exprs.join(` ${this.operator} `);
+    }
+}
+
+/**
+ * @see [String Concatenation](https://neo4j.com/docs/cypher-manual/current/syntax/operators/#syntax-concatenating-two-strings)
+ * @group Expressions
+ * @category Operators
+ */
+export function concat(leftExpr: Expr, rightExpr: Expr, ...exprs: Expr[]): StringOp {
+    return new StringOp("+", [leftExpr, rightExpr, ...exprs]);
+}

--- a/packages/cypher-builder/src/types.ts
+++ b/packages/cypher-builder/src/types.ts
@@ -37,8 +37,9 @@ import type { HasLabel } from "./expressions/HasLabel";
 import type { Reference } from "./references/Reference";
 import type { ApocFunction, ApocPredicate, ApocProcedure } from "./apoc/types";
 import type { ListIndex } from "./expressions/list/ListIndex";
+import type { StringOp } from "./expressions/operations/string";
 
-export type Operation = BooleanOp | ComparisonOp | MathOp;
+export type Operation = BooleanOp | ComparisonOp | MathOp | StringOp;
 
 /** Represents a Cypher Expression
  *  @see [Cypher Documentation](https://neo4j.com/docs/cypher-manual/current/syntax/expressions/)

--- a/packages/graphql/src/translate/where/property-operations/create-comparison-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-comparison-operation.ts
@@ -70,8 +70,8 @@ function createDurationOperation({
     property: Cypher.Expr;
     param: Cypher.Expr;
 }) {
-    const variable = Cypher.plus(Cypher.datetime(), param);
-    const propertyRef = Cypher.plus(Cypher.datetime(), property);
+    const variable = Cypher.append(Cypher.datetime(), param);
+    const propertyRef = Cypher.append(Cypher.datetime(), property);
 
     return createBaseOperation({
         operator,


### PR DESCRIPTION
# Add Math operators, separate string concat

Add other operators to the Math operators and separate the string.concat implementation from the math.plus.
This is a breaking change as the plus and minus are now treated as unary plus and unary minus and while the previous behavior is moved to `add/subtract` respectively. 

## Complexity

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
