### PR TITLE
Remove config.callbacks

### DIFF
--- a/.changeset/shy-moles-invite.md
+++ b/.changeset/shy-moles-invite.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+config.callbacks has been deprecated and replaced with features.populatedBy.callbacks. See https://neo4j.com/docs/graphql-manual/current/guides/v4-migration/#_callback_renamed_to_populatedby for more information.

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -63,12 +63,6 @@ export interface Neo4jGraphQLConfig {
     skipValidateTypeDefs?: boolean;
     startupValidation?: StartupValidationConfig;
     queryOptions?: CypherQueryOptions;
-    /**
-     * @deprecated This argument has been deprecated and will be removed in v4.0.0.
-     * Please use features.populatedBy instead. More information can be found at
-     * https://neo4j.com/docs/graphql-manual/current/guides/v4-migration/#_callback_renamed_to_populatedby
-     */
-    callbacks?: Neo4jGraphQLCallbacks;
 }
 
 export type ValidationConfig = {
@@ -264,7 +258,7 @@ class Neo4jGraphQL {
 
         const config = {
             ...this.config,
-            callbacks: this.features?.populatedBy?.callbacks ?? this.config.callbacks,
+            callbacks: this.features?.populatedBy?.callbacks,
         };
 
         const wrapResolverArgs = {
@@ -330,7 +324,7 @@ class Neo4jGraphQL {
                 features: this.features,
                 validateResolvers: validationConfig.validateResolvers,
                 generateSubscriptions: Boolean(this.plugins?.subscriptions),
-                callbacks: this.features?.populatedBy?.callbacks ?? this.config.callbacks,
+                callbacks: this.features?.populatedBy?.callbacks,
                 userCustomResolvers: this.resolvers,
             });
 
@@ -367,7 +361,7 @@ class Neo4jGraphQL {
             features: this.features,
             validateResolvers: validationConfig.validateResolvers,
             generateSubscriptions: Boolean(this.plugins?.subscriptions),
-            callbacks: this.features?.populatedBy?.callbacks ?? this.config.callbacks,
+            callbacks: this.features?.populatedBy?.callbacks,
             userCustomResolvers: this.resolvers,
             subgraph,
         });

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -267,6 +267,7 @@ class Neo4jGraphQL {
             relationships: this.relationships,
             schemaModel: schemaModel,
             plugins: this.plugins,
+            features: this.features,
         };
 
         const resolversComposition = {

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -30,7 +30,6 @@ import type {
     DriverConfig,
     CypherQueryOptions,
     Neo4jGraphQLPlugins,
-    Neo4jGraphQLCallbacks,
     Neo4jFeaturesSettings,
     StartupValidationConfig,
 } from "../types";
@@ -292,6 +291,7 @@ class Neo4jGraphQL {
             relationships: this.relationships,
             schemaModel: schemaModel,
             plugins: this.plugins,
+            features: this.features,
         };
 
         const resolversComposition = {
@@ -324,7 +324,6 @@ class Neo4jGraphQL {
                 features: this.features,
                 validateResolvers: validationConfig.validateResolvers,
                 generateSubscriptions: Boolean(this.plugins?.subscriptions),
-                callbacks: this.features?.populatedBy?.callbacks,
                 userCustomResolvers: this.resolvers,
             });
 
@@ -361,7 +360,6 @@ class Neo4jGraphQL {
             features: this.features,
             validateResolvers: validationConfig.validateResolvers,
             generateSubscriptions: Boolean(this.plugins?.subscriptions),
-            callbacks: this.features?.populatedBy?.callbacks,
             userCustomResolvers: this.resolvers,
             subgraph,
         });

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -39,6 +39,7 @@ import type Relationship from "./Relationship";
 import checkNeo4jCompat from "./utils/verify-database";
 import type { AssertIndexesAndConstraintsOptions } from "./utils/asserts-indexes-and-constraints";
 import assertIndexesAndConstraints from "./utils/asserts-indexes-and-constraints";
+import type { WrapResolverArguments } from "../schema/resolvers/wrapper";
 import { wrapResolver, wrapSubscription } from "../schema/resolvers/wrapper";
 import { defaultFieldResolver } from "../schema/resolvers/field/defaultField";
 import { asArray } from "../utils/utils";
@@ -260,7 +261,7 @@ class Neo4jGraphQL {
             callbacks: this.features?.populatedBy?.callbacks,
         };
 
-        const wrapResolverArgs = {
+        const wrapResolverArgs: WrapResolverArguments = {
             driver: this.driver,
             config,
             nodes: this.nodes,
@@ -285,7 +286,7 @@ class Neo4jGraphQL {
         resolvers: NonNullable<IExecutableSchemaDefinition["resolvers"]>,
         schemaModel: Neo4jGraphQLSchemaModel
     ) {
-        const wrapResolverArgs = {
+        const wrapResolverArgs: WrapResolverArguments = {
             driver: this.driver,
             config: this.config,
             nodes: this.nodes,

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -30,7 +30,7 @@ import { GraphQLID, GraphQLNonNull, Kind, parse, print } from "graphql";
 import type { ObjectTypeComposer } from "graphql-compose";
 import { SchemaComposer } from "graphql-compose";
 import pluralize from "pluralize";
-import type { BaseField, Neo4jGraphQLCallbacks, Neo4jFeaturesSettings } from "../types";
+import type { BaseField, Neo4jFeaturesSettings } from "../types";
 import { cypherResolver } from "./resolvers/field/cypher";
 import { numericalResolver } from "./resolvers/field/numerical";
 import { aggregateResolver } from "./resolvers/query/aggregate";
@@ -92,14 +92,12 @@ function makeAugmentedSchema(
         features,
         validateResolvers,
         generateSubscriptions,
-        callbacks,
         userCustomResolvers,
         subgraph,
     }: {
         features?: Neo4jFeaturesSettings;
         validateResolvers: boolean;
         generateSubscriptions?: boolean;
-        callbacks?: Neo4jGraphQLCallbacks;
         userCustomResolvers?: IResolvers | Array<IResolvers>;
         subgraph?: Subgraph;
     } = { validateResolvers: true }
@@ -110,6 +108,7 @@ function makeAugmentedSchema(
     resolvers: IResolvers;
 } {
     const composer = new SchemaComposer();
+    const callbacks = features?.populatedBy?.callbacks;
 
     let relationships: Relationship[] = [];
 

--- a/packages/graphql/src/schema/resolvers/wrapper.ts
+++ b/packages/graphql/src/schema/resolvers/wrapper.ts
@@ -37,7 +37,7 @@ import { IncomingMessage } from "http";
 
 const debug = Debug(DEBUG_GRAPHQL);
 
-type WrapResolverArguments = {
+export type WrapResolverArguments = {
     driver?: Driver;
     config: Neo4jGraphQLConfig;
     nodes: Node[];

--- a/packages/graphql/src/schema/resolvers/wrapper.ts
+++ b/packages/graphql/src/schema/resolvers/wrapper.ts
@@ -28,7 +28,7 @@ import { Executor } from "../../classes/Executor";
 import type { ExecutorConstructorParam } from "../../classes/Executor";
 import { DEBUG_GRAPHQL } from "../../constants";
 import createAuthParam from "../../translate/create-auth-param";
-import type { Context, Neo4jGraphQLPlugins } from "../../types";
+import type { Context, Neo4jFeaturesSettings, Neo4jGraphQLPlugins } from "../../types";
 import { getToken, parseBearerToken } from "../../utils/get-token";
 import type { SubscriptionConnectionContext, SubscriptionContext } from "./subscriptions/types";
 import { decodeToken, verifyGlobalAuthentication } from "./wrapper-utils";
@@ -45,15 +45,17 @@ type WrapResolverArguments = {
     schemaModel: Neo4jGraphQLSchemaModel;
     plugins?: Neo4jGraphQLPlugins;
     dbInfo?: Neo4jDatabaseInfo;
+    features?: Neo4jFeaturesSettings;
 };
 
 let neo4jDatabaseInfo: Neo4jDatabaseInfo;
 
 export const wrapResolver =
-    ({ driver, config, nodes, relationships, schemaModel, plugins, dbInfo }: WrapResolverArguments) =>
+    ({ driver, config, nodes, relationships, schemaModel, plugins, dbInfo, features }: WrapResolverArguments) =>
     (next) =>
     async (root, args, context: Context, info: GraphQLResolveInfo) => {
         const { driverConfig } = config;
+        const callbacks = features?.populatedBy?.callbacks;
 
         if (debug.enabled) {
             const query = print(info.operation);
@@ -86,7 +88,7 @@ export const wrapResolver =
         context.schemaModel = schemaModel;
         context.plugins = plugins || {};
         context.subscriptionsEnabled = Boolean(context.plugins?.subscriptions);
-        context.callbacks = config.callbacks;
+        context.callbacks = callbacks;
 
         if (!context.jwt) {
             if (context.plugins.auth) {

--- a/packages/graphql/tests/integration/issues/1756.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1756.int.test.ts
@@ -56,7 +56,7 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
             return `callback_value`;
         };
 
-        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver, config: { callbacks: { nanoid } } });
+        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver, features: { populatedBy: { callbacks: { nanoid } } } });
         schema = await neoGraphql.getSchema();
     });
 

--- a/packages/graphql/tests/tck/issues/1756.test.ts
+++ b/packages/graphql/tests/tck/issues/1756.test.ts
@@ -50,7 +50,7 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            config: { callbacks: { nanoid } },
+            features: { populatedBy: { callbacks: { nanoid } } },
         });
     });
 


### PR DESCRIPTION
# Description

This PR remove `config.callbacks` as it has been deprecated and replaced with features.populatedBy.callbacks.

## Complexity

Low