### PR TITLE
Removes numbers from valid characters for labels

### DIFF
--- a/packages/cypher-builder/src/utils/escape.ts
+++ b/packages/cypher-builder/src/utils/escape.ts
@@ -45,7 +45,7 @@ function normalizeString(str: string): string {
 }
 
 function needsEscape(str: string): boolean {
-    const validCharacter = /^[a-z0-9_]*$/i;
+    const validCharacter = /^[a-z_]*$/i;
     return !validCharacter.test(str);
 }
 


### PR DESCRIPTION
# Description
Removes numbers so it correctly escapes labels such as 
```
(a:`1`)
```