### PR TITLE
boyscouting: Toolbox E2E test tweaks

### DIFF
--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -43,5 +43,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: playwright-report
-          path: tests/artifacts
+          path: packages/graphql-toolbox/tests/artifacts
           retention-days: 3

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -26,7 +26,7 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      # To fail fast, build the Toolbox to see if any errors occur. A common error is when building referenced projects like the introspector.
+      # To fail fast, build the Toolbox to see if any errors occur. A common error is f.e. building referenced projects like the introspector.
       - name: Build the GraphQL Toolbox
         run: yarn build
         working-directory: packages/graphql-toolbox
@@ -46,6 +46,6 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: playwright-report
+          name: playwright-test-failure-report
           path: packages/graphql-toolbox/tests/artifacts
-          retention-days: 3
+          retention-days: 4

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -38,3 +38,10 @@ jobs:
           NEO_USER: neo4j
           NEO_PASSWORD: password
           NEO_URL: bolt://localhost:7687
+      - name: Upload playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 3

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -43,5 +43,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: playwright-report
-          path: playwright-report/
+          path: tests/artifacts
           retention-days: 3

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -26,7 +26,7 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-      # To fail fast, build the Toolbox to see if any errors occur. A common error is f.e. building referenced projects like the introspector.
+      # To fail fast, build the Toolbox to see if any errors occur. For example, a common error is building referenced projects like the introspector.
       - name: Build the GraphQL Toolbox
         run: yarn build
         working-directory: packages/graphql-toolbox

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -26,6 +26,10 @@ jobs:
           cache: yarn
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+      # To fail fast, build the Toolbox to see if any errors occur. A common error is when building referenced projects like the introspector.
+      - name: Build the GraphQL Toolbox
+        run: yarn build
+        working-directory: packages/graphql-toolbox
       - name: Install Playwright
         run: npx playwright install --with-deps
       - name: Run @neo4j/graphql-toolbox unit tests

--- a/packages/graphql-toolbox/.env.example
+++ b/packages/graphql-toolbox/.env.example
@@ -1,3 +1,8 @@
 SEGMENT_GRAPHQL_TOOLBOX_DEV_SOURCE=thesecretkey
 SEGMENT_GRAPHQL_TOOLBOX_PROD_SOURCE=thesecretkey
 CANNY_GRAPHQL_TOOLBOX_APP_ID=theappid
+
+## Localhost usage only! - for the playwright E2E tests
+NEO_USER=neo4j
+NEO_PASSWORD=yourpassword
+NEO_URL=neo4j://localhost:7687

--- a/packages/graphql-toolbox/package.json
+++ b/packages/graphql-toolbox/package.json
@@ -77,6 +77,7 @@
         "copy-webpack-plugin": "11.0.0",
         "cross-env": "7.0.3",
         "css-loader": "6.7.3",
+        "dotenv": "16.0.3",
         "fork-ts-checker-webpack-plugin": "8.0.0",
         "html-inline-script-webpack-plugin": "3.1.0",
         "html-webpack-inline-source-plugin": "0.0.10",

--- a/packages/graphql-toolbox/playwright.config.ts
+++ b/packages/graphql-toolbox/playwright.config.ts
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig = {
     webServer: {
         command: "yarn start",
         url: "http://localhost:4242",
-        timeout: 120 * 1000,
+        timeout: 70 * 1000,
         reuseExistingServer: !process.env.CI,
     },
     use: {

--- a/packages/graphql-toolbox/playwright.config.ts
+++ b/packages/graphql-toolbox/playwright.config.ts
@@ -23,7 +23,7 @@ const config: PlaywrightTestConfig = {
     webServer: {
         command: "yarn start",
         url: "http://localhost:4242",
-        timeout: 70 * 1000,
+        timeout: 120 * 1000,
         reuseExistingServer: !process.env.CI,
     },
     use: {

--- a/packages/graphql-toolbox/tests/drawer.test.ts
+++ b/packages/graphql-toolbox/tests/drawer.test.ts
@@ -18,7 +18,10 @@
  */
 
 import * as base from "@playwright/test";
+import * as dotenv from "dotenv";
 import { test } from "./utils/pagemodel";
+
+dotenv.config();
 
 base.test.describe("drawer", () => {
     const typeDefs = `

--- a/packages/graphql-toolbox/tests/introspection.test.ts
+++ b/packages/graphql-toolbox/tests/introspection.test.ts
@@ -17,9 +17,12 @@
  * limitations under the License.
  */
 
-import * as neo4j from "neo4j-driver";
 import * as base from "@playwright/test";
-import { test, expect, beforeAll, afterAll } from "./utils/pagemodel";
+import * as dotenv from "dotenv";
+import * as neo4j from "neo4j-driver";
+import { afterAll, beforeAll, expect, test } from "./utils/pagemodel";
+
+dotenv.config();
 
 const { NEO_USER = "admin", NEO_PASSWORD = "password", NEO_URL = "neo4j://localhost:7687/neo4j" } = process.env;
 

--- a/packages/graphql-toolbox/tests/introspectionprompt.test.ts
+++ b/packages/graphql-toolbox/tests/introspectionprompt.test.ts
@@ -17,10 +17,13 @@
  * limitations under the License.
  */
 
-import * as neo4j from "neo4j-driver";
 import * as base from "@playwright/test";
+import * as dotenv from "dotenv";
+import * as neo4j from "neo4j-driver";
 import { generate } from "randomstring";
-import { test, beforeEach, afterEach, expect } from "./utils/pagemodel";
+import { afterEach, beforeEach, expect, test } from "./utils/pagemodel";
+
+dotenv.config();
 
 const { NEO_USER = "admin", NEO_PASSWORD = "password", NEO_URL = "neo4j://localhost:7687/neo4j" } = process.env;
 

--- a/packages/graphql-toolbox/tests/login.test.ts
+++ b/packages/graphql-toolbox/tests/login.test.ts
@@ -18,7 +18,10 @@
  */
 
 import * as base from "@playwright/test";
+import * as dotenv from "dotenv";
 import { test } from "./utils/pagemodel";
+
+dotenv.config();
 
 const { NEO_USER = "admin", NEO_PASSWORD = "password", NEO_URL = "neo4j://localhost:7687/neo4j" } = process.env;
 

--- a/packages/graphql-toolbox/tests/settings.test.ts
+++ b/packages/graphql-toolbox/tests/settings.test.ts
@@ -18,7 +18,10 @@
  */
 
 import * as base from "@playwright/test";
+import * as dotenv from "dotenv";
 import { test } from "./utils/pagemodel";
+
+dotenv.config();
 
 base.test.describe("settings", () => {
     test("should be able to enable and disable product usage tracking", async ({

--- a/packages/graphql-toolbox/tests/urlqueryparameters.test.ts
+++ b/packages/graphql-toolbox/tests/urlqueryparameters.test.ts
@@ -17,11 +17,14 @@
  * limitations under the License.
  */
 
-import * as neo4j from "neo4j-driver";
 import * as base from "@playwright/test";
+import * as dotenv from "dotenv";
+import * as neo4j from "neo4j-driver";
 import { generate } from "randomstring";
 import { Login } from "./pages/Login";
-import { test, expect, beforeAll, afterAll } from "./utils/pagemodel";
+import { afterAll, beforeAll, expect, test } from "./utils/pagemodel";
+
+dotenv.config();
 
 const { NEO_USER = "admin", NEO_PASSWORD = "password", NEO_URL = "neo4j://localhost:7687/neo4j" } = process.env;
 

--- a/packages/graphql-toolbox/tests/workflow.test.ts
+++ b/packages/graphql-toolbox/tests/workflow.test.ts
@@ -17,10 +17,13 @@
  * limitations under the License.
  */
 
-import * as neo4j from "neo4j-driver";
 import * as base from "@playwright/test";
+import * as dotenv from "dotenv";
+import * as neo4j from "neo4j-driver";
 import { generate } from "randomstring";
-import { test, expect, beforeAll, afterAll } from "./utils/pagemodel";
+import { afterAll, beforeAll, expect, test } from "./utils/pagemodel";
+
+dotenv.config();
 
 const { NEO_USER = "admin", NEO_PASSWORD = "password", NEO_URL = "neo4j://localhost:7687/neo4j" } = process.env;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3456,6 +3456,7 @@ __metadata:
     copy-webpack-plugin: 11.0.0
     cross-env: 7.0.3
     css-loader: 6.7.3
+    dotenv: 16.0.3
     dotenv-webpack: 8.0.1
     fork-ts-checker-webpack-plugin: 8.0.0
     graphiql-explorer: 0.9.0


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

This PR:
- Updates to the Toolbox e2e-test GHA workflow:
  - Store artifacts of the playwright report when the test run fails.
  - One additional step to build the Toolbox prior to the playwright E2E test execution. This helps to fail fast in case there is a build error that would prevent starting up the Toolbox (called webserver in the playwright config) for the playwright tests.
- For localhost execution of the Toolbox E2E tests:
  - Add `dotenv` to pick up the env variables containing the credentials to your local database.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

