### PR TITLE
OPTIONAL MATCH on single relationships and check count is not 0

### DIFF
--- a/packages/graphql/src/translate/where/property-operations/create-relationship-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-relationship-operation.ts
@@ -224,11 +224,14 @@ function createSimpleRelationshipPredicate({
                 return { predicate: Cypher.single(childNode, patternComprehension, new Cypher.Literal(true)) };
             }
 
-            const matchStatement = new Cypher.Match(matchPattern);
+            const matchStatement = new Cypher.OptionalMatch(matchPattern);
+            const countAlias = new Cypher.Variable();
+            const withStatement = new Cypher.With([Cypher.count(childNode), countAlias], "*");
+            const countNeqZero = Cypher.neq(countAlias, new Cypher.Literal(0));
 
             return {
-                predicate: innerOperation,
-                preComputedSubqueries: Cypher.concat(matchStatement),
+                predicate: Cypher.and(countNeqZero, innerOperation),
+                preComputedSubqueries: Cypher.concat(matchStatement, withStatement),
             };
         }
         case "not":


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

This unblocks development of the new authorization translation, but at the same time, changes the approach taken for performance reasons in #3037.

The changes in #3037 mean that 1:1 relationships are matched using a `MATCH`, which is preventing the evaluation of authorization rules in the new architecture.

This change makes this into an `OPTIONAL MATCH`, and then proceeds to check that the count of the child node is not zero before proceeding with any other filtering.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low
