### PR TITLE
Fix order of operations for nested update

### DIFF
--- a/.changeset/tame-zoos-turn.md
+++ b/.changeset/tame-zoos-turn.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix order of operations for nested update (delete->disconnect->update->connect->create)

--- a/packages/graphql/src/translate/create-update-and-params.ts
+++ b/packages/graphql/src/translate/create-update-and-params.ts
@@ -138,6 +138,45 @@ export default function createUpdateAndParams({
                     const relTypeStr = `[${relationshipVariable}:${relationField.type}]`;
                     const variableName = `${varName}_${key}${relationField.union ? `_${refNode.name}` : ""}${index}`;
 
+                    if (update.delete) {
+                        const innerVarName = `${variableName}_delete`;
+
+                        const deleteAndParams = createDeleteAndParams({
+                            context,
+                            node,
+                            deleteInput: { [key]: update.delete }, // OBJECT ENTIERS key reused twice
+                            varName: innerVarName,
+                            chainStr: innerVarName,
+                            parentVar,
+                            withVars,
+                            parameterPrefix: `${parameterPrefix}.${key}${
+                                relationField.typeMeta.array ? `[${index}]` : ``
+                            }.delete`, // its use here
+                            recursing: true,
+                        });
+                        subquery.push(deleteAndParams[0]);
+                        res.params = { ...res.params, ...deleteAndParams[1] };
+                    }
+
+                    if (update.disconnect) {
+                        const disconnectAndParams = createDisconnectAndParams({
+                            context,
+                            refNodes: [refNode],
+                            value: update.disconnect,
+                            varName: `${variableName}_disconnect`,
+                            withVars,
+                            parentVar,
+                            relationField,
+                            labelOverride: relationField.union ? refNode.name : "",
+                            parentNode: node,
+                            parameterPrefix: `${parameterPrefix}.${key}${
+                                relationField.union ? `.${refNode.name}` : ""
+                            }${relationField.typeMeta.array ? `[${index}]` : ""}.disconnect`,
+                        });
+                        subquery.push(disconnectAndParams[0]);
+                        res.params = { ...res.params, ...disconnectAndParams[1] };
+                    }
+
                     if (update.update) {
                         const whereStrs: string[] = [];
                         const delayedSubquery: string[] = [];
@@ -308,25 +347,6 @@ export default function createUpdateAndParams({
                         }
                     }
 
-                    if (update.disconnect) {
-                        const disconnectAndParams = createDisconnectAndParams({
-                            context,
-                            refNodes: [refNode],
-                            value: update.disconnect,
-                            varName: `${variableName}_disconnect`,
-                            withVars,
-                            parentVar,
-                            relationField,
-                            labelOverride: relationField.union ? refNode.name : "",
-                            parentNode: node,
-                            parameterPrefix: `${parameterPrefix}.${key}${
-                                relationField.union ? `.${refNode.name}` : ""
-                            }${relationField.typeMeta.array ? `[${index}]` : ""}.disconnect`,
-                        });
-                        subquery.push(disconnectAndParams[0]);
-                        res.params = { ...res.params, ...disconnectAndParams[1] };
-                    }
-
                     if (update.connect) {
                         const connectAndParams = createConnectAndParams({
                             context,
@@ -362,26 +382,6 @@ export default function createUpdateAndParams({
                         });
                         subquery.push(cypher);
                         res.params = { ...res.params, ...params };
-                    }
-
-                    if (update.delete) {
-                        const innerVarName = `${variableName}_delete`;
-
-                        const deleteAndParams = createDeleteAndParams({
-                            context,
-                            node,
-                            deleteInput: { [key]: update.delete }, // OBJECT ENTIERS key reused twice
-                            varName: innerVarName,
-                            chainStr: innerVarName,
-                            parentVar,
-                            withVars,
-                            parameterPrefix: `${parameterPrefix}.${key}${
-                                relationField.typeMeta.array ? `[${index}]` : ``
-                            }.delete`, // its use here
-                            recursing: true,
-                        });
-                        subquery.push(deleteAndParams[0]);
-                        res.params = { ...res.params, ...deleteAndParams[1] };
                     }
 
                     if (update.create) {

--- a/packages/graphql/tests/tck/issues/894.test.ts
+++ b/packages/graphql/tests/tck/issues/894.test.ts
@@ -72,6 +72,20 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             WHERE this.name = $param0
             WITH this
             CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_activeOrganization0_rel:ACTIVELY_MANAGING]->(this_disconnect_activeOrganization0:Organization)
+            WHERE NOT (this_disconnect_activeOrganization0._id = $updateUsers_args_disconnect_activeOrganization_where_Organization_this_disconnect_activeOrganization0param0)
+            CALL {
+            	WITH this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel, this
+            	WITH collect(this_disconnect_activeOrganization0) as this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel, this
+            	UNWIND this_disconnect_activeOrganization0 as x
+            	DELETE this_disconnect_activeOrganization0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_activeOrganization_Organization
+            }
+            WITH this
+            CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_activeOrganization0_node:Organization)
             	WHERE this_connect_activeOrganization0_node._id = $this_connect_activeOrganization0_node_param0
@@ -89,20 +103,6 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
             	}
             WITH this, this_connect_activeOrganization0_node
             	RETURN count(*) AS connect_this_connect_activeOrganization_Organization
-            }
-            WITH this
-            CALL {
-            WITH this
-            OPTIONAL MATCH (this)-[this_disconnect_activeOrganization0_rel:ACTIVELY_MANAGING]->(this_disconnect_activeOrganization0:Organization)
-            WHERE NOT (this_disconnect_activeOrganization0._id = $updateUsers_args_disconnect_activeOrganization_where_Organization_this_disconnect_activeOrganization0param0)
-            CALL {
-            	WITH this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel, this
-            	WITH collect(this_disconnect_activeOrganization0) as this_disconnect_activeOrganization0, this_disconnect_activeOrganization0_rel, this
-            	UNWIND this_disconnect_activeOrganization0 as x
-            	DELETE this_disconnect_activeOrganization0_rel
-            	RETURN count(*) AS _
-            }
-            RETURN count(*) AS disconnect_this_disconnect_activeOrganization_Organization
             }
             WITH *
             WITH *

--- a/packages/graphql/tests/tck/operations/update.test.ts
+++ b/packages/graphql/tests/tck/operations/update.test.ts
@@ -792,14 +792,6 @@ describe("Cypher Update", () => {
             "MATCH (this:\`Movie\`)
             WHERE this.id = $param0
             WITH this
-            CALL {
-            	WITH this
-            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
-            	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
-            	SET this_actors0.name = $this_update_actors0_name
-            	RETURN count(*) AS update_this_actors0
-            }
-            WITH this
             OPTIONAL MATCH (this)<-[this_delete_actors0_relationship:ACTED_IN]-(this_delete_actors0:Actor)
             WHERE this_delete_actors0.name = $updateMovies_args_delete_actors0_where_this_delete_actors0param0
             WITH this, collect(DISTINCT this_delete_actors0) AS this_delete_actors0_to_delete
@@ -809,6 +801,14 @@ describe("Cypher Update", () => {
             	DETACH DELETE x
             	RETURN count(*) AS _
             }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_acted_in0_relationship:ACTED_IN]-(this_actors0:Actor)
+            	WHERE this_actors0.name = $updateMovies_args_update_actors0_where_this_actors0param0
+            	SET this_actors0.name = $this_update_actors0_name
+            	RETURN count(*) AS update_this_actors0
+            }
             WITH *
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -816,11 +816,22 @@ describe("Cypher Update", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
             "{
                 \\"param0\\": \\"1\\",
+                \\"updateMovies_args_delete_actors0_where_this_delete_actors0param0\\": \\"Actor to delete\\",
                 \\"updateMovies_args_update_actors0_where_this_actors0param0\\": \\"Actor to update\\",
                 \\"this_update_actors0_name\\": \\"Updated name\\",
-                \\"updateMovies_args_delete_actors0_where_this_delete_actors0param0\\": \\"Actor to delete\\",
                 \\"updateMovies\\": {
                     \\"args\\": {
+                        \\"delete\\": {
+                            \\"actors\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"name\\": \\"Actor to delete\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        },
                         \\"update\\": {
                             \\"actors\\": [
                                 {
@@ -832,17 +843,6 @@ describe("Cypher Update", () => {
                                     \\"update\\": {
                                         \\"node\\": {
                                             \\"name\\": \\"Updated name\\"
-                                        }
-                                    }
-                                }
-                            ]
-                        },
-                        \\"delete\\": {
-                            \\"actors\\": [
-                                {
-                                    \\"where\\": {
-                                        \\"node\\": {
-                                            \\"name\\": \\"Actor to delete\\"
                                         }
                                     }
                                 }

--- a/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
@@ -1342,6 +1342,20 @@ describe("tck/rfs/003", () => {
                         WHERE this.id = $param0
                         WITH this
                         CALL {
+                        WITH this
+                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
+                        CALL {
+                        	WITH this_disconnect_director0, this_disconnect_director0_rel, this
+                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel, this
+                        	UNWIND this_disconnect_director0 as x
+                        	DELETE this_disconnect_director0_rel
+                        	RETURN count(*) AS _
+                        }
+                        RETURN count(*) AS disconnect_this_disconnect_director_Director
+                        }
+                        WITH this
+                        CALL {
                         	WITH this
                         	OPTIONAL MATCH (this_connect_director0_node:Director)
                         	WHERE this_connect_director0_node.id = $this_connect_director0_node_param0
@@ -1359,20 +1373,6 @@ describe("tck/rfs/003", () => {
                         	}
                         WITH this, this_connect_director0_node
                         	RETURN count(*) AS connect_this_connect_director_Director
-                        }
-                        WITH this
-                        CALL {
-                        WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
-                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
-                        CALL {
-                        	WITH this_disconnect_director0, this_disconnect_director0_rel, this
-                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel, this
-                        	UNWIND this_disconnect_director0 as x
-                        	DELETE this_disconnect_director0_rel
-                        	RETURN count(*) AS _
-                        }
-                        RETURN count(*) AS disconnect_this_disconnect_director_Director
                         }
                         WITH *
                         CALL {
@@ -1463,6 +1463,20 @@ describe("tck/rfs/003", () => {
                         WHERE this.id = $param0
                         WITH this
                         CALL {
+                        WITH this
+                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
+                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
+                        CALL {
+                        	WITH this_disconnect_director0, this_disconnect_director0_rel, this
+                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel, this
+                        	UNWIND this_disconnect_director0 as x
+                        	DELETE this_disconnect_director0_rel
+                        	RETURN count(*) AS _
+                        }
+                        RETURN count(*) AS disconnect_this_disconnect_director_Director
+                        }
+                        WITH this
+                        CALL {
                         	WITH this
                         	OPTIONAL MATCH (this_connect_director0_node:Director)
                         	WHERE this_connect_director0_node.id = $this_connect_director0_node_param0
@@ -1480,20 +1494,6 @@ describe("tck/rfs/003", () => {
                         	}
                         WITH this, this_connect_director0_node
                         	RETURN count(*) AS connect_this_connect_director_Director
-                        }
-                        WITH this
-                        CALL {
-                        WITH this
-                        OPTIONAL MATCH (this)<-[this_disconnect_director0_rel:DIRECTED]-(this_disconnect_director0:Director)
-                        WHERE this_disconnect_director0.id = $updateMovies_args_disconnect_director_where_Director_this_disconnect_director0param0
-                        CALL {
-                        	WITH this_disconnect_director0, this_disconnect_director0_rel, this
-                        	WITH collect(this_disconnect_director0) as this_disconnect_director0, this_disconnect_director0_rel, this
-                        	UNWIND this_disconnect_director0 as x
-                        	DELETE this_disconnect_director0_rel
-                        	RETURN count(*) AS _
-                        }
-                        RETURN count(*) AS disconnect_this_disconnect_director_Director
                         }
                         WITH *
                         CALL {


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Enforces the following order for nested update operations:

1. `delete`
2. `disconnect`
3. `update`
4. `connect` (and `connectOrCreate`)
5. `create`

This was discussed in a workshop several weeks ago now. This will prevent items in a nested create or connect being deleted by a proceeding nested delete.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low
