### PR TITLE
Restrict multiple relationship fields with same type

### DIFF
--- a/.changeset/khaki-experts-decide.md
+++ b/.changeset/khaki-experts-decide.md
@@ -18,17 +18,4 @@ type Person {
 }
 ```
 
-In this example, there are multiple fields in the `Team` type which have the same `Person` type, the same `@relationship` type and ("PLAYS_IN") direction (IN). This is an issue when returning data from the database, as there would be no difference between `player1`, `player2` and `backupPlayers`. Selecting these fields would then return the same data.
-
-To disable checks for duplicate relationship fields, the `noDuplicateRelationshipFields` config option should be used:
-
-```ts
-const neoSchema = new Neo4jGraphQL({
-    typeDefs,
-    config: {
-        startupValidation: {
-            noDuplicateRelationshipFields: false,
-        },
-    },
-});
-```
+For more information about this change and how to disable this validation please see the [4.0.0 migration guide](https://neo4j.com/docs/graphql-manual/current/guides/v4-migration/)

--- a/.changeset/khaki-experts-decide.md
+++ b/.changeset/khaki-experts-decide.md
@@ -1,0 +1,34 @@
+---
+"@neo4j/graphql": major
+---
+
+It was possible to define schemas with types that have multiple relationship fields connected by the same type of relationships. Instances of this scenario are now detected during schema generation and an error is thrown so developers are informed to remedy the type definitions.
+
+An example of what is now considered invalid with these checks:
+
+```graphql
+type Team {
+    player1: Person! @relationship(type: "PLAYS_IN", direction: IN)
+    player2: Person! @relationship(type: "PLAYS_IN", direction: IN)
+    backupPlayers: [Person!]! @relationship(type: "PLAYS_IN", direction: IN)
+}
+
+type Person {
+    teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
+}
+```
+
+In this example, there are multiple fields in the `Team` type which have the same `Person` type, the same `@relationship` type and ("PLAYS_IN") direction (IN). This is an issue when returning data from the database, as there would be no difference between `player1`, `player2` and `backupPlayers`. Selecting these fields would then return the same data.
+
+To disable checks for duplicate relationship fields, the `noDuplicateRelationshipFields` config option should be used:
+
+```ts
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    config: {
+        startupValidation: {
+            noDuplicateRelationshipFields: false,
+        },
+    },
+});
+```

--- a/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
+++ b/docs/modules/ROOT/pages/guides/v4-migration/index.adoc
@@ -526,12 +526,48 @@ type User {
 }
 ----
 
+=== Duplicate relationship fields are now checked for
+
+It was possible to define schemas with types that have multiple relationship fields connected by the same type of relationships. Instances of this scenario are now detected during schema generation and an error is thrown so developers are informed to remedy the type definitions.
+
+An example of what is now considered invalid with these checks:
+
+[source, graphql, indent=0]
+----
+type Team {
+    player1: Person! @relationship(type: "PLAYS_IN", direction: IN)
+    player2: Person! @relationship(type: "PLAYS_IN", direction: IN)
+    backupPlayers: [Person!]! @relationship(type: "PLAYS_IN", direction: IN)
+}
+
+type Person {
+    teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
+}
+----
+
+In this example, there are multiple fields in the `Team` type which have the same `Person` type, the same `@relationship` type and ("PLAYS_IN") direction (IN). This is an issue when returning data from the database, as there would be no difference between `player1`, `player2` and `backupPlayers`. Selecting these fields would then return the same data.
+
+To disable checks for duplicate relationship fields, the `noDuplicateRelationshipFields` config option should be used:
+
+[source, javascript, indent=0]
+----
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    config: {
+        startupValidation: {
+            noDuplicateRelationshipFields: false,
+        },
+    },
+});
+----
+
+
 == Miscellaneous changes
 
 [[startup-validation]]
 === Startup validation
 
-In version 4.0.0, startup xref::guides/v4-migration/index.adoc#customResolver-checks[checks for custom resolvers] have been added. As a result, a new configuration option has been added that can disable these checks.
+In version 4.0.0, startup xref::guides/v4-migration/index.adoc#customResolver-checks[checks for custom resolvers], and checks for duplicate relationship fields have been added. As a result, a new configuration option has been added that can disable these checks.
 This new option has been combined with the option to `skipValidateTypeDefs`. As a result, `skipValidateTypeDefs` will be removed and replaced by `startupValidation`.
 
 To only disable strict type definition validation, the following config option should be used:
@@ -561,6 +597,21 @@ const neoSchema = new Neo4jGraphQL({
     },
 })
 ----
+
+To only disable checks for duplicate relationship fields, the following config option should be used:
+
+[source, javascript, indent=0]
+----
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    config: {
+        startupValidation: {
+            noDuplicateRelationshipFields: false
+        },
+    },
+})
+----
+
 
 To disable all startup checks, the following config option should be used:
 

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -312,7 +312,7 @@ class Neo4jGraphQL {
 
             const validationConfig = this.parseStartupValidationConfig();
 
-            validateDocument(document, validationConfig);
+            validateDocument({ document, validationConfig });
 
             this.setSchemaModel(document);
 
@@ -350,7 +350,7 @@ class Neo4jGraphQL {
 
         const validationConfig = this.parseStartupValidationConfig();
 
-        validateDocument(document, validationConfig, directives, types);
+        validateDocument({ document, validationConfig, additionalDirectives: directives, additionalTypes: types });
 
         this.setSchemaModel(document);
 

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -286,6 +286,14 @@ class Neo4jGraphQL {
         return composeResolvers(mergedResolvers, resolversComposition);
     }
 
+    private setSchemaModel(document: DocumentNode) {
+        // This can be run several times but it will always be the same result,
+        // so we memoize the schemaModel.
+        if (!this.schemaModel) {
+            this.schemaModel = generateModel(document);
+        }
+    }
+
     private generateExecutableSchema(): Promise<GraphQLSchema> {
         return new Promise((resolve) => {
             const document = this.getDocument(this.typeDefs);
@@ -294,9 +302,7 @@ class Neo4jGraphQL {
 
             validateDocument(document, validateTypeDefs);
 
-            if (!this.schemaModel) {
-                this.schemaModel = generateModel(document);
-            }
+            this.setSchemaModel(document);
 
             const { nodes, relationships, typeDefs, resolvers } = makeAugmentedSchema(document, {
                 features: this.features,
@@ -334,9 +340,7 @@ class Neo4jGraphQL {
 
         validateDocument(document, validateTypeDefs, directives, types);
 
-        if (!this.schemaModel) {
-            this.schemaModel = generateModel(document);
-        }
+        this.setSchemaModel(document);
 
         const { nodes, relationships, typeDefs, resolvers } = makeAugmentedSchema(document, {
             features: this.features,

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -390,7 +390,7 @@ class Neo4jGraphQL {
     }
 
     private parseStartupValidationConfig(): ValidationConfig {
-        const validationConfig = defaultValidationConfig;
+        const validationConfig: ValidationConfig = { ...defaultValidationConfig };
 
         if (this.config?.startupValidation === false) {
             return {

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -29,7 +29,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow('Directive "@coalesce" may not be used on OBJECT.');
+        expect(() => validateDocument({ document: doc })).toThrow('Directive "@coalesce" may not be used on OBJECT.');
     });
 
     test("should throw an error if a directive is missing an argument", () => {
@@ -39,7 +39,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             'Directive "@coalesce" argument "value" of type "ScalarOrEnum!" is required, but it was not provided.'
         );
     });
@@ -51,7 +51,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow('Unknown type "Unknown".');
+        expect(() => validateDocument({ document: doc })).toThrow('Unknown type "Unknown".');
     });
 
     test("should throw an error if a user tries to pass in their own Point definition", () => {
@@ -66,7 +66,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             'Type "Point" already exists in the schema. It cannot also be defined in this type definition.'
         );
     });
@@ -80,7 +80,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             'Type "DateTime" already exists in the schema. It cannot also be defined in this type definition.'
         );
     });
@@ -94,7 +94,7 @@ describe("validateDocument", () => {
             extend type User @fulltext
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             'Directive "@fulltext" argument "indexes" of type "[FullTextInput]!" is required, but it was not provided.'
         );
     });
@@ -111,7 +111,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             'Type "PointInput" already exists in the schema. It cannot also be defined in this type definition.'
         );
     });
@@ -127,7 +127,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             "Interface field UserInterface.age expected but User does not provide it."
         );
     });
@@ -141,7 +141,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             'Directive "@relationship" already exists in the schema. It cannot be redefined.'
         );
     });
@@ -153,7 +153,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).not.toThrow();
+        expect(() => validateDocument({ document: doc })).not.toThrow();
     });
 
     test("should not throw error on use of internal node input types", () => {
@@ -181,7 +181,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).not.toThrow();
+        expect(() => validateDocument({ document: doc })).not.toThrow();
     });
 
     describe("relationshipProperties directive", () => {
@@ -202,7 +202,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
 
         test("should throw if used on an object type", () => {
@@ -212,7 +212,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).toThrow(
+            expect(() => validateDocument({ document: doc })).toThrow(
                 'Directive "@relationshipProperties" may not be used on OBJECT.'
             );
         });
@@ -224,7 +224,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).toThrow(
+            expect(() => validateDocument({ document: doc })).toThrow(
                 'Directive "@relationshipProperties" may not be used on FIELD_DEFINITION.'
             );
         });
@@ -307,7 +307,7 @@ describe("validateDocument", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).not.toThrow();
+        expect(() => validateDocument({ document: doc })).not.toThrow();
     });
 
     describe("Github Issue 158", () => {
@@ -322,7 +322,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 
@@ -339,7 +339,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
 
         test("should not throw error on validation of schema if SortDirection used", () => {
@@ -354,7 +354,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 
@@ -487,7 +487,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 
@@ -509,7 +509,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 
@@ -520,7 +520,7 @@ describe("validateDocument", () => {
                     name: String @alias
                 }
             `;
-            expect(() => validateDocument(doc)).toThrow(
+            expect(() => validateDocument({ document: doc })).toThrow(
                 'Directive "@alias" argument "property" of type "String!" is required, but it was not provided.'
             );
         });
@@ -530,7 +530,7 @@ describe("validateDocument", () => {
                     name: String
                 }
             `;
-            expect(() => validateDocument(doc)).toThrow('Directive "@alias" may not be used on OBJECT.');
+            expect(() => validateDocument({ document: doc })).toThrow('Directive "@alias" may not be used on OBJECT.');
         });
         test("should not throw when used correctly", () => {
             const doc = gql`
@@ -538,7 +538,7 @@ describe("validateDocument", () => {
                     name: String @alias(property: "dbName")
                 }
             `;
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 
@@ -551,7 +551,7 @@ describe("validateDocument", () => {
                     }
                 `;
 
-                expect(() => validateDocument(doc)).toThrow(
+                expect(() => validateDocument({ document: doc })).toThrow(
                     RESERVED_TYPE_NAMES.find((x) => x.regex.test("PageInfo"))?.error
                 );
             });
@@ -563,7 +563,7 @@ describe("validateDocument", () => {
                     }
                 `;
 
-                expect(() => validateDocument(doc)).toThrow(
+                expect(() => validateDocument({ document: doc })).toThrow(
                     RESERVED_TYPE_NAMES.find((x) => x.regex.test("NodeConnection"))?.error
                 );
             });
@@ -575,7 +575,7 @@ describe("validateDocument", () => {
                     }
                 `;
 
-                expect(() => validateDocument(doc)).toThrow(
+                expect(() => validateDocument({ document: doc })).toThrow(
                     RESERVED_TYPE_NAMES.find((x) => x.regex.test("Node"))?.error
                 );
             });
@@ -598,7 +598,7 @@ describe("validateDocument", () => {
                     }
                 `;
 
-                expect(() => validateDocument(doc)).toThrow(
+                expect(() => validateDocument({ document: doc })).toThrow(
                     RESERVED_TYPE_NAMES.find((x) => x.regex.test("PageInfo"))?.error
                 );
             });
@@ -619,7 +619,7 @@ describe("validateDocument", () => {
                     }
                 `;
 
-                expect(() => validateDocument(doc)).toThrow(
+                expect(() => validateDocument({ document: doc })).toThrow(
                     RESERVED_TYPE_NAMES.find((x) => x.regex.test("NodeConnection"))?.error
                 );
             });
@@ -640,7 +640,7 @@ describe("validateDocument", () => {
                     }
                 `;
 
-                expect(() => validateDocument(doc)).toThrow(
+                expect(() => validateDocument({ document: doc })).toThrow(
                     RESERVED_TYPE_NAMES.find((x) => x.regex.test("Node"))?.error
                 );
             });
@@ -655,7 +655,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 
@@ -675,7 +675,7 @@ describe("validateDocument", () => {
                 }
             `;
 
-            expect(() => validateDocument(doc)).not.toThrow();
+            expect(() => validateDocument({ document: doc })).not.toThrow();
         });
     });
 });

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -40,7 +40,7 @@ import { PointDistance } from "../../graphql/input-objects/PointDistance";
 import { CartesianPointDistance } from "../../graphql/input-objects/CartesianPointDistance";
 import { RESERVED_TYPE_NAMES } from "../../constants";
 import { isRootType } from "../../utils/is-root-type";
-import { validateCustomResolverRequires } from "./validate-custom-resolver-requires";
+import { validateSchemaAugments } from "./validate-schema-augments";
 
 function filterDocument(document: DocumentNode): DocumentNode {
     const nodeNames = document.definitions
@@ -199,7 +199,7 @@ function validateDocument(
             throw new Error(filteredErrors.join("\n"));
         }
     }
-    validateCustomResolverRequires(document, schema);
+    validateSchemaAugments(document, schema);
 }
 
 export default validateDocument;

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -40,7 +40,9 @@ import { PointDistance } from "../../graphql/input-objects/PointDistance";
 import { CartesianPointDistance } from "../../graphql/input-objects/CartesianPointDistance";
 import { RESERVED_TYPE_NAMES } from "../../constants";
 import { isRootType } from "../../utils/is-root-type";
-import { validateSchemaAugments } from "./validate-schema-augments";
+import { validateSchemaCustomizations } from "./validate-schema-customizations";
+import type { ValidationConfig } from "../../classes/Neo4jGraphQL";
+import { defaultValidationConfig } from "../../classes/Neo4jGraphQL";
 
 function filterDocument(document: DocumentNode): DocumentNode {
     const nodeNames = document.definitions
@@ -187,19 +189,19 @@ function getBaseSchema(
 
 function validateDocument(
     document: DocumentNode,
-    validateTypeDefs = true,
+    validationConfig: ValidationConfig = defaultValidationConfig,
     additionalDirectives: Array<GraphQLDirective> = [],
     additionalTypes: Array<GraphQLNamedType> = []
 ): void {
-    const schema = getBaseSchema(document, validateTypeDefs, additionalDirectives, additionalTypes);
-    if (validateTypeDefs) {
+    const schema = getBaseSchema(document, validationConfig.validateTypeDefs, additionalDirectives, additionalTypes);
+    if (validationConfig.validateTypeDefs) {
         const errors = validateSchema(schema);
         const filteredErrors = errors.filter((e) => e.message !== "Query root type must be provided.");
         if (filteredErrors.length) {
             throw new Error(filteredErrors.join("\n"));
         }
     }
-    validateSchemaAugments(document, schema);
+    validateSchemaCustomizations(document, schema, validationConfig);
 }
 
 export default validateDocument;

--- a/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
+++ b/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
@@ -37,7 +37,7 @@ describe("validateDuplicateRelationshipFields", () => {
         `;
 
         expect(() => validateDocument(doc)).toThrow(
-            "Multiple relationship fields with the same type and direction may not have the same relationship type"
+            "Multiple relationship fields with the same type and direction may not have the same relationship type."
         );
     });
 

--- a/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
+++ b/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
@@ -64,19 +64,10 @@ describe("validateDuplicateRelationshipFields", () => {
 
     test("should not throw an error if multiple relationship fields in the same type have the same relationship type but have different directions.", () => {
         const doc = gql`
-            type Team {
-                name: String!
-                player: Person! @relationship(type: "PLAYS_IN", direction: IN)
-                venue: Venue! @relationship(type: "PLAYS_IN", direction: IN)
-            }
-
             type Person {
                 name: String!
-                teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
-            }
-
-            type Venue {
-                location: String!
+                knows: [Person!]! @relationship(type: "KNOWS", direction: OUT)
+                knowedBy: [Person!]! @relationship(type: "KNOWS", direction: IN)
             }
         `;
 

--- a/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
+++ b/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "apollo-server";
+import validateDocument from "./validate-document";
+
+describe("validateDuplicateRelationshipFields", () => {
+    test("should throw an error if multiple relationship fields in the same type have the same relationship type.", () => {
+        const doc = gql`
+            type Team {
+                name: String!
+                player1: Person! @relationship(type: "PLAYS_IN", direction: IN)
+                player2: Person! @relationship(type: "PLAYS_IN", direction: IN)
+                backupPlayers: [Person!]! @relationship(type: "PLAYS_IN", direction: IN)
+            }
+
+            type Person {
+                name: String!
+                teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
+            }
+        `;
+
+        expect(() => validateDocument(doc)).toThrow(
+            "Multiple relationship fields with the same type and direction may not have the same relationship type"
+        );
+    });
+
+    test("should not throw an error if multiple relationship fields of different types have the same relationship type.", () => {
+        const doc = gql`
+            type Team {
+                name: String!
+                player: Person! @relationship(type: "PLAYS_IN", direction: IN)
+                venue: Venue! @relationship(type: "PLAYS_IN", direction: IN)
+            }
+
+            type Person {
+                name: String!
+                teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
+            }
+
+            type Venue {
+                location: String!
+            }
+        `;
+
+        expect(() => validateDocument(doc)).not.toThrow();
+    });
+
+    test("should not throw an error if multiple relationship fields in the same type have the same relationship type but have different directions.", () => {
+        const doc = gql`
+            type Team {
+                name: String!
+                player: Person! @relationship(type: "PLAYS_IN", direction: IN)
+                venue: Venue! @relationship(type: "PLAYS_IN", direction: IN)
+            }
+
+            type Person {
+                name: String!
+                teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
+            }
+
+            type Venue {
+                location: String!
+            }
+        `;
+
+        expect(() => validateDocument(doc)).not.toThrow();
+    });
+});

--- a/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
+++ b/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.test.ts
@@ -36,7 +36,7 @@ describe("validateDuplicateRelationshipFields", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).toThrow(
+        expect(() => validateDocument({ document: doc })).toThrow(
             "Multiple relationship fields with the same type and direction may not have the same relationship type."
         );
     });
@@ -59,7 +59,7 @@ describe("validateDuplicateRelationshipFields", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).not.toThrow();
+        expect(() => validateDocument({ document: doc })).not.toThrow();
     });
 
     test("should not throw an error if multiple relationship fields in the same type have the same relationship type but have different directions.", () => {
@@ -80,6 +80,6 @@ describe("validateDuplicateRelationshipFields", () => {
             }
         `;
 
-        expect(() => validateDocument(doc)).not.toThrow();
+        expect(() => validateDocument({ document: doc })).not.toThrow();
     });
 });

--- a/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.ts
+++ b/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectTypeDefinitionNode } from "graphql";
+import getFieldTypeMeta from "../get-field-type-meta";
+import { Kind } from "graphql";
+
+export function validateDuplicateRelationshipFields(objType: ObjectTypeDefinitionNode) {
+    if (!objType.fields) {
+        return;
+    }
+
+    const relationshipUsages = new Set();
+
+    for (const field of objType.fields) {
+        if (!field.directives) {
+            continue;
+        }
+
+        const relationshipDirective = field.directives.find((directive) => directive.name.value === "relationship");
+        if (!relationshipDirective || !relationshipDirective.arguments) {
+            continue;
+        }
+
+        const typeArg = relationshipDirective.arguments.find((arg) => arg.name.value === "type");
+        const directionArg = relationshipDirective.arguments.find((arg) => arg.name.value === "direction");
+        if (!typeArg || !directionArg) {
+            continue;
+        }
+
+        if (typeArg.value.kind !== Kind.STRING) {
+            throw new Error("@relationship type expects a string");
+        }
+
+        if (directionArg.value.kind !== Kind.ENUM) {
+            throw new Error("@relationship direction expects an enum");
+        }
+
+        const typeMeta = getFieldTypeMeta(field.type);
+
+        if (relationshipUsages.has(`${typeMeta.name}__${typeArg.value.value}__${directionArg.value.value}`)) {
+            throw new Error(
+                "Multiple relationship fields with the same type and direction may not have the same relationship type"
+            );
+        }
+
+        relationshipUsages.add(`${typeMeta.name}__${typeArg.value.value}__${directionArg.value.value}`);
+    }
+}

--- a/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.ts
+++ b/packages/graphql/src/schema/validation/validate-duplicate-relationship-fields.ts
@@ -56,7 +56,7 @@ export function validateDuplicateRelationshipFields(objType: ObjectTypeDefinitio
 
         if (relationshipUsages.has(`${typeMeta.name}__${typeArg.value.value}__${directionArg.value.value}`)) {
             throw new Error(
-                "Multiple relationship fields with the same type and direction may not have the same relationship type"
+                "Multiple relationship fields with the same type and direction may not have the same relationship type."
             );
         }
 

--- a/packages/graphql/src/schema/validation/validate-schema-customizations.ts
+++ b/packages/graphql/src/schema/validation/validate-schema-customizations.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentNode, GraphQLSchema } from "graphql";
+import type { ValidationConfig } from "../../classes/Neo4jGraphQL";
+import { getDefinitionNodes } from "../get-definition-nodes";
+import { validateCustomResolverRequires } from "./validate-custom-resolver-requires";
+import { validateDuplicateRelationshipFields } from "./validate-duplicate-relationship-fields";
+
+export function validateSchemaCustomizations(
+    document: DocumentNode,
+    schema: GraphQLSchema,
+    validationConfig: ValidationConfig
+) {
+    const definitionNodes = getDefinitionNodes(document);
+
+    for (const objectType of definitionNodes.objectTypes) {
+        validateCustomResolverRequires(objectType, schema);
+        if (validationConfig.validateDuplicateRelationshipFields) {
+            validateDuplicateRelationshipFields(objectType);
+        }
+    }
+}

--- a/packages/graphql/src/schema/validation/validate-schema-customizations.ts
+++ b/packages/graphql/src/schema/validation/validate-schema-customizations.ts
@@ -23,11 +23,15 @@ import { getDefinitionNodes } from "../get-definition-nodes";
 import { validateCustomResolverRequires } from "./validate-custom-resolver-requires";
 import { validateDuplicateRelationshipFields } from "./validate-duplicate-relationship-fields";
 
-export function validateSchemaCustomizations(
-    document: DocumentNode,
-    schema: GraphQLSchema,
-    validationConfig: ValidationConfig
-) {
+export function validateSchemaCustomizations({
+    document,
+    schema,
+    validationConfig,
+}: {
+    document: DocumentNode;
+    schema: GraphQLSchema;
+    validationConfig: ValidationConfig;
+}) {
     const definitionNodes = getDefinitionNodes(document);
 
     for (const objectType of definitionNodes.objectTypes) {

--- a/packages/graphql/src/types.ts
+++ b/packages/graphql/src/types.ts
@@ -366,6 +366,7 @@ export interface CypherQueryOptions {
 export interface StartupValidationOptions {
     typeDefs?: boolean;
     resolvers?: boolean;
+    noDuplicateRelationshipFields?: boolean;
 }
 
 /**

--- a/packages/graphql/tests/integration/config-options/startup-validation.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/startup-validation.int.test.ts
@@ -379,16 +379,12 @@ describe("Startup Validation", () => {
         await expect(neoSchema.getSchema()).resolves.not.toThrow();
     });
 
-    test("should throw no errors when startupValidation.customResolver, startupValidation.typeDefs, and startupValidation.noDuplicateRelationshipFields are false", async () => {
+    test("should throw no errors when startupValidation false", async () => {
         const neoSchema = new Neo4jGraphQL({
             typeDefs: invalidAll,
             driver,
             config: {
-                startupValidation: {
-                    resolvers: false,
-                    typeDefs: false,
-                    noDuplicateRelationshipFields: false,
-                },
+                startupValidation: false,
             },
         });
 

--- a/packages/graphql/tests/integration/config-options/startup-validation.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/startup-validation.int.test.ts
@@ -27,6 +27,8 @@ describe("Startup Validation", () => {
 
     const invalidTypeDefsError = 'Type "Point" already exists in the schema.';
     const missingCustomResolverError = "Custom resolver for fullName has not been provided";
+    const duplicateRelationshipFieldsError =
+        "Multiple relationship fields with the same type and direction may not have the same relationship type.";
 
     const customResolverTypeDefs = `
         type User {
@@ -63,6 +65,32 @@ describe("Startup Validation", () => {
             id: ID!
             firstName: String!
             lastName: String!
+        }
+    `;
+
+    const invalidDuplicateRelationship = `
+        type User {
+            id: ID!
+            firstName: String!
+            lastName: String!
+            friend1: User! @relationship(type: "FRIENDS_WITH", direction: IN)
+            friend2: User! @relationship(type: "FRIENDS_WITH", direction: IN)
+        }
+    `;
+
+    const invalidAll = `
+        type User {
+            id: ID!
+            firstName: String!
+            lastName: String!
+            fullName: String @customResolver(requires: "firstName lastName")
+            friend1: User! @relationship(type: "FRIENDS_WITH", direction: IN)
+            friend2: User! @relationship(type: "FRIENDS_WITH", direction: IN)
+        }
+
+        type Point {
+            latitude: Float!
+            longitude: Float!
         }
     `;
 
@@ -312,6 +340,54 @@ describe("Startup Validation", () => {
                 startupValidation: {
                     resolvers: false,
                     typeDefs: false,
+                },
+            },
+        });
+
+        await expect(neoSchema.getSchema()).resolves.not.toThrow();
+    });
+
+    test("should throw an error for duplicate relationship fields when startupValidation.noDuplicateRelationshipFields is true", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs: invalidDuplicateRelationship,
+            driver,
+            config: {
+                startupValidation: {
+                    typeDefs: true,
+                    resolvers: true,
+                    noDuplicateRelationshipFields: true,
+                },
+            },
+        });
+
+        await expect(neoSchema.getSchema()).rejects.toThrow(duplicateRelationshipFieldsError);
+    });
+
+    test("should not throw an error for duplicate relationship fields when startupValidation.noDuplicateRelationshipFields is false", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs: invalidDuplicateRelationship,
+            driver,
+            config: {
+                startupValidation: {
+                    typeDefs: true,
+                    resolvers: true,
+                    noDuplicateRelationshipFields: false,
+                },
+            },
+        });
+
+        await expect(neoSchema.getSchema()).resolves.not.toThrow();
+    });
+
+    test("should throw no errors when startupValidation.customResolver, startupValidation.typeDefs, and startupValidation.noDuplicateRelationshipFields are false", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs: invalidAll,
+            driver,
+            config: {
+                startupValidation: {
+                    resolvers: false,
+                    typeDefs: false,
+                    noDuplicateRelationshipFields: false,
                 },
             },
         });

--- a/packages/graphql/tests/schema/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/schema/rfcs/rfc-003.test.ts
@@ -29,11 +29,19 @@ describe("schema/rfc/003", () => {
             const typeDefs = gql`
                 type Source {
                     targets: [Target!]! @relationship(type: "HAS_TARGET", direction: OUT)
-                    target1: Target! @relationship(type: "HAS_TARGET", direction: OUT)
-                    target2: Target @relationship(type: "HAS_TARGET", direction: OUT)
+                    target1: SecondTarget! @relationship(type: "HAS_TARGET", direction: OUT)
+                    target2: ThirdTarget @relationship(type: "HAS_TARGET", direction: OUT)
                 }
 
                 type Target {
+                    id: ID @id
+                }
+
+                type SecondTarget {
+                    id: ID @id
+                }
+
+                type ThirdTarget {
                     id: ID @id
                 }
             `;


### PR DESCRIPTION
# Description

This PR introduces validation to detect cases where types have duplicate relationship fields. 

A duplicate relationship field is when multiple relationship fields are defined on the same type with the same relationship type and the same direction. 

Here's an example of duplicate relationship fields:

```graphql
type Team {
    player1: Person! @relationship(type: "PLAYS_IN", direction: IN)
    player2: Person! @relationship(type: "PLAYS_IN", direction: IN)
    backupPlayers: [Person!]! @relationship(type: "PLAYS_IN", direction: IN)
}

type Person {
    teams: [Team!]! @relationship(type: "PLAYS_IN", direction: OUT)
}
```

To allow disabling the checks for duplicate relationship fields, the `noDuplicateRelationshipFields` config option has been added.

## Complexity

Medium