### PR TITLE
Add node 16 minimum engine to graphql package

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -21,6 +21,9 @@
         "dist/**/*.js",
         "dist/**/*.js.map"
     ],
+    "engines": {
+        "node": ">=16.0.0"
+    },
     "scripts": {
         "clean": "cd src/ && tsc --build --clean",
         "test": "jest",


### PR DESCRIPTION
# Description

As our project may not be compatible with older versions, we are adding the "engines" field with the specified Node.js version requirement to ensure the minimum required version of Node.js is installed.

## Complexity

Low