### PR TITLE
fix: Toolbox, Codemirror text selection

### DIFF
--- a/.changeset/early-jars-punch.md
+++ b/.changeset/early-jars-punch.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-toolbox": patch
+---
+
+fix: Toolbox, Codemirror text selection visibility

--- a/packages/graphql-toolbox/src/index.css
+++ b/packages/graphql-toolbox/src/index.css
@@ -30,6 +30,11 @@
     color: rgb(var(--colors-neutral-50));
 }
 
+.CodeMirror-selected {
+    background: #d9d9d9;
+    opacity: 0.5;
+}
+
 li.CodeMirror-hint-active {
     background-color: rgb(var(--colors-neutral-50));
     color: rgb(var(--colors-neutral-10));

--- a/packages/graphql-toolbox/src/index.css
+++ b/packages/graphql-toolbox/src/index.css
@@ -31,7 +31,7 @@
 }
 
 .CodeMirror-selected {
-    background: #d9d9d9;
+    background: #d9d9d9 !important;
     opacity: 0.5;
 }
 


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

The opacity and the color of the text selection (select text for instance with the mouse) in the CodeMirror editors got overwritten when introducing the GraphiQL v2 Docs component. This PR addresses this.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low
