### PR TITLE
Move subscriptions to features instead of plugins

### DIFF
--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -320,7 +320,7 @@ class Neo4jGraphQL {
             const { nodes, relationships, typeDefs, resolvers } = makeAugmentedSchema(document, {
                 features: this.features,
                 validateResolvers: validationConfig.validateResolvers,
-                generateSubscriptions: Boolean(this.plugins?.subscriptions),
+                generateSubscriptions: Boolean(this.features?.subscriptions),
                 userCustomResolvers: this.resolvers,
             });
 
@@ -360,7 +360,7 @@ class Neo4jGraphQL {
         const { nodes, relationships, typeDefs, resolvers } = makeAugmentedSchema(document, {
             features: this.features,
             validateResolvers: validationConfig.validateResolvers,
-            generateSubscriptions: Boolean(this.plugins?.subscriptions),
+            generateSubscriptions: Boolean(this.features?.subscriptions),
             userCustomResolvers: this.resolvers,
             subgraph,
         });
@@ -427,7 +427,7 @@ class Neo4jGraphQL {
         }
 
         const setup = async () => {
-            const subscriptionsPlugin = this.plugins?.subscriptions;
+            const subscriptionsPlugin = this.features?.subscriptions;
             if (subscriptionsPlugin) {
                 subscriptionsPlugin.events.setMaxListeners(0); // Removes warning regarding leak. >10 listeners are expected
                 if (subscriptionsPlugin.init) {

--- a/packages/graphql/src/schema/resolvers/mutation/create.ts
+++ b/packages/graphql/src/schema/resolvers/mutation/create.ts
@@ -43,7 +43,7 @@ export function createResolver({ node }: { node: Node }) {
         ) as FieldNode;
         const nodeKey = nodeProjection?.alias ? nodeProjection.alias.value : nodeProjection?.name?.value;
 
-        publishEventsToPlugin(executeResult, context.plugins?.subscriptions, context.schemaModel);
+        publishEventsToPlugin(executeResult, context.features?.subscriptions, context.schemaModel);
 
         return {
             info: {

--- a/packages/graphql/src/schema/resolvers/mutation/delete.ts
+++ b/packages/graphql/src/schema/resolvers/mutation/delete.ts
@@ -37,7 +37,7 @@ export function deleteResolver({ node }: { node: Node }) {
             context,
         });
 
-        publishEventsToPlugin(executeResult, context.plugins?.subscriptions, context.schemaModel);
+        publishEventsToPlugin(executeResult, context.features?.subscriptions, context.schemaModel);
 
         return { bookmark: executeResult.bookmark, ...executeResult.statistics };
     }

--- a/packages/graphql/src/schema/resolvers/mutation/update.ts
+++ b/packages/graphql/src/schema/resolvers/mutation/update.ts
@@ -38,7 +38,7 @@ export function updateResolver({ node, schemaComposer }: { node: Node; schemaCom
             context,
         });
 
-        publishEventsToPlugin(executeResult, context.plugins?.subscriptions, context.schemaModel);
+        publishEventsToPlugin(executeResult, context.features?.subscriptions, context.schemaModel);
 
         const nodeProjection = info.fieldNodes[0]?.selectionSet?.selections.find(
             (selection) => selection.kind === "Field" && selection.name.value === node.plural

--- a/packages/graphql/src/schema/resolvers/wrapper.ts
+++ b/packages/graphql/src/schema/resolvers/wrapper.ts
@@ -91,8 +91,9 @@ export const wrapResolver =
         context.relationships = relationships;
         context.schemaModel = schemaModel;
         context.plugins = plugins || {};
-        context.subscriptionsEnabled = Boolean(context.plugins?.subscriptions);
+        context.subscriptionsEnabled = Boolean(features?.subscriptions);
         context.callbacks = callbacks;
+        context.features = features;
 
         if (!context.jwt) {
             const req: RequestLike = context instanceof IncomingMessage ? context : context.req || context.request;
@@ -157,15 +158,16 @@ export const wrapSubscription =
     (next) =>
     async (root: any, args: any, context: SubscriptionConnectionContext | undefined, info: GraphQLResolveInfo) => {
         const plugins = resolverArgs?.plugins || {};
+        const subscriptionsConfig = resolverArgs?.features?.subscriptions;
         const contextParams = context?.connectionParams || {};
 
-        if (!plugins.subscriptions) {
+        if (!subscriptionsConfig) {
             debug("Subscription Plugin not set");
             return next(root, args, context, info);
         }
 
         const subscriptionContext: SubscriptionContext = {
-            plugin: plugins.subscriptions,
+            plugin: subscriptionsConfig,
         };
 
         if (!context?.jwt && contextParams.authorization) {

--- a/packages/graphql/src/schema/subscriptions/publish-events-to-plugin.ts
+++ b/packages/graphql/src/schema/subscriptions/publish-events-to-plugin.ts
@@ -45,6 +45,7 @@ export function publishEventsToPlugin(
             "delete",
             "create_relationship"
         );
+
         for (const subscriptionsEvent of serializedEventsWithoutDuplicates) {
             try {
                 const publishPromise = plugin.publish(subscriptionsEvent); // Not using await to avoid blocking

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -53,6 +53,7 @@ export interface Context {
     auth?: AuthContext;
     callbacks?: Neo4jGraphQLCallbacks;
     plugins?: Neo4jGraphQLPlugins;
+    features?: Neo4jFeaturesSettings;
     jwt?: JwtPayload;
     subscriptionsEnabled: boolean;
     executionContext: Driver | Session | Transaction;
@@ -479,7 +480,6 @@ export interface Neo4jGraphQLSubscriptionsPlugin {
 
 export interface Neo4jGraphQLPlugins {
     auth?: Neo4jGraphQLAuthPlugin;
-    subscriptions?: Neo4jGraphQLSubscriptionsPlugin;
 }
 
 export type CallbackReturnValue = string | number | boolean | undefined | null;
@@ -532,6 +532,7 @@ export interface Neo4jFeaturesSettings {
     filters?: Neo4jFiltersSettings;
     populatedBy?: Neo4jPopulatedBySettings;
     authorization?: Neo4jAuthorizationSettings;
+    subscriptions?: Neo4jGraphQLSubscriptionsPlugin;
 }
 
 export type PredicateReturn = {

--- a/packages/graphql/tests/e2e/subscriptions/auth/authentication.int.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/auth/authentication.int.test.ts
@@ -67,8 +67,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
@@ -190,8 +192,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
@@ -330,8 +334,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
@@ -671,8 +677,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
@@ -759,8 +767,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
@@ -828,8 +838,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
@@ -916,8 +928,10 @@ describe("Subscription authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),

--- a/packages/graphql/tests/e2e/subscriptions/auth/global-authentication.int.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/auth/global-authentication.int.test.ts
@@ -67,8 +67,10 @@ describe("Subscription global authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret,
                         globalAuthentication: true,
@@ -142,8 +144,10 @@ describe("Subscription global authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret,
                         globalAuthentication: true,
@@ -217,8 +221,10 @@ describe("Subscription global authentication", () => {
                         database: neo4j.getIntegrationDatabaseName(),
                     },
                 },
-                plugins: {
+                features: {
                     subscriptions: new TestSubscriptionsPlugin(),
+                },
+                plugins: {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret,
                         globalAuthentication: true,

--- a/packages/graphql/tests/e2e/subscriptions/auth/roles.int.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/auth/roles.int.test.ts
@@ -58,8 +58,10 @@ describe("Subscription auth roles", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
+            },
+            plugins: {
                 auth: new Neo4jGraphQLAuthJWTPlugin({
                     secret: "secret",
                 }),

--- a/packages/graphql/tests/e2e/subscriptions/create-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create-relationship.e2e.test.ts
@@ -108,7 +108,7 @@ describe("Create Relationship Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create.e2e.test.ts
@@ -60,7 +60,7 @@ describe("Create Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/delete-complex.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-complex.e2e.test.ts
@@ -102,7 +102,7 @@ describe("Delete Subscriptions - with interfaces, unions and nested operations",
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-additional-labels.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-additional-labels.e2e.test.ts
@@ -100,7 +100,7 @@ describe("Delete Subscriptions when only nodes are targeted - when nodes employ 
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-with-relationships.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-with-relationships.e2e.test.ts
@@ -102,7 +102,7 @@ describe("Delete Subscriptions when relationships are targeted- with interfaces,
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete.e2e.test.ts
@@ -102,7 +102,7 @@ describe("Delete Subscriptions when only nodes are targeted - with interfaces, u
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship.e2e.test.ts
@@ -110,7 +110,7 @@ describe("Delete Relationship Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete.e2e.test.ts
@@ -59,7 +59,7 @@ describe("Delete Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-array-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-array-filters.e2e.test.ts
@@ -64,7 +64,7 @@ describe("Create Subscription with optional filters valid for all types", () => 
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-number-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-number-filters.e2e.test.ts
@@ -60,7 +60,7 @@ describe("Create Subscription with filters valid of number types (Int, Float, Bi
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship-same-type.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship-same-type.e2e.test.ts
@@ -74,7 +74,7 @@ describe("Connect Subscription with optional filters valid for all types", () =>
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship.e2e.test.ts
@@ -107,7 +107,7 @@ describe("Connect Subscription with optional filters valid for all types", () =>
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-string-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-string-filters.e2e.test.ts
@@ -60,7 +60,7 @@ describe("Create Subscription with filters valid on string types (String, ID)", 
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create.e2e.test.ts
@@ -61,7 +61,7 @@ describe("Create Subscription with optional filters valid for all types", () => 
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete-array-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete-array-filters.e2e.test.ts
@@ -65,7 +65,7 @@ describe("Create Subscription with optional filters valid for all types", () => 
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete-number-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete-number-filters.e2e.test.ts
@@ -60,7 +60,7 @@ describe("Delete Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete-string-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete-string-filters.e2e.test.ts
@@ -60,7 +60,7 @@ describe("Delete Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/delete.e2e.test.ts
@@ -61,7 +61,7 @@ describe("Delete Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update-array-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update-array-filters.e2e.test.ts
@@ -65,7 +65,7 @@ describe("Create Subscription with optional filters valid for all types", () => 
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update-number-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update-number-filters.e2e.test.ts
@@ -55,7 +55,7 @@ describe("Update Subscriptions", () => {
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update-string-filters.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update-string-filters.e2e.test.ts
@@ -55,7 +55,7 @@ describe("Update Subscriptions", () => {
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/filtering/update.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/update.e2e.test.ts
@@ -62,7 +62,7 @@ describe("Update Subscriptions", () => {
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/single-instance-plugin.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/single-instance-plugin.e2e.test.ts
@@ -70,7 +70,7 @@ describe("Create Subscription", () => {
                     database: neo4j.getIntegrationDatabaseName(),
                 },
             },
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/e2e/subscriptions/update.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/update.e2e.test.ts
@@ -55,7 +55,7 @@ describe("Update Subscriptions", () => {
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
@@ -66,7 +66,7 @@ describe("array-subscription", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/deprecated/allow.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/allow.int.test.ts
@@ -92,6 +92,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -146,6 +148,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -211,6 +215,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -280,6 +286,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -347,6 +355,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -418,6 +428,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -499,6 +511,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -556,6 +570,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -613,6 +629,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -680,6 +698,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -749,6 +769,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -805,6 +827,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -879,6 +903,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -948,6 +974,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -1036,6 +1064,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -1107,6 +1137,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });
@@ -1196,6 +1228,8 @@ describe("auth/allow", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });

--- a/packages/graphql/tests/integration/deprecated/create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/create-auth.int.test.ts
@@ -92,6 +92,8 @@ describe("auth/bind", () => {
                     auth: new Neo4jGraphQLAuthJWTPlugin({
                         secret: "secret",
                     }),
+                },
+                features: {
                     subscriptions: plugin,
                 },
             });

--- a/packages/graphql/tests/integration/deprecated/delete-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/delete-auth.int.test.ts
@@ -76,6 +76,8 @@ describe("Subscriptions delete", () => {
                 auth: new Neo4jGraphQLAuthJWTPlugin({
                     secret: "secret",
                 }),
+            },
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/issues/2250.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2250.int.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/2250", () => {
         neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new Neo4jGraphQLSubscriptionsSingleInstancePlugin(),
             },
         });

--- a/packages/graphql/tests/integration/issues/2261.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2261.int.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/2261", () => {
         neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new Neo4jGraphQLSubscriptionsSingleInstancePlugin(),
             },
         });

--- a/packages/graphql/tests/integration/issues/440.int.test.ts
+++ b/packages/graphql/tests/integration/issues/440.int.test.ts
@@ -188,7 +188,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: new TestSubscriptionsPlugin(),
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
@@ -91,8 +91,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -147,8 +145,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -214,8 +210,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -285,8 +279,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -354,8 +346,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -427,8 +417,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -510,8 +498,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -569,8 +555,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -628,8 +612,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -697,8 +679,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -768,8 +748,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -826,8 +804,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -902,8 +878,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -973,8 +947,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -1063,8 +1035,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -1136,8 +1106,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });
@@ -1227,8 +1195,6 @@ describe("auth/allow", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });

--- a/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
@@ -99,7 +99,7 @@ describe("Subscriptions connect with create", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/create-relationship/delete.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create-relationship/delete.int.test.ts
@@ -102,7 +102,7 @@ describe("Subscriptions connect with delete", () => {
         `;
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/create/connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/connect-or-create.int.test.ts
@@ -65,7 +65,7 @@ describe("Create -> ConnectOrCreate", () => {
     beforeEach(async () => {
         session = await neo4j.getSession();
         plugin = new TestSubscriptionsPlugin();
-        neoSchema = new Neo4jGraphQL({ typeDefs, plugins: { subscriptions: plugin } });
+        neoSchema = new Neo4jGraphQL({ typeDefs, features: { subscriptions: plugin } });
     });
 
     afterEach(async () => {

--- a/packages/graphql/tests/integration/subscriptions/create/create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create-auth.int.test.ts
@@ -91,8 +91,6 @@ describe("auth/bind", () => {
                     authorization: {
                         key: secret,
                     },
-                },
-                plugins: {
                     subscriptions: plugin,
                 },
             });

--- a/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
@@ -52,7 +52,7 @@ describe("Subscriptions create", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
@@ -77,7 +77,7 @@ describe("interface relationships", () => {
         subscriptionsPlugin = new TestSubscriptionsPlugin();
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: subscriptionsPlugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/delete/delete-auth.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete-auth.int.test.ts
@@ -76,6 +76,8 @@ describe("Subscriptions delete", () => {
                 auth: new Neo4jGraphQLAuthJWTPlugin({
                     secret: "secret",
                 }),
+            },
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
@@ -61,7 +61,7 @@ describe("Subscriptions delete", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
@@ -85,7 +85,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
         neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
@@ -45,7 +45,7 @@ describe("Subscriptions Single Instance Plugin", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -52,7 +52,7 @@ describe("Subscriptions to spatial types", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
@@ -88,7 +88,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
         neoSchema = new Neo4jGraphQL({
             typeDefs,
             driver,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
@@ -65,7 +65,7 @@ describe("Subscriptions update", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });
@@ -97,7 +97,7 @@ describe("Subscriptions update", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
             },
         });

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -46,9 +46,9 @@ describe("Subscriptions", () => {
         `;
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
 
@@ -670,9 +670,9 @@ describe("Subscriptions", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
 
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
@@ -1414,9 +1414,9 @@ describe("Subscriptions", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
 
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
@@ -2523,9 +2523,9 @@ describe("Subscriptions", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
 
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
@@ -3381,9 +3381,9 @@ describe("Subscriptions", () => {
         `;
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
 
@@ -3895,9 +3895,9 @@ describe("Subscriptions", () => {
         `;
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
 
@@ -4334,9 +4334,9 @@ describe("Subscriptions", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
 
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
@@ -5402,9 +5402,9 @@ describe("Subscriptions", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
 
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));

--- a/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
@@ -48,12 +48,14 @@ describe("Subscriptions metadata on create", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
+            },
+            plugins: {
                 auth: new Neo4jGraphQLAuthJWTPlugin({
                     secret: "secret",
                 }),
-            } as any,
+            },
         });
     });
 

--- a/packages/graphql/tests/tck/subscriptions/create.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create.test.ts
@@ -45,9 +45,9 @@ describe("Subscriptions metadata on create", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
     });
 
@@ -97,9 +97,9 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(
             new Neo4jGraphQL({
                 typeDefs,
-                plugins: {
+                features: {
                     subscriptions: plugin,
-                } as any,
+                },
             }),
             query,
             {
@@ -181,9 +181,9 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(
             new Neo4jGraphQL({
                 typeDefs,
-                plugins: {
+                features: {
                     subscriptions: plugin,
-                } as any,
+                },
             }),
             query,
             {
@@ -282,9 +282,9 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(
             new Neo4jGraphQL({
                 typeDefs,
-                plugins: {
+                features: {
                     subscriptions: plugin,
-                } as any,
+                },
             }),
             query,
             {
@@ -401,9 +401,9 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(
             new Neo4jGraphQL({
                 typeDefs,
-                plugins: {
+                features: {
                     subscriptions: plugin,
-                } as any,
+                },
             }),
             query,
             {
@@ -545,9 +545,9 @@ describe("Subscriptions metadata on create", () => {
         const result = await translateQuery(
             new Neo4jGraphQL({
                 typeDefs,
-                plugins: {
+                features: {
                     subscriptions: plugin,
-                } as any,
+                },
             }),
             query,
             {

--- a/packages/graphql/tests/tck/subscriptions/delete.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/delete.test.ts
@@ -45,9 +45,9 @@ describe("Subscriptions metadata on delete", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
     });
 

--- a/packages/graphql/tests/tck/subscriptions/update.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/update.test.ts
@@ -45,9 +45,9 @@ describe("Subscriptions metadata on update", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            plugins: {
+            features: {
                 subscriptions: plugin,
-            } as any,
+            },
         });
     });
 


### PR DESCRIPTION
# Description
As we move away from plugins, the subscription configuration will be set through the `features` option, instead of plugins
