### PR TITLE
Authorization JWTPayload filters

### DIFF
--- a/packages/graphql/src/graphql/directives/index.ts
+++ b/packages/graphql/src/graphql/directives/index.ts
@@ -36,3 +36,5 @@ export { relationshipDirective } from "./relationship";
 export { timestampDirective } from "./timestamp";
 export { uniqueDirective } from "./unique";
 export { writeonlyDirective } from "./writeonly";
+export { jwtPayload } from "./jwt-payload";
+export { jwtClaim } from "./jwt-claim";

--- a/packages/graphql/src/graphql/directives/jwt-claim.ts
+++ b/packages/graphql/src/graphql/directives/jwt-claim.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DirectiveLocation, GraphQLDirective, GraphQLString, GraphQLNonNull } from "graphql";
+
+export const jwtClaim = new GraphQLDirective({
+    name: "jwtClaim",
+    description: "Instructs @neo4j/graphql that the flagged field has a mapped path within the JWT Payload.",
+    locations: [DirectiveLocation.FIELD_DEFINITION],
+    args: {
+        path: {
+            description: "The path of the field in the real JWT as mapped within the JWT Payload.",
+            type: new GraphQLNonNull(GraphQLString),
+        },
+    },
+});

--- a/packages/graphql/src/graphql/directives/jwt-payload.ts
+++ b/packages/graphql/src/graphql/directives/jwt-payload.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DirectiveLocation, GraphQLDirective } from "graphql";
+
+export const jwtPayload = new GraphQLDirective({
+    name: "jwtPayload",
+    description: "Instructs @neo4j/graphql that the flagged object represents the relevant JWT payload",
+    locations: [DirectiveLocation.OBJECT],
+});

--- a/packages/graphql/src/schema/get-nodes.ts
+++ b/packages/graphql/src/schema/get-nodes.ts
@@ -73,6 +73,7 @@ function getNodes(
                     "plural",
                     "shareable",
                     "deprecated",
+                    "jwtPayload",
                 ].includes(x.name.value)
         );
         const propagatedDirectives = (definition.directives || []).filter((x) =>

--- a/packages/graphql/src/schema/get-obj-field-meta.ts
+++ b/packages/graphql/src/schema/get-obj-field-meta.ts
@@ -32,7 +32,7 @@ import type {
     EnumValueNode,
     UnionTypeDefinitionNode,
     ValueNode,
-    ConstDirectiveNode,
+    DirectiveNode,
 } from "graphql";
 import { Kind } from "graphql";
 import getAuth from "./get-auth";
@@ -207,7 +207,7 @@ function getObjFieldMeta({
                         "@jwtClaim directive can only be used on fields within a type annotated with @jwtPayload"
                     );
                 }
-                if ((field.directives as ConstDirectiveNode[]).length > 1) {
+                if ((field.directives as DirectiveNode[]).length > 1) {
                     throw new Error("@jwtClaim directive cannot be combined with other directives.");
                 }
             }

--- a/packages/graphql/src/schema/make-schema-to-augment.ts
+++ b/packages/graphql/src/schema/make-schema-to-augment.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DocumentNode, ObjectTypeDefinitionNode } from "graphql";
+import { Kind } from "graphql";
+import getFieldTypeMeta from "./get-field-type-meta";
+
+// TODO: alternatively use get-obj-field-meta for validation and make schema-validation find the @jwtPayload annotated type
+function makeSchemaToAugment(document: DocumentNode): {
+    document: DocumentNode;
+    typesExcludedFromGeneration: { jwtPayload?: ObjectTypeDefinitionNode };
+} {
+    const jwtPayloadAnnotatedTypes = document.definitions.filter(
+        (def) =>
+            def.kind === Kind.OBJECT_TYPE_DEFINITION &&
+            (def.directives || []).find((x) => x.name.value === "jwtPayload")
+    );
+    if (!jwtPayloadAnnotatedTypes.length) {
+        return {
+            document,
+            typesExcludedFromGeneration: {},
+        };
+    }
+
+    if (jwtPayloadAnnotatedTypes.length > 1) {
+        throw new Error(`@jwtPayload directive can only be used once in the Type Definitions.`);
+    }
+    const jwtPayload = jwtPayloadAnnotatedTypes[0] as ObjectTypeDefinitionNode;
+    if ((jwtPayload.directives || []).length > 1) {
+        throw new Error(`@jwtPayload directive cannot be combined with other directives.`);
+    }
+    jwtPayload.fields?.forEach((f) => {
+        const typeMeta = getFieldTypeMeta(f.type);
+        if (!["String", "ID", "Int", "Float", "Boolean"].includes(typeMeta.name)) {
+            throw new Error("fields of a @jwtPayload type can only be Scalars or Lists of Scalars.");
+        }
+    });
+
+    return {
+        document: {
+            ...document,
+            definitions: document.definitions.filter((d) => !jwtPayloadAnnotatedTypes.includes(d)),
+        },
+        typesExcludedFromGeneration: { jwtPayload },
+    };
+}
+
+export default makeSchemaToAugment;

--- a/packages/graphql/src/schema/validation/schema-validation.test.ts
+++ b/packages/graphql/src/schema/validation/schema-validation.test.ts
@@ -36,7 +36,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -49,7 +49,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -67,7 +67,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -80,7 +80,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -96,7 +96,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -111,7 +111,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -129,7 +129,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -143,7 +143,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -166,7 +166,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -187,7 +187,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -208,7 +208,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -225,7 +225,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@MemberAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -244,7 +244,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -270,7 +270,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -291,7 +291,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
     });
@@ -307,7 +307,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -326,7 +326,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"The directive \\"@UserAuthorization\\" can only be used once at this location."`
             );
@@ -349,7 +349,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"The directive \\"@UserAuthorization\\" can only be used once at this location."`
             );
@@ -372,7 +372,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -394,7 +394,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -420,7 +420,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -441,7 +441,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"The directive \\"@UserAuthorization\\" can only be used once at this location."`
             );
@@ -457,7 +457,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -476,7 +476,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -492,7 +492,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -514,7 +514,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -532,7 +532,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@MemberAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -552,7 +552,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"The directive \\"@MemberAuthorization\\" can only be used once at this location."`
             );
@@ -574,7 +574,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"The directive \\"@MemberAuthorization\\" can only be used once at this location."`
             );
@@ -602,7 +602,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -630,7 +630,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -653,7 +653,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -671,7 +671,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"The directive \\"@MemberAuthorization\\" can only be used once at this location."`
             );
@@ -692,7 +692,7 @@ describe("schema-validation", () => {
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
 
@@ -709,7 +709,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@MemberAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -745,7 +745,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).not.toThrow();
         });
         test("should returns errors when incorrectly used in several place", () => {
@@ -776,7 +776,7 @@ describe("schema-validation", () => {
             `;
 
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument);
+            const executeValidate = () => validateUserDefinition({ userDocument, augmentedDocument });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@PostAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -802,7 +802,13 @@ describe("schema-validation", () => {
             const { directives, types } = subgraph.getValidationDefinitions();
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument, directives, types);
+            const executeValidate = () =>
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: directives,
+                    additionalTypes: types,
+                });
             expect(executeValidate).not.toThrow();
         });
 
@@ -824,7 +830,13 @@ describe("schema-validation", () => {
             const { directives, types } = subgraph.getValidationDefinitions();
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument, directives, types);
+            const executeValidate = () =>
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: directives,
+                    additionalTypes: types,
+                });
             expect(executeValidate).not.toThrow();
         });
 
@@ -846,7 +858,13 @@ describe("schema-validation", () => {
             const { directives, types } = subgraph.getValidationDefinitions();
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument, directives, types);
+            const executeValidate = () =>
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: directives,
+                    additionalTypes: types,
+                });
             expect(executeValidate).not.toThrow();
         });
 
@@ -868,7 +886,13 @@ describe("schema-validation", () => {
             const { directives, types } = subgraph.getValidationDefinitions();
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument, directives, types);
+            const executeValidate = () =>
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: directives,
+                    additionalTypes: types,
+                });
 
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
@@ -896,7 +920,13 @@ describe("schema-validation", () => {
             const { directives, types } = subgraph.getValidationDefinitions();
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument, directives, types);
+            const executeValidate = () =>
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: directives,
+                    additionalTypes: types,
+                });
             expect(executeValidate).not.toThrow();
         });
 
@@ -921,7 +951,13 @@ describe("schema-validation", () => {
             const { directives, types } = subgraph.getValidationDefinitions();
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
-            const executeValidate = () => validateUserDefinition(userDocument, augmentedDocument, directives, types);
+            const executeValidate = () =>
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: directives,
+                    additionalTypes: types,
+                });
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(
                 `"Unknown argument \\"wrongFilter\\" on directive \\"@UserAuthorization\\". Did you mean \\"filter\\"?"`
             );
@@ -940,7 +976,13 @@ describe("schema-validation", () => {
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
             const executeValidate = () =>
-                validateUserDefinition(userDocument, augmentedDocument, [], [], [noKeanuFields]);
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: [],
+                    additionalTypes: [],
+                    rules: [noKeanuFields],
+                });
             expect(executeValidate).not.toThrow();
         });
 
@@ -955,11 +997,17 @@ describe("schema-validation", () => {
             const { typeDefs: augmentedDocument } = makeAugmentedSchema(userDocument);
 
             const executeValidate = () =>
-                validateUserDefinition(userDocument, augmentedDocument, [], [], [noKeanuFields]);
+                validateUserDefinition({
+                    userDocument,
+                    augmentedDocument,
+                    additionalDirectives: [],
+                    additionalTypes: [],
+                    rules: [noKeanuFields],
+                });
             // It returns two time the error as in the ValidationSchema keanu appears two times.
             expect(executeValidate).toThrowErrorMatchingInlineSnapshot(`
-                "Field cannot named keanu
-                Field cannot named keanu"
+                "Field cannot be named keanu
+                Field cannot be named keanu"
             `);
         });
     });
@@ -969,7 +1017,7 @@ function noKeanuFields(context: SDLValidationContext): ASTVisitor {
     return {
         FieldDefinition(node: FieldDefinitionNode) {
             if (node.name.value === "keanu") {
-                context.reportError(new GraphQLError("Field cannot named keanu"));
+                context.reportError(new GraphQLError("Field cannot be named keanu"));
             }
         },
     };


### PR DESCRIPTION
# Description

Implements directives: `@jwtPayload`, `@jwtClaim`
Generates filters based on fields in the `@jwtPayload` annotated type + JWT spec Registered Claim Names
No operations are generated for the `@jwtPayload`  annotated type

Validations:
- The `@jwtPayload` directive can be used only once in a user's type definitions.
- The type decorated with `@jwtPayload` will only be allowed to contain fields of primitive types, or their list variants.
- The `@jwtClaim` directive can only be used within the type flagged with the `@jwtPayload` directive.
- Both directives cannot be used in conjunction with other directives

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
