### PR TITLE
fix: broken GHA with neo4j 5.X

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -19,7 +19,7 @@ jobs:
         image: neo4j:5-enterprise
         env:
           NEO4J_AUTH: neo4j/password
-          NEO4J_PLUGINS: '["apoc-core"]'
+          NEO4J_PLUGINS: '["apoc"]'
           NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
         ports:
           - 7687:7687

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -127,7 +127,7 @@ jobs:
         image: neo4j:5-enterprise
         env:
           NEO4J_AUTH: neo4j/password
-          NEO4J_PLUGINS: '["apoc-core"]'
+          NEO4J_PLUGINS: '["apoc"]'
           NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
         ports:
           - 7687:7687

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -82,8 +82,6 @@ jobs:
         neo4j-version:
           - 4.4-community
           - 4.4-enterprise
-          - 5-community
-          - 5-enterprise
 
     services:
       neo4j:

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -90,7 +90,7 @@ jobs:
         image: neo4j:${{ matrix.neo4j-version }}
         env:
           NEO4J_AUTH: neo4j/password
-          NEO4J_PLUGINS: '["apoc-core"]'
+          NEO4J_PLUGINS: '["apoc"]'
           NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
         ports:
           - 7687:7687

--- a/.github/workflows/reusable-api-library-tests.yml
+++ b/.github/workflows/reusable-api-library-tests.yml
@@ -82,6 +82,8 @@ jobs:
         neo4j-version:
           - 4.4-community
           - 4.4-enterprise
+          - 5-community
+          - 5-enterprise
 
     services:
       neo4j:

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -109,7 +109,7 @@ jobs:
         image: neo4j:${{ matrix.neo4j-version }}
         env:
           NEO4J_AUTH: neo4j/password
-          NEO4J_PLUGINS: '["apoc-core"]'
+          NEO4J_PLUGINS: '["apoc"]'
           NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
         ports:
           - 7687:7687

--- a/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
+++ b/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
@@ -21,7 +21,7 @@ jobs:
         image: neo4j:${{ matrix.neo4j-version }}
         env:
           NEO4J_AUTH: neo4j/mypassword
-          NEO4J_PLUGINS: '["apoc-core"]'
+          NEO4J_PLUGINS: '["apoc"]'
           NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
         ports:
           - 7687:7687

--- a/.github/workflows/reusable-toolbox-tests.yml
+++ b/.github/workflows/reusable-toolbox-tests.yml
@@ -12,7 +12,7 @@ jobs:
         image: neo4j:5-enterprise
         env:
           NEO4J_AUTH: neo4j/password
-          NEO4J_PLUGINS: '["apoc-core"]'
+          NEO4J_PLUGINS: '["apoc"]'
           NEO4J_ACCEPT_LICENSE_AGREEMENT: yes
         ports:
           - 7687:7687


### PR DESCRIPTION
# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

Replacing `NEO4J_PLUGINS: apoc-core` with `NEO4J_PLUGINS: apoc` for the GHA services that use Neo4j 4.4 and 5.X. 
Reason: Neo4j 5.X is failing due to `“apoc-core” is not a known Neo4j plugin`.

This means that for Neo4j 4.4, the apoc plugin will be fetched remotely. For Neo4j 5.X, the bundled apoc plugin will be used.

Connected to https://github.com/neo4j/graphql/pull/3345

