### PR TITLE
Remove extra comma from return statement for update mutation returning info object

### DIFF
--- a/packages/graphql/src/translate/translate-update.ts
+++ b/packages/graphql/src/translate/translate-update.ts
@@ -505,7 +505,8 @@ function generateUpdateReturnStatement(
     if (subscriptionsEnabled) {
         statements = Cypher.concat(
             statements,
-            new Cypher.RawCypher(`, collect(DISTINCT m) as ${META_CYPHER_VARIABLE}`)
+            new Cypher.RawCypher(statements ? ", " : ""),
+            new Cypher.RawCypher(`collect(DISTINCT m) as ${META_CYPHER_VARIABLE}`)
         );
     }
 


### PR DESCRIPTION
# Description

Removes extra comma from the return statement on an update mutation returning just the info object.

## Complexity

Complexity: Low

# Issue

Closes #3355 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
