### PR TITLE
Update relationships.adoc

### DIFF
--- a/docs/modules/ROOT/pages/type-definitions/relationships.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/relationships.adoc
@@ -57,7 +57,7 @@ The following should be noted about the fields you just added:
 Relationship properties can be added to the above type definitions in two steps:
 
 1. Add an interface definition containing the desired relationship properties
-2. Add a `properties` argument to either or both "sides" of the `@relationship` directive which points to the newly defined interface
+2. Add a `properties` argument to both "sides" (or just one side, if you prefer) of the `@relationship` directive which points to the newly defined interface
 
 For example, to distinguish which roles an actor played in a movie:
 

--- a/docs/modules/ROOT/pages/type-definitions/relationships.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/relationships.adoc
@@ -57,7 +57,7 @@ The following should be noted about the fields you just added:
 Relationship properties can be added to the above type definitions in two steps:
 
 1. Add an interface definition containing the desired relationship properties
-2. Add a `properties` argument to both "sides" of the `@relationship` directive which points to the newly defined interface
+2. Add a `properties` argument to either or both "sides" of the `@relationship` directive which points to the newly defined interface
 
 For example, to distinguish which roles an actor played in a movie:
 


### PR DESCRIPTION
documentation tweak: make it more clear that the relationship interface is not required to live on both sides of the relationship

# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below
documentation tweak: make it more clear that the relationship interface is not required to live on both sides of the relationship


## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ x] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
