### PR TITLE
Fix context injection for Apollo Federation resolvers

### DIFF
--- a/.changeset/sharp-keys-move.md
+++ b/.changeset/sharp-keys-move.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix: context is now fully populated when using Apollo Federation, therefore, driver is no longer mandatory on construction and can be injected into the context like usual

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -92,6 +92,17 @@ jobs:
           NEO_PASSWORD: password
           NEO_URL: bolt://localhost:7687
 
+      - name: PR Branch - Run @neo4j/graphql Subgraph Schema performance tests
+        run: |
+          yarn performance --subgraph-schema # Warmup
+          yarn performance --subgraph-schema >> ./performance/subgraphSchemaPerformance
+          cat ./performance/schemaPerformance >> ./performance/performanceReport
+        working-directory: packages/graphql
+        env:
+          NEO_USER: neo4j
+          NEO_PASSWORD: password
+          NEO_URL: bolt://localhost:7687
+
       - name: Save PR number
         env:
           PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -19,8 +19,7 @@
 
 import type { Driver } from "neo4j-driver";
 import type { DocumentNode, GraphQLSchema } from "graphql";
-import type { IExecutableSchemaDefinition } from "@graphql-tools/schema";
-import { makeExecutableSchema } from "@graphql-tools/schema";
+import { addResolversToSchema, IExecutableSchemaDefinition, makeExecutableSchema } from "@graphql-tools/schema";
 import { composeResolvers } from "@graphql-tools/resolvers-composition";
 import { mergeResolvers, mergeTypeDefs } from "@graphql-tools/merge";
 import Debug from "debug";
@@ -46,7 +45,7 @@ import { getNeo4jDatabaseInfo, Neo4jDatabaseInfo } from "./Neo4jDatabaseInfo";
 import { Executor, ExecutorConstructorParam } from "./Executor";
 import { generateModel } from "../schema-model/generate-model";
 import type { Neo4jGraphQLSchemaModel } from "../schema-model/Neo4jGraphQLSchemaModel";
-import { forEachField, TypeSource } from "@graphql-tools/utils";
+import { forEachField, getResolversFromSchema, TypeSource } from "@graphql-tools/utils";
 import { validateDocument } from "../schema/validation";
 
 export interface Neo4jGraphQLConfig {
@@ -136,10 +135,6 @@ class Neo4jGraphQL {
         console.warn(
             "Apollo Federation support is currently experimental. There will be missing functionality, and breaking changes may occur in patch and minor releases. It is not recommended to use it in a production environment."
         );
-
-        if (!this.driver) {
-            throw new Error("Driver must be provided when running in subgraph mode");
-        }
 
         if (!this.subgraphSchema) {
             this.subgraphSchema = this.generateSubgraphSchema();
@@ -259,6 +254,29 @@ class Neo4jGraphQL {
         return composeResolvers(mergedResolvers, resolversComposition);
     }
 
+    private wrapFederationResolvers(resolvers: NonNullable<IExecutableSchemaDefinition["resolvers"]>) {
+        if (!this.schemaModel) {
+            throw new Error("Schema Model is not defined");
+        }
+
+        const wrapResolverArgs = {
+            driver: this.driver,
+            config: this.config,
+            nodes: this.nodes,
+            relationships: this.relationships,
+            schemaModel: this.schemaModel,
+            plugins: this.plugins,
+        };
+
+        const resolversComposition = {
+            "Query.{_entities, _service}": [wrapResolver(wrapResolverArgs)],
+        };
+
+        // Merge generated and custom resolvers
+        const mergedResolvers = mergeResolvers([...asArray(resolvers)]);
+        return composeResolvers(mergedResolvers, resolversComposition);
+    }
+
     private generateExecutableSchema(): Promise<GraphQLSchema> {
         return new Promise((resolve) => {
             const document = this.getDocument(this.schemaDefinition.typeDefs);
@@ -329,13 +347,24 @@ class Neo4jGraphQL {
         this._nodes = nodes;
         this._relationships = relationships;
 
-        const referenceResolvers = subgraph.getReferenceResolvers(this._nodes, this.driver as Driver);
+        // TODO: Move into makeAugmentedSchema, add resolvers alongside other resolvers
+        const referenceResolvers = subgraph.getReferenceResolvers(this._nodes);
+
         const wrappedResolvers = this.wrapResolvers([resolvers, referenceResolvers]);
 
         const schema = subgraph.buildSchema({
             typeDefs,
             resolvers: wrappedResolvers as Record<string, any>,
         });
+
+        // Get resolvers from subgraph schema - this will include generated _entities and _service
+        const subgraphResolvers = getResolversFromSchema(schema);
+
+        // Wrap the _entities and _service Query resolvers
+        const wrappedSubgraphResolvers = this.wrapFederationResolvers(subgraphResolvers);
+
+        // Add the wrapped resolvers back to the schema, context will now be populated
+        addResolversToSchema({ schema, resolvers: wrappedSubgraphResolvers, updateResolversInPlace: true });
 
         return this.addDefaultFieldResolvers(schema);
     }

--- a/packages/graphql/tests/performance/performance.ts
+++ b/packages/graphql/tests/performance/performance.ts
@@ -31,6 +31,7 @@ import type * as Performance from "./types";
 import { schemaPerformance } from "./schema-performance";
 import { MarkdownFormatter } from "./utils/formatters/MarkdownFormatter";
 import { TTYFormatter } from "./utils/formatters/TTYFormatter";
+import { subgraphSchemaPerformance } from "./subgraph-schema-performance";
 
 let driver: Driver;
 
@@ -124,6 +125,8 @@ async function afterAll() {
 async function main() {
     if (process.argv.includes("--schema")) {
         await schemaPerformance();
+    } else if (process.argv.includes("--subgraph-schema")) {
+        await subgraphSchemaPerformance();
     } else {
         await queryPerformance();
     }

--- a/packages/graphql/tests/performance/subgraph-schema-performance.ts
+++ b/packages/graphql/tests/performance/subgraph-schema-performance.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Neo4jGraphQL from "../../src/classes/Neo4jGraphQL";
+
+const basicTypeDefs = `
+    extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])
+
+    type Journalist {
+        articles: [Article!]! @relationship(type: "HAS_ARTICLE", direction: OUT, properties: "HasArticle")
+    }
+
+    interface HasArticle @relationshipProperties {
+        createdAt: DateTime! @timestamp
+    }
+
+    type Article @key(fields: "id") {
+        id: ID! @id
+        blocks: [Block!]! @relationship(type: "HAS_BLOCK", direction: OUT, properties: "HasBlock")
+        images: [Image!]! @relationship(type: "HAS_IMAGE", direction: OUT)
+    }
+
+    interface HasBlock @relationshipProperties {
+        order: Int!
+    }
+
+    interface Block {
+        id: ID @id
+    }
+
+    type TextBlock implements Block {
+        id: ID @id
+        text: String
+    }
+
+    type DividerBlock implements Block {
+        id: ID @id
+    }
+
+    type ImageBlock implements Block {
+        id: ID @id
+        images: [Image!]! @relationship(type: "HAS_IMAGE", direction: OUT)
+    }
+
+    interface Image {
+        featuredIn: [Article!]
+    }
+
+    type PDFImage implements Image {
+        featuredIn: [Article!]! @relationship(type: "HAS_IMAGE", direction: IN)
+        url: String!
+    }
+`;
+
+export async function subgraphSchemaPerformance() {
+    let typeDefs = "";
+    const toReplace =
+        /(Journalist|Article|HasArticle|Block|Image|HasBlock|TextBlock|DividerBlock|ImageBlock|PDFImage|HAS_ARTICLE|HAS_BLOCK|HAS_IMAGE)/g;
+
+    for (let i = 0; i < 500; i++) {
+        const partialTypes = basicTypeDefs.replaceAll(toReplace, `$1${i}`);
+        typeDefs = typeDefs + partialTypes;
+    }
+    const neoSchema = new Neo4jGraphQL({
+        typeDefs,
+    });
+    console.time("Schema Generation");
+    await neoSchema.getSubgraphSchema();
+    console.timeEnd("Schema Generation");
+}


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

This fixes the context injection for Federation resolvers. These resolvers are added _after_ we wrap the initial resolvers, so this change extracts the Federation resolvers from the schema, and then wraps a second time to catch these generated resolvers.

The driver now no longer needs to be passed into the constructor for Federation, and this will open the door to auth in the Federation resolvers.

This seems to perform well, and I have added simple subgraph schema performance tests as part of this change.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low