### PR TITLE
Escape property aliases

### DIFF
--- a/.changeset/curly-scissors-help.md
+++ b/.changeset/curly-scissors-help.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+Aliased properties are now automatically escaped using backticks. If you were using backticks in the `property` argument of your `@alias` directives, these should now be removed.

--- a/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
+++ b/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
@@ -503,25 +503,6 @@ interface ActedIn {
 }
 ----
 
-Instead, they would need to be updated as below:
-
-[source, graphql, indent=0]
-----
-type Person {
-  name: String!
-  movies: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
-}
-
-type Movie {
-  title: String!
-  actors: [Person!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
-}
-
-interface ActedIn @relationshipProperties {
-  screenTime: Int!
-}
-----
-
 == Miscellaneous changes
 
 [[startup-validation]]

--- a/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
+++ b/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
@@ -484,7 +484,7 @@ As a result, in version 4.0.0, the following type definitions are invalid:
 
 === Relationship types are now automatically escaped
 
-Relationship types are now automatically escaped. If you users have previously escaped their relationship types, you should now remove the escape strings as this is covered by the library.
+Relationship types are now automatically escaped. If you have previously escaped your relationship types, you should now remove the escape strings as this is covered by the library.
 
 [source, graphql, indent=0]
 ----

--- a/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
+++ b/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
@@ -503,6 +503,18 @@ interface ActedIn {
 }
 ----
 
+=== Properties in the alias directive are now automatically escaped
+
+Properties in the alias directive automatically escaped using backticks. If you were using backticks in the `property` argument of your `@alias` directives, you should now remove the escape strings as this is covered by the library.
+
+[source, graphql, indent=0]
+----
+type User {
+    id: ID! @id
+    username: String! @alias(property: "dbUserName")
+}
+----
+
 == Miscellaneous changes
 
 [[startup-validation]]

--- a/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/database-mapping.adoc
@@ -43,6 +43,10 @@ interface UserLivesInProperties @relationshipProperties {
 }
 ----
 
+==== Properties are automatically escaped
+
+The property in aliases are automatically escaped (wrapped with backticks ``), so there's no need to add escape characters around them.
+
 [[type-definitions-plural]]
 == `@plural`
 

--- a/packages/graphql/src/classes/utils/asserts-indexes-and-constraints.ts
+++ b/packages/graphql/src/classes/utils/asserts-indexes-and-constraints.ts
@@ -22,7 +22,6 @@ import Debug from "debug";
 import type Node from "../Node";
 import type { DriverConfig } from "../..";
 import { DEBUG_EXECUTE } from "../../constants";
-import type { Neo4jDatabaseInfo } from "../Neo4jDatabaseInfo";
 
 const debug = Debug(DEBUG_EXECUTE);
 
@@ -82,14 +81,16 @@ async function createIndexesAndConstraints({ nodes, session }: { nodes: Node[]; 
                 } else {
                     index.fields.forEach((field) => {
                         const stringField = node.primitiveFields.find((f) => f.fieldName === field);
-                        const fieldName = stringField?.dbPropertyName || field;
+                        const fieldName = stringField?.dbPropertyNameUnescaped || field;
 
                         const property = existingIndex.properties.find((p) => p === fieldName);
                         if (!property) {
-                            const aliasError = stringField?.dbPropertyName ? ` aliased to field '${fieldName}''` : "";
+                            const aliasError = stringField?.dbPropertyNameUnescaped
+                                ? ` aliased to field '${fieldName}'`
+                                : "";
 
                             indexErrors.push(
-                                `@fulltext index '${indexName}' on Node '${node.name}' already exists, but is missing field '${field}'${aliasError}`
+                                `@fulltext index '${indexName}' on Node '${node.name}' already exists, but is missing field '${fieldName}'${aliasError}`
                             );
                         }
                     });
@@ -186,11 +187,13 @@ async function checkIndexesAndConstraints({ nodes, session }: { nodes: Node[]; s
 
                 index.fields.forEach((field) => {
                     const stringField = node.primitiveFields.find((f) => f.fieldName === field);
-                    const fieldName = stringField?.dbPropertyName || field;
+                    const fieldName = stringField?.dbPropertyNameUnescaped || field;
 
                     const property = existingIndex.properties.find((p) => p === fieldName);
                     if (!property) {
-                        const aliasError = stringField?.dbPropertyName ? ` aliased to field '${fieldName}''` : "";
+                        const aliasError = stringField?.dbPropertyNameUnescaped
+                            ? ` aliased to field '${fieldName}'`
+                            : "";
 
                         indexErrors.push(
                             `@fulltext index '${indexName}' on Node '${node.name}' is missing field '${field}'${aliasError}`
@@ -208,13 +211,15 @@ async function checkIndexesAndConstraints({ nodes, session }: { nodes: Node[]; s
     debug("Successfully checked for the existence of all necessary indexes");
 }
 
+type MissingConstraint = { constraintName: string; label: string; property: string };
+
 async function getMissingConstraints({
     nodes,
     session,
 }: {
     nodes: Node[];
     session: Session;
-}): Promise<{ constraintName: string; label: string; property: string }[]> {
+}): Promise<MissingConstraint[]> {
     const existingConstraints: Record<string, string[]> = {};
 
     const constraintsCypher = "SHOW UNIQUE CONSTRAINTS";
@@ -236,11 +241,11 @@ async function getMissingConstraints({
             }
         });
 
-    const missingConstraints: { constraintName: string; label: string; property: string }[] = [];
+    const missingConstraints: MissingConstraint[] = [];
 
     nodes.forEach((node) => {
         node.uniqueFields.forEach((field) => {
-            const property = field.dbPropertyName || field.fieldName;
+            const property = field.dbPropertyNameUnescaped || field.fieldName;
             if (node.getAllLabels().every((label) => !existingConstraints[label]?.includes(property))) {
                 missingConstraints.push({
                     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/graphql/src/schema/get-alias-meta.ts
+++ b/packages/graphql/src/schema/get-alias-meta.ts
@@ -17,10 +17,12 @@
  * limitations under the License.
  */
 
+import Cypher from "@neo4j/cypher-builder";
 import type { DirectiveNode, StringValueNode } from "graphql";
 
 type AliasMeta = {
     property: string;
+    propertyUnescaped: string;
 };
 
 function getAliasMeta(directive: DirectiveNode): AliasMeta | undefined {
@@ -32,7 +34,8 @@ function getAliasMeta(directive: DirectiveNode): AliasMeta | undefined {
     const property = (stmtArg.value as StringValueNode).value;
 
     return {
-        property,
+        property: Cypher.utils.escapeLabel(property),
+        propertyUnescaped: property,
     };
 }
 

--- a/packages/graphql/src/schema/get-obj-field-meta.ts
+++ b/packages/graphql/src/schema/get-obj-field-meta.ts
@@ -199,6 +199,7 @@ function getObjFieldMeta({
                 const aliasMeta = getAliasMeta(aliasDirective);
                 if (aliasMeta) {
                     baseField.dbPropertyName = aliasMeta.property;
+                    baseField.dbPropertyNameUnescaped = aliasMeta.propertyUnescaped;
                 }
             }
 

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -143,6 +143,7 @@ export interface BaseField {
     readonly?: boolean;
     writeonly?: boolean;
     dbPropertyName?: string;
+    dbPropertyNameUnescaped?: string;
     unique?: Unique;
 }
 

--- a/packages/graphql/src/utils/map-to-db-property.ts
+++ b/packages/graphql/src/utils/map-to-db-property.ts
@@ -24,7 +24,7 @@ function mapToDbProperty(item: GraphElement, graphQLField: string): string {
     const itemProp = item.primitiveFields
         .concat(item.temporalFields, item.pointFields)
         .find(({ fieldName }) => fieldName === graphQLField);
-    return itemProp?.dbPropertyName || graphQLField;
+    return itemProp?.dbPropertyNameUnescaped || graphQLField;
 }
 
 export default mapToDbProperty;

--- a/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
+++ b/packages/graphql/tests/tck/aggregations/alias-directive.test.ts
@@ -75,21 +75,21 @@ describe("Cypher Aggregations Many with Alias directive", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Movie\`)
-            RETURN { id: { shortest: min(this._id), longest: max(this._id) }, title: { shortest:
-                                        reduce(aggVar = collect(this._title)[0], current IN collect(this._title) |
+            RETURN { id: { shortest: min(this.\`_id\`), longest: max(this.\`_id\`) }, title: { shortest:
+                                        reduce(aggVar = collect(this.\`_title\`)[0], current IN collect(this.\`_title\`) |
                                             CASE
                                             WHEN size(current) < size(aggVar) THEN current
                                             ELSE aggVar
                                             END
                                         )
                                     , longest:
-                                        reduce(aggVar = collect(this._title)[0], current IN collect(this._title) |
+                                        reduce(aggVar = collect(this.\`_title\`)[0], current IN collect(this.\`_title\`) |
                                             CASE
                                             WHEN size(current) > size(aggVar) THEN current
                                             ELSE aggVar
                                             END
                                         )
-                                     }, imdbRating: { min: min(this._imdbRating), max: max(this._imdbRating), average: avg(this._imdbRating) }, createdAt: { min: apoc.date.convertFormat(toString(min(this._createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this._createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } }"
+                                     }, imdbRating: { min: min(this.\`_imdbRating\`), max: max(this.\`_imdbRating\`), average: avg(this.\`_imdbRating\`) }, createdAt: { min: apoc.date.convertFormat(toString(min(this.\`_createdAt\`)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.\`_createdAt\`)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } }"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/issues/1131.test.ts
+++ b/packages/graphql/tests/tck/issues/1131.test.ts
@@ -94,9 +94,9 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
             WITH this
             CALL {
                 WITH this
-                MERGE (this_isInPublication0_connectOrCreate0:\`Concept\`:\`Resource\` { uri: $this_isInPublication0_connectOrCreate_param0 })
+                MERGE (this_isInPublication0_connectOrCreate0:\`Concept\`:\`Resource\` { \`uri\`: $this_isInPublication0_connectOrCreate_param0 })
                 ON CREATE SET
-                    this_isInPublication0_connectOrCreate0.uri = $this_isInPublication0_connectOrCreate_param1,
+                    this_isInPublication0_connectOrCreate0.\`uri\` = $this_isInPublication0_connectOrCreate_param1,
                     this_isInPublication0_connectOrCreate0.prefLabel = $this_isInPublication0_connectOrCreate_param2
                 MERGE (this)-[this_isInPublication0_connectOrCreate_this0:\`isInPublication\`]->(this_isInPublication0_connectOrCreate0)
                 RETURN COUNT(*) AS _
@@ -104,9 +104,9 @@ describe("https://github.com/neo4j/graphql/issues/1131", () => {
             WITH this
             CALL {
                 WITH this
-                MERGE (this_isInPublication1_connectOrCreate0:\`Concept\`:\`Resource\` { uri: $this_isInPublication1_connectOrCreate_param0 })
+                MERGE (this_isInPublication1_connectOrCreate0:\`Concept\`:\`Resource\` { \`uri\`: $this_isInPublication1_connectOrCreate_param0 })
                 ON CREATE SET
-                    this_isInPublication1_connectOrCreate0.uri = $this_isInPublication1_connectOrCreate_param1,
+                    this_isInPublication1_connectOrCreate0.\`uri\` = $this_isInPublication1_connectOrCreate_param1,
                     this_isInPublication1_connectOrCreate0.prefLabel = $this_isInPublication1_connectOrCreate_param2
                 MERGE (this)-[this_isInPublication1_connectOrCreate_this0:\`isInPublication\`]->(this_isInPublication1_connectOrCreate0)
                 RETURN COUNT(*) AS _


### PR DESCRIPTION
# Description

This PR adds escaping to property alias strings.

There is still a need for an unescaped version of the property alias string so this is added as a new property `dbPropertyNameUnescaped` on the `BaseField` type.

## Complexity

Low