### PR TITLE
Fix relationship validation for update Mutations with multiple operations

### DIFF
--- a/.changeset/cool-cooks-rhyme.md
+++ b/.changeset/cool-cooks-rhyme.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix relationship validation when an update and connect are used in the same Mutation.

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -174,7 +174,7 @@ export default async function translateUpdate({
             parentVar: varName,
             withVars,
             parameterPrefix: `${resolveTree.name}.args.update`,
-            includeRelationshipValidation: true,
+            includeRelationshipValidation: false,
         });
         [updateStr] = updateAndParams;
         cypherParams = {
@@ -435,7 +435,7 @@ export default async function translateUpdate({
 
     const returnStatement = generateUpdateReturnStatement(varName, projStr, context.subscriptionsEnabled);
 
-    const relationshipValidationStr = !updateInput ? createRelationshipValidationStr({ node, context, varName }) : "";
+    const relationshipValidationStr = createRelationshipValidationStr({ node, context, varName });
 
     const updateQuery = new Cypher.RawCypher((env: Cypher.Environment) => {
         const projectionSubqueryStr = projectionSubquery ? projectionSubquery.getCypher(env) : "";

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -459,8 +459,7 @@ export default async function translateUpdate({
             projectionSubqueryStr,
             ...(connectionStrs.length ? [`WITH *`] : []), // When FOREACH is the last line of update 'Neo4jError: WITH is required between FOREACH and CALL'
             ...(projAuth ? [projAuth.getCypher(env)] : []),
-            "WITH *",
-            relationshipValidationStr,
+            ...(relationshipValidationStr ? [`WITH *`, relationshipValidationStr] : []),
             ...connectionStrs,
             ...interfaceStrs,
             ...(context.subscriptionsEnabled

--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -459,7 +459,8 @@ export default async function translateUpdate({
             projectionSubqueryStr,
             ...(connectionStrs.length ? [`WITH *`] : []), // When FOREACH is the last line of update 'Neo4jError: WITH is required between FOREACH and CALL'
             ...(projAuth ? [projAuth.getCypher(env)] : []),
-            ...(relationshipValidationStr ? [`WITH *`, relationshipValidationStr] : []),
+            "WITH *",
+            relationshipValidationStr,
             ...connectionStrs,
             ...interfaceStrs,
             ...(context.subscriptionsEnabled

--- a/packages/graphql/tests/integration/issues/3251.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3251.int.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { UniqueType } from "../../utils/graphql-types";
+import { cleanNodes } from "../../utils/clean-nodes";
+
+describe("https://github.com/neo4j/graphql/issues/3251", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neoSchema: Neo4jGraphQL;
+    let session: Session;
+
+    let Movie: UniqueType;
+    let Genre: UniqueType;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+
+        Movie = new UniqueType("Movie");
+        Genre = new UniqueType("Genre");
+
+        const typeDefs = `#graphql
+            type ${Movie} {
+                name: String!
+                genre: ${Genre}! @relationship(type: "HAS_GENRE", direction: OUT)
+            }
+
+            type ${Genre} {
+                name: String! @unique
+                movies: [${Movie}!]! @relationship(type: "HAS_GENRE", direction: IN)
+            }
+        `;
+
+        await session.run(`
+            CREATE (a:${Genre} { name: "Action" })
+            CREATE (:${Genre} { name: "Thriller" })
+            CREATE (:${Movie} { name: "TestMovie1" })-[:HAS_GENRE]->(a)
+        `);
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+        });
+    });
+
+    afterEach(async () => {
+        await cleanNodes(session, [Movie, Genre]);
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("Mutation which would violate 1:1 should throw error", async () => {
+        const mutation = `#graphql
+            mutation UpdateMovieWithConnectAndUpdate {
+                ${Movie.operations.update}(
+                    where: { name: "TestMovie1" }
+                    update: { name: "TestMovie1" }
+                    connect: { genre: { where: { node: { name: "Thriller" } } } }
+                ) {
+                    ${Movie.plural} {
+                        name
+                        genre {
+                            name
+                        }
+                    }
+                }
+            }
+        `;
+
+        const schema = await neoSchema.getSchema();
+
+        const mutationResult = await graphql({
+            schema,
+            source: mutation,
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(mutationResult.errors).toHaveLength(1);
+        expect((mutationResult.errors as any)[0]?.message).toBe(`${Movie}.genre required exactly once`);
+    });
+});

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/allow.test.ts
@@ -373,7 +373,7 @@ describe("Cypher Auth Allow", () => {
             	SET this_creator0.id = $this_update_creator0_id
             	RETURN count(*) AS update_this_creator0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
@@ -428,7 +428,7 @@ describe("Cypher Auth Allow", () => {
             	SET this_creator0.password = $this_update_creator0_password
             	RETURN count(*) AS update_this_creator0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
@@ -660,7 +660,7 @@ describe("Cypher Auth Allow", () => {
             }
             RETURN count(*) AS disconnect_this_post0_disconnect_Post
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/inherited.test.ts
@@ -366,7 +366,7 @@ describe("@auth allow when inherited from interface", () => {
             	SET this_creator0.id = $this_update_creator0_id
             	RETURN count(*) AS update_this_creator0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
@@ -421,7 +421,7 @@ describe("@auth allow when inherited from interface", () => {
             	SET this_creator0.password = $this_update_creator0_password
             	RETURN count(*) AS update_this_creator0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
@@ -653,7 +653,7 @@ describe("@auth allow when inherited from interface", () => {
             }
             RETURN count(*) AS disconnect_this_post0_disconnect_Post
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)

--- a/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -342,7 +342,7 @@ describe("@auth allow with interface relationships", () => {
             	SET this_creator0.password = $this_update_creator0_password
             	RETURN count(*) AS update_this_creator0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)

--- a/packages/graphql/tests/tck/directives/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/roles/roles.test.ts
@@ -533,7 +533,7 @@ describe("Cypher Auth Roles", () => {
             	}
             	RETURN count(*) AS update_this_post0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
@@ -681,7 +681,7 @@ describe("Cypher Auth Roles", () => {
             	}
             	RETURN count(*) AS update_this_post0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -323,7 +323,7 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`Post\`)
             WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             SET this.content = $this_update_content
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
@@ -363,7 +363,7 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`Post\`)
             WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             SET this.content = $this_update_content
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)

--- a/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/directives/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -328,7 +328,7 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`Post\`)
             WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
             SET this.content = $this_update_content
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
@@ -368,7 +368,7 @@ describe("Cypher Auth Where", () => {
             "MATCH (this:\`Post\`)
             WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
             SET this.content = $this_update_content
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)

--- a/packages/graphql/tests/tck/issues/324.test.ts
+++ b/packages/graphql/tests/tck/issues/324.test.ts
@@ -143,7 +143,7 @@ describe("#324", () => {
             	}
             	RETURN count(*) AS update_this_car0
             }
-            WITH this
+            WITH *
             CALL {
             	WITH this
             	MATCH (this)-[this_car_Car_unique:CAR]->(:Car)

--- a/packages/graphql/tests/tck/issues/3251.test.ts
+++ b/packages/graphql/tests/tck/issues/3251.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gql from "graphql-tag";
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/3251", () => {
+    describe("1:1 schema validation", () => {
+        let neoSchema: Neo4jGraphQL;
+
+        const typeDefs = `#graphql
+            type Movie {
+                name: String!
+                genre: Genre! @relationship(type: "HAS_GENRE", direction: OUT)
+            }
+
+            type Genre {
+                name: String! @unique
+                movies: [Movie!]! @relationship(type: "HAS_GENRE", direction: IN)
+            }
+        `;
+
+        beforeAll(() => {
+            neoSchema = new Neo4jGraphQL({
+                typeDefs,
+            });
+        });
+
+        test("should have check in correct place following update and connect", async () => {
+            const query = gql`
+                mutation UpdateMovieWithConnectAndUpdate {
+                    updateMovies(
+                        where: { name: "TestMovie1" }
+                        update: { name: "TestMovie1" }
+                        connect: { genre: { where: { node: { name: "Thriller" } } } }
+                    ) {
+                        movies {
+                            name
+                            genre {
+                                name
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:\`Movie\`)
+                WHERE this.name = $param0
+                SET this.name = $this_update_name
+                WITH this
+                CALL {
+                	WITH this
+                	MATCH (this)-[this_genre_Genre_unique:HAS_GENRE]->(:Genre)
+                	WITH count(this_genre_Genre_unique) as c
+                	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.genre required exactly once', [0])
+                	RETURN c AS this_genre_Genre_unique_ignored
+                }
+                WITH this
+                CALL {
+                	WITH this
+                	OPTIONAL MATCH (this_connect_genre0_node:Genre)
+                	WHERE this_connect_genre0_node.name = $this_connect_genre0_node_param0
+                	CALL {
+                		WITH *
+                		WITH collect(this_connect_genre0_node) as connectedNodes, collect(this) as parentNodes
+                		CALL {
+                			WITH connectedNodes, parentNodes
+                			UNWIND parentNodes as this
+                			UNWIND connectedNodes as this_connect_genre0_node
+                			MERGE (this)-[:HAS_GENRE]->(this_connect_genre0_node)
+                			RETURN count(*) AS _
+                		}
+                		RETURN count(*) AS _
+                	}
+                WITH this, this_connect_genre0_node
+                	RETURN count(*) AS connect_this_connect_genre_Genre
+                }
+                WITH *
+                CALL {
+                    WITH this
+                    MATCH (this)-[update_this0:HAS_GENRE]->(update_this1:\`Genre\`)
+                    WITH update_this1 { .name } AS update_this1
+                    RETURN head(collect(update_this1)) AS update_var2
+                }
+                WITH *
+                CALL {
+                	WITH this
+                	MATCH (this)-[this_genre_Genre_unique:HAS_GENRE]->(:Genre)
+                	WITH count(this_genre_Genre_unique) as c
+                	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.genre required exactly once', [0])
+                	RETURN c AS this_genre_Genre_unique_ignored
+                }
+                RETURN collect(DISTINCT this { .name, genre: update_var2 }) AS data"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`
+                "{
+                    \\"param0\\": \\"TestMovie1\\",
+                    \\"this_update_name\\": \\"TestMovie1\\",
+                    \\"this_connect_genre0_node_param0\\": \\"Thriller\\",
+                    \\"resolvedCallbacks\\": {}
+                }"
+            `);
+        });
+    });
+});

--- a/packages/graphql/tests/tck/issues/3251.test.ts
+++ b/packages/graphql/tests/tck/issues/3251.test.ts
@@ -70,14 +70,6 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
                 WITH this
                 CALL {
                 	WITH this
-                	MATCH (this)-[this_genre_Genre_unique:HAS_GENRE]->(:Genre)
-                	WITH count(this_genre_Genre_unique) as c
-                	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDMovie.genre required exactly once', [0])
-                	RETURN c AS this_genre_Genre_unique_ignored
-                }
-                WITH this
-                CALL {
-                	WITH this
                 	OPTIONAL MATCH (this_connect_genre0_node:Genre)
                 	WHERE this_connect_genre0_node.name = $this_connect_genre0_node_param0
                 	CALL {

--- a/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-003.test.ts
@@ -374,7 +374,7 @@ describe("tck/rfs/003", () => {
                         "MATCH (this:\`Movie\`)
                         WHERE this.id = $param0
                         SET this.id = $this_update_id
-                        WITH this
+                        WITH *
                         CALL {
                         	WITH this
                         	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
@@ -428,7 +428,7 @@ describe("tck/rfs/003", () => {
                         "MATCH (this:\`Movie\`)
                         WHERE this.id = $param0
                         SET this.id = $this_update_id
-                        WITH this
+                        WITH *
                         CALL {
                         	WITH this
                         	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
@@ -506,7 +506,7 @@ describe("tck/rfs/003", () => {
                             	}
                             	RETURN count(*) AS update_this_director0
                             }
-                            WITH this
+                            WITH *
                             CALL {
                             	WITH this
                             	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
@@ -583,7 +583,7 @@ describe("tck/rfs/003", () => {
                             	}
                             	RETURN count(*) AS update_this_director0
                             }
-                            WITH this
+                            WITH *
                             CALL {
                             	WITH this
                             	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)
@@ -657,7 +657,7 @@ describe("tck/rfs/003", () => {
                             	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDDirector.address required exactly once', [0])
                             	RETURN c AS this_director0_create0_node_address_Address_unique_ignored
                             }
-                            WITH this
+                            WITH *
                             CALL {
                             	WITH this
                             	MATCH (this)<-[this_director_Director_unique:DIRECTED]-(:Director)


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

The generation of relationship validation string was being skipped if a nested update was within the input.

This swaps this logic around, skipping the relationship validation at the nested level, instead generating it at the root.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes #3251

