### PR TITLE
Remove cypherSortFields

### DIFF
--- a/packages/graphql/src/translate/create-projection-and-params.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.ts
@@ -46,7 +46,6 @@ interface Res {
 
 export interface ProjectionMeta {
     authValidatePredicates?: Cypher.Predicate[];
-    cypherSortFields?: string[];
 }
 
 export type ProjectionResult = {
@@ -85,7 +84,7 @@ export default function createProjectionAndParams({
         const pointField = node.pointFields.find((x) => x.fieldName === field.name);
         const temporalField = node.temporalFields.find((x) => x.fieldName === field.name);
         const authableField = node.authableFields.find((x) => x.fieldName === field.name);
-        
+
         if (authableField) {
             // TODO: move this to translate-top-level
             if (authableField.auth) {

--- a/packages/graphql/src/translate/projection/subquery/translate-cypher-directive-projection.ts
+++ b/packages/graphql/src/translate/projection/subquery/translate-cypher-directive-projection.ts
@@ -207,10 +207,6 @@ export function translateCypherDirectiveProjection({
         []) as GraphQLSortArg[];
     const isSortArg = sortInput.find((obj) => Object.keys(obj).includes(alias));
     if (isSortArg) {
-        if (!res.meta.cypherSortFields) {
-            res.meta.cypherSortFields = [];
-        }
-        res.meta.cypherSortFields.push(alias);
         res.subqueriesBeforeSort.push(callSt);
     } else {
         res.subqueries.push(callSt);


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Removes `cypherSortFields` from projection return... This appears to be completely unused, and no tests fail as a result of removing this. Will make tidying up for authorization easier.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low