### PR TITLE
Fix custom resolver date serialization

### DIFF
--- a/packages/graphql/src/graphql/scalars/Date.ts
+++ b/packages/graphql/src/graphql/scalars/Date.ts
@@ -22,16 +22,18 @@ import { GraphQLError, GraphQLScalarType, Kind } from "graphql";
 import type { Date as Neo4jDate, Integer } from "neo4j-driver";
 import neo4j, { isDate } from "neo4j-driver";
 
+const formatDateString = (dateString: string) => new Date(dateString).toISOString().split("T")[0];
+
 export const GraphQLDate = new GraphQLScalarType({
     name: "Date",
     description: "A date, represented as a 'yyyy-mm-dd' string",
     serialize: (outputValue: unknown) => {
         if (typeof outputValue === "string") {
-            return new Date(outputValue).toISOString();
+            return formatDateString(outputValue);
         }
 
         if (isDate(outputValue as object)) {
-            return new Date((outputValue as typeof neo4j.types.Date).toString()).toISOString().split("T")[0];
+            return formatDateString((outputValue as typeof neo4j.types.Date).toString());
         }
 
         throw new GraphQLError(`Date cannot represent value: ${outputValue}`);

--- a/packages/graphql/tests/integration/issues/3009.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3009.int.test.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql } from "graphql";
+import type { Session } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import Neo4j from "../neo4j";
+
+describe("https://github.com/neo4j/graphql/issues/3009", () => {
+    let neo4j: Neo4j;
+    let session: Session;
+
+    beforeAll(() => {
+        neo4j = new Neo4j();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+    });
+
+    afterEach(async () => await session.close());
+    afterAll(async () => await (await neo4j.getDriver()).close());
+
+    test("custom resolvers should correctly format dates", async () => {
+        const typeDefs = `
+            type User {
+                joinedAt: Date!
+            }
+        `;
+
+        const resolvers = { Query: { users: () => [{ joinedAt: "2020-01-01" }] } };
+        const neoSchema = new Neo4jGraphQL({ typeDefs, resolvers });
+
+        const query = `
+            query {
+                users {
+                    joinedAt
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            variableValues: {},
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmarks()),
+        });
+
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({ users: [{ joinedAt: "2020-01-01" }] });
+    });
+
+    test("custom resolvers should correctly format dateTimes", async () => {
+const typeDefs = `
+    type User {
+        joinedAt: DateTime!
+    }
+`;
+
+const resolvers = { Query: { users: () => [{ joinedAt: new Date("2020-01-01").toISOString() }] } };
+const neoSchema = new Neo4jGraphQL({ typeDefs, resolvers });
+
+        const query = `
+            query {
+                users {
+                    joinedAt
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            variableValues: {},
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmarks()),
+        });
+
+        expect(result.errors).toBeFalsy();
+        expect(result.data).toEqual({ users: [{ joinedAt: "2020-01-01T00:00:00.000Z" }] });
+    });
+});


### PR DESCRIPTION
# Description

When a string is passed to the `GraphQLDate` function and the serializer function is called, a javascript `Date` will be constructed, and the result of `toISOString` will be returned as is. This will always be a `DateTime` and not a `Date` object. The code path in `serialize` for a string `outputValue` is identical to `GraphQLDateTime`, in fact.

Since there already was a call removing the `T00:00:00.000Z` prefix in the case of Neo4j database dates being passed in, I simply used the same code for both code paths. I think this is relatively easy to read, but please tell me if you have a better idea.

## Complexity

Complexity: Low

# Issue

Closes #3009  

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
