### PR TITLE
Move auth tests to deprecated directories

### DIFF
--- a/packages/graphql/tests/integration/deprecated/1115.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/1115.int.test.ts
@@ -25,6 +25,7 @@ import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 import { runCypher } from "../../utils/run-cypher";
 import { createJwtRequest } from "../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
 
 describe("https://github.com/neo4j/graphql/issues/1115", () => {
     const parentType = new UniqueType("Parent");
@@ -57,10 +58,8 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
         const neoGraphql = new Neo4jGraphQL({
             typeDefs,
             driver,
-            features: {
-                authorization: {
-                    key: "secret",
-                },
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "secret" }),
             },
         });
         schema = await neoGraphql.getSchema();

--- a/packages/graphql/tests/integration/deprecated/1150.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/1150.int.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GraphQLSchema } from "graphql";
+import { graphql } from "graphql";
+import { gql } from "graphql-tag";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { createJwtRequest } from "../../utils/create-jwt-request";
+
+describe("https://github.com/neo4j/graphql/issues/1150", () => {
+    const secret = "secret";
+    let schema: GraphQLSchema;
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+
+        const typeDefs = gql`
+            type Battery {
+                id: ID! @id(autogenerate: false)
+                current: Boolean!
+            }
+
+            extend type Battery @auth(rules: [{ isAuthenticated: true, roles: ["admin"] }])
+
+            type CombustionEngine {
+                id: ID! @id(autogenerate: false)
+                current: Boolean!
+            }
+
+            type Drive {
+                id: ID! @id(autogenerate: false)
+                current: Boolean!
+                driveCompositions: [DriveComposition!]!
+                    @relationship(type: "CONSISTS_OF", properties: "RelationProps", direction: OUT)
+            }
+
+            union DriveComponent = Battery | CombustionEngine
+
+            type DriveComposition {
+                id: ID! @id(autogenerate: false)
+                current: Boolean!
+                driveComponent: [DriveComponent!]!
+                    @relationship(type: "HAS", properties: "RelationProps", direction: OUT)
+            }
+
+            interface RelationProps {
+                current: Boolean!
+            }
+        `;
+        const neoGraphql = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+        schema = await neoGraphql.getSchema();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should handle union types with auth and connection-where", async () => {
+        const query = `
+            query getDrivesWithFilteredUnionType {
+                drives(where: { current: true }) {
+                    current
+                    driveCompositionsConnection(where: { edge: { current: true } }) {
+                        edges {
+                            node {
+                                driveComponentConnection(
+                                    where: {
+                                        Battery: { edge: { current: true } }
+                                        CombustionEngine: { edge: { current: true } }
+                                    }
+                                ) {
+                                    edges {
+                                        current
+                                        node {
+                                            ... on Battery {
+                                                id
+                                            }
+                                            ... on CombustionEngine {
+                                                id
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest(secret, { roles: "admin" });
+        const res = await graphql({
+            schema,
+            source: query,
+            contextValue: neo4j.getContextValues({ req }),
+        });
+
+        expect(res.errors).toBeUndefined();
+
+        expect(res.data).toEqual({ drives: [] });
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/1760.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/1760.int.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import type { GraphQLSchema } from "graphql";
+import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { getQuerySource } from "../../utils/get-query-source";
+import { Neo4jGraphQL } from "../../../src";
+import Neo4j from "../neo4j";
+
+describe("https://github.com/neo4j/graphql/issues/1760", () => {
+    let schema: GraphQLSchema;
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        const typeDefs = gql`
+            interface BusinessObject {
+                id: ID! @id(autogenerate: false)
+                nameDetails: NameDetails
+            }
+
+            type ApplicationVariant implements BusinessObject
+                @auth(rules: [{ isAuthenticated: true, roles: ["ALL"] }])
+                @exclude(operations: [CREATE, UPDATE, DELETE]) {
+                markets: [Market!]! @relationship(type: "HAS_MARKETS", direction: OUT)
+                id: ID! @id(autogenerate: false)
+                relatedId: ID @cypher(statement: "MATCH (this)<-[:HAS_BASE]-(n:BaseObject) RETURN n.id")
+                baseObject: BaseObject! @relationship(type: "HAS_BASE", direction: IN)
+                current: Boolean!
+                nameDetails: NameDetails @relationship(type: "HAS_NAME", direction: OUT)
+            }
+
+            type NameDetails
+                @auth(rules: [{ isAuthenticated: true, roles: ["ALL"] }])
+                @exclude(operations: [CREATE, READ, UPDATE, DELETE]) {
+                fullName: String!
+            }
+
+            type Market implements BusinessObject
+                @auth(rules: [{ isAuthenticated: true, roles: ["ALL"] }])
+                @exclude(operations: [CREATE, UPDATE, DELETE]) {
+                id: ID! @id(autogenerate: false)
+                nameDetails: NameDetails @relationship(type: "HAS_NAME", direction: OUT)
+            }
+
+            type BaseObject
+                @auth(rules: [{ isAuthenticated: true, roles: ["ALL"] }])
+                @exclude(operations: [CREATE, UPDATE, DELETE]) {
+                id: ID! @id
+            }
+        `;
+        const neoGraphql = new Neo4jGraphQL({ typeDefs, driver });
+        schema = await neoGraphql.getSchema();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("provided query does not result in an error", async () => {
+        const query = gql`
+            query getApplicationVariants($where: ApplicationVariantWhere, $options: ApplicationVariantOptions) {
+                applicationVariants(where: $where, options: $options) {
+                    relatedId
+                    nameDetailsConnection {
+                        edges {
+                            node {
+                                fullName
+                            }
+                        }
+                    }
+                    marketsConnection {
+                        edges {
+                            node {
+                                nameDetailsConnection {
+                                    edges {
+                                        node {
+                                            fullName
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    baseObjectConnection {
+                        edges {
+                            node {
+                                id
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await graphql({
+            schema,
+            source: getQuerySource(query),
+            variableValues: {
+                where: {
+                    current: true,
+                },
+                options: {
+                    sort: {
+                        relatedId: "ASC",
+                    },
+                    offset: 0,
+                    limit: 50,
+                },
+            },
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(result.errors).toBeFalsy();
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/2068.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/2068.int.test.ts
@@ -1,0 +1,1005 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import type { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { Neo4jGraphQL } from "../../../src/classes";
+import Neo4j from "../neo4j";
+import { createJwtRequest } from "../../utils/create-jwt-request";
+import { UniqueType } from "../../utils/graphql-types";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe("https://github.com/neo4j/graphql/pull/2068", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+    describe("Updates within updates", () => {
+        const contentType = new UniqueType("Content");
+        const userType = new UniqueType("User");
+        const commentType = new UniqueType("Comment");
+
+        const typeDefs = gql`
+            interface ${contentType.name} {
+                id: ID
+                content: String
+                creator: ${userType.name}! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type ${userType.name} {
+                id: ID
+                name: String
+                content: [${contentType.name}!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            type ${commentType.name} implements ${contentType.name} {
+                id: ID
+                content: String
+                creator: ${userType.name}!
+            }
+
+            extend type ${userType.name}
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT], where: { id: "$jwt.sub" } }])
+
+            extend type ${userType.name} {
+                password: String! @auth(rules: [{ operations: [READ], where: { id: "$jwt.sub" } }])
+            }
+        `;
+
+        test("Connect node - update within an update", async () => {
+            const userID = "someID";
+            const contentID = "someContentID";
+            const query = `
+                mutation {
+                    ${userType.operations.update}(update: { content: { connect: { where: { node: {} } } } }) {
+                        ${userType.plural} {
+                            id
+                            contentConnection {
+                                totalCount
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userID}"})
+                    CREATE (:${contentType.name} {id: "${contentID}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: userID });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+
+                const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
+                expect(users).toEqual([{ id: userID, contentConnection: { totalCount: 0 } }]);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Connect node - user defined update where within an update", async () => {
+            const userID1 = "someID";
+            const userID2 = "differentID";
+            const contentID = "someContentID";
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(update: { content: { connect: { where: { node: { id: "${userID2}" } } } } }) {
+                        ${userType.plural} {
+                            id
+                            contentConnection {
+                                totalCount
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userID1}"})
+                    CREATE (:${userType.name} {id: "${userID2}"})
+                    CREATE (:${contentType.name} {id: "${contentID}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: userID1 });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+
+                const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
+                expect(users).toEqual([{ id: userID1, contentConnection: { totalCount: 0 } }]);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Disconnect node - update within an update", async () => {
+            const userID = "someID";
+            const contentID = "someContentID";
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(update: { content: { disconnect: { where: {} } } }) {
+                        ${userType.plural} {
+                            id
+                            contentConnection {
+                                totalCount
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userID}"})-[:HAS_CONTENT]->(:${contentType.name} {id: "${contentID}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: userID });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+
+                const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
+                expect(users).toEqual([{ id: userID, contentConnection: { totalCount: 0 } }]);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Disconnect node - user defined update where within an update", async () => {
+            const userID = "someID";
+            const contentID = "someContentID";
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(update: { content: [{ disconnect: { where: { node: { id: "${userID}" } } } }] }) {
+                        ${userType.plural} {
+                            id
+                            contentConnection {
+                                totalCount
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userID}"})-[:HAS_CONTENT]->(:${contentType.name} {id: "${contentID}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: userID });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+
+                const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
+                expect(users).toEqual([{ id: userID, contentConnection: { totalCount: 0 } }]);
+            } finally {
+                await session.close();
+            }
+        });
+    });
+    test("Unions in cypher directives", async () => {
+        const actorName = "someName";
+        const actorAge = 43;
+        const numberOfSeasons = 2;
+        const sharedTitle = "someTitle";
+
+        const actorType = new UniqueType("Actor");
+        const movieType = new UniqueType("Movie");
+        const tvShowType = new UniqueType("TVShow");
+        const movieOrTVShowType = new UniqueType("MovieOrTVShow");
+
+        const typeDefs = `
+            type ${actorType.name} {
+                name: String
+                age: Int
+                movies(title: String): [${movieType.name}]
+                    @cypher(
+                        statement: """
+                        MATCH (m:${movieType.name} {title: $title})
+                        RETURN m
+                        """
+                    )
+
+                tvShows(title: String): [${movieType.name}]
+                    @cypher(
+                        statement: """
+                        MATCH (t:${tvShowType.name} {title: $title})
+                        RETURN t
+                        """
+                    )
+
+                movieOrTVShow(title: String): [${movieOrTVShowType.name}]
+                    @cypher(
+                        statement: """
+                        MATCH (n)
+                        WHERE (n:${tvShowType.name} OR n:${movieType.name}) AND ($title IS NULL OR n.title = $title)
+                        RETURN n
+                        """
+                    )
+            }
+
+            union ${movieOrTVShowType.name} = ${movieType.name} | ${tvShowType.name}
+
+            type ${tvShowType.name} {
+                id: ID
+                title: String
+                numSeasons: Int
+                actors: [${actorType.name}]
+                    @cypher(
+                        statement: """
+                        MATCH (a:${actorType.name})
+                        RETURN a
+                        """
+                    )
+                topActor: ${actorType.name}
+                    @cypher(
+                        statement: """
+                        MATCH (a:${actorType.name})
+                        RETURN a
+                        """
+                    )
+            }
+
+            type ${movieType.name} {
+                id: ID
+                title: String
+                actors: [${actorType.name}]
+                    @cypher(
+                        statement: """
+                        MATCH (a:${actorType.name})
+                        RETURN a
+                        """
+                    )
+                topActor: ${actorType.name}
+                    @cypher(
+                        statement: """
+                        MATCH (a:${actorType.name})
+                        RETURN a
+                        """
+                    )
+            }
+        `;
+
+        const query = `
+            {
+                ${actorType.plural} {
+                    movieOrTVShow(title: "${sharedTitle}") {
+                        ... on ${movieType.name} {
+                            title
+                            topActor {
+                                name
+                                age
+                            }
+                        }
+                        ... on ${tvShowType.name} {
+                            title
+                            numSeasons
+                            topActor {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        try {
+            await session.run(`
+                CREATE (:${actorType.name} { name: "${actorName}", age: ${actorAge} })
+                CREATE (:${tvShowType.name} { title: "${sharedTitle}", numSeasons: ${numberOfSeasons} })
+                CREATE (:${movieType.name} { title: "${sharedTitle}" })
+            `);
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+            });
+
+            expect(gqlResult.errors).toBeUndefined();
+            expect((gqlResult.data as any)?.[actorType.plural]?.[0].movieOrTVShow).toIncludeSameMembers([
+                {
+                    title: sharedTitle,
+                    numSeasons: numberOfSeasons,
+                    topActor: {
+                        name: actorName,
+                    },
+                },
+                {
+                    title: sharedTitle,
+                    topActor: {
+                        name: actorName,
+                        age: actorAge,
+                    },
+                },
+            ]);
+        } finally {
+            await session.close();
+        }
+    });
+    describe("connectOrCreate auth ordering", () => {
+        const movieTitle = "Cool Movie";
+        const requiredRole = "admin";
+        const forbiddenMessage = "Forbidden";
+        const validReq = createJwtRequest(secret, { roles: [requiredRole] });
+        const invalidReq = createJwtRequest(secret, { roles: [] });
+
+        /**
+         * Generate type definitions for connectOrCreate auth tests.
+         * @param operations The operations argument of auth rules.
+         * @returns Unique types and a graphql type deinition string.
+         */
+        function getTypedef(operations: string): [UniqueType, UniqueType, string] {
+            const movieType = new UniqueType("Movie");
+            const genreType = new UniqueType("Genre");
+            const typeDefs = `
+                type ${movieType.name} {
+                    title: String
+                    genres: [${genreType.name}!]! @relationship(type: "IN_GENRE", direction: OUT)
+                }
+        
+                type ${genreType.name} @auth(rules: [{ operations: ${operations}, roles: ["${requiredRole}"] }]) {
+                    name: String @unique
+                }
+            `;
+
+            return [movieType, genreType, typeDefs];
+        }
+
+        /**
+         * Generate a query for connectOrCreate auth tests.
+         * @param mutationType The type of mutation to perform.
+         * @param movieTypePlural The plural of the movie type.
+         * @returns A graphql query.
+         */
+        function getQuery(mutationType: string, movieTypePlural: string): string {
+            let argType = "update";
+
+            if (mutationType.startsWith("create")) {
+                argType = "input";
+            }
+
+            return `
+                mutation {
+                    ${mutationType}(
+                        ${argType}: {
+                            title: "${movieTitle}"
+                            genres: {
+                                connectOrCreate: [
+                                    { where: { node: { name: "Horror" } }, onCreate: { node: { name: "Horror" } } }
+                                ]
+                            }
+                        }
+                    ) {
+                        ${movieTypePlural} {
+                            title
+                        }
+                    }
+                }
+            `;
+        }
+        test("Create with createOrConnect and CONNECT operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CONNECT]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [createOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Create with createOrConnect and CONNECT operation rule - invalid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CONNECT]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+                });
+
+                expect((gqlResult as any).errors[0].message as string).toBe(forbiddenMessage);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Create with createOrConnect and CREATE operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [createOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Create with createOrConnect and CREATE operation rule - invalid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+                });
+
+                expect((gqlResult as any).errors[0].message as string).toBe(forbiddenMessage);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Create with createOrConnect and CREATE, CONNECT operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE, CONNECT]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [createOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Create with createOrConnect and CREATE, CONNECT operation rule - invalid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE, CONNECT]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+                });
+
+                expect((gqlResult as any).errors[0].message as string).toBe(forbiddenMessage);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Create with createOrConnect and DELETE operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[DELETE]");
+            const createOperation = movieType.operations.create;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(createOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [createOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and CONNECT operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CONNECT]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [updateOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and CONNECT operation rule - invalid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CONNECT]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+                });
+
+                expect((gqlResult as any).errors[0].message as string).toBe(forbiddenMessage);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and CREATE operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [updateOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and CREATE operation rule - invalid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+                });
+
+                expect((gqlResult as any).errors[0].message as string).toBe(forbiddenMessage);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and CREATE, CONNECT operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE, CONNECT]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [updateOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and CREATE, CONNECT operation rule - invalid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[CREATE, CONNECT]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+                });
+
+                expect((gqlResult as any).errors[0].message as string).toBe(forbiddenMessage);
+            } finally {
+                await session.close();
+            }
+        });
+        test("Update with createOrConnect and DELETE operation rule - valid auth", async () => {
+            const [movieType, , typeDefs] = getTypedef("[DELETE]");
+            const updateOperation = movieType.operations.update;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+            });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                await session.run(`CREATE (:${movieType.name})`);
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: getQuery(updateOperation, movieType.plural),
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: validReq }),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [updateOperation]: {
+                        [movieType.plural]: [
+                            {
+                                title: movieTitle,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+    });
+    describe("Select connections following the creation of a multiple nodes", () => {
+        const movieType = new UniqueType("Movie");
+        const actorType = new UniqueType("Actor");
+
+        const typeDefs = `
+            type ${movieType.name} {
+                title: String
+                actors: [${actorType.name}!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+            }
+            
+            type ${actorType.name} {
+                name: String
+                movies: [${movieType.name}!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+            }
+
+            interface ActedIn @relationshipProperties {
+                screenTime: Int
+            }
+        `;
+        test("Filtered results", async () => {
+            const filmName1 = "Forrest Gump";
+            const filmName2 = "Toy Story";
+            const actorName = "Tom Hanks";
+
+            const query = `
+                mutation {
+                    ${movieType.operations.create}(input: [{ title: "${filmName1}" }, { title: "${filmName2}" }]) {
+                        ${movieType.plural} {
+                            title
+                            actorsConnection(where: { node: { name: "${actorName}" } }) {
+                                edges {
+                                    screenTime
+                                    node {
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [movieType.operations.create]: {
+                        [movieType.plural]: [
+                            {
+                                actorsConnection: {
+                                    edges: [],
+                                },
+                                title: filmName1,
+                            },
+                            {
+                                actorsConnection: {
+                                    edges: [],
+                                },
+                                title: filmName2,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+        test("Unfiltered results", async () => {
+            const filmName1 = "Forrest Gump";
+            const filmName2 = "Toy Story";
+
+            const query = `
+                mutation {
+                    ${movieType.operations.create}(input: [{ title: "${filmName1}" }, { title: "${filmName2}" }]) {
+                        ${movieType.plural} {
+                            title
+                            actorsConnection {
+                                edges {
+                                    screenTime
+                                    node {
+                                        name
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            try {
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+                });
+
+                expect(gqlResult.errors).toBeUndefined();
+                expect(gqlResult.data).toEqual({
+                    [movieType.operations.create]: {
+                        [movieType.plural]: [
+                            {
+                                actorsConnection: {
+                                    edges: [],
+                                },
+                                title: filmName1,
+                            },
+                            {
+                                actorsConnection: {
+                                    edges: [],
+                                },
+                                title: filmName2,
+                            },
+                        ],
+                    },
+                });
+            } finally {
+                await session.close();
+            }
+        });
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-auth-fields.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-auth-fields.int.test.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import type { IncomingMessage } from "http";
+import Neo4j from "../../../../neo4j";
+import { Neo4jGraphQL } from "../../../../../../src/classes";
+import { UniqueType } from "../../../../../utils/graphql-types";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe(`Field Level Auth Where Requests`, () => {
+    let neoSchema: Neo4jGraphQL;
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+    let req: IncomingMessage;
+    const typeMovie = new UniqueType("Movie");
+    const typeActor = new UniqueType("Actor");
+    const typeDefs = `
+    type ${typeMovie.name} {
+        name: String
+        year: Int
+        ${typeActor.plural}: [${typeActor.name}!]! @relationship(type: "ACTED_IN", direction: IN)
+    }
+
+    type ${typeActor.name} {
+        name: String @auth(rules: [{ isAuthenticated: true }])
+        year: Int
+        testId: Int
+        ${typeMovie.plural}: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
+    }`;
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        session = await neo4j.getSession();
+
+        await session.run(`
+            CREATE (m:${typeMovie.name}
+                {name: "Terminator",year:1999})
+                <-[:ACTED_IN]-
+                (:${typeActor.name} { name: "Arnold", year: 1970 })
+                CREATE (m)<-[:ACTED_IN]-(:${typeActor.name} {name: "Linda", year:1985 })`);
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        req = createJwtRequest(secret);
+    });
+
+    afterAll(async () => {
+        await session.close();
+        await driver.close();
+    });
+
+    test("unauthenticated query on normal field", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate {
+                    node {
+                        year {
+                            max
+                            }
+                        }
+                    }
+                }
+            }`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+        expect(gqlResult.errors).toBeUndefined();
+    });
+
+    test("unauthenticated query on auth field", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate {
+                    node {
+                        name {
+                            longest
+                            }
+                        }
+                    }
+                }
+            }`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+        expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+    });
+
+    test("authenticated query on auth field", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate {
+                    node {
+                        name {
+                            longest
+                            }
+                        }
+                    }
+                }
+            }`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+        });
+        expect(gqlResult.errors).toBeUndefined();
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-auth-where.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-auth-where.int.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../../../../neo4j";
+import { Neo4jGraphQL } from "../../../../../../src/classes";
+import { UniqueType } from "../../../../../utils/graphql-types";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe(`Field Level Auth Where Requests`, () => {
+    let neoSchema: Neo4jGraphQL;
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+    const typeMovie = new UniqueType("Movie");
+    const typeActor = new UniqueType("Actor");
+    const typeDefs = `
+    type ${typeMovie.name} {
+        name: String
+        year: Int
+        createdAt: DateTime
+        ${typeActor.plural}: [${typeActor.name}!]! @relationship(type: "ACTED_IN", direction: IN)
+    }
+
+    type ${typeActor.name} {
+        name: String
+        year: Int
+        createdAt: DateTime
+        testId: Int
+        ${typeMovie.plural}: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
+    }`;
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        session = await neo4j.getSession();
+
+        await session.run(`
+            CREATE (m:${typeMovie.name}
+                {name: "Terminator",year:1990,createdAt: datetime()})
+                <-[:ACTED_IN]-
+                (:${typeActor.name} { name: "Arnold", year: 1970, createdAt: datetime(), testId: 1234})
+                CREATE (m)<-[:ACTED_IN]-(:${typeActor.name} {name: "Linda", year:1985, createdAt: datetime(), testId: 1235})`);
+
+        const extendedTypeDefs = `${typeDefs}
+        extend type ${typeActor.name} @auth(rules: [{ where: { testId: "$jwt.sub" } }])`;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs: extendedTypeDefs,
+            plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
+        });
+    });
+
+    afterAll(async () => {
+        await session.close();
+        await driver.close();
+    });
+
+    test("authenticated query", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate {
+                    count
+                    }
+                }
+            }`;
+
+        const req = createJwtRequest(secret, { sub: 1234 });
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+        });
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
+            count: 1,
+        });
+    });
+
+    test("unauthenticated query", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate {
+                    count
+                    }
+                }
+            }`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+        expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+    });
+
+    test("authenticated query with wrong credentials", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate {
+                    count
+                    }
+                }
+            }`;
+
+        const invalidReq = createJwtRequest(secret, { sub: 2222 });
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req: invalidReq }),
+        });
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
+            count: 0,
+        });
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-auth.int.test.ts
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import type { IncomingMessage } from "http";
+import Neo4j from "../../../../neo4j";
+import { Neo4jGraphQL } from "../../../../../../src/classes";
+import { UniqueType } from "../../../../../utils/graphql-types";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe("Field Level Aggregations Auth", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+    const typeMovie = new UniqueType("Movie");
+    const typeActor = new UniqueType("Actor");
+    const typeDefs = `
+    type ${typeMovie.name} {
+        name: String
+        year: Int
+        createdAt: DateTime
+        testId: Int
+        ${typeActor.plural}: [${typeActor.name}!]! @relationship(type: "ACTED_IN", direction: IN)
+    }
+
+    type ${typeActor.name} {
+        name: String
+        year: Int
+        createdAt: DateTime
+        ${typeMovie.plural}: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
+    }`;
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        session = await neo4j.getSession();
+
+        await session.run(`
+        CREATE (m:${typeMovie.name}
+            {name: "Terminator",testId: 1234,year:1990,createdAt: datetime()})
+            <-[:ACTED_IN]-
+            (:${typeActor.name} { name: "Arnold", year: 1970, createdAt: datetime()})
+
+        CREATE (m)<-[:ACTED_IN]-(:${typeActor.name} {name: "Linda", year:1985, createdAt: datetime()})`);
+    });
+
+    afterAll(async () => {
+        await session.close();
+        await driver.close();
+    });
+
+    const testCases = [
+        { name: "count", query: "count" },
+        { name: "string", query: `node {name {longest, shortest}}` },
+        { name: "number", query: `node {year {max, min, average}}` },
+        { name: "default", query: `node { createdAt {max, min}}` },
+    ];
+
+    testCases.forEach((testCase) => {
+        describe(`isAuthenticated auth requests ~ ${testCase.name}`, () => {
+            let req: IncomingMessage;
+            let neoSchema: Neo4jGraphQL;
+
+            beforeAll(() => {
+                const extendedTypeDefs = `${typeDefs}
+                extend type ${typeMovie.name} @auth(rules: [{ isAuthenticated: true }])`;
+
+                neoSchema = new Neo4jGraphQL({
+                    typeDefs: extendedTypeDefs,
+                    plugins: {
+                        auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "secret" }),
+                    },
+                });
+
+                req = createJwtRequest(secret);
+            });
+
+            test("accepts authenticated requests to movie -> actorAggregate", async () => {
+                const query = `query {
+                ${typeMovie.plural} {
+                    ${typeActor.plural}Aggregate {
+                        count
+                        }
+                    }
+                }`;
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+                expect(gqlResult.errors).toBeUndefined();
+            });
+
+            test("accepts authenticated requests to actor -> movieAggregate", async () => {
+                const query = `query {
+                ${typeActor.plural} {
+                    ${typeMovie.plural}Aggregate {
+                        ${testCase.query}
+                        }
+                    }
+                }`;
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+                expect(gqlResult.errors).toBeUndefined();
+            });
+
+            test("rejects unauthenticated requests to movie -> actorAggregate", async () => {
+                const query = `query {
+                ${typeMovie.plural} {
+                    ${typeActor.plural}Aggregate {
+                        ${testCase.query}
+                        }
+                    }
+                }`;
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+                });
+                expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+            });
+
+            test("rejects unauthenticated requests to actor -> movieAggregate", async () => {
+                const query = `query {
+                ${typeActor.plural} {
+                    ${typeMovie.plural}Aggregate {
+                        ${testCase.query}
+                        }
+                    }
+                }`;
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+                });
+                expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+            });
+        });
+        describe(`allow requests ~ ${testCase.name}`, () => {
+            let neoSchema: Neo4jGraphQL;
+
+            beforeAll(() => {
+                const extendedTypeDefs = `${typeDefs}
+                extend type ${typeMovie.name} @auth(rules: [{
+                    allow: { testId: "$jwt.sub" }
+                }])`;
+
+                neoSchema = new Neo4jGraphQL({
+                    typeDefs: extendedTypeDefs,
+                    plugins: {
+                        auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "secret" }),
+                    },
+                });
+            });
+
+            test("authenticated query", async () => {
+                const query = `query {
+                    ${typeActor.plural} {
+                        ${typeMovie.plural}Aggregate {
+                            ${testCase.query}
+                            }
+                        }
+                    }`;
+
+                const req = createJwtRequest(secret, { sub: 1234 });
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+                expect(gqlResult.errors).toBeUndefined();
+            });
+
+            test("unauthenticated query", async () => {
+                const query = `query {
+                    ${typeActor.plural} {
+                        ${typeMovie.plural}Aggregate {
+                            ${testCase.query}
+                            }
+                        }
+                    }`;
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+                });
+                expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
+            });
+
+            test("authenticated query with wrong credentials", async () => {
+                const query = `query {
+                    ${typeActor.plural} {
+                        ${typeMovie.plural}Aggregate {
+                            ${testCase.query}
+                            }
+                        }
+                    }`;
+                const invalidReq = createJwtRequest(secret, { sub: 2222 });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), {
+                        req: invalidReq,
+                    }),
+                });
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            });
+        });
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-where-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/aggregations/field-level/auth/field-aggregation-where-with-auth.int.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import jsonwebtoken from "jsonwebtoken";
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
+import Neo4j from "../../../../neo4j";
+import { Neo4jGraphQL } from "../../../../../../src/classes";
+import { UniqueType } from "../../../../../utils/graphql-types";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe(`Field Level Auth Where Requests`, () => {
+    let neoSchema: Neo4jGraphQL;
+    let token: string;
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+    const typeMovie = new UniqueType("Movie");
+    const typeActor = new UniqueType("Actor");
+    const typeDefs = `
+    type ${typeMovie.name} {
+        name: String
+        year: Int
+        createdAt: DateTime
+        ${typeActor.plural}: [${typeActor.name}!]! @relationship(type: "ACTED_IN", direction: IN)
+    }
+
+    type ${typeActor.name} {
+        name: String
+        year: Int
+        createdAt: DateTime
+        testId: Int
+        ${typeMovie.plural}: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
+    }`;
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        session = await neo4j.getSession();
+
+        await session.run(`
+            CREATE (m:${typeMovie.name}
+                {name: "Terminator",year:1990,createdAt: datetime()})
+                <-[:ACTED_IN]-
+                (:${typeActor.name} { name: "Arnold", year: 1970, createdAt: datetime(), testId: 1234})
+                CREATE (m)<-[:ACTED_IN]-(:${typeActor.name} {name: "Linda", year:1985, createdAt: datetime(), testId: 1235})`);
+
+        const extendedTypeDefs = `${typeDefs}
+        extend type ${typeActor.name} @auth(rules: [{ where: { testId: "$jwt.sub" } }])`;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs: extendedTypeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "secret" }),
+            },
+        });
+
+        token = jsonwebtoken.sign(
+            {
+                roles: [],
+                sub: 1234,
+            },
+            secret
+        );
+    });
+
+    afterAll(async () => {
+        await session.close();
+        await driver.close();
+    });
+
+    test("authenticated query", async () => {
+        const query = `query {
+            ${typeMovie.plural} {
+                ${typeActor.plural}Aggregate(where: {year_GT: 10}) {
+                    count
+                    node {
+                        year {
+                            max
+                        },
+                        name {
+                            longest,
+                            shortest
+                        }
+                    },
+                    }
+                }
+            }`;
+
+        const socket = new Socket({ readable: true });
+        const req = new IncomingMessage(socket);
+        req.headers.authorization = `Bearer ${token}`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+        });
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
+            count: 1,
+            node: {
+                year: {
+                    max: 1970,
+                },
+                name: {
+                    longest: "Arnold",
+                    shortest: "Arnold",
+                },
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/array-pop-and-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/array-pop-and-push-errors.int.test.ts
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import type { GraphQLError } from "graphql";
+import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
+import { generate } from "randomstring";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { Neo4jGraphQL } from "../../../src/classes";
+import Neo4j from "../neo4j";
+import { UniqueType } from "../../utils/graphql-types";
+
+describe("array-pop-and-push", () => {
+    let driver: Driver;
+    let session: Session;
+    let neo4j: Neo4j;
+    const jwtPlugin = new Neo4jGraphQLAuthJWTPlugin({
+        secret: "secret",
+    });
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+    });
+
+    afterEach(async () => {
+        await session.close();
+    });
+
+    test("should throw an error when trying to pop an element from a non-existing array", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+                moreTags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_PUSH: "xyz", moreTags_POP: 2 }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                        moreTags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc"] })
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("moreTags cannot be NULL"))
+        ).toBeTruthy();
+
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error if not authenticated on field definition", async () => {
+        const typeMovie = new UniqueType("Movie");
+        const typeDefs = `
+            type ${typeMovie} {
+                title: String
+                tags: [String] @auth(rules: [{
+                    operations: [UPDATE],
+                    isAuthenticated: true
+                }])
+                moreTags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs, plugins: { auth: jwtPlugin } });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_POP: 1, moreTags_PUSH: "new tag" }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                        moreTags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags: ['a', 'b'], moreTags: []})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const token = "not valid token";
+
+        const socket = new Socket({ readable: true });
+        const req = new IncomingMessage(socket);
+        req.headers.authorization = `Bearer ${token}`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect((gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Unauthenticated"))).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error when input is invalid", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+                moreTags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_PUSH: 1, moreTags_POP: 2 }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                        moreTags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc"], moreTags: ["this", "that", "them"] })
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("String cannot represent a non string value")
+            )
+        ).toBeTruthy();
+
+        expect(gqlResult.data).toBeUndefined();
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/array-pop-errors.int.test.ts
@@ -1,0 +1,408 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import type { GraphQLError } from "graphql";
+import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
+import { generate } from "randomstring";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { Neo4jGraphQL } from "../../../src/classes";
+import Neo4j from "../neo4j";
+import { UniqueType } from "../../utils/graphql-types";
+
+describe("array-pop-errors", () => {
+    let driver: Driver;
+    let session: Session;
+    let neo4j: Neo4j;
+    const jwtPlugin = new Neo4jGraphQLAuthJWTPlugin({
+        secret: "secret",
+    });
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+    });
+
+    afterEach(async () => {
+        await session.close();
+    });
+    test("should throw an error when trying to pop an element from a non-existing array", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_POP: 1 }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        // Created deliberately without the tags property.
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Property tags cannot be NULL"))
+        ).toBeTruthy();
+
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error when trying to pop an element from multiple non-existing arrays", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+                otherTags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_POP: 1, otherTags_POP: 1 }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                        otherTags
+                    }
+                }
+            }
+        `;
+
+        // Created deliberately without the tags or otherTags properties.
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("Properties tags, otherTags cannot be NULL")
+            )
+        ).toBeTruthy();
+
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error if not authenticated on field definition", async () => {
+        const typeMovie = new UniqueType("Movie");
+        const typeDefs = `
+            type ${typeMovie} {
+                title: String
+                tags: [String] @auth(rules: [{
+                    operations: [UPDATE],
+                    isAuthenticated: true
+                }])
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs, plugins: { auth: jwtPlugin } });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_POP: 1 }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags: ['a', 'b']})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const token = "not valid token";
+
+        const socket = new Socket({ readable: true });
+        const req = new IncomingMessage(socket);
+        req.headers.authorization = `Bearer ${token}`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect((gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Unauthenticated"))).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error when input is invalid", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_POP: a }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc", "xyz"]})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("Int cannot represent non-integer value")
+            )
+        ).toBeTruthy();
+
+        expect(gqlResult.data).toBeUndefined();
+    });
+
+    test("should throw an error when performing an ambiguous property update", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_POP: 1, tags: [] }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags:["existing value"]})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error when performing an ambiguous property update on relationship properties", async () => {
+        const initialPay = 100;
+        const movie = new UniqueType("Movie");
+        const actor = new UniqueType("Actor");
+        const typeDefs = `
+            type ${movie.name} {
+                title: String
+                actors: [${actor.name}!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+            }
+            
+            type ${actor.name} {
+                id: ID!
+                name: String!
+                actedIn: [${movie.name}!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+            }
+
+            interface ActedIn @relationshipProperties {
+                pay: [Float]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const id = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            mutation Mutation($id: ID, $numberToPop: Int) {
+                ${actor.operations.update}(where: { id: $id }, update: {
+                    actedIn: [
+                        {
+                            update: {
+                                edge: {
+                                    pay: [],
+                                    pay_POP: $numberToPop
+                                }
+                            }
+                        }
+                    ]
+                }) {
+                    ${actor.plural} {
+                        name
+                        actedIn {
+                            title
+                        }
+                        actedInConnection {
+                            edges {
+                                pay
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        // Create new movie
+        await session.run(
+            `
+                CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ pay: $initialPay }]-(b) RETURN a, actedIn, b
+                `,
+            {
+                id,
+                initialPay: [initialPay],
+            }
+        );
+        // Update movie
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            variableValues: { id, numberToPop: 1 },
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/array-push-errors.int.test.ts
@@ -1,0 +1,342 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import type { GraphQLError } from "graphql";
+import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
+import { generate } from "randomstring";
+import { IncomingMessage } from "http";
+import { Socket } from "net";
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { Neo4jGraphQL } from "../../../src/classes";
+import Neo4j from "../neo4j";
+import { UniqueType } from "../../utils/graphql-types";
+
+describe("array-push", () => {
+    let driver: Driver;
+    let session: Session;
+    let neo4j: Neo4j;
+    const jwtPlugin = new Neo4jGraphQLAuthJWTPlugin({
+        secret: "secret",
+    });
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+    });
+
+    afterEach(async () => {
+        await session.close();
+    });
+
+    test("should throw an error when trying to push on to a non-existing array", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_PUSH: "test" }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        // Created deliberately without the tags property.
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Property tags cannot be NULL"))
+        ).toBeTruthy();
+
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error if not authenticated on field definition", async () => {
+        const typeMovie = new UniqueType("Movie");
+        const typeDefs = `
+            type ${typeMovie} {
+                title: String
+                tags: [String] @auth(rules: [{ operations: [UPDATE], isAuthenticated: true }])
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs, plugins: { auth: jwtPlugin } });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_PUSH: "test" }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags: []})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const token = "not valid token";
+
+        const socket = new Socket({ readable: true });
+        const req = new IncomingMessage(socket);
+        req.headers.authorization = `Bearer ${token}`;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect((gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Unauthenticated"))).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error when input is invalid", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_PUSH: 123 }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags:[]})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("String cannot represent a non string value")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeUndefined();
+    });
+
+    test("should throw an error when performing an ambiguous property update", async () => {
+        const typeMovie = new UniqueType("Movie");
+
+        const typeDefs = gql`
+            type ${typeMovie} {
+                title: String
+                tags: [String]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const movieTitle = generate({
+            charset: "alphabetic",
+        });
+
+        const update = `
+            mutation {
+                ${typeMovie.operations.update} (update: { tags_PUSH: "test", tags: [] }) {
+                    ${typeMovie.plural} {
+                        title
+                        tags
+                    }
+                }
+            }
+        `;
+
+        const cypher = `
+            CREATE (m:${typeMovie} {title:$movieTitle, tags:["existing value"]})
+        `;
+
+        await session.run(cypher, { movieTitle });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: update,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should throw an error when performing an ambiguous property update on relationship properties", async () => {
+        const initialPay = 100;
+        const payIncrement = 50;
+        const movie = new UniqueType("Movie");
+        const actor = new UniqueType("Actor");
+        const typeDefs = `
+            type ${movie.name} {
+                title: String
+                actors: [${actor.name}!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: IN)
+            }
+            
+            type ${actor.name} {
+                id: ID!
+                name: String!
+                actedIn: [${movie.name}!]! @relationship(type: "ACTED_IN", properties: "ActedIn", direction: OUT)
+            }
+
+            interface ActedIn @relationshipProperties {
+                pay: [Float]
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+
+        const id = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            mutation Mutation($id: ID, $payIncrement: [Float]) {
+                ${actor.operations.update}(where: { id: $id }, update: {
+                    actedIn: [
+                        {
+                            update: {
+                                edge: {
+                                    pay: [],
+                                    pay_PUSH: $payIncrement
+                                }
+                            }
+                        }
+                    ]
+                }) {
+                    ${actor.plural} {
+                        name
+                        actedIn {
+                            title
+                        }
+                        actedInConnection {
+                            edges {
+                                pay
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        // Create new movie
+        await session.run(
+            `
+                CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ pay: $initialPay }]-(b) RETURN a, actedIn, b
+                `,
+            {
+                id,
+                initialPay: [initialPay],
+            }
+        );
+        // Update movie
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            variableValues: { id, payIncrement },
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        if (gqlResult.errors) {
+            console.log(JSON.stringify(gqlResult.errors, null, 2));
+        }
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as GraphQLError[]).some((el) =>
+                el.message.includes("Cannot mutate the same field multiple times in one Mutation")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/auth/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/auth/custom-resolvers.int.test.ts
@@ -23,6 +23,7 @@ import { generate } from "randomstring";
 import Neo4j from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
 
 describe("auth/custom-resolvers", () => {
     let driver: Driver;
@@ -69,7 +70,7 @@ describe("auth/custom-resolvers", () => {
                         me: (_, __, ctx) => ({ id: ctx.auth.jwt.sub }),
                     },
                 },
-                features: { authorization: { key: secret } },
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
             });
 
             const req = createJwtRequest(secret, { sub: userId });
@@ -110,7 +111,7 @@ describe("auth/custom-resolvers", () => {
             const neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 resolvers: { Mutation: { me: (_, __, ctx) => ({ id: ctx.auth.jwt.sub }) } },
-                features: { authorization: { key: secret } },
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
             });
 
             const req = createJwtRequest(secret, { sub: userId });
@@ -154,7 +155,7 @@ describe("auth/custom-resolvers", () => {
                     Query: { me: () => ({}) },
                     User: { customId: (_, __, ctx) => ctx.auth.jwt.sub },
                 },
-                features: { authorization: { key: secret } },
+                plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
             });
 
             const req = createJwtRequest(secret, { sub: userId });

--- a/packages/graphql/tests/integration/deprecated/field-level-aggregate-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/field-level-aggregate-auth.int.test.ts
@@ -1,0 +1,574 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { generate } from "randomstring";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { createJwtRequest } from "../../utils/create-jwt-request";
+import { UniqueType } from "../../utils/graphql-types";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe("aggregations-top_level-auth", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should throw forbidden when incorrect allow on aggregate count", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const randomType = new UniqueType("Movie");
+
+        const typeDefs = `
+            type ${randomType.name} {
+                id: ID
+            }
+
+            extend type ${randomType.name} @auth(rules: [{ allow: { id: "$jwt.sub" } }])
+        `;
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                ${randomType.operations.aggregate} {
+                    count
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:${randomType.name} {id: "${userId}"})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should append auth where to predicate and return post count for this user", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type User {
+                id: ID
+                posts: [Post!]! @relationship(type: "POSTED", direction: OUT)
+            }
+
+            type Post {
+                content: String
+                creator: User! @relationship(type: "POSTED", direction: IN)
+            }
+
+            extend type Post @auth(rules: [{ where: { creator: { id: "$jwt.sub" } } }])
+        `;
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                postsAggregate {
+                    count
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:User {id: "${userId}"})-[:POSTED]->(:Post {content: randomUUID()})
+            `);
+
+            const req = createJwtRequest(secret, { sub: userId });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect(gqlResult.errors).toBeUndefined();
+
+            expect(gqlResult.data).toEqual({
+                postsAggregate: {
+                    count: 1,
+                },
+            });
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a Int field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                imdbRatingInt: Int @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    imdbRatingInt {
+                        min
+                        max
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", imdbRatingInt: rand()})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a ID field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                someId: ID @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    someId {
+                        shortest
+                        longest
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", someId: "some-random-string"})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a String field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                someString: String @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    someString {
+                        shortest
+                        longest
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", someString: "some-random-string"})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a Float field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                imdbRatingFloat: Float @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    imdbRatingFloat {
+                        min
+                        max
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", imdbRatingFloat: rand()})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a BigInt field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                imdbRatingBigInt: BigInt @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    imdbRatingBigInt {
+                        min
+                        max
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", imdbRatingBigInt: rand()})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a DateTime field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                createdAt: DateTime @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    createdAt {
+                        min
+                        max
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", createdAt: datetime()})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+
+    test("should throw when invalid allow when aggregating a Duration field", async () => {
+        const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+        const typeDefs = `
+            type Movie {
+                id: ID
+                director: Person! @relationship(type: "DIRECTED", direction: IN)
+                screenTime: Duration @auth(rules: [{ allow: { director: { id: "$jwt.sub" } } }])
+            }
+
+            type Person {
+                id: ID
+            }
+        `;
+
+        const movieId = generate({
+            charset: "alphabetic",
+        });
+
+        const userId = generate({
+            charset: "alphabetic",
+        });
+
+        const query = `
+            {
+                moviesAggregate(where: {id: "${movieId}"}) {
+                    screenTime {
+                        min
+                        max
+                    }
+                }
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+            },
+        });
+
+        try {
+            await session.run(`
+                CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", createdAt: datetime()})
+            `);
+
+            const req = createJwtRequest(secret, { sub: "invalid" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+
+            expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+        } finally {
+            await session.close();
+        }
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/global-authentication-jwks-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/global-authentication-jwks-auth-plugin.int.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWKSPlugin } from "@neo4j/graphql-plugin-auth";
+import type { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import type { JWKSMock } from "mock-jwks";
+import createJWKSMock from "mock-jwks";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import type { Neo4jGraphQLAuthenticationError } from "../../../src/classes";
+import { UniqueType } from "../../utils/graphql-types";
+
+// TODO: fix this file with global auth
+describe("Global authentication - Auth JWKS plugin", () => {
+    let jwksMock: JWKSMock;
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    const testMovie = new UniqueType("Movie");
+
+    const typeDefs = `
+        type ${testMovie} {
+            name: String
+        }
+    `;
+
+    const query = `
+        {
+            ${testMovie.plural} {
+                name
+            }
+        }
+    `;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    beforeEach(() => {
+        // This creates a local Public Key Infrastructure (PKI)
+        jwksMock = createJWKSMock("https://myAuthTest.auth0.com");
+    });
+
+    afterEach(() => {
+        jwksMock.stop();
+    });
+
+    test("should fail if no JWT token is present and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWKSPlugin({
+                    jwksEndpoint: "https://myAuthTest.auth0.com/.well-known/jwks.json",
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as unknown as Neo4jGraphQLAuthenticationError[]).some((el) =>
+                el.message.includes("Unauthenticated")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should fail if invalid JWT token is provided and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWKSPlugin({
+                    jwksEndpoint: "https://myAuthTest.auth0.com/.well-known/jwks.json",
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues({
+                request: {
+                    headers: { Authorization: `Bearer xxx.invalidtoken.xxxx` },
+                },
+            }),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as unknown as Neo4jGraphQLAuthenticationError[]).some((el) =>
+                el.message.includes("Unauthenticated")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should not fail if valid JWT token is present and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWKSPlugin({
+                    jwksEndpoint: "https://myAuthTest.auth0.com/.well-known/jwks.json",
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        jwksMock.start();
+
+        const accessToken = jwksMock.token({
+            iat: 1600000000,
+        });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues({
+                request: {
+                    headers: { Authorization: `Bearer ${accessToken}` },
+                },
+            }),
+        });
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult.data as any)[testMovie.plural]).toHaveLength(0);
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/global-authentication-jwt-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/global-authentication-jwt-auth-plugin.int.test.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import type { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import type { Neo4jGraphQLAuthenticationError } from "../../../src/classes";
+import { UniqueType } from "../../utils/graphql-types";
+import { createJwtRequest } from "../../utils/create-jwt-request";
+
+// TODO: fix this file with global auth
+describe("Global authentication - Auth JWT plugin", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    const secret = "secret";
+    const testMovie = new UniqueType("Movie");
+
+    const typeDefs = `
+        type ${testMovie} {
+            name: String
+        }
+    `;
+
+    const query = `
+        {
+            ${testMovie.plural} {
+                name
+            }
+        }
+    `;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should fail if no JWT token is present and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as unknown as Neo4jGraphQLAuthenticationError[]).some((el) =>
+                el.message.includes("Unauthenticated")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should fail if invalid JWT token is present and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        const req = { headers: { authorization: "Bearer xxx.invalidtoken.xxx" } };
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues({ req }),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as unknown as Neo4jGraphQLAuthenticationError[]).some((el) =>
+                el.message.includes("Unauthenticated")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should fail if a JWT token with a wrong secret is present and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        const req = createJwtRequest("wrong-secret", { sub: "test" });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues({ req }),
+        });
+
+        expect(gqlResult.errors).toBeDefined();
+        expect(
+            (gqlResult.errors as unknown as Neo4jGraphQLAuthenticationError[]).some((el) =>
+                el.message.includes("Unauthenticated")
+            )
+        ).toBeTruthy();
+        expect(gqlResult.data).toBeNull();
+    });
+
+    test("should fail if noVerify and global authentication are both enabled", async () => {
+        let initError: Error | null | unknown;
+        try {
+            const neoSchema = new Neo4jGraphQL({
+                driver,
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({
+                        secret,
+                        noVerify: true,
+                        globalAuthentication: true,
+                    }),
+                },
+            });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues(),
+            });
+            expect(gqlResult.errors).toBeUndefined();
+        } catch (error) {
+            initError = error;
+        }
+
+        expect(initError).toBeDefined();
+        expect(
+            (initError as Error)?.message.includes(
+                "Neo4jGraphQLAuthJWTPlugin, noVerify and globalAuthentication can not both be enabled simultaneously."
+            )
+        ).toBeTruthy();
+    });
+
+    test("should not fail if noVerify is false and global authentication is true", async () => {
+        let initError: Error | null | unknown;
+        try {
+            const neoSchema = new Neo4jGraphQL({
+                driver,
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({
+                        secret,
+                        noVerify: false,
+                        globalAuthentication: true,
+                    }),
+                },
+            });
+
+            const req = createJwtRequest(secret, { sub: "test" });
+
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: query,
+                contextValue: neo4j.getContextValues({ req }),
+            });
+            expect(gqlResult.errors).toBeUndefined();
+            expect((gqlResult.data as any)[testMovie.plural]).toHaveLength(0);
+        } catch (error) {
+            initError = error;
+        }
+
+        expect(initError).toBeUndefined();
+    });
+
+    test("should not fail if valid JWT token is present and global authentication is enabled", async () => {
+        const neoSchema = new Neo4jGraphQL({
+            driver,
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                    globalAuthentication: true,
+                }),
+            },
+        });
+
+        const req = createJwtRequest(secret, { sub: "test" });
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues({ req }),
+        });
+
+        expect(gqlResult.errors).toBeUndefined();
+        expect((gqlResult.data as any)[testMovie.plural]).toHaveLength(0);
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/labels-fulltext.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/labels-fulltext.int.test.ts
@@ -30,6 +30,7 @@ import { delay } from "../../../src/utils/utils";
 import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
 import { createJwtRequest } from "../../utils/create-jwt-request";
 import { SCORE_FIELD } from "../../../src/graphql/directives/fulltext";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
 
 function generatedTypeDefs(personType: UniqueType, movieType: UniqueType): string {
     return `
@@ -1429,7 +1430,7 @@ describe("@fulltext directive", () => {
 
             const typeDefs = `
                 type ${personType.name} @fulltext(indexes: [{ indexName: "${personType.name}Index", fields: ["name"] }])
-                @auth(rules: [{ where: { name: "$jwt.name" } }]) {
+                @auth(rules: [{ where: { name: "$jwt.name" } }]){
                     name: String!
                     born: Int!
                     actedInMovies: [${movieType.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
@@ -1446,10 +1447,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();
@@ -1516,10 +1515,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();
@@ -1582,10 +1579,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();
@@ -1663,10 +1658,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();
@@ -1728,10 +1721,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();
@@ -1796,10 +1787,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();
@@ -1861,10 +1850,8 @@ describe("@fulltext directive", () => {
             neoSchema = new Neo4jGraphQL({
                 typeDefs,
                 driver,
-                features: {
-                    authorization: {
-                        key: secret,
-                    },
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
                 },
             });
             generatedSchema = await neoSchema.getSchema();

--- a/packages/graphql/tests/integration/deprecated/labels-label-cypher-injection.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/labels-label-cypher-injection.int.test.ts
@@ -24,6 +24,7 @@ import Neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 import { createJwtRequest } from "../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "../../../../plugins/graphql-plugin-auth/src";
 
 describe("Label cypher injection", () => {
     let schema: GraphQLSchema;
@@ -94,9 +95,7 @@ describe("Label cypher injection", () => {
         const neoGraphql = new Neo4jGraphQL({
             typeDefs,
             driver,
-            features: {
-                authorization: { key: "1234" },
-            },
+            plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret: "1234" }) },
         });
         schema = await neoGraphql.getSchema();
 

--- a/packages/graphql/tests/integration/deprecated/labels-label.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/labels-label.int.test.ts
@@ -23,6 +23,7 @@ import Neo4j from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 import { createJwtRequest } from "../../utils/create-jwt-request";
+import { Neo4jGraphQLAuthJWTPlugin } from "../../../../plugins/graphql-plugin-auth/src";
 
 describe("Node directive labels", () => {
     let driver: Driver;
@@ -83,11 +84,7 @@ describe("Node directive labels", () => {
 
         const neoSchema = new Neo4jGraphQL({
             typeDefs,
-            features: {
-                authorization: {
-                    key: secret,
-                },
-            },
+            plugins: { auth: new Neo4jGraphQLAuthJWTPlugin({ secret }) },
         });
 
         const query = `query {

--- a/packages/graphql/tests/integration/deprecated/subscriptions/allow.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/subscriptions/allow.int.test.ts
@@ -1,0 +1,1189 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import { generate } from "randomstring";
+import Neo4j from "../../neo4j";
+import { Neo4jGraphQL } from "../../../../src/classes";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+
+describe("auth/allow", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+    let plugin: TestSubscriptionsPlugin;
+    const secret = "secret";
+
+    let userType: UniqueType;
+    let postType: UniqueType;
+    let commentType: UniqueType;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    beforeEach(async () => {
+        userType = new UniqueType("User");
+        postType = new UniqueType("Post");
+        commentType = new UniqueType("Comment");
+
+        session = await neo4j.getSession();
+        plugin = new TestSubscriptionsPlugin();
+    });
+
+    afterEach(async () => {
+        await cleanNodes(session, [userType, postType]);
+        await session.close();
+    });
+
+    describe("read", () => {
+        test("should throw forbidden when reading a node with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} @auth(rules: [{ operations: [READ], allow: { id: "$jwt.sub" } }])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${userType.plural}(where: {id: "${userId}"}) {
+                        id
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw forbidden when reading a property with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} {
+                    password: String @auth(rules: [{ operations: [READ], allow: { id: "$jwt.sub" } }])
+                }
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${userType.plural}(where: {id: "${userId}"}) {
+                        password
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}", password: "letmein"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw forbidden when reading a nested property with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${postType.name} {
+                    id: ID
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} {
+                    password: String @auth(rules: [{ operations: [READ], allow: { id: "$jwt.sub" } }])
+                }
+            `;
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${postType.plural}(where: {id: "${postId}"}) {
+                        creator {
+                            password
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${postType.name} {id: "${postId}"})<-[:HAS_POST]-(:${userType.name} {id: "${userId}", password: "letmein"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw forbidden when reading a nested property with invalid allow (using connections)", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${postType.name} {
+                    id: ID
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} {
+                    password: String @auth(rules: [{ operations: [READ], allow: { id: "$jwt.sub" } }])
+                }
+            `;
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${postType.plural}(where: {id: "${postId}"}) {
+                        creatorConnection {
+                            edges {
+                                node {
+                                    password
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${postType.name} {id: "${postId}"})<-[:HAS_POST]-(:${userType.name} {id: "${userId}", password: "letmein"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw forbidden when reading a node with invalid allow (across a single relationship)", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${postType.name} {
+                    content: String
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    name: String
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${postType.name}
+                    @auth(rules: [{ operations: [READ], allow: { creator: { id: "$jwt.sub" } } }])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${userType.plural}(where: {id: "${userId}"}) {
+                        id
+                        posts {
+                            content
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw forbidden when reading a node with invalid allow (across a single relationship)(using connections)", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${postType.name} {
+                    content: String
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    name: String
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${postType.name}
+                    @auth(rules: [{ operations: [READ], allow: { creator: { id: "$jwt.sub" } } }])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${userType.plural}(where: {id: "${userId}"}) {
+                        id
+                        postsConnection {
+                            edges {
+                                node {
+                                    content
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw forbidden when reading a node with invalid allow (across multi relationship)", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${commentType.name}  {
+                    id: ID
+                    content: String
+                    creator: ${userType.name}! @relationship(type: "HAS_COMMENT", direction: IN)
+                }
+
+                type ${postType.name} {
+                    id: ID
+                    content: String
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                    comments: [${commentType.name}!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    name: String
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${commentType.name}
+                    @auth(rules: [{ operations: [READ], allow: { creator: { id: "$jwt.sub" } } }])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const commentId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                {
+                    ${userType.plural}(where: {id: "${userId}"}) {
+                        id
+                        posts(where: {id: "${postId}"}) {
+                            comments(where: {id: "${commentId}"}) {
+                                content
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})-[:HAS_COMMENT]->(:${commentType.name} {id: "${commentId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("update", () => {
+        test("should throw Forbidden when editing a node with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${userType.name}  {
+                    id: ID
+                }
+
+                extend type ${userType.name}
+                    @auth(rules: [{ operations: [UPDATE], allow: { id: "$jwt.sub"  } }])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(where: {id: "${userId}"}, update: {id: "new-id"}) {
+                        ${userType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (: ${userType.name} {id: "${userId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw Forbidden when editing a property with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} {
+                    password: String @auth(rules: [{ operations: [UPDATE], allow: { id: "$jwt.sub" }}])
+                }
+
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(where: {id: "${userId}"}, update: {password: "new-password"}) {
+                        ${userType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw Forbidden when editing a nested node with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${postType.name} {
+                    id: ID
+                    content: String
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} @auth(rules: [{ operations: [UPDATE], allow: { id: "$jwt.sub" }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${postType.operations.update}(
+                        where: { id: "${postId}" }
+                        update: { creator: { update: { node: { id: "new-id" } } } }
+                    ) {
+                        ${postType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw Forbidden when editing a nested node property with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${postType.name} {
+                    id: ID
+                    content: String
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} {
+                    password: String @auth(rules: [{ operations: [UPDATE], allow: { id: "$jwt.sub" }}])
+                }
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${postType.operations.update}(
+                        where: { id: "${postId}" }
+                        update: { creator: { update: { node: { password: "new-password" } } } }
+                    ) {
+                        ${postType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("delete", () => {
+        test("should throw Forbidden when deleting a node with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${userType.name} {
+                    id: ID
+                }
+
+                extend type ${userType.name} @auth(rules: [{ operations: [DELETE], allow: { id: "$jwt.sub" }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${userType.operations.delete}(
+                        where: { id: "${userId}" }
+                    ) {
+                       nodesDeleted
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw Forbidden when deleting a nested node with invalid allow", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type ${userType.name} {
+                    id: ID
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                type ${postType.name} {
+                    id: ID
+                    name: String
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                extend type ${postType.name} @auth(rules: [{ operations: [DELETE], allow: { creator: { id: "$jwt.sub" } }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${userType.operations.delete}(
+                        where: { id: "${userId}" },
+                        delete: {
+                            posts: {
+                                where: {
+                                    node: {
+                                        id: "${postId}"
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                       nodesDeleted
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("disconnect", () => {
+        test("should throw Forbidden when disconnecting a node with invalid allow", async () => {
+            const session = await neo4j.getSession();
+
+            const typeDefs = `
+                type ${postType.name} {
+                    id: ID
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${postType.name} @auth(rules: [{ operations: [DISCONNECT], allow: { creator: { id: "$jwt.sub" } }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(
+                        where: { id: "${userId}" }
+                        disconnect: { posts: { where: { node: { id: "${postId}" } } } }
+                    ) {
+                        ${userType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->(:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw Forbidden when disconnecting a nested node with invalid allow", async () => {
+            const session = await neo4j.getSession();
+
+            const typeDefs = `
+                type ${commentType.name} {
+                    id: ID
+                    content: String
+                    post: ${postType.name}! @relationship(type: "HAS_COMMENT", direction: IN)
+                }
+
+                type ${postType.name} {
+                    id: ID
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                    comments: ${commentType.name}! @relationship(type: "HAS_COMMENT", direction: OUT)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${postType.name} @auth(rules: [{ operations: [DISCONNECT], allow: { creator: { id: "$jwt.sub" } }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const commentId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${commentType.operations.update}(
+                        where: { id: "${commentId}" }
+                        update: {
+                            post: {
+                                disconnect: {
+                                    disconnect: {
+                                        creator: {
+                                            where: { node: { id: "${userId}" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        ${commentType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})-[:HAS_POST]->
+                                (:${postType.name} {id: "${postId}"})-[:HAS_COMMENT]->
+                                    (:${commentType.name} {id: "${commentId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+    });
+
+    describe("connect", () => {
+        test("should throw Forbidden when connecting a node with invalid allow", async () => {
+            const session = await neo4j.getSession();
+
+            const typeDefs = `
+                type ${postType.name} {
+                    id: ID
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${postType.name} @auth(rules: [{ operations: [CONNECT], allow: { creator: { id: "$jwt.sub" } }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${userType.operations.update}(
+                        where: { id: "${userId}" }
+                        connect: { posts: { where: { node: { id: "${postId}" } } } }
+                    ) {
+                        ${userType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})
+                    CREATE (:${postType.name} {id: "${postId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+
+        test("should throw Forbidden when connecting a nested node with invalid allow", async () => {
+            const session = await neo4j.getSession();
+
+            const typeDefs = `
+                type ${commentType.name} {
+                    id: ID
+                    content: String
+                    post: ${postType.name}! @relationship(type: "HAS_COMMENT", direction: IN)
+                }
+
+                type ${postType.name} {
+                    id: ID
+                    creator: ${userType.name}! @relationship(type: "HAS_POST", direction: IN)
+                    comments: ${commentType.name}! @relationship(type: "HAS_COMMENT", direction: OUT)
+                }
+
+                type ${userType.name} {
+                    id: ID
+                    posts: [${postType.name}!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type ${postType.name} @auth(rules: [{ operations: [CONNECT], allow: { creator: { id: "$jwt.sub" } }}])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const postId = generate({
+                charset: "alphabetic",
+            });
+
+            const commentId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    ${commentType.operations.update}(
+                        where: { id: "${commentId}" }
+                        update: {
+                            post: {
+                                connect: {
+                                    connect: {
+                                        creator: {
+                                            where: { node: { id: "${userId}" } }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    ) {
+                        ${commentType.plural} {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                await session.run(`
+                    CREATE (:${userType.name} {id: "${userId}"})
+                    CREATE (:${postType.name} {id: "${postId}"})-[:HAS_COMMENT]->(:${commentType.name} {id: "${commentId}"})
+                `);
+
+                const req = createJwtRequest(secret, { sub: "invalid" });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+            } finally {
+                await session.close();
+            }
+        });
+    });
+});

--- a/packages/graphql/tests/integration/deprecated/subscriptions/create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/deprecated/subscriptions/create-auth.int.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver } from "neo4j-driver";
+import { graphql } from "graphql";
+import { generate } from "randomstring";
+import Neo4j from "../../neo4j";
+import { Neo4jGraphQL } from "../../../../src/classes";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { TestSubscriptionsPlugin } from "../../../utils/TestSubscriptionPlugin";
+import { Neo4jGraphQLAuthJWTPlugin } from "../../../../../plugins/graphql-plugin-auth/src";
+
+describe("auth/bind", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    const secret = "secret";
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    describe("create", () => {
+        test("should throw forbidden when creating a nested node with invalid bind", async () => {
+            const session = await neo4j.getSession({ defaultAccessMode: "WRITE" });
+
+            const typeDefs = `
+                type Post {
+                    id: ID
+                    creator: User! @relationship(type: "HAS_POST", direction: IN)
+                }
+
+                type User {
+                    id: ID
+                    posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+                }
+
+                extend type Post @auth(rules: [{ operations: [CREATE], bind: { id: "$jwt.sub" } }])
+            `;
+
+            const userId = generate({
+                charset: "alphabetic",
+            });
+
+            const query = `
+                mutation {
+                    createUsers(input: [{
+                        id: "${userId}",
+                        posts: {
+                            create: [{
+                                node: {
+                                    id: "post-id-1",
+                                    creator: {
+                                        create: { node: {id: "not valid"} }
+                                    }
+                                }
+                            }]
+                        }
+                    }]) {
+                        users {
+                            id
+                        }
+                    }
+                }
+            `;
+
+            const plugin = new TestSubscriptionsPlugin();
+
+            const neoSchema = new Neo4jGraphQL({
+                typeDefs,
+                plugins: {
+                    auth: new Neo4jGraphQLAuthJWTPlugin({ secret }),
+                    subscriptions: plugin,
+                },
+            });
+
+            try {
+                const req = createJwtRequest(secret, { sub: userId });
+
+                const gqlResult = await graphql({
+                    schema: await neoSchema.getSchema(),
+                    source: query,
+                    contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark(), { req }),
+                });
+
+                expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
+
+                expect(plugin.eventList).toEqual([]);
+            } finally {
+                await session.close();
+            }
+        });
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/allow/allow.test.ts
@@ -1,0 +1,767 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../../../utils/tck-test-utils";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+
+describe("Cypher Auth Allow", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Comment {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_COMMENT", direction: IN)
+                post: Post! @relationship(type: "HAS_COMMENT", direction: IN)
+            }
+
+            type Post {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_POST", direction: IN)
+                comments: [Comment!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+            }
+
+            type User {
+                id: ID
+                name: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT], allow: { id: "$jwt.sub" } }])
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ, UPDATE, DELETE], allow: { id: "$jwt.sub" } }])
+            }
+
+            extend type Post
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT]
+                            allow: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                )
+
+            extend type Comment
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT]
+                            allow: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                )
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Node & Protected Field", async () => {
+        const query = gql`
+            {
+                users {
+                    password
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .password } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Relationship", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    posts {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this1 { .content } AS this1
+                RETURN collect(this1) AS var3
+            }
+            RETURN this { .id, posts: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Relationship & Protected Field", async () => {
+        const query = gql`
+            {
+                posts {
+                    creator {
+                        password
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE apoc.util.validatePredicate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(this0 IN [(this)<-[:HAS_POST]-(this0:\`User\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                MATCH (this)<-[this1:HAS_POST]-(this2:\`User\`)
+                WHERE (apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH this2 { .password } AS this2
+                RETURN head(collect(this2)) AS var3
+            }
+            RETURN this { creator: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Two Relationships", async () => {
+        const query = gql`
+            {
+                users(where: { id: "1" }) {
+                    id
+                    posts(where: { id: "1" }) {
+                        comments(where: { id: "1" }) {
+                            content
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                CALL {
+                    WITH this1
+                    MATCH (this1)-[this3:HAS_COMMENT]->(this4:\`Comment\`)
+                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_COMMENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_COMMENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WITH this4 { .content } AS this4
+                    RETURN collect(this4) AS var6
+                }
+                WITH this1 { comments: var6 } AS this1
+                RETURN collect(this1) AS var7
+            }
+            RETURN this { .id, posts: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"1\\",
+                \\"param3\\": \\"id-01\\",
+                \\"param4\\": \\"1\\",
+                \\"param5\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "old-id" }, update: { id: "new-id" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "old-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"old-id\\",
+                \\"this_update_id\\": \\"new-id\\",
+                \\"thisauth_param0\\": \\"old-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node Property", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "id-01" }, update: { password: "new-password" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.password = $this_update_password
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"this_update_password\\": \\"new-password\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Update Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { id: "post-id" }, update: { creator: { update: { node: { id: "new-id" } } } }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	WITH this, this_creator0
+            	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_creator0.id = $this_update_creator0_id
+            	RETURN count(*) AS update_this_creator0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"this_update_creator0_id\\": \\"new-id\\",
+                \\"this_creator0auth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Update Property", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(
+                    where: { id: "post-id" }
+                    update: { creator: { update: { node: { password: "new-password" } } } }
+                ) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	WITH this, this_creator0
+            	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0) AND (this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_creator0.password = $this_update_creator0_password
+            	RETURN count(*) AS update_this_creator0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"this_update_creator0_password\\": \\"new-password\\",
+                \\"this_creator0auth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { id: "user-id" }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\"
+            }"
+        `);
+    });
+
+    test("Nested Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { id: "user-id" }, delete: { posts: { where: { node: { id: "post-id" } } } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0
+            WITH this, this_posts0
+            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
+            CALL {
+            	WITH this_posts0_to_delete
+            	UNWIND this_posts0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_deleteUsers\\": {
+                    \\"args\\": {
+                        \\"delete\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"this_deleteUsers_args_delete_posts0_where_this_posts0param0\\": \\"post-id\\",
+                \\"this_posts0auth_param0\\": \\"user-id\\"
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, disconnect: { posts: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0
+            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"post-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_disconnect_posts0auth_param0\\": \\"user-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateComments(
+                    where: { id: "comment-id" }
+                    update: {
+                        post: { disconnect: { disconnect: { creator: { where: { node: { id: "user-id" } } } } } }
+                    }
+                ) {
+                    comments {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Comment\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
+            WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
+            	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
+            	UNWIND this_post0_disconnect0 as x
+            	DELETE this_post0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            CALL {
+            WITH this, this_post0_disconnect0
+            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
+            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0
+            WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
+            	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
+            	UNWIND this_post0_disconnect0_creator0 as x
+            	DELETE this_post0_disconnect0_creator0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_post0_disconnect0_creator_User
+            }
+            RETURN count(*) AS disconnect_this_post0_disconnect_Post
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	WITH count(this_post_Post_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
+            	RETURN c AS this_post_Post_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"comment-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_post0_disconnect0auth_param0\\": \\"user-id\\",
+                \\"updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0\\": \\"user-id\\",
+                \\"this_post0_disconnect0_creator0auth_param0\\": \\"user-id\\",
+                \\"updateComments\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"post\\": {
+                                \\"disconnect\\": {
+                                    \\"disconnect\\": {
+                                        \\"creator\\": {
+                                            \\"where\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"user-id\\"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, connect: { posts: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
+            	WITH this, this_connect_posts0_node
+            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_connect_posts0_node_param0\\": \\"post-id\\",
+                \\"this_connect_posts0_nodeauth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/allow/inherited.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/allow/inherited.test.ts
@@ -1,0 +1,760 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../src";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../utils/tck-test-utils";
+
+describe("@auth allow when inherited from interface", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT]
+                            allow: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                ) {
+                id: ID
+                content: String
+            }
+
+            type Comment implements Content {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_COMMENT", direction: IN)
+                post: Post! @relationship(type: "HAS_COMMENT", direction: IN)
+            }
+
+            type Post implements Content {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_POST", direction: IN)
+                comments: [Comment!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+            }
+
+            type User {
+                id: ID
+                name: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT], allow: { id: "$jwt.sub" } }])
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ, UPDATE, DELETE], allow: { id: "$jwt.sub" } }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Node & Protected Field", async () => {
+        const query = gql`
+            {
+                users {
+                    password
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .password } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Relationship", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    posts {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH this1 { .content } AS this1
+                RETURN collect(this1) AS var3
+            }
+            RETURN this { .id, posts: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Relationship & Protected Field", async () => {
+        const query = gql`
+            {
+                posts {
+                    creator {
+                        password
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE apoc.util.validatePredicate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(this0 IN [(this)<-[:HAS_POST]-(this0:\`User\`) | this0] WHERE (this0.id IS NOT NULL AND this0.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                MATCH (this)<-[this1:HAS_POST]-(this2:\`User\`)
+                WHERE (apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ((this2.id IS NOT NULL AND this2.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH this2 { .password } AS this2
+                RETURN head(collect(this2)) AS var3
+            }
+            RETURN this { creator: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Two Relationships", async () => {
+        const query = gql`
+            {
+                users(where: { id: "1" }) {
+                    id
+                    posts(where: { id: "1" }) {
+                        comments(where: { id: "1" }) {
+                            content
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                CALL {
+                    WITH this1
+                    MATCH (this1)-[this3:HAS_COMMENT]->(this4:\`Comment\`)
+                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_COMMENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_COMMENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WITH this4 { .content } AS this4
+                    RETURN collect(this4) AS var6
+                }
+                WITH this1 { comments: var6 } AS this1
+                RETURN collect(this1) AS var7
+            }
+            RETURN this { .id, posts: var7 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"1\\",
+                \\"param3\\": \\"id-01\\",
+                \\"param4\\": \\"1\\",
+                \\"param5\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "old-id" }, update: { id: "new-id" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "old-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"old-id\\",
+                \\"this_update_id\\": \\"new-id\\",
+                \\"thisauth_param0\\": \\"old-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node Property", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "id-01" }, update: { password: "new-password" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.password = $this_update_password
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"this_update_password\\": \\"new-password\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Update Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { id: "post-id" }, update: { creator: { update: { node: { id: "new-id" } } } }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	WITH this, this_creator0
+            	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_creator0.id = $this_update_creator0_id
+            	RETURN count(*) AS update_this_creator0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"this_update_creator0_id\\": \\"new-id\\",
+                \\"this_creator0auth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Update Property", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(
+                    where: { id: "post-id" }
+                    update: { creator: { update: { node: { password: "new-password" } } } }
+                ) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
+            	WITH this, this_creator0
+            	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0) AND (this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_creator0.password = $this_update_creator0_password
+            	RETURN count(*) AS update_this_creator0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"this_update_creator0_password\\": \\"new-password\\",
+                \\"this_creator0auth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { id: "user-id" }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\"
+            }"
+        `);
+    });
+
+    test("Nested Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { id: "user-id" }, delete: { posts: { where: { node: { id: "post-id" } } } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0
+            WITH this, this_posts0
+            CALL apoc.util.validate(NOT ((exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
+            CALL {
+            	WITH this_posts0_to_delete
+            	UNWIND this_posts0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_deleteUsers\\": {
+                    \\"args\\": {
+                        \\"delete\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"this_deleteUsers_args_delete_posts0_where_this_posts0param0\\": \\"post-id\\",
+                \\"this_posts0auth_param0\\": \\"user-id\\"
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, disconnect: { posts: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0
+            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"post-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_disconnect_posts0auth_param0\\": \\"user-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateComments(
+                    where: { id: "comment-id" }
+                    update: {
+                        post: { disconnect: { disconnect: { creator: { where: { node: { id: "user-id" } } } } } }
+                    }
+                ) {
+                    comments {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Comment\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
+            WITH this, this_post0_disconnect0, this_post0_disconnect0_rel
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_COMMENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_COMMENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0))) AND (exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
+            	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
+            	UNWIND this_post0_disconnect0 as x
+            	DELETE this_post0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            CALL {
+            WITH this, this_post0_disconnect0
+            OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
+            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0
+            WITH this, this_post0_disconnect0, this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel
+            CALL apoc.util.validate(NOT ((exists((this_post0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_post0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_post0_disconnect0auth_param0))) AND (this_post0_disconnect0_creator0.id IS NOT NULL AND this_post0_disconnect0_creator0.id = $this_post0_disconnect0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
+            	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
+            	UNWIND this_post0_disconnect0_creator0 as x
+            	DELETE this_post0_disconnect0_creator0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_post0_disconnect0_creator_User
+            }
+            RETURN count(*) AS disconnect_this_post0_disconnect_Post
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_COMMENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	WITH count(this_post_Post_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
+            	RETURN c AS this_post_Post_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"comment-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_post0_disconnect0auth_param0\\": \\"user-id\\",
+                \\"updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0\\": \\"user-id\\",
+                \\"this_post0_disconnect0_creator0auth_param0\\": \\"user-id\\",
+                \\"updateComments\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"post\\": {
+                                \\"disconnect\\": {
+                                    \\"disconnect\\": {
+                                        \\"creator\\": {
+                                            \\"where\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"user-id\\"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, connect: { posts: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0
+            	WITH this, this_connect_posts0_node
+            	CALL apoc.util.validate(NOT ((exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_connect_posts0_node_param0\\": \\"post-id\\",
+                \\"this_connect_posts0_nodeauth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -1,0 +1,629 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("@auth allow on specific interface implementation", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type Comment implements Content {
+                id: ID
+                content: String
+                creator: User!
+                post: Post! @relationship(type: "HAS_COMMENT", direction: IN)
+            }
+
+            type Post implements Content
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT]
+                            allow: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                ) {
+                id: ID
+                content: String
+                creator: User!
+                comments: [Comment!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("read allow protected interface relationship", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    content {
+                        id
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this), .id, .content } AS this1
+                    RETURN this1 AS var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this4
+                    RETURN this4 AS var2
+                }
+                WITH var2
+                RETURN collect(var2) AS var2
+            }
+            RETURN this { .id, content: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Two Relationships", async () => {
+        const query = gql`
+            {
+                users(where: { id: "1" }) {
+                    id
+                    content(where: { id: "1" }) {
+                        ... on Post {
+                            comments(where: { id: "1" }) {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE this1.id = $param1
+                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
+                    RETURN this1 AS var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
+                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    CALL {
+                        WITH this4
+                        MATCH (this4)-[this6:HAS_COMMENT]->(this7:\`Comment\`)
+                        WHERE this7.id = $param4
+                        WITH this7 { .content } AS this7
+                        RETURN collect(this7) AS var8
+                    }
+                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), comments: var8 } AS this4
+                    RETURN this4 AS var2
+                }
+                WITH var2
+                RETURN collect(var2) AS var2
+            }
+            RETURN this { .id, content: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"param1\\": \\"1\\",
+                \\"param2\\": \\"1\\",
+                \\"param3\\": \\"id-01\\",
+                \\"param4\\": \\"1\\"
+            }"
+        `);
+    });
+
+    test("Nested Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, update: { content: { update: { node: { id: "new-id" } } } }) {
+                    users {
+                        id
+                        content {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_post_Post_unique:HAS_COMMENT]-(:Post)
+            		WITH count(this_content0_post_Post_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
+            		RETURN c AS this_content0_post_Post_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	WITH this, this_content0
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            WITH *
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[update_this0:HAS_CONTENT]->(update_this1:\`Comment\`)
+                    WITH update_this1 { __resolveType: \\"Comment\\", __id: id(this), .id } AS update_this1
+                    RETURN update_this1 AS update_var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[update_this3:HAS_CONTENT]->(update_this4:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this4)<-[:HAS_CONTENT]-(:\`User\`)) AND any(update_this5 IN [(update_this4)<-[:HAS_CONTENT]-(update_this5:\`User\`) | update_this5] WHERE (update_this5.id IS NOT NULL AND update_this5.id = $update_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH update_this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS update_this4
+                    RETURN update_this4 AS update_var2
+                }
+                WITH update_var2
+                RETURN collect(update_var2) AS update_var2
+            }
+            RETURN collect(DISTINCT this { .id, content: update_var2 }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"update_param0\\": \\"user-id\\",
+                \\"param0\\": \\"user-id\\",
+                \\"this_update_content0_id\\": \\"new-id\\",
+                \\"this_content0auth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { id: "user-id" }, delete: { content: { where: { node: { id: "post-id" } } } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_this_content_Comment0param0
+            WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
+            CALL {
+            	WITH this_content_Comment0_to_delete
+            	UNWIND this_content_Comment0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0
+            WITH this, this_content_Post0
+            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
+            CALL {
+            	WITH this_content_Post0_to_delete
+            	UNWIND this_content_Post0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_deleteUsers\\": {
+                    \\"args\\": {
+                        \\"delete\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"this_deleteUsers_args_delete_content0_where_this_content_Comment0param0\\": \\"post-id\\",
+                \\"this_deleteUsers_args_delete_content0_where_this_content_Post0param0\\": \\"post-id\\",
+                \\"this_content_Post0auth_param0\\": \\"user-id\\"
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, disconnect: { content: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"user-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "user-id" }
+                    disconnect: {
+                        content: {
+                            where: { node: { id: "post-id" } }
+                            disconnect: { _on: { Post: { comments: { where: { node: { id: "comment-id" } } } } } }
+                        }
+                    }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            CALL {
+            WITH this, this_disconnect_content0
+            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
+            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
+            	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
+            	UNWIND this_disconnect_content0_comments0 as x
+            	DELETE this_disconnect_content0_comments0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content0_comments_Comment
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0\\": \\"comment-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"disconnect\\": {
+                                        \\"_on\\": {
+                                            \\"Post\\": [
+                                                {
+                                                    \\"comments\\": [
+                                                        {
+                                                            \\"where\\": {
+                                                                \\"node\\": {
+                                                                    \\"id\\": \\"comment-id\\"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, connect: { content: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0
+            	WITH this, this_connect_content1_node
+            	CALL apoc.util.validate(NOT ((exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_connect_content0_node_param0\\": \\"post-id\\",
+                \\"this_connect_content1_node_param0\\": \\"post-id\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/allow/interface-relationships/interface-allow.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/allow/interface-relationships/interface-allow.test.ts
@@ -1,0 +1,724 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("@auth allow with interface relationships", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT]
+                            allow: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                ) {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type Comment implements Content {
+                id: ID
+                content: String
+                creator: User!
+                post: Post! @relationship(type: "HAS_COMMENT", direction: IN)
+            }
+
+            type Post implements Content {
+                id: ID
+                content: String
+                creator: User!
+                comments: [Comment!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, DISCONNECT, CONNECT], allow: { id: "$jwt.sub" } }])
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ, UPDATE, DELETE], allow: { id: "$jwt.sub" } }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("read allow protected interface relationship", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    content {
+                        id
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this), .id, .content } AS this1
+                    RETURN this1 AS var3
+                    UNION
+                    WITH *
+                    MATCH (this)-[this4:HAS_CONTENT]->(this5:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this5)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this6 IN [(this5)<-[:HAS_CONTENT]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param2)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH this5 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this5
+                    RETURN this5 AS var3
+                }
+                WITH var3
+                RETURN collect(var3) AS var3
+            }
+            RETURN this { .id, content: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Two Relationships", async () => {
+        const query = gql`
+            {
+                users(where: { id: "1" }) {
+                    id
+                    content(where: { id: "1" }) {
+                        ... on Post {
+                            comments(where: { id: "1" }) {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE (this1.id = $param2 AND apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
+                    RETURN this1 AS var3
+                    UNION
+                    WITH *
+                    MATCH (this)-[this4:HAS_CONTENT]->(this5:\`Post\`)
+                    WHERE (this5.id = $param4 AND apoc.util.validatePredicate(NOT ((exists((this5)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this6 IN [(this5)<-[:HAS_CONTENT]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param5)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    CALL {
+                        WITH this5
+                        MATCH (this5)-[this7:HAS_COMMENT]->(this8:\`Comment\`)
+                        WHERE (this8.id = $param6 AND apoc.util.validatePredicate(NOT ((exists((this8)<-[:HAS_CONTENT]-(:\`User\`)) AND any(this9 IN [(this8)<-[:HAS_CONTENT]-(this9:\`User\`) | this9] WHERE (this9.id IS NOT NULL AND this9.id = $param7)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                        WITH this8 { .content } AS this8
+                        RETURN collect(this8) AS var10
+                    }
+                    WITH this5 { __resolveType: \\"Post\\", __id: id(this), comments: var10 } AS this5
+                    RETURN this5 AS var3
+                }
+                WITH var3
+                RETURN collect(var3) AS var3
+            }
+            RETURN this { .id, content: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"1\\",
+                \\"param3\\": \\"id-01\\",
+                \\"param4\\": \\"1\\",
+                \\"param5\\": \\"id-01\\",
+                \\"param6\\": \\"1\\",
+                \\"param7\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Nested Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, update: { content: { update: { node: { id: "new-id" } } } }) {
+                    users {
+                        id
+                        content {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	WITH this, this_content0
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_post_Post_unique:HAS_COMMENT]-(:Post)
+            		WITH count(this_content0_post_Post_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
+            		RETURN c AS this_content0_post_Post_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	WITH this, this_content0
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            WITH *
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[update_this0:HAS_CONTENT]->(update_this1:\`Comment\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this1)<-[:HAS_CONTENT]-(:\`User\`)) AND any(update_this2 IN [(update_this1)<-[:HAS_CONTENT]-(update_this2:\`User\`) | update_this2] WHERE (update_this2.id IS NOT NULL AND update_this2.id = $update_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH update_this1 { __resolveType: \\"Comment\\", __id: id(this), .id } AS update_this1
+                    RETURN update_this1 AS update_var3
+                    UNION
+                    WITH *
+                    MATCH (this)-[update_this4:HAS_CONTENT]->(update_this5:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((update_this5)<-[:HAS_CONTENT]-(:\`User\`)) AND any(update_this6 IN [(update_this5)<-[:HAS_CONTENT]-(update_this6:\`User\`) | update_this6] WHERE (update_this6.id IS NOT NULL AND update_this6.id = $update_param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH update_this5 { __resolveType: \\"Post\\", __id: id(this), .id } AS update_this5
+                    RETURN update_this5 AS update_var3
+                }
+                WITH update_var3
+                RETURN collect(update_var3) AS update_var3
+            }
+            RETURN collect(DISTINCT this { .id, content: update_var3 }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"update_param0\\": \\"user-id\\",
+                \\"update_param1\\": \\"user-id\\",
+                \\"param0\\": \\"user-id\\",
+                \\"this_update_content0_id\\": \\"new-id\\",
+                \\"this_content0auth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Update Property", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(
+                    where: { id: "post-id" }
+                    update: { creator: { update: { node: { password: "new-password" } } } }
+                ) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT ((exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $thisauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_content0_relationship:HAS_CONTENT]-(this_creator0:User)
+            	WITH this, this_creator0
+            	CALL apoc.util.validate(NOT ((this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0) AND (this_creator0.id IS NOT NULL AND this_creator0.id = $this_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_creator0.password = $this_update_creator0_password
+            	RETURN count(*) AS update_this_creator0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"this_update_creator0_password\\": \\"new-password\\",
+                \\"this_creator0auth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { id: "user-id" }, delete: { content: { where: { node: { id: "post-id" } } } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            WHERE this_content_Comment0.id = $this_deleteUsers_args_delete_content0_where_this_content_Comment0param0
+            WITH this, this_content_Comment0
+            CALL apoc.util.validate(NOT ((exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
+            CALL {
+            	WITH this_content_Comment0_to_delete
+            	UNWIND this_content_Comment0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0
+            WITH this, this_content_Post0
+            CALL apoc.util.validate(NOT ((exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
+            CALL {
+            	WITH this_content_Post0_to_delete
+            	UNWIND this_content_Post0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_deleteUsers\\": {
+                    \\"args\\": {
+                        \\"delete\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"this_deleteUsers_args_delete_content0_where_this_content_Comment0param0\\": \\"post-id\\",
+                \\"this_content_Comment0auth_param0\\": \\"user-id\\",
+                \\"this_deleteUsers_args_delete_content0_where_this_content_Post0param0\\": \\"post-id\\",
+                \\"this_content_Post0auth_param0\\": \\"user-id\\"
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, disconnect: { content: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Nested Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "user-id" }
+                    disconnect: {
+                        content: [
+                            {
+                                where: { node: { id: "post-id" } }
+                                disconnect: { _on: { Post: [{ comments: { where: { node: { id: "comment-id" } } } }] } }
+                            }
+                        ]
+                    }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            CALL {
+            WITH this, this_disconnect_content0
+            OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
+            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0
+            WITH this, this_disconnect_content0, this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0))) AND (exists((this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_disconnect_content0_comments0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0_comments0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
+            	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
+            	UNWIND this_disconnect_content0_comments0 as x
+            	DELETE this_disconnect_content0_comments0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content0_comments_Comment
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"post-id\\",
+                \\"updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0\\": \\"comment-id\\",
+                \\"this_disconnect_content0_comments0auth_param0\\": \\"user-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"disconnect\\": {
+                                        \\"_on\\": {
+                                            \\"Post\\": [
+                                                {
+                                                    \\"comments\\": [
+                                                        {
+                                                            \\"where\\": {
+                                                                \\"node\\": {
+                                                                    \\"id\\": \\"comment-id\\"
+                                                                }
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, connect: { content: { where: { node: { id: "post-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "user-id", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+            	WITH this, this_connect_content0_node
+            	CALL apoc.util.validate(NOT ((exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0
+            	WITH this, this_connect_content1_node
+            	CALL apoc.util.validate(NOT ((exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND any(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0))) AND (this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_connect_content0_node_param0\\": \\"post-id\\",
+                \\"this_connect_content0_nodeauth_param0\\": \\"user-id\\",
+                \\"thisauth_param0\\": \\"user-id\\",
+                \\"this_connect_content1_node_param0\\": \\"post-id\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/bind/bind.test.ts
@@ -1,0 +1,477 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../src";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../utils/tck-test-utils";
+
+describe("Cypher Auth Allow", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Post {
+                id: ID
+                creator: User! @relationship(type: "HAS_POST", direction: IN)
+            }
+
+            type User {
+                id: ID
+                name: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [CREATE, UPDATE, CONNECT, DISCONNECT], bind: { id: "$jwt.sub" } }])
+
+            extend type Post
+                @auth(rules: [{ operations: [CREATE, CONNECT, DISCONNECT], bind: { creator: { id: "$jwt.sub" } } }])
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Create Node", async () => {
+        const query = gql`
+            mutation {
+                createUsers(input: [{ id: "user-id", name: "bob" }]) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.name = create_var0.name
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT ((create_this1.id IS NOT NULL AND create_this1.id = $create_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"user-id\\",
+                        \\"name\\": \\"bob\\"
+                    }
+                ],
+                \\"create_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Create Nested Node", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "user-id"
+                            name: "bob"
+                            posts: {
+                                create: [
+                                    { node: { id: "post-id-1", creator: { create: { node: { id: "some-user-id" } } } } }
+                                ]
+                            }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.name = create_var0.name
+                WITH create_this1, create_var0
+                CALL {
+                    WITH create_this1, create_var0
+                    UNWIND create_var0.posts.create AS create_var2
+                    WITH create_var2.node AS create_var3, create_var2.edge AS create_var4, create_this1
+                    CREATE (create_this5:\`Post\`)
+                    SET
+                        create_this5.id = create_var3.id
+                    MERGE (create_this1)-[create_this6:HAS_POST]->(create_this5)
+                    WITH create_this5, create_var3
+                    CALL {
+                        WITH create_this5, create_var3
+                        UNWIND create_var3.creator.create AS create_var7
+                        WITH create_var7.node AS create_var8, create_var7.edge AS create_var9, create_this5
+                        CREATE (create_this10:\`User\`)
+                        SET
+                            create_this10.id = create_var8.id
+                        MERGE (create_this5)<-[create_this11:HAS_POST]-(create_this10)
+                        WITH *
+                        WHERE apoc.util.validatePredicate(NOT ((create_this10.id IS NOT NULL AND create_this10.id = $create_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        RETURN collect(NULL) AS create_var12
+                    }
+                    WITH *
+                    WHERE apoc.util.validatePredicate(NOT ((exists((create_this5)<-[:HAS_POST]-(:\`User\`)) AND all(create_this13 IN [(create_this5)<-[:HAS_POST]-(create_this13:\`User\`) | create_this13] WHERE (create_this13.id IS NOT NULL AND create_this13.id = $create_param2)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH create_this5
+                    CALL {
+                    	WITH create_this5
+                    	MATCH (create_this5)<-[create_this5_creator_User_unique:HAS_POST]-(:User)
+                    	WITH count(create_this5_creator_User_unique) as c
+                    	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+                    	RETURN c AS create_this5_creator_User_unique_ignored
+                    }
+                    RETURN collect(NULL) AS create_var14
+                }
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT ((create_this1.id IS NOT NULL AND create_this1.id = $create_param3)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"user-id\\",
+                        \\"name\\": \\"bob\\",
+                        \\"posts\\": {
+                            \\"create\\": [
+                                {
+                                    \\"node\\": {
+                                        \\"id\\": \\"post-id-1\\",
+                                        \\"creator\\": {
+                                            \\"create\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"some-user-id\\"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ],
+                \\"create_param1\\": \\"id-01\\",
+                \\"create_param2\\": \\"id-01\\",
+                \\"create_param3\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "id-01" }, update: { id: "not bound" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            SET this.id = $this_update_id
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"this_update_id\\": \\"not bound\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "id-01" }
+                    update: {
+                        posts: {
+                            where: { node: { id: "post-id" } }
+                            update: { node: { creator: { update: { node: { id: "not bound" } } } } }
+                        }
+                    }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
+            	WHERE this_posts0.id = $updateUsers_args_update_posts0_where_this_posts0param0
+            	WITH this, this_posts0
+            	CALL {
+            		WITH this, this_posts0
+            		MATCH (this_posts0)<-[this_posts0_has_post0_relationship:HAS_POST]-(this_posts0_creator0:User)
+            		SET this_posts0_creator0.id = $this_update_posts0_creator0_id
+            		WITH this, this_posts0, this_posts0_creator0
+            		CALL apoc.util.validate(NOT ((this_posts0_creator0.id IS NOT NULL AND this_posts0_creator0.id = $this_posts0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		RETURN count(*) AS update_this_posts0_creator0
+            	}
+            	WITH this, this_posts0
+            	CALL {
+            		WITH this_posts0
+            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:HAS_POST]-(:User)
+            		WITH count(this_posts0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_posts0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_posts0
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_posts0_where_this_posts0param0\\": \\"post-id\\",
+                \\"this_update_posts0_creator0_id\\": \\"not bound\\",
+                \\"this_posts0_creator0auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    },
+                                    \\"update\\": {
+                                        \\"node\\": {
+                                            \\"creator\\": {
+                                                \\"update\\": {
+                                                    \\"node\\": {
+                                                        \\"id\\": \\"not bound\\"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { id: "post-id" }, connect: { creator: { where: { node: { id: "user-id" } } } }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_creator0_node:User)
+            	WHERE this_connect_creator0_node.id = $this_connect_creator0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_creator0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_creator0_node
+            			MERGE (this)<-[:HAS_POST]-(this_connect_creator0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_creator0_node
+            	WITH this, this_connect_creator0_node
+            	CALL apoc.util.validate(NOT ((exists((this_connect_creator0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_creator0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_creator0_nodeauth_param0))) AND (this_connect_creator0_node.id IS NOT NULL AND this_connect_creator0_node.id = $this_connect_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	RETURN count(*) AS connect_this_connect_creator_User
+            }
+            WITH *
+            WITH *
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"this_connect_creator0_node_param0\\": \\"user-id\\",
+                \\"this_connect_creator0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { id: "post-id" }, disconnect: { creator: { where: { node: { id: "user-id" } } } }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)<-[this_disconnect_creator0_rel:HAS_POST]-(this_disconnect_creator0:User)
+            WHERE this_disconnect_creator0.id = $updatePosts_args_disconnect_creator_where_User_this_disconnect_creator0param0
+            CALL {
+            	WITH this_disconnect_creator0, this_disconnect_creator0_rel, this
+            	WITH collect(this_disconnect_creator0) as this_disconnect_creator0, this_disconnect_creator0_rel, this
+            	UNWIND this_disconnect_creator0 as x
+            	DELETE this_disconnect_creator0_rel
+            	RETURN count(*) AS _
+            }
+            WITH this, this_disconnect_creator0
+            CALL apoc.util.validate(NOT ((exists((this_disconnect_creator0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_creator0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_creator0auth_param0))) AND (this_disconnect_creator0.id IS NOT NULL AND this_disconnect_creator0.id = $this_disconnect_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN count(*) AS disconnect_this_disconnect_creator_User
+            }
+            WITH *
+            WITH *
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_POST]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"post-id\\",
+                \\"updatePosts_args_disconnect_creator_where_User_this_disconnect_creator0param0\\": \\"user-id\\",
+                \\"this_disconnect_creator0auth_param0\\": \\"id-01\\",
+                \\"updatePosts\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"creator\\": {
+                                \\"where\\": {
+                                    \\"node\\": {
+                                        \\"id\\": \\"user-id\\"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -1,0 +1,523 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+
+describe("Cypher Auth Allow", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content {
+                id: ID
+                creator: User! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type Comment implements Content {
+                id: ID
+                creator: User!
+            }
+
+            type Post implements Content
+                @auth(
+                    rules: [
+                        { operations: [CREATE, UPDATE, CONNECT, DISCONNECT], bind: { creator: { id: "$jwt.sub" } } }
+                    ]
+                ) {
+                id: ID
+                creator: User!
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [CREATE, UPDATE, CONNECT, DISCONNECT], bind: { id: "$jwt.sub" } }])
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Create Nested Node with bind", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "user-id"
+                            name: "bob"
+                            content: {
+                                create: [
+                                    {
+                                        node: {
+                                            Post: {
+                                                id: "post-id-1"
+                                                creator: { create: { node: { id: "some-user-id" } } }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            WITH this0
+            CREATE (this0_contentPost0_node:Post)
+            SET this0_contentPost0_node.id = $this0_contentPost0_node_id
+            WITH this0, this0_contentPost0_node
+            CREATE (this0_contentPost0_node_creator0_node:User)
+            SET this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_node_id
+            WITH this0, this0_contentPost0_node, this0_contentPost0_node_creator0_node
+            CALL apoc.util.validate(NOT ((this0_contentPost0_node_creator0_node.id IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0_contentPost0_node)<-[:HAS_CONTENT]-(this0_contentPost0_node_creator0_node)
+            WITH this0, this0_contentPost0_node
+            CALL apoc.util.validate(NOT ((exists((this0_contentPost0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_contentPost0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_contentPost0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0)-[:HAS_CONTENT]->(this0_contentPost0_node)
+            WITH this0, this0_contentPost0_node
+            CALL {
+            	WITH this0_contentPost0_node
+            	MATCH (this0_contentPost0_node)<-[this0_contentPost0_node_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this0_contentPost0_node_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
+            }
+            WITH this0
+            CALL apoc.util.validate(NOT ((this0.id IS NOT NULL AND this0.id = $this0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"user-id\\",
+                \\"this0_name\\": \\"bob\\",
+                \\"this0_contentPost0_node_id\\": \\"post-id-1\\",
+                \\"this0_contentPost0_node_creator0_node_id\\": \\"some-user-id\\",
+                \\"this0_contentPost0_node_creator0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0_contentPost0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Create Nested Node without bind", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "user-id"
+                            name: "bob"
+                            content: {
+                                create: [
+                                    {
+                                        node: {
+                                            Comment: {
+                                                id: "post-id-1"
+                                                creator: { create: { node: { id: "some-user-id" } } }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            WITH this0
+            CREATE (this0_contentComment0_node:Comment)
+            SET this0_contentComment0_node.id = $this0_contentComment0_node_id
+            WITH this0, this0_contentComment0_node
+            CREATE (this0_contentComment0_node_creator0_node:User)
+            SET this0_contentComment0_node_creator0_node.id = $this0_contentComment0_node_creator0_node_id
+            WITH this0, this0_contentComment0_node, this0_contentComment0_node_creator0_node
+            CALL apoc.util.validate(NOT ((this0_contentComment0_node_creator0_node.id IS NOT NULL AND this0_contentComment0_node_creator0_node.id = $this0_contentComment0_node_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0_contentComment0_node)<-[:HAS_CONTENT]-(this0_contentComment0_node_creator0_node)
+            MERGE (this0)-[:HAS_CONTENT]->(this0_contentComment0_node)
+            WITH this0, this0_contentComment0_node
+            CALL {
+            	WITH this0_contentComment0_node
+            	MATCH (this0_contentComment0_node)<-[this0_contentComment0_node_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this0_contentComment0_node_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            	RETURN c AS this0_contentComment0_node_creator_User_unique_ignored
+            }
+            WITH this0
+            CALL apoc.util.validate(NOT ((this0.id IS NOT NULL AND this0.id = $this0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"user-id\\",
+                \\"this0_name\\": \\"bob\\",
+                \\"this0_contentComment0_node_id\\": \\"post-id-1\\",
+                \\"this0_contentComment0_node_creator0_node_id\\": \\"some-user-id\\",
+                \\"this0_contentComment0_node_creator0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "id-01" }
+                    update: {
+                        content: {
+                            where: { node: { id: "post-id" } }
+                            update: { node: { creator: { update: { node: { id: "not bound" } } } } }
+                        }
+                    }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
+            	WITH this, this_content0
+            	CALL {
+            		WITH this, this_content0
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		SET this_content0_creator0.id = $this_update_content0_creator0_id
+            		WITH this, this_content0, this_content0_creator0
+            		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		RETURN count(*) AS update_this_content0_creator0
+            	}
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
+            	WITH this, this_content0
+            	CALL {
+            		WITH this, this_content0
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		SET this_content0_creator0.id = $this_update_content0_creator0_id
+            		WITH this, this_content0, this_content0_creator0
+            		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		RETURN count(*) AS update_this_content0_creator0
+            	}
+            	WITH this, this_content0
+            	CALL apoc.util.validate(NOT ((exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_content0_where_this_content0param0\\": \\"post-id\\",
+                \\"this_update_content0_creator0_id\\": \\"not bound\\",
+                \\"this_content0_creator0auth_param0\\": \\"id-01\\",
+                \\"this_content0auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"content\\": [
+                                {
+                                    \\"update\\": {
+                                        \\"node\\": {
+                                            \\"creator\\": {
+                                                \\"update\\": {
+                                                    \\"node\\": {
+                                                        \\"id\\": \\"not bound\\"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, connect: { content: { where: { node: { id: "content-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	WITH this, this_connect_content0_node
+            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	WITH this, this_connect_content1_node
+            	CALL apoc.util.validate(NOT ((this_connect_content1_node.id IS NOT NULL AND this_connect_content1_node.id = $this_connect_content1_nodeauth_param0) AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_connect_content0_node_param0\\": \\"content-id\\",
+                \\"this_connect_content0_nodeauth_param0\\": \\"id-01\\",
+                \\"this_connect_content1_node_param0\\": \\"content-id\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "user-id" }
+                    disconnect: { content: { where: { node: { id: "content-id" } } } }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            WITH this, this_disconnect_content0
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            WITH this, this_disconnect_content0
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"content-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"content-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"content-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/bind/interface-relationships/interface-bind.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/bind/interface-relationships/interface-bind.test.ts
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("Cypher Auth Allow", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content
+                @auth(rules: [{ operations: [CREATE, CONNECT, DISCONNECT], bind: { creator: { id: "$jwt.sub" } } }]) {
+                id: ID
+                creator: User! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type Comment implements Content {
+                id: ID
+                creator: User!
+            }
+
+            type Post implements Content {
+                id: ID
+                creator: User!
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [CREATE, UPDATE, CONNECT, DISCONNECT], bind: { id: "$jwt.sub" } }])
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Create Nested Node", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "user-id"
+                            name: "bob"
+                            content: {
+                                create: [
+                                    {
+                                        node: {
+                                            Post: {
+                                                id: "post-id-1"
+                                                creator: { create: { node: { id: "some-user-id" } } }
+                                            }
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            WITH this0
+            CREATE (this0_contentPost0_node:Post)
+            SET this0_contentPost0_node.id = $this0_contentPost0_node_id
+            WITH this0, this0_contentPost0_node
+            CREATE (this0_contentPost0_node_creator0_node:User)
+            SET this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_node_id
+            WITH this0, this0_contentPost0_node, this0_contentPost0_node_creator0_node
+            CALL apoc.util.validate(NOT ((this0_contentPost0_node_creator0_node.id IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_nodeauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0_contentPost0_node)<-[:HAS_CONTENT]-(this0_contentPost0_node_creator0_node)
+            WITH this0, this0_contentPost0_node
+            CALL apoc.util.validate(NOT ((exists((this0_contentPost0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_contentPost0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_contentPost0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            MERGE (this0)-[:HAS_CONTENT]->(this0_contentPost0_node)
+            WITH this0, this0_contentPost0_node
+            CALL {
+            	WITH this0_contentPost0_node
+            	MATCH (this0_contentPost0_node)<-[this0_contentPost0_node_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this0_contentPost0_node_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
+            }
+            WITH this0
+            CALL apoc.util.validate(NOT ((this0.id IS NOT NULL AND this0.id = $this0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"user-id\\",
+                \\"this0_name\\": \\"bob\\",
+                \\"this0_contentPost0_node_id\\": \\"post-id-1\\",
+                \\"this0_contentPost0_node_creator0_node_id\\": \\"some-user-id\\",
+                \\"this0_contentPost0_node_creator0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0_contentPost0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "id-01" }
+                    update: {
+                        content: {
+                            where: { node: { id: "post-id" } }
+                            update: { node: { creator: { update: { node: { id: "not bound" } } } } }
+                        }
+                    }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
+            	WITH this, this_content0
+            	CALL {
+            		WITH this, this_content0
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		SET this_content0_creator0.id = $this_update_content0_creator0_id
+            		WITH this, this_content0, this_content0_creator0
+            		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		RETURN count(*) AS update_this_content0_creator0
+            	}
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	WHERE this_content0.id = $updateUsers_args_update_content0_where_this_content0param0
+            	WITH this, this_content0
+            	CALL {
+            		WITH this, this_content0
+            		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
+            		SET this_content0_creator0.id = $this_update_content0_creator0_id
+            		WITH this, this_content0, this_content0_creator0
+            		CALL apoc.util.validate(NOT ((this_content0_creator0.id IS NOT NULL AND this_content0_creator0.id = $this_content0_creator0auth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		RETURN count(*) AS update_this_content0_creator0
+            	}
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_content0_where_this_content0param0\\": \\"post-id\\",
+                \\"this_update_content0_creator0_id\\": \\"not bound\\",
+                \\"this_content0_creator0auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"content\\": [
+                                {
+                                    \\"update\\": {
+                                        \\"node\\": {
+                                            \\"creator\\": {
+                                                \\"update\\": {
+                                                    \\"node\\": {
+                                                        \\"id\\": \\"not bound\\"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"post-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "user-id" }, connect: { content: { where: { node: { id: "content-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	WITH this, this_connect_content0_node
+            	CALL apoc.util.validate(NOT ((this_connect_content0_node.id IS NOT NULL AND this_connect_content0_node.id = $this_connect_content0_nodeauth_param0) AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	WITH this, this_connect_content1_node
+            	CALL apoc.util.validate(NOT ((this_connect_content1_node.id IS NOT NULL AND this_connect_content1_node.id = $this_connect_content1_nodeauth_param0) AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"this_connect_content0_node_param0\\": \\"content-id\\",
+                \\"this_connect_content0_nodeauth_param0\\": \\"id-01\\",
+                \\"this_connect_content1_node_param0\\": \\"content-id\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(
+                    where: { id: "user-id" }
+                    disconnect: { content: { where: { node: { id: "content-id" } } } }
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            WITH this, this_disconnect_content0
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            WITH this, this_disconnect_content0
+            CALL apoc.util.validate(NOT ((this_disconnect_content0.id IS NOT NULL AND this_disconnect_content0.id = $this_disconnect_content0auth_param0) AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"user-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"content-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"content-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"content-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/is-authenticated/interface-relationships/implementation-is-authenticated.test.ts
@@ -1,0 +1,524 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("Cypher Auth isAuthenticated", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type History {
+                url: String @auth(rules: [{ operations: [READ], isAuthenticated: true }])
+            }
+
+            interface Content {
+                id: String
+                content: String
+            }
+
+            type Comment implements Content {
+                id: String
+                content: String
+            }
+
+            type Post implements Content
+                @auth(
+                    rules: [{ operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE], isAuthenticated: true }]
+                ) {
+                id: String
+                content: String
+            }
+
+            type User {
+                id: ID
+                name: String
+                password: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Create Node with isAuthenticated", async () => {
+        const query = gql`
+            mutation {
+                createPosts(input: [{ id: "1", content: "content" }]) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`Post\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.content = create_var0.content
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\",
+                        \\"content\\": \\"content\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Create Node without isAuthenticated", async () => {
+        const query = gql`
+            mutation {
+                createComments(input: [{ id: "1", content: "content" }]) {
+                    comments {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`Comment\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.content = create_var0.content
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\",
+                        \\"content\\": \\"content\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node with bind", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { id: "1" }, update: { id: "id-1" }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_id\\": \\"id-1\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node without bind", async () => {
+        const query = gql`
+            mutation {
+                updateComments(where: { id: "1" }, update: { id: "id-1" }) {
+                    comments {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Comment\`)
+            WHERE this.id = $param0
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_id\\": \\"id-1\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { content: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WITH this, this_connect_content1_node
+            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { content: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete nodes with bind", async () => {
+        const query = gql`
+            mutation {
+                deletePosts {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete nodes without bind", async () => {
+        const query = gql`
+            mutation {
+                deleteComments {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Comment\`)
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+
+    test("Nested Delete", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { content: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
+            CALL {
+            	WITH this_content_Comment0_to_delete
+            	UNWIND this_content_Comment0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            WITH this, this_content_Post0
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
+            CALL {
+            	WITH this_content_Post0_to_delete
+            	UNWIND this_content_Post0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/is-authenticated/interface-relationships/interface-is-authenticated.test.ts
@@ -1,0 +1,451 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("Cypher Auth isAuthenticated", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type History {
+                url: String @auth(rules: [{ operations: [READ], isAuthenticated: true }])
+            }
+
+            interface Content
+                @auth(
+                    rules: [{ operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE], isAuthenticated: true }]
+                ) {
+                id: String
+                content: String
+            }
+
+            type Comment implements Content {
+                id: String
+                content: String
+            }
+
+            type Post implements Content {
+                id: String
+                content: String
+            }
+
+            type User {
+                id: ID
+                name: String
+                password: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            extend type User
+                @auth(
+                    rules: [{ operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE], isAuthenticated: true }]
+                )
+
+            extend type User {
+                password: String @auth(rules: [{ operations: [READ, CREATE, UPDATE], isAuthenticated: true }])
+            }
+
+            extend type User {
+                history: [History]
+                    @cypher(statement: "MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h")
+                    @auth(rules: [{ operations: [READ], isAuthenticated: true }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Create Node", async () => {
+        const query = gql`
+            mutation {
+                createPosts(input: [{ id: "1", content: "content" }]) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`Post\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.content = create_var0.content
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\",
+                        \\"content\\": \\"content\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { id: "1" }, update: { id: "id-1" }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_id\\": \\"id-1\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { content: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WITH this, this_connect_content0_node
+            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WITH this, this_connect_content1_node
+            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { content: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WITH this, this_disconnect_content0, this_disconnect_content0_rel
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete", async () => {
+        const query = gql`
+            mutation {
+                deletePosts {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Nested Delete", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { content: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            WITH this, this_content_Comment0
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
+            CALL {
+            	WITH this_content_Comment0_to_delete
+            	UNWIND this_content_Comment0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            WITH this, this_content_Post0
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
+            CALL {
+            	WITH this_content_Post0_to_delete
+            	UNWIND this_content_Post0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/is-authenticated/is-authenticated.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/is-authenticated/is-authenticated.test.ts
@@ -1,0 +1,625 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../src";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../utils/tck-test-utils";
+
+describe("Cypher Auth isAuthenticated", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type History {
+                url: String @auth(rules: [{ operations: [READ], isAuthenticated: true }])
+            }
+
+            type Post {
+                id: String
+                content: String
+            }
+
+            type User {
+                id: ID
+                name: String
+                password: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User
+                @auth(
+                    rules: [{ operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE], isAuthenticated: true }]
+                )
+
+            extend type Post @auth(rules: [{ operations: [CONNECT, DISCONNECT, DELETE], isAuthenticated: true }])
+
+            extend type User {
+                password: String @auth(rules: [{ operations: [READ, CREATE, UPDATE], isAuthenticated: true }])
+            }
+
+            extend type User {
+                history: [History]
+                    @cypher(statement: "MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h")
+                    @auth(rules: [{ operations: [READ], isAuthenticated: true }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    name
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .id, .name } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Node & Field", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    name
+                    password
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .id, .name, .password } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Node & Cypher Field", async () => {
+        const query = gql`
+            {
+                users {
+                    history {
+                        url
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                UNWIND apoc.cypher.runFirstColumnMany(\\"MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h\\", { this: this, auth: $auth }) AS this0
+                RETURN collect(this0 { .url }) AS this0
+            }
+            RETURN this { history: this0 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Create Node", async () => {
+        const query = gql`
+            mutation {
+                createUsers(input: [{ id: "1" }]) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Create Node & Field", async () => {
+        const query = gql`
+            mutation {
+                createUsers(input: [{ id: "1", password: "super-password" }]) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.password = create_var0.password
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (create_var0.password IS NULL OR apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\",
+                        \\"password\\": \\"super-password\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "1" }, update: { id: "id-1" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_id\\": \\"id-1\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node & Field", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "1" }, update: { password: "password" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.password = $this_update_password
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_password\\": \\"password\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { posts: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WITH this, this_connect_posts0_node
+            	CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { posts: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0]) AND apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Nested Delete", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { posts: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            WITH this, this_posts0
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
+            CALL {
+            	WITH this_posts0_to_delete
+            	UNWIND this_posts0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT (apoc.util.validatePredicate(NOT ($auth.isAuthenticated = true), \\"@neo4j/graphql/UNAUTHENTICATED\\", [0])), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/roles-where.test.ts
@@ -1,0 +1,1569 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../src";
+import { createJwtRequest } from "../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../utils/tck-test-utils";
+
+describe("Cypher Auth Where with Roles", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            union Search = Post
+
+            type User {
+                id: ID
+                name: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+                content: [Search!]! @relationship(type: "HAS_POST", direction: OUT) # something to test unions
+            }
+
+            type Post {
+                id: ID
+                content: String
+                creator: User @relationship(type: "HAS_POST", direction: IN)
+            }
+
+            extend type User
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT]
+                            roles: ["user"]
+                            where: { id: "$jwt.sub" }
+                        }
+                        { operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT], roles: ["admin"] }
+                    ]
+                )
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ], where: { id: "$jwt.sub" } }])
+            }
+
+            extend type Post {
+                secretKey: String! @auth(rules: [{ operations: [READ], where: { creator: { id: "$jwt.sub" } } }])
+            }
+
+            extend type Post
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT]
+                            roles: ["user"]
+                            where: { creator: { id: "$jwt.sub" } }
+                        }
+                        { operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT], roles: ["admin"] }
+                    ]
+                )
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Node + User Defined Where", async () => {
+        const query = gql`
+            {
+                users(where: { name: "bob" }) {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((this.name = $param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param1\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Relationship", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    posts {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH this5 { .content } AS this5
+                RETURN collect(this5) AS var15
+            }
+            RETURN this { .id, posts: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param4\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Connection", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    postsConnection {
+                        edges {
+                            node {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH { node: { content: this5.content } } AS edge
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var15
+            }
+            RETURN this { .id, postsConnection: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param4\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Connection + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    postsConnection(where: { node: { id: "some-id" } }) {
+                        edges {
+                            node {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                WHERE (this5.id = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH { node: { content: this5.content } } AS edge
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var15
+            }
+            RETURN this { .id, postsConnection: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param3\\": \\"some-id\\",
+                \\"param5\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Union Relationship + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    posts(where: { content: "cool" }) {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                WHERE (this5.content = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH this5 { .content } AS this5
+                RETURN collect(this5) AS var15
+            }
+            RETURN this { .id, posts: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param3\\": \\"cool\\",
+                \\"param5\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Union", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    content {
+                        ... on Post {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                    WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WITH this5 { __resolveType: \\"Post\\", __id: id(this), .id } AS this5
+                    RETURN this5 AS var15
+                }
+                WITH var15
+                RETURN collect(var15) AS var15
+            }
+            RETURN this { .id, content: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param4\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Union Using Connection", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                    WHERE (((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param4)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this5), id: this5.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var15
+            }
+            RETURN this { .id, contentConnection: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param4\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Union Using Connection + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection(where: { Post: { node: { id: "some-id" } } }) {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND apoc.util.validatePredicate(NOT ((any(var1 IN [\\"user\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1)) OR any(var3 IN [\\"admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this4:HAS_POST]->(this5:\`Post\`)
+                    WHERE (this5.id = $param3 AND ((any(var7 IN [\\"user\\"] WHERE any(var6 IN $auth.roles WHERE var6 = var7)) AND (exists((this5)<-[:HAS_POST]-(:\`User\`)) AND all(this8 IN [(this5)<-[:HAS_POST]-(this8:\`User\`) | this8] WHERE (this8.id IS NOT NULL AND this8.id = $param5)))) OR any(var10 IN [\\"admin\\"] WHERE any(var9 IN $auth.roles WHERE var9 = var10))) AND apoc.util.validatePredicate(NOT ((any(var12 IN [\\"user\\"] WHERE any(var11 IN $auth.roles WHERE var11 = var12)) OR any(var14 IN [\\"admin\\"] WHERE any(var13 IN $auth.roles WHERE var13 = var14)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this5), id: this5.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var15
+            }
+            RETURN this { .id, contentConnection: var15 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"param3\\": \\"some-id\\",
+                \\"param5\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { name: "Bob" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.name = $this_update_name
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"this_update_name\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { name: "bob" }, update: { name: "Bob" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.name = $param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.name = $this_update_name
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param1\\": \\"id-01\\",
+                \\"this_update_name\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { update: { node: { id: "new-id" } } } }) {
+                    users {
+                        id
+                        posts {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this, this_posts0
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	SET this_posts0.id = $this_update_posts0_id
+            	WITH this, this_posts0
+            	CALL {
+            		WITH this_posts0
+            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:HAS_POST]-(:User)
+            		WITH count(this_posts0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator must be less than or equal to one', [0])
+            		RETURN c AS this_posts0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_posts0
+            }
+            WITH *
+            CALL {
+                WITH this
+                MATCH (this)-[update_this0:HAS_POST]->(update_this1:\`Post\`)
+                WHERE (((any(update_var3 IN [\\"user\\"] WHERE any(update_var2 IN $auth.roles WHERE update_var2 = update_var3)) AND (exists((update_this1)<-[:HAS_POST]-(:\`User\`)) AND all(update_this4 IN [(update_this1)<-[:HAS_POST]-(update_this4:\`User\`) | update_this4] WHERE (update_this4.id IS NOT NULL AND update_this4.id = $update_param1)))) OR any(update_var6 IN [\\"admin\\"] WHERE any(update_var5 IN $auth.roles WHERE update_var5 = update_var6))) AND apoc.util.validatePredicate(NOT ((any(update_var8 IN [\\"user\\"] WHERE any(update_var7 IN $auth.roles WHERE update_var7 = update_var8)) OR any(update_var10 IN [\\"admin\\"] WHERE any(update_var9 IN $auth.roles WHERE update_var9 = update_var10)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WITH update_this1 { .id } AS update_this1
+                RETURN collect(update_this1) AS update_var11
+            }
+            RETURN collect(DISTINCT this { .id, posts: update_var11 }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"update_param1\\": \\"id-01\\",
+                \\"auth_param1\\": \\"id-01\\",
+                \\"this_posts0auth_param1\\": \\"id-01\\",
+                \\"this_update_posts0_id\\": \\"new-id\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete Nested Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { posts: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            WITH this, this_posts0
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
+            CALL {
+            	WITH this_posts0_to_delete
+            	UNWIND this_posts0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"this_posts0auth_param1\\": \\"id-01\\",
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect Node (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        { id: "123", name: "Bob", password: "password", posts: { connect: { where: { node: {} } } } }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this0, this0_posts_connect0_node
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_posts_connect0_node
+            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_posts_connect0_node
+            	RETURN count(*) AS connect_this0_posts_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_posts_connect0_nodeauth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "123"
+                            name: "Bob"
+                            password: "password"
+                            posts: { connect: { where: { node: { id: "post-id" } } } }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this0_posts_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this0, this0_posts_connect0_node
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_posts_connect0_node
+            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_posts_connect0_node
+            	RETURN count(*) AS connect_this0_posts_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_posts_connect0_node_param0\\": \\"post-id\\",
+                \\"this0_posts_connect0_nodeauth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { connect: { where: { node: {} } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this, this_posts0_connect0_node
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_posts0_connect0_node
+            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_posts0_connect0_node
+            	RETURN count(*) AS connect_this_posts0_connect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"this_posts0_connect0_nodeauth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { connect: { where: { node: { id: "new-id" } } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_connect0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this, this_posts0_connect0_node
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_posts0_connect0_node
+            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_posts0_connect0_node
+            	RETURN count(*) AS connect_this_posts0_connect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"this_posts0_connect0_node_param0\\": \\"new-id\\",
+                \\"this_posts0_connect0_nodeauth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect Node (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { posts: { where: { node: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this, this_connect_posts0_node
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"this_connect_posts0_nodeauth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { posts: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_connect_posts0_nodeauth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            	WITH this, this_connect_posts0_node
+            	CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"this_connect_posts0_node_param0\\": \\"some-id\\",
+                \\"this_connect_posts0_nodeauth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { disconnect: { where: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	UNWIND this_posts0_disconnect0 as x
+            	DELETE this_posts0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"this_posts0_disconnect0auth_param1\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: [{ disconnect: { where: { node: { id: "new-id" } } } }] }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_posts0_disconnect0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            WITH this, this_posts0_disconnect0, this_posts0_disconnect0_rel
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	UNWIND this_posts0_disconnect0 as x
+            	DELETE this_posts0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0\\": \\"new-id\\",
+                \\"this_posts0_disconnect0auth_param1\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"disconnect\\": [
+                                        {
+                                            \\"where\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"new-id\\"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { posts: { where: {} } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"this_disconnect_posts0auth_param1\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {}
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { posts: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $auth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            WHERE ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (this.id IS NOT NULL AND this.id = $thisauth_param1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this2 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this2:\`User\`) | auth_this2] WHERE (auth_this2.id IS NOT NULL AND auth_this2.id = $this_disconnect_posts0auth_param1)))) OR any(auth_var4 IN [\\"admin\\"] WHERE any(auth_var3 IN $auth.roles WHERE auth_var3 = auth_var4)))
+            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+            CALL apoc.util.validate(NOT ((any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3))) AND (any(auth_var1 IN [\\"user\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) OR any(auth_var3 IN [\\"admin\\"] WHERE any(auth_var2 IN $auth.roles WHERE auth_var2 = auth_var3)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param1\\": \\"id-01\\",
+                \\"thisauth_param1\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"some-id\\",
+                \\"this_disconnect_posts0auth_param1\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"some-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"id-01\\"
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/roles/roles.test.ts
@@ -1,0 +1,824 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "apollo-server";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../../../utils/tck-test-utils";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+
+describe("Cypher Auth Roles", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type History {
+                url: String @auth(rules: [{ operations: [READ], roles: ["super-admin"] }])
+            }
+
+            type Comment {
+                id: String
+                content: String
+                post: Post! @relationship(type: "HAS_COMMENT", direction: IN)
+            }
+
+            type Post {
+                id: String
+                content: String
+                creator: User! @relationship(type: "HAS_POST", direction: OUT)
+                comments: [Comment!]! @relationship(type: "HAS_COMMENT", direction: OUT)
+            }
+
+            type User {
+                id: ID
+                name: String
+                password: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, CREATE, UPDATE, CONNECT, DISCONNECT, DELETE], roles: ["admin"] }])
+
+            extend type Post @auth(rules: [{ operations: [CONNECT, DISCONNECT, DELETE], roles: ["super-admin"] }])
+
+            extend type User {
+                password: String @auth(rules: [{ operations: [READ, CREATE, UPDATE], roles: ["super-admin"] }])
+            }
+
+            extend type User {
+                history: [History]
+                    @cypher(statement: "MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h")
+                    @auth(rules: [{ operations: [READ], roles: ["super-admin"] }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    name
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT (any(var1 IN [\\"admin\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .id, .name } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Node & Field", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    name
+                    password
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT (any(var1 IN [\\"admin\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT (any(var3 IN [\\"super-admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this { .id, .name, .password } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Read Node & Cypher Field", async () => {
+        const query = gql`
+            {
+                users {
+                    history {
+                        url
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT (any(var1 IN [\\"admin\\"] WHERE any(var0 IN $auth.roles WHERE var0 = var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT (any(var3 IN [\\"super-admin\\"] WHERE any(var2 IN $auth.roles WHERE var2 = var3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                UNWIND apoc.cypher.runFirstColumnMany(\\"MATCH (this)-[:HAS_HISTORY]->(h:History) RETURN h\\", { this: this, auth: $auth }) AS this4
+                RETURN collect(this4 { .url }) AS this4
+            }
+            RETURN this { history: this4 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Create Node", async () => {
+        const query = gql`
+            mutation {
+                createUsers(input: [{ id: "1" }]) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (any(create_var3 IN [\\"admin\\"] WHERE any(create_var2 IN $auth.roles WHERE create_var2 = create_var3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Create Node & Field", async () => {
+        const query = gql`
+            mutation {
+                createUsers(input: [{ id: "1", password: "super-password" }]) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id,
+                    create_this1.password = create_var0.password
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (any(create_var3 IN [\\"admin\\"] WHERE any(create_var2 IN $auth.roles WHERE create_var2 = create_var3))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH *
+                WHERE apoc.util.validatePredicate(NOT (create_var0.password IS NULL OR any(create_var5 IN [\\"super-admin\\"] WHERE any(create_var4 IN $auth.roles WHERE create_var4 = create_var5))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"1\\",
+                        \\"password\\": \\"super-password\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "1" }, update: { id: "id-1" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_id\\": \\"id-1\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Update Node & Field", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { id: "1" }, update: { password: "password" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE this.id = $param0
+            WITH this
+            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.password = $this_update_password
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"1\\",
+                \\"this_update_password\\": \\"password\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Connect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { posts: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WITH this, this_connect_posts0_node
+            	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Nested Connect", async () => {
+        const query = gql`
+            mutation {
+                updateComments(
+                    update: {
+                        post: { update: { node: { creator: { connect: { where: { node: { id: "user-id" } } } } } } }
+                    }
+                ) {
+                    comments {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Comment\`)
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+            	WITH this, this_post0
+            	CALL {
+            		WITH this, this_post0
+            		OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
+            		WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_param0
+            		WITH this, this_post0, this_post0_creator0_connect0_node
+            		CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		CALL {
+            			WITH *
+            			WITH this, collect(this_post0_creator0_connect0_node) as connectedNodes, collect(this_post0) as parentNodes
+            			CALL {
+            				WITH connectedNodes, parentNodes
+            				UNWIND parentNodes as this_post0
+            				UNWIND connectedNodes as this_post0_creator0_connect0_node
+            				MERGE (this_post0)-[:HAS_POST]->(this_post0_creator0_connect0_node)
+            				RETURN count(*) AS _
+            			}
+            			RETURN count(*) AS _
+            		}
+            	WITH this, this_post0, this_post0_creator0_connect0_node
+            		RETURN count(*) AS connect_this_post0_creator0_connect_User
+            	}
+            	WITH this, this_post0
+            	CALL {
+            		WITH this_post0
+            		MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+            		WITH count(this_post0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_post0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_post0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	WITH count(this_post_Post_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
+            	RETURN c AS this_post_Post_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .content }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this_post0_creator0_connect0_node_param0\\": \\"user-id\\",
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Disconnect", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { posts: {} }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WITH this, this_disconnect_posts0, this_disconnect_posts0_rel
+            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {}
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Nested Disconnect", async () => {
+        const query = gql`
+            mutation {
+                updateComments(
+                    update: {
+                        post: { update: { node: { creator: { disconnect: { where: { node: { id: "user-id" } } } } } } }
+                    }
+                ) {
+                    comments {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Comment\`)
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_has_comment0_relationship:HAS_COMMENT]-(this_post0:Post)
+            	WITH this, this_post0
+            	CALL {
+            	WITH this, this_post0
+            	OPTIONAL MATCH (this_post0)-[this_post0_creator0_disconnect0_rel:HAS_POST]->(this_post0_creator0_disconnect0:User)
+            	WHERE this_post0_creator0_disconnect0.id = $updateComments_args_update_post_update_node_creator_disconnect_where_User_this_post0_creator0_disconnect0param0
+            	WITH this, this_post0, this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel
+            	CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1)) AND any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	CALL {
+            		WITH this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel, this_post0
+            		WITH collect(this_post0_creator0_disconnect0) as this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel, this_post0
+            		UNWIND this_post0_creator0_disconnect0 as x
+            		DELETE this_post0_creator0_disconnect0_rel
+            		RETURN count(*) AS _
+            	}
+            	RETURN count(*) AS disconnect_this_post0_creator0_disconnect_User
+            	}
+            	WITH this, this_post0
+            	CALL {
+            		WITH this_post0
+            		MATCH (this_post0)-[this_post0_creator_User_unique:HAS_POST]->(:User)
+            		WITH count(this_post0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_post0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_post0
+            }
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_post_Post_unique:HAS_COMMENT]-(:Post)
+            	WITH count(this_post_Post_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.post required exactly once', [0])
+            	RETURN c AS this_post_Post_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .content }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"updateComments_args_update_post_update_node_creator_disconnect_where_User_this_post0_creator0_disconnect0param0\\": \\"user-id\\",
+                \\"updateComments\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"post\\": {
+                                \\"update\\": {
+                                    \\"node\\": {
+                                        \\"creator\\": {
+                                            \\"disconnect\\": {
+                                                \\"where\\": {
+                                                    \\"node\\": {
+                                                        \\"id\\": \\"user-id\\"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {},
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Delete", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+
+    test("Nested Delete", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { posts: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            WITH this, this_posts0
+            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"super-admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
+            CALL {
+            	WITH this_posts0_to_delete
+            	UNWIND this_posts0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            CALL apoc.util.validate(NOT (any(auth_var1 IN [\\"admin\\"] WHERE any(auth_var0 IN $auth.roles WHERE auth_var0 = auth_var1))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth\\": {
+                    \\"isAuthenticated\\": true,
+                    \\"roles\\": [
+                        \\"admin\\"
+                    ],
+                    \\"jwt\\": {
+                        \\"roles\\": [
+                            \\"admin\\"
+                        ],
+                        \\"sub\\": \\"super_admin\\"
+                    }
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/where/interface-relationships/implementation-where.test.ts
@@ -1,0 +1,1364 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("Cypher Auth Where", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            type Comment implements Content {
+                id: ID
+                content: String
+                creator: User!
+            }
+
+            type Post implements Content
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT]
+                            where: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                ) {
+                id: ID
+                content: String
+                creator: User!
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT], where: { id: "$jwt.sub" } }])
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ], where: { id: "$jwt.sub" } }])
+            }
+
+            extend type Post {
+                secretKey: String! @auth(rules: [{ operations: [READ], where: { creator: { id: "$jwt.sub" } } }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                posts {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Node + User Defined Where", async () => {
+        const query = gql`
+            {
+                posts(where: { content: "bob" }) {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read interface relationship field", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    content {
+                        ... on Post {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
+                    RETURN this1 AS var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
+                    WHERE (exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param1)))
+                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS this4
+                    RETURN this4 AS var2
+                }
+                WITH var2
+                RETURN collect(var2) AS var2
+            }
+            RETURN this { .id, content: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read interface relationship Using Connection", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
+                    RETURN edge
+                    UNION
+                    WITH this
+                    MATCH (this)-[this2:HAS_CONTENT]->(this3:\`Post\`)
+                    WHERE (exists((this3)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this4 IN [(this3)<-[:HAS_CONTENT]-(this4:\`User\`) | this4] WHERE (this4.id IS NOT NULL AND this4.id = $param1)))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var5
+            }
+            RETURN this { .id, contentConnection: var5 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read interface relationship Using Connection + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection(where: { node: { id: "some-id" } }) {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE this1.id = $param1
+                    WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
+                    RETURN edge
+                    UNION
+                    WITH this
+                    MATCH (this)-[this2:HAS_CONTENT]->(this3:\`Post\`)
+                    WHERE (this3.id = $param2 AND (exists((this3)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this4 IN [(this3)<-[:HAS_CONTENT]-(this4:\`User\`) | this4] WHERE (this4.id IS NOT NULL AND this4.id = $param3))))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var5
+            }
+            RETURN this { .id, contentConnection: var5 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"some-id\\",
+                \\"param2\\": \\"some-id\\",
+                \\"param3\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(update: { content: "Bob" }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            SET this.content = $this_update_content
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_content\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { content: "bob" }, update: { content: "Bob" }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            SET this.content = $this_update_content
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_content\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { update: { node: { id: "new-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_content0_id\\": \\"new-id\\",
+                \\"this_content0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deletePosts {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Delete Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                deletePosts(where: { content: "Bob" }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Bob\\",
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Delete Nested Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { content: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
+            CALL {
+            	WITH this_content_Comment0_to_delete
+            	UNWIND this_content_Comment0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
+            WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
+            CALL {
+            	WITH this_content_Post0_to_delete
+            	UNWIND this_content_Post0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_content_Post0auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Connect Node (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        { id: "123", name: "Bob", password: "password", content: { connect: { where: { node: {} } } } }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect0_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect0_node
+            	RETURN count(*) AS connect_this0_content_connect_Comment
+            }
+            CALL {
+            		WITH this0
+            	OPTIONAL MATCH (this0_content_connect1_node:Post)
+            	WHERE (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect1_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect1_node
+            	RETURN count(*) AS connect_this0_content_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_content_connect1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "123"
+                            name: "Bob"
+                            password: "password"
+                            content: { connect: { where: { node: { id: "post-id" } } } }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect0_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect0_node
+            	RETURN count(*) AS connect_this0_content_connect_Comment
+            }
+            CALL {
+            		WITH this0
+            	OPTIONAL MATCH (this0_content_connect1_node:Post)
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect1_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect1_node
+            	RETURN count(*) AS connect_this0_content_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_content_connect0_node_param0\\": \\"post-id\\",
+                \\"this0_content_connect1_node_param0\\": \\"post-id\\",
+                \\"this0_content_connect1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { connect: { where: { node: {} } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Post)
+            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_content0_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { connect: { where: { node: { id: "new-id" } } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Post)
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_content0_connect0_node_param0\\": \\"new-id\\",
+                \\"this_content0_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { content: { where: { node: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { content: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_connect_content0_node_param0\\": \\"some-id\\",
+                \\"this_connect_content1_node_param0\\": \\"some-id\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { disconnect: { where: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_content0_disconnect0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: [{ disconnect: { where: { node: { id: "new-id" } } } }] }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0\\": \\"new-id\\",
+                \\"updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0\\": \\"new-id\\",
+                \\"this_content0_disconnect0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"content\\": [
+                                {
+                                    \\"disconnect\\": [
+                                        {
+                                            \\"where\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"new-id\\"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { content: { where: {} } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_disconnect_content0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {}
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { content: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"some-id\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"some-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"some-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/where/interface-relationships/interface-where.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/where/interface-relationships/interface-where.test.ts
@@ -1,0 +1,1381 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../../src";
+import { createJwtRequest } from "../../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../../utils/tck-test-utils";
+
+describe("Cypher Auth Where", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Content
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT]
+                            where: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                ) {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_CONTENT", direction: IN)
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "HAS_CONTENT", direction: OUT)
+            }
+
+            type Comment implements Content {
+                id: ID
+                content: String
+                creator: User!
+            }
+
+            type Post implements Content {
+                id: ID
+                content: String
+                creator: User!
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT], where: { id: "$jwt.sub" } }])
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ], where: { id: "$jwt.sub" } }])
+            }
+
+            extend type Post {
+                secretKey: String! @auth(rules: [{ operations: [READ], where: { creator: { id: "$jwt.sub" } } }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                posts {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Node + User Defined Where", async () => {
+        const query = gql`
+            {
+                posts(where: { content: "bob" }) {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read interface relationship field", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    content {
+                        ... on Post {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE (exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this) } AS this1
+                    RETURN this1 AS var3
+                    UNION
+                    WITH *
+                    MATCH (this)-[this4:HAS_CONTENT]->(this5:\`Post\`)
+                    WHERE (exists((this5)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this6 IN [(this5)<-[:HAS_CONTENT]-(this6:\`User\`) | this6] WHERE (this6.id IS NOT NULL AND this6.id = $param2)))
+                    WITH this5 { __resolveType: \\"Post\\", __id: id(this), .id } AS this5
+                    RETURN this5 AS var3
+                }
+                WITH var3
+                RETURN collect(var3) AS var3
+            }
+            RETURN this { .id, content: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read interface relationship Using Connection", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE (exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
+                    RETURN edge
+                    UNION
+                    WITH this
+                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
+                    WHERE (exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param2)))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this4), id: this4.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var6
+            }
+            RETURN this { .id, contentConnection: var6 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read interface relationship Using Connection + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection(where: { node: { id: "some-id" } }) {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
+                    WHERE (this1.id = $param1 AND (exists((this1)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_CONTENT]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                    WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
+                    RETURN edge
+                    UNION
+                    WITH this
+                    MATCH (this)-[this3:HAS_CONTENT]->(this4:\`Post\`)
+                    WHERE (this4.id = $param3 AND (exists((this4)<-[:HAS_CONTENT]-(:\`User\`)) AND all(this5 IN [(this4)<-[:HAS_CONTENT]-(this5:\`User\`) | this5] WHERE (this5.id IS NOT NULL AND this5.id = $param4))))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this4), id: this4.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var6
+            }
+            RETURN this { .id, contentConnection: var6 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"some-id\\",
+                \\"param2\\": \\"id-01\\",
+                \\"param3\\": \\"some-id\\",
+                \\"param4\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(update: { content: "Bob" }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            SET this.content = $this_update_content
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_content\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                updatePosts(where: { content: "bob" }, update: { content: "Bob" }) {
+                    posts {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            SET this.content = $this_update_content
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)<-[this_creator_User_unique:HAS_CONTENT]-(:User)
+            	WITH count(this_creator_User_unique) as c
+            	CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            	RETURN c AS this_creator_User_unique_ignored
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_content\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { update: { node: { id: "new-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Comment)
+            	WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDComment.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
+            	WHERE (exists((this_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0auth_param0)))
+            	SET this_content0.id = $this_update_content0_id
+            	WITH this, this_content0
+            	CALL {
+            		WITH this_content0
+            		MATCH (this_content0)<-[this_content0_creator_User_unique:HAS_CONTENT]-(:User)
+            		WITH count(this_content0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_content0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_content0
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_content0auth_param0\\": \\"id-01\\",
+                \\"this_update_content0_id\\": \\"new-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deletePosts {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0)))
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Delete Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                deletePosts(where: { content: "Bob" }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Post\`)
+            WHERE (this.content = $param0 AND (exists((this)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $auth_param0))))
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Bob\\",
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Delete Nested Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { content: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
+            WHERE (exists((this_content_Comment0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Comment0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Comment0auth_param0)))
+            WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
+            CALL {
+            	WITH this_content_Comment0_to_delete
+            	UNWIND this_content_Comment0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            WITH this
+            OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
+            WHERE (exists((this_content_Post0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content_Post0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content_Post0auth_param0)))
+            WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
+            CALL {
+            	WITH this_content_Post0_to_delete
+            	UNWIND this_content_Post0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_content_Comment0auth_param0\\": \\"id-01\\",
+                \\"this_content_Post0auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Connect Node (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        { id: "123", name: "Bob", password: "password", content: { connect: { where: { node: {} } } } }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+            	WHERE (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect0_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect0_node
+            	RETURN count(*) AS connect_this0_content_connect_Comment
+            }
+            CALL {
+            		WITH this0
+            	OPTIONAL MATCH (this0_content_connect1_node:Post)
+            	WHERE (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect1_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect1_node
+            	RETURN count(*) AS connect_this0_content_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_content_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0_content_connect1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "123"
+                            name: "Bob"
+                            password: "password"
+                            content: { connect: { where: { node: { id: "post-id" } } } }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_content_connect0_node:Comment)
+            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND (exists((this0_content_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect0_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect0_node
+            	RETURN count(*) AS connect_this0_content_connect_Comment
+            }
+            CALL {
+            		WITH this0
+            	OPTIONAL MATCH (this0_content_connect1_node:Post)
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (exists((this0_content_connect1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this0_content_connect1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_content_connect1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_content_connect1_node
+            			MERGE (this0)-[:HAS_CONTENT]->(this0_content_connect1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_content_connect1_node
+            	RETURN count(*) AS connect_this0_content_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_content_connect0_node_param0\\": \\"post-id\\",
+                \\"this0_content_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"this0_content_connect1_node_param0\\": \\"post-id\\",
+                \\"this0_content_connect1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { connect: { where: { node: {} } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Post)
+            	WHERE (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_content0_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { connect: { where: { node: { id: "new-id" } } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Comment)
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_content0_connect0_node:Post)
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (exists((this_content0_connect0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_connect0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_content0_connect0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_content0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_content0_connect0_node
+            	RETURN count(*) AS connect_this_content0_connect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_content0_connect0_node_param0\\": \\"new-id\\",
+                \\"this_content0_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { content: { where: { node: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_connect_content0_nodeauth_param0\\": \\"id-01\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { content: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_content0_node:Comment)
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND (exists((this_connect_content0_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content0_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content0_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content0_node
+            	RETURN count(*) AS connect_this_connect_content_Comment
+            }
+            CALL {
+            		WITH this
+            	OPTIONAL MATCH (this_connect_content1_node:Post)
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (exists((this_connect_content1_node)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_content1_node)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_content1_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_content1_node
+            			MERGE (this)-[:HAS_CONTENT]->(this_connect_content1_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_content1_node
+            	RETURN count(*) AS connect_this_connect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_connect_content0_node_param0\\": \\"some-id\\",
+                \\"this_connect_content0_nodeauth_param0\\": \\"id-01\\",
+                \\"this_connect_content1_node_param0\\": \\"some-id\\",
+                \\"this_connect_content1_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: { disconnect: { where: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+            WHERE (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_content0_disconnect0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { content: [{ disconnect: { where: { node: { id: "new-id" } } } }] }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	 WITH this
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Comment
+            }
+            RETURN count(*) AS update_this_Comment
+            }
+            CALL {
+            	 WITH this
+            	WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (exists((this_content0_disconnect0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_content0_disconnect0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_content0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
+            	UNWIND this_content0_disconnect0 as x
+            	DELETE this_content0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_content0_disconnect_Post
+            }
+            RETURN count(*) AS update_this_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0\\": \\"new-id\\",
+                \\"this_content0_disconnect0auth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0\\": \\"new-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"content\\": [
+                                {
+                                    \\"disconnect\\": [
+                                        {
+                                            \\"where\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"new-id\\"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { content: { where: {} } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_disconnect_content0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {}
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { content: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Comment
+            }
+            CALL {
+            	WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (exists((this_disconnect_content0)<-[:HAS_CONTENT]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_content0)<-[:HAS_CONTENT]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_content0auth_param0)))
+            CALL {
+            	WITH this_disconnect_content0, this_disconnect_content0_rel, this
+            	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
+            	UNWIND this_disconnect_content0 as x
+            	DELETE this_disconnect_content0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_content_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"some-id\\",
+                \\"this_disconnect_content0auth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"some-id\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"content\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"some-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/arguments/where/where.test.ts
@@ -1,0 +1,1256 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../../../src";
+import { createJwtRequest } from "../../../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../../../utils/tck-test-utils";
+
+describe("Cypher Auth Where", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            union Search = Post
+
+            type User {
+                id: ID
+                name: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+                content: [Search!]! @relationship(type: "HAS_POST", direction: OUT) # something to test unions
+            }
+
+            type Post {
+                id: ID
+                content: String
+                creator: User! @relationship(type: "HAS_POST", direction: IN)
+            }
+
+            extend type User
+                @auth(rules: [{ operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT], where: { id: "$jwt.sub" } }])
+
+            extend type User {
+                password: String! @auth(rules: [{ operations: [READ], where: { id: "$jwt.sub" } }])
+            }
+
+            extend type Post {
+                secretKey: String! @auth(rules: [{ operations: [READ], where: { creator: { id: "$jwt.sub" } } }])
+            }
+
+            extend type Post
+                @auth(
+                    rules: [
+                        {
+                            operations: [READ, UPDATE, DELETE, CONNECT, DISCONNECT]
+                            where: { creator: { id: "$jwt.sub" } }
+                        }
+                    ]
+                )
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Read Node", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Node + User Defined Where", async () => {
+        const query = gql`
+            {
+                users(where: { name: "bob" }) {
+                    id
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.name = $param0 AND (this.id IS NOT NULL AND this.id = $auth_param0))
+            RETURN this { .id } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Relationship", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    posts {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                WITH this1 { .content } AS this1
+                RETURN collect(this1) AS var3
+            }
+            RETURN this { .id, posts: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Connection", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    postsConnection {
+                        edges {
+                            node {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                WITH { node: { content: this1.content } } AS edge
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var3
+            }
+            RETURN this { .id, postsConnection: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Connection + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    postsConnection(where: { node: { id: "some-id" } }) {
+                        edges {
+                            node {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE (this1.id = $param1 AND (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                WITH { node: { content: this1.content } } AS edge
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var3
+            }
+            RETURN this { .id, postsConnection: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"some-id\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Union Relationship + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    posts(where: { content: "cool" }) {
+                        content
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE (this1.content = $param1 AND (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                WITH this1 { .content } AS this1
+                RETURN collect(this1) AS var3
+            }
+            RETURN this { .id, posts: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"cool\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Union", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    content {
+                        ... on Post {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                    WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
+                    RETURN this1 AS var3
+                }
+                WITH var3
+                RETURN collect(var3) AS var3
+            }
+            RETURN this { .id, content: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Union Using Connection", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                    WHERE (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var3
+            }
+            RETURN this { .id, contentConnection: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Read Union Using Connection + User Defined Where", async () => {
+        const query = gql`
+            {
+                users {
+                    id
+                    contentConnection(where: { Post: { node: { id: "some-id" } } }) {
+                        edges {
+                            node {
+                                ... on Post {
+                                    id
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                    WHERE (this1.id = $param1 AND (exists((this1)<-[:HAS_POST]-(:\`User\`)) AND all(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param2))))
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var3
+            }
+            RETURN this { .id, contentConnection: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"param1\\": \\"some-id\\",
+                \\"param2\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { name: "Bob" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            SET this.name = $this_update_name
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_name\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(where: { name: "bob" }, update: { name: "Bob" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.name = $param0 AND (this.id IS NOT NULL AND this.id = $auth_param0))
+            SET this.name = $this_update_name
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"bob\\",
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_update_name\\": \\"Bob\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Update Nested Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { update: { node: { id: "new-id" } } } }) {
+                    users {
+                        id
+                        posts {
+                            id
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
+            	WHERE (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
+            	SET this_posts0.id = $this_update_posts0_id
+            	WITH this, this_posts0
+            	CALL {
+            		WITH this_posts0
+            		MATCH (this_posts0)<-[this_posts0_creator_User_unique:HAS_POST]-(:User)
+            		WITH count(this_posts0_creator_User_unique) as c
+            		CALL apoc.util.validate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDPost.creator required exactly once', [0])
+            		RETURN c AS this_posts0_creator_User_unique_ignored
+            	}
+            	RETURN count(*) AS update_this_posts0
+            }
+            WITH *
+            CALL {
+                WITH this
+                MATCH (this)-[update_this0:HAS_POST]->(update_this1:\`Post\`)
+                WHERE (exists((update_this1)<-[:HAS_POST]-(:\`User\`)) AND all(update_this2 IN [(update_this1)<-[:HAS_POST]-(update_this2:\`User\`) | update_this2] WHERE (update_this2.id IS NOT NULL AND update_this2.id = $update_param0)))
+                WITH update_this1 { .id } AS update_this1
+                RETURN collect(update_this1) AS update_var3
+            }
+            RETURN collect(DISTINCT this { .id, posts: update_var3 }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"update_param0\\": \\"id-01\\",
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_posts0auth_param0\\": \\"id-01\\",
+                \\"this_update_posts0_id\\": \\"new-id\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Delete Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Delete Node + User Defined Where", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(where: { name: "Bob" }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.name = $param0 AND (this.id IS NOT NULL AND this.id = $auth_param0))
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"Bob\\",
+                \\"auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Delete Nested Node", async () => {
+        const query = gql`
+            mutation {
+                deleteUsers(delete: { posts: { where: {} } }) {
+                    nodesDeleted
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
+            WHERE (exists((this_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0auth_param0)))
+            WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
+            CALL {
+            	WITH this_posts0_to_delete
+            	UNWIND this_posts0_to_delete AS x
+            	DETACH DELETE x
+            	RETURN count(*) AS _
+            }
+            DETACH DELETE this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"this_posts0auth_param0\\": \\"id-01\\"
+            }"
+        `);
+    });
+
+    test("Connect Node (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        { id: "123", name: "Bob", password: "password", posts: { connect: { where: { node: {} } } } }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+            	WHERE (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_posts_connect0_node
+            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_posts_connect0_node
+            	RETURN count(*) AS connect_this0_posts_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_posts_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from create)", async () => {
+        const query = gql`
+            mutation {
+                createUsers(
+                    input: [
+                        {
+                            id: "123"
+                            name: "Bob"
+                            password: "password"
+                            posts: { connect: { where: { node: { id: "post-id" } } } }
+                        }
+                    ]
+                ) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:User)
+            SET this0.id = $this0_id
+            SET this0.name = $this0_name
+            SET this0.password = $this0_password
+            WITH this0
+            CALL {
+            	WITH this0
+            	OPTIONAL MATCH (this0_posts_connect0_node:Post)
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (exists((this0_posts_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this0_posts_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this0
+            			UNWIND connectedNodes as this0_posts_connect0_node
+            			MERGE (this0)-[:HAS_POST]->(this0_posts_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this0, this0_posts_connect0_node
+            	RETURN count(*) AS connect_this0_posts_connect_Post
+            }
+            RETURN this0
+            }
+            RETURN [ this0 { .id } ] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"this0_id\\": \\"123\\",
+                \\"this0_name\\": \\"Bob\\",
+                \\"this0_password\\": \\"password\\",
+                \\"this0_posts_connect0_node_param0\\": \\"post-id\\",
+                \\"this0_posts_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { connect: { where: { node: {} } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+            	WHERE (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_posts0_connect0_node
+            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_posts0_connect0_node
+            	RETURN count(*) AS connect_this_posts0_connect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_posts0_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { connect: { where: { node: { id: "new-id" } } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_posts0_connect0_node:Post)
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (exists((this_posts0_connect0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_connect0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_posts0_connect0_node
+            			MERGE (this)-[:HAS_POST]->(this_posts0_connect0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_posts0_connect0_node
+            	RETURN count(*) AS connect_this_posts0_connect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_posts0_connect0_node_param0\\": \\"new-id\\",
+                \\"this_posts0_connect0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { posts: { where: { node: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WHERE (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_connect_posts0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Connect Node + User Defined Where (from update connect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(connect: { posts: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            	WITH this
+            	OPTIONAL MATCH (this_connect_posts0_node:Post)
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (exists((this_connect_posts0_node)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_connect_posts0_nodeauth_param0)))
+            	CALL {
+            		WITH *
+            		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
+            		CALL {
+            			WITH connectedNodes, parentNodes
+            			UNWIND parentNodes as this
+            			UNWIND connectedNodes as this_connect_posts0_node
+            			MERGE (this)-[:HAS_POST]->(this_connect_posts0_node)
+            			RETURN count(*) AS _
+            		}
+            		RETURN count(*) AS _
+            	}
+            WITH this, this_connect_posts0_node
+            	RETURN count(*) AS connect_this_connect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_connect_posts0_node_param0\\": \\"some-id\\",
+                \\"this_connect_posts0_nodeauth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: { disconnect: { where: {} } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+            WHERE (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	UNWIND this_posts0_disconnect0 as x
+            	DELETE this_posts0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_posts0_disconnect0auth_param0\\": \\"id-01\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update update)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { posts: [{ disconnect: { where: { node: { id: "new-id" } } } }] }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (exists((this_posts0_disconnect0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_posts0_disconnect0auth_param0)))
+            CALL {
+            	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
+            	UNWIND this_posts0_disconnect0 as x
+            	DELETE this_posts0_disconnect0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_posts0_disconnect_Post
+            }
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0\\": \\"new-id\\",
+                \\"this_posts0_disconnect0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"update\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"disconnect\\": [
+                                        {
+                                            \\"where\\": {
+                                                \\"node\\": {
+                                                    \\"id\\": \\"new-id\\"
+                                                }
+                                            }
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { posts: { where: {} } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WHERE (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"this_disconnect_posts0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {}
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Disconnect Node + User Defined Where (from update disconnect)", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(disconnect: { posts: { where: { node: { id: "some-id" } } } }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "id-01", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE (this.id IS NOT NULL AND this.id = $auth_param0)
+            WITH this
+            WHERE (this.id IS NOT NULL AND this.id = $thisauth_param0)
+            WITH this
+            CALL {
+            WITH this
+            OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (exists((this_disconnect_posts0)<-[:HAS_POST]-(:\`User\`)) AND all(auth_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(auth_this0:\`User\`) | auth_this0] WHERE (auth_this0.id IS NOT NULL AND auth_this0.id = $this_disconnect_posts0auth_param0)))
+            CALL {
+            	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
+            	UNWIND this_disconnect_posts0 as x
+            	DELETE this_disconnect_posts0_rel
+            	RETURN count(*) AS _
+            }
+            RETURN count(*) AS disconnect_this_disconnect_posts_Post
+            }
+            WITH *
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"auth_param0\\": \\"id-01\\",
+                \\"thisauth_param0\\": \\"id-01\\",
+                \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"some-id\\",
+                \\"this_disconnect_posts0auth_param0\\": \\"id-01\\",
+                \\"updateUsers\\": {
+                    \\"args\\": {
+                        \\"disconnect\\": {
+                            \\"posts\\": [
+                                {
+                                    \\"where\\": {
+                                        \\"node\\": {
+                                            \\"id\\": \\"some-id\\"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                },
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/projection-connection-union.test.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("Cypher Auth Projection On Connections On Unions", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Post {
+                content: String
+                creator: User! @relationship(type: "HAS_POST", direction: IN)
+            }
+
+            type User {
+                id: ID
+                name: String
+                content: [Content!]! @relationship(type: "PUBLISHED", direction: OUT)
+            }
+
+            union Content = Post
+
+            extend type User @auth(rules: [{ allow: { id: "$jwt.sub" } }])
+            extend type Post @auth(rules: [{ allow: { creator: { id: "$jwt.sub" } } }])
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Two connection", async () => {
+        const query = gql`
+            {
+                users {
+                    contentConnection {
+                        edges {
+                            node {
+                                ... on Post {
+                                    content
+                                    creatorConnection {
+                                        edges {
+                                            node {
+                                                name
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin" });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:PUBLISHED]->(this1:\`Post\`)
+                    WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    CALL {
+                        WITH this1
+                        MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)
+                        WHERE apoc.util.validatePredicate(NOT ((this4.id IS NOT NULL AND this4.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        WITH { node: { name: this4.name } } AS edge
+                        WITH collect(edge) AS edges
+                        WITH edges, size(edges) AS totalCount
+                        RETURN { edges: edges, totalCount: totalCount } AS var5
+                    }
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var5 } } AS edge
+                    RETURN edge
+                }
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var6
+            }
+            RETURN this { contentConnection: var6 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"super_admin\\",
+                \\"param1\\": \\"super_admin\\",
+                \\"param2\\": \\"super_admin\\"
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/projection-connection.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("Cypher Auth Projection On Connections", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type Post {
+                content: String
+                creator: User! @relationship(type: "HAS_POST", direction: IN)
+            }
+
+            type User {
+                id: ID
+                name: String
+                posts: [Post!]! @relationship(type: "HAS_POST", direction: OUT)
+            }
+
+            extend type User @auth(rules: [{ allow: { id: "$jwt.sub" } }])
+            extend type Post @auth(rules: [{ allow: { creator: { id: "$jwt.sub" } } }])
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("One connection", async () => {
+        const query = gql`
+            {
+                users {
+                    name
+                    postsConnection {
+                        edges {
+                            node {
+                                content
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin" });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WITH { node: { content: this1.content } } AS edge
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var3
+            }
+            RETURN this { .name, postsConnection: var3 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"super_admin\\",
+                \\"param1\\": \\"super_admin\\"
+            }"
+        `);
+    });
+
+    test("Two connection", async () => {
+        const query = gql`
+            {
+                users {
+                    name
+                    postsConnection {
+                        edges {
+                            node {
+                                content
+                                creatorConnection {
+                                    edges {
+                                        node {
+                                            name
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin" });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            CALL {
+                WITH this
+                MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
+                WHERE apoc.util.validatePredicate(NOT ((exists((this1)<-[:HAS_POST]-(:\`User\`)) AND any(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) | this2] WHERE (this2.id IS NOT NULL AND this2.id = $param1)))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                CALL {
+                    WITH this1
+                    MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)
+                    WHERE apoc.util.validatePredicate(NOT ((this4.id IS NOT NULL AND this4.id = $param2)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH { node: { name: this4.name } } AS edge
+                    WITH collect(edge) AS edges
+                    WITH edges, size(edges) AS totalCount
+                    RETURN { edges: edges, totalCount: totalCount } AS var5
+                }
+                WITH { node: { content: this1.content, creatorConnection: var5 } } AS edge
+                WITH collect(edge) AS edges
+                WITH edges, size(edges) AS totalCount
+                RETURN { edges: edges, totalCount: totalCount } AS var6
+            }
+            RETURN this { .name, postsConnection: var6 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"super_admin\\",
+                \\"param1\\": \\"super_admin\\",
+                \\"param2\\": \\"super_admin\\"
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/projection-interface-relationships.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("Auth projections for interface relationship fields", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            interface Production {
+                title: String!
+            }
+
+            type Movie implements Production {
+                title: String!
+                runtime: Int!
+            }
+
+            type Series implements Production {
+                title: String!
+                episodes: Int!
+            }
+
+            extend type Series @auth(rules: [{ allow: { episodes: "$jwt.sub" } }])
+
+            interface ActedIn @relationshipProperties {
+                screenTime: Int!
+            }
+
+            type Actor {
+                name: String!
+                actedIn: [Production!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Simple Interface Relationship Query for protected type", async () => {
+        const query = gql`
+            query {
+                actors {
+                    actedIn {
+                        title
+                        ... on Movie {
+                            runtime
+                        }
+                        ... on Series {
+                            episodes
+                        }
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin" });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Actor\`)
+            CALL {
+                WITH this
+                CALL {
+                    WITH *
+                    MATCH (this)-[this0:ACTED_IN]->(this1:\`Movie\`)
+                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
+                    RETURN this1 AS var2
+                    UNION
+                    WITH *
+                    MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
+                    WHERE apoc.util.validatePredicate(NOT ((this4.episodes IS NOT NULL AND this4.episodes = $param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
+                    RETURN this4 AS var2
+                }
+                WITH var2
+                RETURN collect(var2) AS var2
+            }
+            RETURN this { actedIn: var2 } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": \\"super_admin\\"
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/deprecated/auth/projection.test.ts
+++ b/packages/graphql/tests/tck/deprecated/auth/projection.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQLAuthJWTPlugin } from "@neo4j/graphql-plugin-auth";
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { createJwtRequest } from "../../../utils/create-jwt-request";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("Cypher Auth Projection", () => {
+    const secret = "secret";
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type User {
+                id: ID
+                name: String
+            }
+
+            extend type User {
+                id: ID @auth(rules: [{ allow: { id: "$jwt.sub" } }])
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            plugins: {
+                auth: new Neo4jGraphQLAuthJWTPlugin({
+                    secret,
+                }),
+            },
+        });
+    });
+
+    test("Update Node", async () => {
+        const query = gql`
+            mutation {
+                updateUsers(update: { id: "new-id" }) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`User\`)
+            WITH this
+            CALL apoc.util.validate(NOT ((this.id IS NOT NULL AND this.id = $thisauth_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            SET this.id = $this_update_id
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT ((this.id IS NOT NULL AND this.id = $update_param0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN collect(DISTINCT this { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"update_param0\\": \\"super_admin\\",
+                \\"this_update_id\\": \\"new-id\\",
+                \\"thisauth_param0\\": \\"super_admin\\",
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+
+    test("Create Node", async () => {
+        const query = gql`
+            mutation {
+                createUsers(input: [{ id: "id-1" }, { id: "id-2" }]) {
+                    users {
+                        id
+                    }
+                }
+            }
+        `;
+
+        const req = createJwtRequest("secret", { sub: "super_admin", roles: ["admin"] });
+        const result = await translateQuery(neoSchema, query, {
+            req,
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "UNWIND $create_param0 AS create_var0
+            CALL {
+                WITH create_var0
+                CREATE (create_this1:\`User\`)
+                SET
+                    create_this1.id = create_var0.id
+                RETURN create_this1
+            }
+            RETURN collect(create_this1 { .id }) AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"create_param0\\": [
+                    {
+                        \\"id\\": \\"id-1\\"
+                    },
+                    {
+                        \\"id\\": \\"id-2\\"
+                    }
+                ],
+                \\"resolvedCallbacks\\": {}
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

In an effort to reduce the number of files in the giant authorization PR, this PR includes all of the simple file moves and updates which move the old auth tests out of the way to make room for the new authorization tests.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low