### PR TITLE
feat: Auth plugin, optional iss and aud JWT claim check

### DIFF
--- a/.changeset/witty-roses-deliver.md
+++ b/.changeset/witty-roses-deliver.md
@@ -1,5 +1,4 @@
 ---
-"graphql-manual": patch
 "@neo4j/graphql-plugin-auth": minor
 ---
 

--- a/.changeset/witty-roses-deliver.md
+++ b/.changeset/witty-roses-deliver.md
@@ -1,0 +1,6 @@
+---
+"graphql-manual": patch
+"@neo4j/graphql-plugin-auth": minor
+---
+
+feat: Auth plugins, constructor arguments for optional `iss` and `aud` JWT claim check on token verification

--- a/docs/modules/ROOT/pages/auth/setup.adoc
+++ b/docs/modules/ROOT/pages/auth/setup.adoc
@@ -94,8 +94,8 @@ It is also possible to pass in JWTs which have already been decoded, in which ca
 
 ==== Optional Constructor Arguments
 
-Additionally, for both the `Neo4jGraphQLAuthJWTPlugin` and the `Neo4jGraphQLAuthJWKSPlugin` one may optionally specify an `issuer` and an `audience` argument. These reference to the `iss` and the `aud` claim in a JWT token, see https://www.rfc-editor.org/rfc/rfc7519#page-9[JWT RFC].
-If the `issuer` and/or the `audience` values are provided, they will be checked as part of the token verification.
+Additionally, for both the `Neo4jGraphQLAuthJWTPlugin` and the `Neo4jGraphQLAuthJWKSPlugin` one may optionally specify an `issuer` and an `audience` constructor argument. These reference to the `iss` and the `aud` claim respectively in a JWT token, see https://www.rfc-editor.org/rfc/rfc7519#page-9[JWT RFC].
+If the `issuer` and/or the `audience` arguments are provided, they will be checked as part of the token verification.
 
 An example on how to provide an `issuer` for the `Neo4jGraphQLAuthJWKSPlugin` is shown below. In this case, any JWT token must contain the `iss` claim `"https://YOUR_DOMAIN"` for the token validation to be successful.
 [source, javascript, indent=0]

--- a/docs/modules/ROOT/pages/auth/setup.adoc
+++ b/docs/modules/ROOT/pages/auth/setup.adoc
@@ -92,6 +92,28 @@ interface Neo4jGraphQLAuthPlugin {
 
 It is also possible to pass in JWTs which have already been decoded, in which case the `jwt` option is _not necessary_. This is covered in the section xref::auth/setup.adoc#auth-setup-passing-in[Passing in JWTs] below. Note that the plugin's base decode method only supports HS256 and RS256 algorithms.
 
+==== Optional Constructor Arguments
+
+Additionally, for both the `Neo4jGraphQLAuthJWTPlugin` and the `Neo4jGraphQLAuthJWKSPlugin` one may optionally specify an `issuer` and an `audience` argument. These reference to the `iss` and the `aud` claim in a JWT token, see https://www.rfc-editor.org/rfc/rfc7519#page-9[JWT RFC].
+If the `issuer` and/or the `audience` values are provided, they will be checked as part of the token verification.
+
+An example on how to provide an `issuer` for the `Neo4jGraphQLAuthJWKSPlugin` is shown below. In this case, any JWT token must contain the `iss` claim `"https://YOUR_DOMAIN"` for the token validation to be successful.
+[source, javascript, indent=0]
+----
+import { Neo4jGraphQL } from "@neo4j/graphql";
+import { Neo4jGraphQLAuthJWKSPlugin } from "@neo4j/graphql-plugin-auth";
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    plugins: {
+        auth: new Neo4jGraphQLAuthJWKSPlugin({
+            jwksEndpoint: "https://YOUR_DOMAIN/well-known/jwks.json",
+            issuer: "https://YOUR_DOMAIN"
+        }),
+    },
+});
+----
+
 === Auth Roles Object Paths
 
 If you are using a 3rd party auth provider such as Auth0 you may find your roles property being nested inside an object:

--- a/docs/modules/ROOT/pages/auth/setup.adoc
+++ b/docs/modules/ROOT/pages/auth/setup.adoc
@@ -92,7 +92,7 @@ interface Neo4jGraphQLAuthPlugin {
 
 It is also possible to pass in JWTs which have already been decoded, in which case the `jwt` option is _not necessary_. This is covered in the section xref::auth/setup.adoc#auth-setup-passing-in[Passing in JWTs] below. Note that the plugin's base decode method only supports HS256 and RS256 algorithms.
 
-==== Optional Constructor Arguments
+=== Optional Constructor Arguments
 
 Additionally, for both the `Neo4jGraphQLAuthJWTPlugin` and the `Neo4jGraphQLAuthJWKSPlugin` one may optionally specify an `issuer` and an `audience` constructor argument. These reference to the `iss` and the `aud` claim respectively in a JWT token, see https://www.rfc-editor.org/rfc/rfc7519#page-9[JWT RFC].
 If the `issuer` and/or the `audience` arguments are provided, they will be checked as part of the token verification.

--- a/packages/graphql/tests/integration/directives/auth/jwks-endpoint.int.test.ts
+++ b/packages/graphql/tests/integration/directives/auth/jwks-endpoint.int.test.ts
@@ -243,6 +243,189 @@ describe("auth/jwks-endpoint", () => {
             await session.close();
         }
     });
+
+    test("should throw Unauthenticated if the issuer in the JWT token does not match the issuer provided in the Neo4jGraphQLAuthJWKSPlugin", async () => {
+        const session = await neo4j.getSession();
+
+        const typeDefs = `
+            type User {
+                id: ID
+            }
+            extend type User @auth(rules: [{ isAuthenticated: true }])
+        `;
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                users(where: {id: "${userId}"}) {
+                    id
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWKSPlugin({
+                    jwksEndpoint: "https://myAuthTest.auth0.com/.well-known/jwks.json",
+                    issuer: "https://testcompany.com",
+                }),
+            },
+        });
+
+        try {
+            // Start the JWKS Mock Server Application
+            jwksMock.start();
+
+            await session.run(`
+                CREATE (:User {id: "${userId}"})
+            `);
+
+            const accessToken = jwksMock.token({
+                iat: 1600000000,
+                iss: "https://anothercompany.com",
+            });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), {
+                    request: {
+                        headers: { Authorization: `Bearer ${accessToken}` },
+                    },
+                }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should verify the issuer in the JWT token against the provided issuer in the Neo4jGraphQLAuthJWKSPlugin", async () => {
+        const session = await neo4j.getSession();
+
+        const typeDefs = `
+            type User {
+                id: ID
+            }
+            extend type User @auth(rules: [{ isAuthenticated: true }])
+        `;
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                users(where: {id: "${userId}"}) {
+                    id
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWKSPlugin({
+                    jwksEndpoint: "https://myAuthTest.auth0.com/.well-known/jwks.json",
+                    issuer: "https://company.com",
+                }),
+            },
+        });
+
+        try {
+            // Start the JWKS Mock Server Application
+            jwksMock.start();
+
+            await session.run(`
+                CREATE (:User {id: "${userId}"})
+            `);
+
+            const accessToken = jwksMock.token({
+                iat: 1600000000,
+                iss: "https://company.com",
+            });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), {
+                    request: {
+                        headers: { Authorization: `Bearer ${accessToken}` },
+                    },
+                }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw Unauthenticated if the audience in the JWT token does not match the audience provided in the Neo4jGraphQLAuthJWKSPlugin", async () => {
+        const session = await neo4j.getSession();
+
+        const typeDefs = `
+            type User {
+                id: ID
+            }
+            extend type User @auth(rules: [{ isAuthenticated: true }])
+        `;
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                users(where: {id: "${userId}"}) {
+                    id
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWKSPlugin({
+                    jwksEndpoint: "https://myAuthTest.auth0.com/.well-known/jwks.json",
+                    audience: "urn:user",
+                }),
+            },
+        });
+
+        try {
+            // Start the JWKS Mock Server Application
+            jwksMock.start();
+
+            await session.run(`
+                CREATE (:User {id: "${userId}"})
+            `);
+
+            const accessToken = jwksMock.token({
+                iat: 1600000000,
+                aud: "urn:anotheruser",
+            });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), {
+                    request: {
+                        headers: { Authorization: `Bearer ${accessToken}` },
+                    },
+                }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+        } finally {
+            await session.close();
+        }
+    });
 });
 
 const createContext = () => {

--- a/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWKSPlugin.ts
+++ b/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWKSPlugin.ts
@@ -35,8 +35,6 @@ export interface JWKSPluginInput {
     audience?: string | RegExp | (string | RegExp)[];
 }
 
-// TODO: update docs!
-
 class Neo4jGraphQLAuthJWKSPlugin {
     rolesPath?: string;
     isGlobalAuthenticationEnabled?: boolean;

--- a/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWKSPlugin.ts
+++ b/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWKSPlugin.ts
@@ -31,7 +31,11 @@ export interface JWKSPluginInput {
     rolesPath?: string;
     globalAuthentication?: boolean;
     bindPredicate?: "all" | "any";
+    issuer?: string | string[];
+    audience?: string | RegExp | (string | RegExp)[];
 }
+
+// TODO: update docs!
 
 class Neo4jGraphQLAuthJWKSPlugin {
     rolesPath?: string;
@@ -40,6 +44,7 @@ class Neo4jGraphQLAuthJWKSPlugin {
     options!: JwksRsa.Options;
     bindPredicate: "all" | "any";
     input: JWKSPluginInput;
+
     constructor(input: JWKSPluginInput) {
         //We are going to use this input later, so we need to save it here.
         this.input = input;
@@ -118,6 +123,8 @@ class Neo4jGraphQLAuthJWKSPlugin {
                 getKey,
                 {
                     algorithms: ["HS256", "RS256"],
+                    issuer: this.input.issuer,
+                    audience: this.input.audience,
                 },
                 (err, decoded) => {
                     if (err) {

--- a/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWTPlugin.test.ts
+++ b/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWTPlugin.test.ts
@@ -125,4 +125,72 @@ describe("Neo4jGraphQLAuthJWTPlugin", () => {
             "Neo4jGraphQLAuthJWTPlugin, noVerify and globalAuthentication can not both be enabled simultaneously."
         );
     });
+
+    test("should decode token and verify issuer", async () => {
+        const payload = {
+            sub: "my-id",
+            iss: "https://testcompany.com",
+        };
+        const encoded = jsonwebtoken.sign(payload, secret);
+
+        const plugin = new Neo4jGraphQLAuthJWTPlugin({
+            secret,
+            issuer: "https://testcompany.com",
+        });
+
+        const decoded = await plugin.decode(encoded);
+
+        expect(decoded).toMatchObject(payload);
+    });
+
+    test("decode function should return undefined if token contains a different issuer than specified in Neo4jGraphQLAuthJWTPlugin", async () => {
+        const payload = {
+            sub: "my-id",
+            iss: "https://testcompany.com",
+        };
+        const encoded = jsonwebtoken.sign(payload, secret);
+
+        const plugin = new Neo4jGraphQLAuthJWTPlugin({
+            secret,
+            issuer: "https://anothercomapny.com",
+        });
+
+        const decoded = await plugin.decode(encoded);
+
+        expect(decoded).toBeUndefined();
+    });
+
+    test("should decode token and verify audience", async () => {
+        const payload = {
+            sub: "my-id",
+            aud: "urn:user",
+        };
+        const encoded = jsonwebtoken.sign(payload, secret);
+
+        const plugin = new Neo4jGraphQLAuthJWTPlugin({
+            secret,
+            audience: "urn:user",
+        });
+
+        const decoded = await plugin.decode(encoded);
+
+        expect(decoded).toMatchObject(payload);
+    });
+
+    test("decode function should return undefined if token contains a different audience than specified in Neo4jGraphQLAuthJWTPlugin", async () => {
+        const payload = {
+            sub: "my-id",
+            aud: "urn:user",
+        };
+        const encoded = jsonwebtoken.sign(payload, secret);
+
+        const plugin = new Neo4jGraphQLAuthJWTPlugin({
+            secret,
+            audience: "urn:otheruser",
+        });
+
+        const decoded = await plugin.decode(encoded);
+
+        expect(decoded).toBeUndefined();
+    });
 });

--- a/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWTPlugin.ts
+++ b/packages/plugins/graphql-plugin-auth/src/Neo4jGraphQLAuthJWTPlugin.ts
@@ -31,6 +31,8 @@ export interface JWTPluginInput {
     globalAuthentication?: boolean;
     rolesPath?: string;
     bindPredicate?: "all" | "any";
+    issuer?: string | string[];
+    audience?: string | RegExp | (string | RegExp)[];
 }
 
 class Neo4jGraphQLAuthJWTPlugin {
@@ -80,6 +82,8 @@ class Neo4jGraphQLAuthJWTPlugin {
 
                 result = jsonwebtoken.verify(token, this.secret, {
                     algorithms: ["HS256", "RS256"],
+                    issuer: this.input.issuer,
+                    audience: this.input.audience,
                 }) as unknown as T;
             } else if (typeof this.input.secret === "function" && !this.secret) {
                 debug("'secret' should not be null, make sure the 'tryToResolveKeys' is ran before the decode method.");


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Add optional constructor arguments to the `Neo4jGraphQLAuthJWTPlugin` and the `Neo4jGraphQLAuthJWKSPlugin` to check the `iss` and the `aud` claim in a JWT token on token verification.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] Integration tests have been updated
