### PR TITLE
Remove federationResolvable

### DIFF
--- a/.changeset/fluffy-pillows-flow.md
+++ b/.changeset/fluffy-pillows-flow.md
@@ -2,4 +2,4 @@
 "@neo4j/graphql": patch
 ---
 
-Setting resolvable to false no longer prevents queries and mutations for a type from being generated.
+Federation: Setting `@key` resolvable to false no longer prevents queries and mutations for a type from being generated.

--- a/.changeset/fluffy-pillows-flow.md
+++ b/.changeset/fluffy-pillows-flow.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Setting resolvable to false no longer prevents queries and mutations for a type from being generated.

--- a/packages/graphql/src/classes/Node.ts
+++ b/packages/graphql/src/classes/Node.ts
@@ -17,8 +17,8 @@
  * limitations under the License.
  */
 
-import type { DirectiveNode, NamedTypeNode } from "graphql";
 import camelcase from "camelcase";
+import type { DirectiveNode, NamedTypeNode } from "graphql";
 import pluralize from "pluralize";
 import type {
     ConnectionField,
@@ -36,14 +36,14 @@ import type {
     UnionField,
 } from "../types";
 import type { Auth } from "../types/deprecated/auth/auth";
+import type { DecodedGlobalId } from "../utils/global-ids";
+import { fromGlobalId, toGlobalId } from "../utils/global-ids";
+import { upperFirst } from "../utils/upper-first";
 import type Exclude from "./Exclude";
 import type { GraphElementConstructor } from "./GraphElement";
 import { GraphElement } from "./GraphElement";
 import type { NodeDirective } from "./NodeDirective";
-import type { DecodedGlobalId } from "../utils/global-ids";
-import { fromGlobalId, toGlobalId } from "../utils/global-ids";
 import type { QueryOptionsDirective } from "./QueryOptionsDirective";
-import { upperFirst } from "../utils/upper-first";
 import { NodeAuth } from "./deprecated/NodeAuth";
 
 export interface NodeConstructor extends GraphElementConstructor {
@@ -72,7 +72,6 @@ export interface NodeConstructor extends GraphElementConstructor {
     isGlobalNode?: boolean;
     globalIdField?: string;
     globalIdFieldIsInt?: boolean;
-    federationResolvable: boolean;
 }
 
 type MutableField =
@@ -155,7 +154,6 @@ class Node extends GraphElement {
     public singular: string;
     public plural: string;
     public isGlobalNode: boolean | undefined;
-    public federationResolvable: boolean;
     private _idField: string | undefined;
     private _idFieldIsInt?: boolean;
 
@@ -180,7 +178,6 @@ class Node extends GraphElement {
         this._idFieldIsInt = input.globalIdFieldIsInt;
         this.singular = this.generateSingular();
         this.plural = this.generatePlural(input.plural);
-        this.federationResolvable = input.federationResolvable;
     }
 
     // Fields you can set in a create or update mutation

--- a/packages/graphql/src/schema/augment/fulltext.ts
+++ b/packages/graphql/src/schema/augment/fulltext.ts
@@ -20,10 +20,10 @@
 import { GraphQLFloat, GraphQLNonNull, GraphQLString } from "graphql";
 import type { SchemaComposer } from "graphql-compose";
 import type { Node } from "../../classes";
-import { fulltextResolver } from "../resolvers/query/fulltext";
-import { upperFirst } from "../../utils/upper-first";
-import { FloatWhere } from "../../graphql/input-objects/FloatWhere";
 import { SCORE_FIELD } from "../../graphql/directives/fulltext";
+import { FloatWhere } from "../../graphql/input-objects/FloatWhere";
+import { upperFirst } from "../../utils/upper-first";
+import { fulltextResolver } from "../resolvers/query/fulltext";
 
 export const fulltextArgDeprecationMessage =
     "This argument has been deprecated and will be removed in future versions of the library. " +
@@ -81,30 +81,28 @@ export function augmentFulltextSchema(
             },
         });
 
-        if (node.federationResolvable) {
-            composer.createObjectTC({
-                name: node.fulltextTypeNames.result,
-                description: fulltextResultDescription,
-                fields: {
-                    [SCORE_FIELD]: new GraphQLNonNull(GraphQLFloat),
-                    [node.singular]: `${node.name}!`,
-                },
-            });
+        composer.createObjectTC({
+            name: node.fulltextTypeNames.result,
+            description: fulltextResultDescription,
+            fields: {
+                [SCORE_FIELD]: new GraphQLNonNull(GraphQLFloat),
+                [node.singular]: `${node.name}!`,
+            },
+        });
 
-            node.fulltextDirective.indexes.forEach((index) => {
-                // TODO: remove indexName assignment and undefined check once the name argument has been removed.
-                const indexName = index.indexName || index.name;
-                if (indexName === undefined) {
-                    throw new Error("The name of the fulltext index should be defined using the indexName argument.");
-                }
-                let queryName = `${node.plural}Fulltext${upperFirst(indexName)}`;
-                if (index.queryName) {
-                    queryName = index.queryName;
-                }
-                composer.Query.addFields({
-                    [queryName]: fulltextResolver({ node }, index),
-                });
+        node.fulltextDirective.indexes.forEach((index) => {
+            // TODO: remove indexName assignment and undefined check once the name argument has been removed.
+            const indexName = index.indexName || index.name;
+            if (indexName === undefined) {
+                throw new Error("The name of the fulltext index should be defined using the indexName argument.");
+            }
+            let queryName = `${node.plural}Fulltext${upperFirst(indexName)}`;
+            if (index.queryName) {
+                queryName = index.queryName;
+            }
+            composer.Query.addFields({
+                [queryName]: fulltextResolver({ node }, index),
             });
-        }
+        });
     }
 }

--- a/packages/graphql/src/schema/get-nodes.ts
+++ b/packages/graphql/src/schema/get-nodes.ts
@@ -26,15 +26,15 @@ import type { NodeDirective } from "../classes/NodeDirective";
 import type { QueryOptionsDirective } from "../classes/QueryOptionsDirective";
 import type { FullText, Neo4jGraphQLCallbacks } from "../types";
 import type { Auth } from "../types/deprecated/auth/auth";
-import getObjFieldMeta from "./get-obj-field-meta";
-import parsePluralDirective from "./parse/parse-plural-directive";
-import { parseQueryOptionsDirective } from "./parse/parse-query-options-directive";
-import parseFulltextDirective from "./parse/parse-fulltext-directive";
-import parseNodeDirective from "./parse-node-directive";
-import parseExcludeDirective from "./parse-exclude-directive";
+import { asArray } from "../utils/utils";
 import getAuth from "./get-auth";
 import type { DefinitionNodes } from "./get-definition-nodes";
-import { asArray } from "../utils/utils";
+import getObjFieldMeta from "./get-obj-field-meta";
+import parseExcludeDirective from "./parse-exclude-directive";
+import parseNodeDirective from "./parse-node-directive";
+import parseFulltextDirective from "./parse/parse-fulltext-directive";
+import parsePluralDirective from "./parse/parse-plural-directive";
+import { parseQueryOptionsDirective } from "./parse/parse-query-options-directive";
 
 type Nodes = {
     nodes: Node[];
@@ -278,7 +278,6 @@ function getNodes(
             globalIdField: globalIdField?.fieldName,
             globalIdFieldIsInt: globalIdField?.typeMeta?.name === "Int",
             plural: parsePluralDirective(pluralDirectiveDefinition),
-            federationResolvable: resolvable,
         });
 
         return node;

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -30,61 +30,61 @@ import { GraphQLID, GraphQLNonNull, Kind, parse, print } from "graphql";
 import type { InputTypeComposer, ObjectTypeComposer } from "graphql-compose";
 import { SchemaComposer } from "graphql-compose";
 import pluralize from "pluralize";
-import type { BaseField, Neo4jGraphQLCallbacks, Neo4jFeaturesSettings } from "../types";
-import { cypherResolver } from "./resolvers/field/cypher";
-import { numericalResolver } from "./resolvers/field/numerical";
-import { aggregateResolver } from "./resolvers/query/aggregate";
-import { findResolver } from "./resolvers/query/read";
-import { rootConnectionResolver } from "./resolvers/query/root-connection";
-import { createResolver } from "./resolvers/mutation/create";
-import { deleteResolver } from "./resolvers/mutation/delete";
-import { updateResolver } from "./resolvers/mutation/update";
-import { AggregationTypesMapper } from "./aggregations/aggregation-types-mapper";
-import { augmentFulltextSchema } from "./augment/fulltext";
-import * as constants from "../constants";
-import * as Scalars from "../graphql/scalars";
 import type { Node } from "../classes";
 import type Relationship from "../classes/Relationship";
+import * as constants from "../constants";
+import * as Scalars from "../graphql/scalars";
+import type { BaseField, Neo4jFeaturesSettings, Neo4jGraphQLCallbacks } from "../types";
+import { isRootType } from "../utils/is-root-type";
+import { upperFirst } from "../utils/upper-first";
+import { AggregationTypesMapper } from "./aggregations/aggregation-types-mapper";
+import { augmentFulltextSchema } from "./augment/fulltext";
 import createConnectionFields from "./create-connection-fields";
 import createRelationshipFields from "./create-relationship-fields";
+import { ensureNonEmptyInput } from "./ensure-non-empty-input";
 import getCustomResolvers from "./get-custom-resolvers";
+import { getDefinitionNodes } from "./get-definition-nodes";
 import type { ObjectFields } from "./get-obj-field-meta";
 import getObjFieldMeta from "./get-obj-field-meta";
 import getSortableFields from "./get-sortable-fields";
+import getUniqueFields from "./get-unique-fields";
+import getWhereFields from "./get-where-fields";
+import { cypherResolver } from "./resolvers/field/cypher";
+import { numericalResolver } from "./resolvers/field/numerical";
+import { createResolver } from "./resolvers/mutation/create";
+import { deleteResolver } from "./resolvers/mutation/delete";
+import { updateResolver } from "./resolvers/mutation/update";
+import { aggregateResolver } from "./resolvers/query/aggregate";
+import { findResolver } from "./resolvers/query/read";
+import { rootConnectionResolver } from "./resolvers/query/root-connection";
 import {
     graphqlDirectivesToCompose,
     objectFieldsToComposeFields,
     objectFieldsToCreateInputFields,
     objectFieldsToUpdateInputFields,
 } from "./to-compose";
-import getUniqueFields from "./get-unique-fields";
-import getWhereFields from "./get-where-fields";
-import { upperFirst } from "../utils/upper-first";
-import { ensureNonEmptyInput } from "./ensure-non-empty-input";
-import { getDefinitionNodes } from "./get-definition-nodes";
-import { isRootType } from "../utils/is-root-type";
 
 // GraphQL type imports
+import type { Subgraph } from "../classes/Subgraph";
+import { SortDirection } from "../graphql/enums/SortDirection";
+import { CartesianPointDistance } from "../graphql/input-objects/CartesianPointDistance";
+import { CartesianPointInput } from "../graphql/input-objects/CartesianPointInput";
+import { FloatWhere } from "../graphql/input-objects/FloatWhere";
+import { PointDistance } from "../graphql/input-objects/PointDistance";
+import { PointInput } from "../graphql/input-objects/PointInput";
+import { QueryOptions } from "../graphql/input-objects/QueryOptions";
+import { CartesianPoint } from "../graphql/objects/CartesianPoint";
 import { CreateInfo } from "../graphql/objects/CreateInfo";
 import { DeleteInfo } from "../graphql/objects/DeleteInfo";
-import { UpdateInfo } from "../graphql/objects/UpdateInfo";
 import { PageInfo } from "../graphql/objects/PageInfo";
-import { SortDirection } from "../graphql/enums/SortDirection";
-import { QueryOptions } from "../graphql/input-objects/QueryOptions";
 import { Point } from "../graphql/objects/Point";
-import { CartesianPoint } from "../graphql/objects/CartesianPoint";
-import { PointInput } from "../graphql/input-objects/PointInput";
-import { CartesianPointInput } from "../graphql/input-objects/CartesianPointInput";
-import { PointDistance } from "../graphql/input-objects/PointDistance";
-import { CartesianPointDistance } from "../graphql/input-objects/CartesianPointDistance";
-import getNodes from "./get-nodes";
-import { generateSubscriptionTypes } from "./subscriptions/generate-subscription-types";
-import { getResolveAndSubscriptionMethods } from "./get-resolve-and-subscription-methods";
-import { addGlobalNodeFields } from "./create-global-nodes";
-import { addMathOperatorsToITC } from "./math";
+import { UpdateInfo } from "../graphql/objects/UpdateInfo";
 import { addArrayMethodsToITC } from "./array-methods";
-import { FloatWhere } from "../graphql/input-objects/FloatWhere";
-import type { Subgraph } from "../classes/Subgraph";
+import { addGlobalNodeFields } from "./create-global-nodes";
+import getNodes from "./get-nodes";
+import { getResolveAndSubscriptionMethods } from "./get-resolve-and-subscription-methods";
+import { addMathOperatorsToITC } from "./math";
+import { generateSubscriptionTypes } from "./subscriptions/generate-subscription-types";
 
 function makeAugmentedSchema(
     document: DocumentNode,
@@ -185,7 +185,9 @@ function makeAugmentedSchema(
     const interfaceCommonFields = new Map<string, ObjectFields>();
 
     relationshipProperties.forEach((relationship) => {
-        const authDirective = (relationship.directives || []).find((x) => ["auth", "authoization"].includes(x.name.value));
+        const authDirective = (relationship.directives || []).find((x) =>
+            ["auth", "authoization"].includes(x.name.value)
+        );
         if (authDirective) {
             throw new Error("Cannot have @auth directive on relationship properties interface");
         }
@@ -543,7 +545,6 @@ function makeAugmentedSchema(
     }
 
     nodes.forEach((node) => {
-        
         const nodeFields = objectFieldsToComposeFields([
             ...node.primitiveFields,
             ...node.cypherFields,
@@ -640,30 +641,28 @@ function makeAugmentedSchema(
             args: {},
         };
 
-        if (node.federationResolvable) {
-            composer.createObjectTC({
-                name: node.aggregateTypeNames.selection,
-                fields: {
-                    count: countField,
-                    ...[...node.primitiveFields, ...node.temporalFields].reduce((res, field) => {
-                        if (field.typeMeta.array) {
-                            return res;
-                        }
-                        const objectTypeComposer = aggregationTypesMapper.getAggregationType({
-                            fieldName: field.typeMeta.name,
-                            nullable: !field.typeMeta.required,
-                        });
-
-                        if (!objectTypeComposer) return res;
-
-                        res[field.fieldName] = objectTypeComposer.NonNull;
-
+        composer.createObjectTC({
+            name: node.aggregateTypeNames.selection,
+            fields: {
+                count: countField,
+                ...[...node.primitiveFields, ...node.temporalFields].reduce((res, field) => {
+                    if (field.typeMeta.array) {
                         return res;
-                    }, {}),
-                },
-                directives: graphqlDirectivesToCompose(node.propagatedDirectives),
-            });
-        }
+                    }
+                    const objectTypeComposer = aggregationTypesMapper.getAggregationType({
+                        fieldName: field.typeMeta.name,
+                        nullable: !field.typeMeta.required,
+                    });
+
+                    if (!objectTypeComposer) return res;
+
+                    res[field.fieldName] = objectTypeComposer.NonNull;
+
+                    return res;
+                }, {}),
+            },
+            directives: graphqlDirectivesToCompose(node.propagatedDirectives),
+        });
 
         const nodeWhereTypeName = `${node.name}Where`;
         composer.createInputTC({
@@ -708,25 +707,23 @@ function makeAugmentedSchema(
 
         const mutationResponseTypeNames = node.mutationResponseTypeNames;
 
-        if (node.federationResolvable) {
-            composer.createObjectTC({
-                name: mutationResponseTypeNames.create,
-                fields: {
-                    info: `CreateInfo!`,
-                    [node.plural]: `[${node.name}!]!`,
-                },
-                directives: graphqlDirectivesToCompose(node.propagatedDirectives),
-            });
+        composer.createObjectTC({
+            name: mutationResponseTypeNames.create,
+            fields: {
+                info: `CreateInfo!`,
+                [node.plural]: `[${node.name}!]!`,
+            },
+            directives: graphqlDirectivesToCompose(node.propagatedDirectives),
+        });
 
-            composer.createObjectTC({
-                name: mutationResponseTypeNames.update,
-                fields: {
-                    info: `UpdateInfo!`,
-                    [node.plural]: `[${node.name}!]!`,
-                },
-                directives: graphqlDirectivesToCompose(node.propagatedDirectives),
-            });
-        }
+        composer.createObjectTC({
+            name: mutationResponseTypeNames.update,
+            fields: {
+                info: `UpdateInfo!`,
+                [node.plural]: `[${node.name}!]!`,
+            },
+            directives: graphqlDirectivesToCompose(node.propagatedDirectives),
+        });
 
         createRelationshipFields({
             relationshipFields: node.relationFields,
@@ -753,67 +750,65 @@ function makeAugmentedSchema(
         ensureNonEmptyInput(composer, `${node.name}UpdateInput`);
         ensureNonEmptyInput(composer, `${node.name}CreateInput`);
 
-        if (node.federationResolvable) {
-            const rootTypeFieldNames = node.rootTypeFieldNames;
+        const rootTypeFieldNames = node.rootTypeFieldNames;
 
-            if (!node.exclude?.operations.includes("read")) {
-                composer.Query.addFields({
-                    [rootTypeFieldNames.read]: findResolver({ node }),
-                });
-                composer.Query.setFieldDirectives(
-                    rootTypeFieldNames.read,
-                    graphqlDirectivesToCompose(node.propagatedDirectives)
-                );
+        if (!node.exclude?.operations.includes("read")) {
+            composer.Query.addFields({
+                [rootTypeFieldNames.read]: findResolver({ node }),
+            });
+            composer.Query.setFieldDirectives(
+                rootTypeFieldNames.read,
+                graphqlDirectivesToCompose(node.propagatedDirectives)
+            );
 
-                composer.Query.addFields({
-                    [rootTypeFieldNames.aggregate]: aggregateResolver({ node }),
-                });
-                composer.Query.setFieldDirectives(
-                    rootTypeFieldNames.aggregate,
-                    graphqlDirectivesToCompose(node.propagatedDirectives)
-                );
+            composer.Query.addFields({
+                [rootTypeFieldNames.aggregate]: aggregateResolver({ node }),
+            });
+            composer.Query.setFieldDirectives(
+                rootTypeFieldNames.aggregate,
+                graphqlDirectivesToCompose(node.propagatedDirectives)
+            );
 
-                composer.Query.addFields({
-                    [`${node.plural}Connection`]: rootConnectionResolver({ node, composer }),
-                });
-                composer.Query.setFieldDirectives(
-                    `${node.plural}Connection`,
-                    graphqlDirectivesToCompose(node.propagatedDirectives)
-                );
-            }
+            composer.Query.addFields({
+                [`${node.plural}Connection`]: rootConnectionResolver({ node, composer }),
+            });
+            composer.Query.setFieldDirectives(
+                `${node.plural}Connection`,
+                graphqlDirectivesToCompose(node.propagatedDirectives)
+            );
+        }
 
-            if (!node.exclude?.operations.includes("create")) {
-                composer.Mutation.addFields({
-                    [rootTypeFieldNames.create]: createResolver({ node }),
-                });
-                composer.Mutation.setFieldDirectives(
-                    rootTypeFieldNames.create,
-                    graphqlDirectivesToCompose(node.propagatedDirectives)
-                );
-            }
+        if (!node.exclude?.operations.includes("create")) {
+            composer.Mutation.addFields({
+                [rootTypeFieldNames.create]: createResolver({ node }),
+            });
+            composer.Mutation.setFieldDirectives(
+                rootTypeFieldNames.create,
+                graphqlDirectivesToCompose(node.propagatedDirectives)
+            );
+        }
 
-            if (!node.exclude?.operations.includes("delete")) {
-                composer.Mutation.addFields({
-                    [rootTypeFieldNames.delete]: deleteResolver({ node }),
-                });
-                composer.Mutation.setFieldDirectives(
-                    rootTypeFieldNames.delete,
-                    graphqlDirectivesToCompose(node.propagatedDirectives)
-                );
-            }
+        if (!node.exclude?.operations.includes("delete")) {
+            composer.Mutation.addFields({
+                [rootTypeFieldNames.delete]: deleteResolver({ node }),
+            });
+            composer.Mutation.setFieldDirectives(
+                rootTypeFieldNames.delete,
+                graphqlDirectivesToCompose(node.propagatedDirectives)
+            );
+        }
 
-            if (!node.exclude?.operations.includes("update")) {
-                composer.Mutation.addFields({
-                    [rootTypeFieldNames.update]: updateResolver({
-                        node,
-                        schemaComposer: composer,
-                    }),
-                });
-                composer.Mutation.setFieldDirectives(
-                    rootTypeFieldNames.update,
-                    graphqlDirectivesToCompose(node.propagatedDirectives)
-                );
-            }
+        if (!node.exclude?.operations.includes("update")) {
+            composer.Mutation.addFields({
+                [rootTypeFieldNames.update]: updateResolver({
+                    node,
+                    schemaComposer: composer,
+                }),
+            });
+            composer.Mutation.setFieldDirectives(
+                rootTypeFieldNames.update,
+                graphqlDirectivesToCompose(node.propagatedDirectives)
+            );
         }
     });
 

--- a/packages/graphql/tests/e2e/federation/entities-basics.e2e.test.ts
+++ b/packages/graphql/tests/e2e/federation/entities-basics.e2e.test.ts
@@ -20,10 +20,10 @@
 import supertest from "supertest";
 import { UniqueType } from "../../utils/graphql-types";
 import { GatewayServer } from "./setup/gateway-server";
+import { Neo4j } from "./setup/neo4j";
 import type { Server } from "./setup/server";
 import { TestSubgraph } from "./setup/subgraph";
 import { SubgraphServer } from "./setup/subgraph-server";
-import { Neo4j } from "./setup/neo4j";
 
 describe("Federation 2 Entities Basics (https://www.apollographql.com/docs/federation/entities/)", () => {
     let productsServer: Server;
@@ -44,7 +44,7 @@ describe("Federation 2 Entities Basics (https://www.apollographql.com/docs/feder
         const products = `
             extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
 
-            type ${Product} @key(fields: "id") {
+            type ${Product} @key(fields: "id") @shareable {
                 id: ID!
                 name: String
                 price: Int
@@ -54,7 +54,7 @@ describe("Federation 2 Entities Basics (https://www.apollographql.com/docs/feder
         const reviews = `
             extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key", "@shareable"])
 
-            type ${Product} @key(fields: "id", resolvable: false) {
+            type ${Product} @key(fields: "id", resolvable: false) @shareable {
                 id: ID!
             }
 

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -683,6 +683,11 @@ describe("Apollo Federation", () => {
               posts: [Post!]!
             }
 
+            type CreateUsersMutationResponse {
+              info: CreateInfo!
+              users: [User!]!
+            }
+
             type DeleteInfo @federation__shareable {
               bookmark: String
               nodesDeleted: Int!
@@ -691,8 +696,11 @@ describe("Apollo Federation", () => {
 
             type Mutation {
               createPosts(input: [PostCreateInput!]!): CreatePostsMutationResponse!
+              createUsers(input: [UserCreateInput!]!): CreateUsersMutationResponse!
               deletePosts(delete: PostDeleteInput, where: PostWhere): DeleteInfo!
+              deleteUsers(where: UserWhere): DeleteInfo!
               updatePosts(connect: PostConnectInput, create: PostRelationInput, delete: PostDeleteInput, disconnect: PostDisconnectInput, update: PostUpdateInput, where: PostWhere): UpdatePostsMutationResponse!
+              updateUsers(update: UserUpdateInput, where: UserWhere): UpdateUsersMutationResponse!
             }
 
             \\"\\"\\"Pagination information (Relay)\\"\\"\\"
@@ -918,6 +926,9 @@ describe("Apollo Federation", () => {
               posts(options: PostOptions, where: PostWhere): [Post!]!
               postsAggregate(where: PostWhere): PostAggregateSelection!
               postsConnection(after: String, first: Int, sort: [PostSort], where: PostWhere): PostsConnection!
+              users(options: UserOptions, where: UserWhere): [User!]!
+              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersConnection(after: String, first: Int, sort: [UserSort], where: UserWhere): UsersConnection!
             }
 
             enum SortDirection {
@@ -945,8 +956,18 @@ describe("Apollo Federation", () => {
               posts: [Post!]!
             }
 
+            type UpdateUsersMutationResponse {
+              info: UpdateInfo!
+              users: [User!]!
+            }
+
             type User @key(fields: \\"name\\", resolvable: false) {
               name: String!
+            }
+
+            type UserAggregateSelection {
+              count: Int!
+              name: StringAggregateSelectionNonNullable!
             }
 
             input UserConnectWhere {
@@ -955,6 +976,20 @@ describe("Apollo Federation", () => {
 
             input UserCreateInput {
               name: String!
+            }
+
+            type UserEdge {
+              cursor: String!
+              node: User!
+            }
+
+            input UserOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [UserSort!]
             }
 
             \\"\\"\\"
@@ -982,6 +1017,12 @@ describe("Apollo Federation", () => {
               name_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
               name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
               name_STARTS_WITH: String
+            }
+
+            type UsersConnection {
+              edges: [UserEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
             }
 
             scalar _Any

--- a/packages/graphql/tests/utils/builders/node-builder.ts
+++ b/packages/graphql/tests/utils/builders/node-builder.ts
@@ -42,7 +42,6 @@ export class NodeBuilder extends Builder<Node, NodeConstructor> {
             temporalFields: [],
             pointFields: [],
             customResolverFields: [],
-            federationResolvable: true,
             ...newOptions,
         });
     }


### PR DESCRIPTION
# Description

Previously, `federationResolvable` was implemented to prevent queries and mutations for a type from being generated when resolvable is set to false. This was determined to be the wrong action to take, so this PR removes this logic.

## Complexity

Low
