### PR TITLE
Fix count aggregate field in inline fragments

### DIFF
--- a/.changeset/chilled-zebras-vanish.md
+++ b/.changeset/chilled-zebras-vanish.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix count aggregate field translation resulting in a syntax error when used inside inline fragments

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -190,7 +190,6 @@ export default function createProjectionAndParams({
                         // as well as any surrounding whitespace.
                         const nestedProj = recurse.projection
                             .getCypher(env)
-                            .replaceAll("\n", " ")
                             .replaceAll(/(^\s*{\s*)|(\s*}\s*$)/g, "");
 
                         return `{ __resolveType: "${refNode.name}", __id: id(${varName.getCypher(env)})${

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -185,7 +185,14 @@ export default function createProjectionAndParams({
                     const direction = getCypherRelationshipDirection(relationField, field.args);
 
                     const nestedProjection = new Cypher.RawCypher((env) => {
-                        const nestedProj = recurse.projection.getCypher(env).replace(/^{|}$/gm, "").trim();
+                        // The nested projection will be surrounded by brackets, so we want to remove
+                        // any linebreaks, and then the first opening and the last closing bracket of the line,
+                        // as well as any surrounding whitespace.
+                        const nestedProj = recurse.projection
+                            .getCypher(env)
+                            .replace("\n", " ")
+                            .replace(/^\s*{\s*|\s*}\s*$/g, "");
+
                         return `{ __resolveType: "${refNode.name}", __id: id(${varName.getCypher(env)})${
                             nestedProj && `, ${nestedProj}`
                         } }`;

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -191,7 +191,7 @@ export default function createProjectionAndParams({
                         const nestedProj = recurse.projection
                             .getCypher(env)
                             .replaceAll("\n", " ")
-                            .replace(/^\s*{\s*|\s*}\s*$/g, "");
+                            .replaceAll(/(^\s*{\s*)|(\s*}\s*$)/g, "");
 
                         return `{ __resolveType: "${refNode.name}", __id: id(${varName.getCypher(env)})${
                             nestedProj && `, ${nestedProj}`

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -185,7 +185,7 @@ export default function createProjectionAndParams({
                     const direction = getCypherRelationshipDirection(relationField, field.args);
 
                     const nestedProjection = new Cypher.RawCypher((env) => {
-                        const nestedProj = recurse.projection.getCypher(env).replace(/{|}/gm, "").trim();
+                        const nestedProj = recurse.projection.getCypher(env).replace(/^{|}$/gm, "").trim();
                         return `{ __resolveType: "${refNode.name}", __id: id(${varName.getCypher(env)})${
                             nestedProj && `, ${nestedProj}`
                         } }`;

--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -190,7 +190,7 @@ export default function createProjectionAndParams({
                         // as well as any surrounding whitespace.
                         const nestedProj = recurse.projection
                             .getCypher(env)
-                            .replace("\n", " ")
+                            .replaceAll("\n", " ")
                             .replace(/^\s*{\s*|\s*}\s*$/g, "");
 
                         return `{ __resolveType: "${refNode.name}", __id: id(${varName.getCypher(env)})${

--- a/packages/graphql/tests/integration/issues/2982.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2982.int.test.ts
@@ -25,7 +25,7 @@ import { Neo4jGraphQL } from "../../../src/classes";
 import Neo4j from "../neo4j";
 import { cleanNodes } from "../../utils/clean-nodes";
 
-describe("https://github.com/neo4j/graphql/issues/tbd", () => {
+describe("https://github.com/neo4j/graphql/issues/2982", () => {
     let driver: Driver;
     let neo4j: Neo4j;
     let neoSchema: Neo4jGraphQL;

--- a/packages/graphql/tests/integration/issues/inline-fragment-aggregate.int.test.ts
+++ b/packages/graphql/tests/integration/issues/inline-fragment-aggregate.int.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
+import { generate } from "randomstring";
+import { UniqueType } from "../../utils/graphql-types";
+import { Neo4jGraphQL } from "../../../src/classes";
+import Neo4j from "../neo4j";
+import { cleanNodes } from "../../utils/clean-nodes";
+
+describe("https://github.com/neo4j/graphql/issues/tbd", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neoSchema: Neo4jGraphQL;
+    let session: Session;
+
+    let User: UniqueType;
+    let Post: UniqueType;
+    let Comment: UniqueType;
+    let BlogArticle: UniqueType;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+
+        User = new UniqueType("User");
+        Post = new UniqueType("Post");
+        Comment = new UniqueType("Comment");
+        BlogArticle = new UniqueType("BlogArticle");
+
+        const typeDefs = `
+            type ${User} {
+                id: ID!
+                ${Post.plural}: [${Post}!]! @relationship(type: "USER_POSTS", direction: OUT)
+            }
+
+            interface ${Post} {
+                id: ID!
+            }
+
+            type ${Comment} {
+                id: ID!
+            }
+
+            type ${BlogArticle} implements ${Post} {
+                id: ID!
+                ${Comment.plural}: [${Comment}!]! @relationship(type: "ARTICLE_COMMENTS", direction: OUT)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({ typeDefs, driver });
+    });
+
+    afterEach(async () => {
+        await cleanNodes(session, [User, Post, BlogArticle, Comment]);
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("count aggregate should work in inline fragments", async () => {
+        const query = `
+            query {
+                ${User.plural} {
+                    ${Post.plural} {
+                        ... on ${BlogArticle} {
+                            ${Comment.operations.aggregate} {
+                                count
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const userId = generate({ charset: "alphabetic" });
+        const articleId = generate({ charset: "alphabetic" });
+        const userName = generate({ charset: "alphabetic" });
+
+        await session.run(
+            `
+                CREATE (user:${User} { id: $userId })
+                CREATE (article:${BlogArticle} { id: $articleId })
+                MERGE (user)-[:USER_POSTS]->(article)
+            `,
+            { userId, articleId, userName }
+        );
+
+        const result = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            variableValues: {},
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmarks()),
+        });
+
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({
+            [User.plural]: [{ [Post.plural]: [{ [Comment.operations.aggregate]: { count: 0 } }] }],
+        });
+    });
+});


### PR DESCRIPTION
# Description

This PR fixes a syntax error that occurred when querying the count aggregate field inside an inline fragment. The problem here was that the code responsible for sanitizing nested projections in inline fragments would remove all opening and closing brackets in the nested query, which would result in invalid syntax when the nested query contained more nested fields:

`{ .id } -> .id // works`  
`{ fieldAggregate: { count: var }} -> fieldAggregate:  count: var // syntax error`

The offending regex here was `/{|)/gm`. I've looked through all the test cases triggering this code, and it seems there is never more than 1 set of brackets in all other cases, and never any multiline strings. I've adjusted the replace regexes to first remove any newlines, and then clear any opening brackets and closing brackets from the start and end of the string, including surrounding whitespace.

I'm not sure if this is the best way to do it, since we essentially want to remove "1 surrounding pair of brackets" here, but this seemed like the easiest way to achieve this without using any advanced regex features. Please let me know if you have a better idea.

## Complexity

Complexity: Low

# Issue

Closes #2982

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
