### PR TITLE
Add MATCHES features.filters settings to deprecate enableRegex

### DIFF
--- a/.changeset/hot-carrots-reflect.md
+++ b/.changeset/hot-carrots-reflect.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+enableRegex has been deprecated and replaced with MATCHES filters in the features configuration object.

--- a/docs/modules/ROOT/pages/api-reference/neo4jgraphql.adoc
+++ b/docs/modules/ROOT/pages/api-reference/neo4jgraphql.adoc
@@ -277,7 +277,7 @@ const { CypherRuntime } = require("@neo4j/graphql");
 ==== `Neo4jGraphQLPlugins`
 
 |===
-|Name and Type |DescriptionW
+|Name and Type |Description
 
 |`auth` +
  +

--- a/docs/modules/ROOT/pages/api-reference/neo4jgraphql.adoc
+++ b/docs/modules/ROOT/pages/api-reference/neo4jgraphql.adoc
@@ -221,8 +221,11 @@ const { CypherRuntime } = require("@neo4j/graphql");
  +
  Type: xref::api-reference/neo4jgraphql.adoc#api-reference-neo4jgraphql-input-neo4jstringfilterssettings[`Neo4jStringFiltersSettings`]
 |Additional configuration for String filters.
+|`ID` +
+ +
+ Type: xref::api-reference/neo4jgraphql.adoc#api-reference-neo4jgraphql-input-neo4jstringfilterssettings[`Neo4jIDFiltersSettings`]
+|Additional configuration for String filters.
 |===
-
 
 [[api-reference-neo4jgraphql-input-neo4jstringfilterssettings]]
 ==== `Neo4jStringFiltersSettings`
@@ -250,13 +253,31 @@ const { CypherRuntime } = require("@neo4j/graphql");
  Type: `boolean`
 | Enables LTE comparator.
 
+|`MATCHES` +
+ +
+ Type: `boolean`
+| Enables MATCHES comparator.
+
+|===
+
+[[api-reference-neo4jgraphql-input-neo4jidfilterssettings]]
+==== `Neo4jIDFiltersSettings`
+
+|===
+|Name and Type |Description
+
+|`MATCHES` +
+ +
+ Type: `boolean`
+| Enables MATCHES comparator.
+
 |===
 
 [[api-reference-neo4jgraphql-input-neo4jgraphqlplugins]]
 ==== `Neo4jGraphQLPlugins`
 
 |===
-|Name and Type |Description
+|Name and Type |DescriptionW
 
 |`auth` +
  +
@@ -414,4 +435,3 @@ Accepts the arguments below:
  Type: `boolean`
 |Whether or not to create constraints if they do not yet exist. Disabled by default.
 |===
-

--- a/docs/modules/ROOT/pages/api-reference/neo4jgraphql.adoc
+++ b/docs/modules/ROOT/pages/api-reference/neo4jgraphql.adoc
@@ -223,7 +223,7 @@ const { CypherRuntime } = require("@neo4j/graphql");
 |Additional configuration for String filters.
 |`ID` +
  +
- Type: xref::api-reference/neo4jgraphql.adoc#api-reference-neo4jgraphql-input-neo4jstringfilterssettings[`Neo4jIDFiltersSettings`]
+ Type: xref::api-reference/neo4jgraphql.adoc#api-reference-neo4jgraphql-input-neo4jidfilterssettings[`Neo4jIDFiltersSettings`]
 |Additional configuration for String filters.
 |===
 

--- a/docs/modules/ROOT/pages/filtering.adoc
+++ b/docs/modules/ROOT/pages/filtering.adoc
@@ -75,7 +75,60 @@ const neoSchema = new Neo4jGraphQL({ features, typeDefs, driver });
 The filter `_MATCHES` is also available for comparison of `String` and `ID` types, which accepts a RegEx string as an argument and returns any matches.
 Note that RegEx matching filters are **disabled by default**.
 
-To enable the inclusion of this filter, set the config option `enableRegex` to `true`.
+To enable the inclusion of this filter, set the features configuration object for each.
+
+For `String`:
+
+[source, javascript, indent=0]
+----
+const features = {
+    filters: {
+        String: {
+            MATCHES: true,
+        }
+    }
+};
+
+const neoSchema = new Neo4jGraphQL({ features, typeDefs, driver });
+----
+
+For `ID`:
+
+
+[source, javascript, indent=0]
+----
+const features = {
+    filters: {
+        String: {
+            ID: true,
+        }
+    }
+};
+
+const neoSchema = new Neo4jGraphQL({ features, typeDefs, driver });
+----
+
+For both `String` and `ID`:
+
+
+[source, javascript, indent=0]
+----
+const features = {
+    filters: {
+        String: {
+            MATCHES: true,
+        },
+        ID: {
+            MATCHES: true,
+        }
+    }
+};
+
+const neoSchema = new Neo4jGraphQL({ features, typeDefs, driver });
+----
+
+
+Previously to enable to this filter the config option `enableRegex` was used, it has been deprecated. Use the `features` configuration object as described here, as the `enableRegex` will be removed in the future.
 
 > The nature of RegEx matching means that on an unprotected API, this could potentially be used to execute a ReDoS attack (https://owasp.org/www-community/attacks/Regular_expression_Denial_of_Service_-_ReDoS) against the backing Neo4j database.
 

--- a/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
+++ b/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
@@ -99,12 +99,25 @@ export const SchemaView = ({ hasSchema, onChange }: Props) => {
 
                 Storage.storeJSON(LOCAL_STATE_TYPE_DEFS, typeDefs);
 
+                const features = isRegexChecked
+                    ? {
+                          filters: {
+                              String: {
+                                  MATCHES: true,
+                              },
+                              ID: {
+                                  MATCHES: true,
+                              },
+                          },
+                      }
+                    : {};
+
                 const options = {
                     typeDefs,
                     driver: auth.driver,
+                    features,
                     config: {
                         enableDebug: isDebugChecked === "true",
-                        enableRegex: isRegexChecked === "true",
                         driverConfig: {
                             database: auth.selectedDatabaseName || DEFAULT_DATABASE_NAME,
                         },

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -54,6 +54,11 @@ import { validateDocument } from "../schema/validation";
 
 export interface Neo4jGraphQLConfig {
     driverConfig?: DriverConfig;
+    /**
+     * @deprecated This argument has been deprecated and will be removed in v4.0.0.
+     * Please use features.filters instead. More information can be found at
+     * https://neo4j.com/docs/graphql-manual/current/guides/v4-migration/#features
+     */
     enableRegex?: boolean;
     enableDebug?: boolean;
     /**

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -132,7 +132,7 @@ function getWhereFields({
                         res[`${f.fieldName}_MATCHES`] = { type: "String", directives: deprecatedDirectives };
                     }
                 } else if (enableRegex) {
-                    // Deprecated. To be removed.
+                    // TODO: This is deprecated. To be removed in 4.0.0.
                     res[`${f.fieldName}_MATCHES`] = { type: "String", directives: deprecatedDirectives };
                 }
 

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -134,9 +134,9 @@ function getWhereFields({
 
                 const stringWhereOperatorsNegate = ["_NOT_CONTAINS", "_NOT_STARTS_WITH", "_NOT_ENDS_WITH"];
 
-                Object.entries(features?.filters?.String || {}).forEach(([key, value]) => {
-                    if (value) {
-                        stringWhereOperators.push(`_${key}`);
+                Object.entries(features?.filters?.String || {}).forEach(([filter, enabled]) => {
+                    if (enabled) {
+                        stringWhereOperators.push(`_${filter}`);
                     }
                 });
                 stringWhereOperators.forEach((comparator) => {

--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -126,7 +126,13 @@ function getWhereFields({
             }
 
             if (["String", "ID"].includes(f.typeMeta.name)) {
-                if (enableRegex) {
+                const matchesSetting: boolean | undefined = features?.filters?.[f.typeMeta.name]?.MATCHES;
+                if (matchesSetting !== undefined) {
+                    if (matchesSetting === true) {
+                        res[`${f.fieldName}_MATCHES`] = { type: "String", directives: deprecatedDirectives };
+                    }
+                } else if (enableRegex) {
+                    // Deprecated. To be removed.
                     res[`${f.fieldName}_MATCHES`] = { type: "String", directives: deprecatedDirectives };
                 }
 
@@ -135,6 +141,9 @@ function getWhereFields({
                 const stringWhereOperatorsNegate = ["_NOT_CONTAINS", "_NOT_STARTS_WITH", "_NOT_ENDS_WITH"];
 
                 Object.entries(features?.filters?.String || {}).forEach(([filter, enabled]) => {
+                    if (filter === "MATCHES") {
+                        return;
+                    }
                     if (enabled) {
                         stringWhereOperators.push(`_${filter}`);
                     }

--- a/packages/graphql/src/schema/make-augmented-schema.test.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.test.ts
@@ -173,6 +173,139 @@ describe("makeAugmentedSchema", () => {
 
             expect(matchesField).toBeDefined();
         });
+
+        test("should add the name_MATCHES filter when Features.Filters.String.MATCHES is set", () => {
+            const typeDefs = gql`
+                type User {
+                    name: String
+                }
+            `;
+
+            const neoSchema = makeAugmentedSchema(typeDefs, {
+                validateResolvers: true,
+                features: {
+                    filters: {
+                        String: {
+                            MATCHES: true,
+                        },
+                    },
+                },
+            });
+
+            const document = neoSchema.typeDefs;
+
+            const nodeWhereInput = document.definitions.find(
+                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "UserWhere"
+            ) as InputObjectTypeDefinitionNode;
+
+            const matchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("name_MATCHES"));
+
+            expect(matchesField).toBeDefined();
+        });
+
+        test("should add the id_MATCHES filter when Features.Filters.ID.MATCHES is set", () => {
+            const typeDefs = gql`
+                type User {
+                    id: ID
+                    name: String
+                }
+            `;
+
+            const neoSchema = makeAugmentedSchema(typeDefs, {
+                validateResolvers: true,
+                features: {
+                    filters: {
+                        ID: {
+                            MATCHES: true,
+                        },
+                    },
+                },
+            });
+
+            const document = neoSchema.typeDefs;
+
+            const nodeWhereInput = document.definitions.find(
+                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "UserWhere"
+            ) as InputObjectTypeDefinitionNode;
+
+            const matchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("id_MATCHES"));
+
+            expect(matchesField).toBeDefined();
+        });
+
+        test("should not add the id_MATCHES filter when Features.Filters.String.MATCHES is set but Features.Filters.ID.MATCHES is not set", () => {
+            const typeDefs = gql`
+                type User {
+                    id: ID
+                    name: String
+                }
+            `;
+
+            const neoSchema = makeAugmentedSchema(typeDefs, {
+                validateResolvers: true,
+                features: {
+                    filters: {
+                        String: {
+                            MATCHES: true,
+                        },
+                        ID: {
+                            MATCHES: false,
+                        },
+                    },
+                },
+            });
+
+            const document = neoSchema.typeDefs;
+
+            const nodeWhereInput = document.definitions.find(
+                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "UserWhere"
+            ) as InputObjectTypeDefinitionNode;
+
+            const nameMatchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("name_MATCHES"));
+
+            expect(nameMatchesField).toBeDefined();
+
+            const idMatchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("id_MATCHES"));
+
+            expect(idMatchesField).toBeUndefined();
+        });
+
+        test("should not add the name_MATCHES filter when Features.Filters.ID.MATCHES is set but Features.Filters.Name.MATCHES is not set", () => {
+            const typeDefs = gql`
+                type User {
+                    id: ID
+                    name: String
+                }
+            `;
+
+            const neoSchema = makeAugmentedSchema(typeDefs, {
+                validateResolvers: true,
+                features: {
+                    filters: {
+                        String: {
+                            MATCHES: false,
+                        },
+                        ID: {
+                            MATCHES: true,
+                        },
+                    },
+                },
+            });
+
+            const document = neoSchema.typeDefs;
+
+            const nodeWhereInput = document.definitions.find(
+                (x) => x.kind === "InputObjectTypeDefinition" && x.name.value === "UserWhere"
+            ) as InputObjectTypeDefinitionNode;
+
+            const nameMatchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("name_MATCHES"));
+
+            expect(nameMatchesField).toBeUndefined();
+
+            const idMatchesField = nodeWhereInput.fields?.find((x) => x.name.value.endsWith("id_MATCHES"));
+
+            expect(idMatchesField).toBeDefined();
+        });
     });
 
     describe("issues", () => {

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -492,10 +492,16 @@ export interface Neo4jStringFiltersSettings {
     GTE?: boolean;
     LT?: boolean;
     LTE?: boolean;
+    MATCHES?: boolean;
+}
+
+export interface Neo4jIDFiltersSettings {
+    MATCHES?: boolean;
 }
 
 export interface Neo4jFiltersSettings {
     String?: Neo4jStringFiltersSettings;
+    ID?: Neo4jIDFiltersSettings;
 }
 
 export interface Neo4jFeaturesSettings {

--- a/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
@@ -115,7 +115,16 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                    const neoSchema = new Neo4jGraphQL({ typeDefs, config: { enableRegex: true } });
+                    const neoSchema = new Neo4jGraphQL({
+                        typeDefs,
+                        features: {
+                            filters: {
+                                [type]: {
+                                    MATCHES: true,
+                                },
+                            },
+                        },
+                    });
 
                     const value = generate({
                         readable: true,

--- a/packages/graphql/tests/tck/advanced-filtering.test.ts
+++ b/packages/graphql/tests/tck/advanced-filtering.test.ts
@@ -47,9 +47,6 @@ describe("Cypher Advanced Filtering", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: {
-                enableRegex: true,
-            },
             features: {
                 filters: {
                     String: {
@@ -57,6 +54,10 @@ describe("Cypher Advanced Filtering", () => {
                         GT: true,
                         LTE: true,
                         GTE: true,
+                        MATCHES: true,
+                    },
+                    ID: {
+                        MATCHES: true,
                     },
                 },
             },

--- a/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
@@ -54,7 +54,13 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: { enableRegex: true },
+            features: {
+                filters: {
+                    String: {
+                        MATCHES: true,
+                    },
+                },
+            },
             plugins: {
                 auth: new Neo4jGraphQLAuthJWTPlugin({
                     secret,

--- a/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
@@ -55,7 +55,13 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: { enableRegex: true },
+            features: {
+                filters: {
+                    String: {
+                        MATCHES: true,
+                    },
+                },
+            },
             plugins: {
                 auth: new Neo4jGraphQLAuthJWTPlugin({
                     secret,

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -53,7 +53,13 @@ describe("Cypher coalesce()", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: { enableRegex: true },
+            features: {
+                filters: {
+                    String: {
+                        MATCHES: true,
+                    },
+                },
+            },
         });
 
         const query = gql`
@@ -132,7 +138,13 @@ describe("Cypher coalesce()", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: { enableRegex: true },
+            features: {
+                filters: {
+                    String: {
+                        MATCHES: true,
+                    },
+                },
+            },
             plugins: {
                 auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
             },
@@ -183,7 +195,13 @@ describe("Cypher coalesce()", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: { enableRegex: true },
+            features: {
+                filters: {
+                    String: {
+                        MATCHES: true,
+                    },
+                },
+            },
             plugins: {
                 auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
             },


### PR DESCRIPTION
# Description

This PR deprecates the `enableRegex` config option in favour of a new `MATCHES` option added to `features.filters`.

The `_MATCHES` comparator can now be enabled separately for `String` or `ID`, as follows:

```ts
const features = {
    filters: {
        String: {
            MATCHES: true,
        },
        ID: {
            MATCHES: true,
        }
    }
};

const neoSchema = new Neo4jGraphQL({ features, typeDefs, driver });
```

## Complexity

Complexity:

Medium

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
