### PR TITLE
Optimise query source metadata in executor

### DIFF
--- a/.changeset/curvy-boxes-cry.md
+++ b/.changeset/curvy-boxes-cry.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Optimise query source metadata in executor

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -225,7 +225,7 @@ export class Executor {
 
         if (info) {
             const source = {
-                // We avoid using print here if possible for performance reasons
+                // We avoid using print here, when possible, as it is a heavy process
                 query: info.operation.loc?.source.body || print(info.operation),
                 params: info.variableValues,
             };

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -225,7 +225,8 @@ export class Executor {
 
         if (info) {
             const source = {
-                query: print(info.operation),
+                // We avoid using print here if possible for performance reasons
+                query: info.operation.loc?.source.body || print(info.operation),
                 params: info.variableValues,
             };
 


### PR DESCRIPTION
# Description
Following the flame graph analysis in #3304, by avoiding the operation `print` in the executor, we can avoid another "hot code" that is being executed with each query.

The previous behaviours of printing the AST is still a fallback in case `source.query` is not available.

The following measurements where taken to validate this fix, with 1000 Virtual Users sending requests for 1:45. Two runs were done and the average taken per measure:


| query                   | server | requestsBefore | RequestAfter   |
| ----------------------- | ------ | -------------- | -------------- |
| SimpleQuery             | Apollo | 186447         | 202900 (+8.8%) |
| HighComplexityWithLimit | Apollo | 19523          | 20442 (+4.7%)  |
| SimpleQuery             | Yoga   | 226092         | 247651 (+9.5%) |


In simple queries, where the database and returned data is not the main limitation, we measure improvements between 8% and 10%

For more complex and bigger queries, the improvement is not as noticeable, but still around the 4~5%

This improvement is consistent across servers (Yoga vs Apollo)