### PR TITLE
3394 ordering not taking alias into account

### DIFF
--- a/.changeset/fuzzy-fishes-hear.md
+++ b/.changeset/fuzzy-fishes-hear.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix sorting fields with @alias directive

--- a/packages/graphql/src/classes/GraphElement.ts
+++ b/packages/graphql/src/classes/GraphElement.ts
@@ -25,6 +25,7 @@ import type {
     TemporalField,
     PointField,
     CustomResolverField,
+    BaseField,
 } from "../types";
 
 export interface GraphElementConstructor {
@@ -58,5 +59,29 @@ export abstract class GraphElement {
         this.temporalFields = input.temporalFields;
         this.pointFields = input.pointFields;
         this.customResolverFields = input.customResolverFields;
+    }
+
+    public getField(name: string): BaseField | undefined {
+        for (const fieldList of this.getAllFields()) {
+            const field = this.searchField(fieldList, name);
+            if (field) return field;
+        }
+    }
+
+    private getAllFields(): Array<BaseField[]> {
+        return [
+            this.primitiveFields,
+            this.scalarFields,
+            this.enumFields,
+            this.temporalFields,
+            this.pointFields,
+            this.customResolverFields,
+        ];
+    }
+
+    private searchField(fields: BaseField[], fieldName: string): BaseField | undefined {
+        return fields.find((field) => {
+            return field.fieldName === fieldName;
+        });
     }
 }

--- a/packages/graphql/src/classes/GraphElement.ts
+++ b/packages/graphql/src/classes/GraphElement.ts
@@ -63,7 +63,7 @@ export abstract class GraphElement {
 
     public getField(name: string): BaseField | undefined {
         for (const fieldList of this.getAllFields()) {
-            const field = this.searchField(fieldList, name);
+            const field = this.searchFieldInList(name, fieldList);
             if (field) return field;
         }
     }
@@ -79,7 +79,7 @@ export abstract class GraphElement {
         ];
     }
 
-    private searchField(fields: BaseField[], fieldName: string): BaseField | undefined {
+    private searchFieldInList(fieldName: string, fields: BaseField[]): BaseField | undefined {
         return fields.find((field) => {
             return field.fieldName === fieldName;
         });

--- a/packages/graphql/src/translate/projection/subquery/add-sort-and-limit-to-clause.ts
+++ b/packages/graphql/src/translate/projection/subquery/add-sort-and-limit-to-clause.ts
@@ -28,7 +28,7 @@ import type {
 } from "../../../types";
 import Cypher from "@neo4j/cypher-builder";
 import { SCORE_FIELD } from "../../../graphql/directives/fulltext";
-import { GraphElement } from "../../../classes";
+import type { GraphElement } from "../../../classes";
 
 export function addLimitOrOffsetOptionsToClause({
     optionsInput,

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -125,6 +125,7 @@ export function translateRead(
             fulltextScoreVariable: context.fulltextIndex?.scoreVariable,
             cypherFields: node.cypherFields,
             cypherFieldAliasMap,
+            graphElement: node,
         });
     }
 

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -163,6 +163,7 @@ export function translateRead(
                 fulltextScoreVariable: context.fulltextIndex?.scoreVariable,
                 cypherFields: node.cypherFields,
                 cypherFieldAliasMap,
+                graphElement: node,
             });
         }
 

--- a/packages/graphql/tests/integration/issues/3394.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3394.int.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { UniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/3394", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+
+    const Product = new UniqueType("Product");
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+    });
+
+    afterEach(async () => {
+        await session.close();
+    });
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("should sort elements by aliased field", async () => {
+        const typeDefs = `#graphql
+            type ${Product} {
+                id: String! @alias(property: "fg_item_id")
+                description: String!
+                partNumber: ID! @alias(property: "fg_item")
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+
+        const query = `#graphql
+            query listProducts {
+                ${Product.plural}(options: { sort: { partNumber: DESC } }) {
+                    id
+                    partNumber
+                    description
+                }
+            }
+        `;
+
+        await session.run(
+            `
+                CREATE (:${Product} {fg_item_id: "p1", description: "a p1", fg_item: "part1"})
+                CREATE (:${Product} {fg_item_id: "p2", description: "a p2", fg_item: "part2"})
+            `
+        );
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValuesWithBookmarks(session.lastBookmark()),
+        });
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult.data?.[Product.plural]).toEqual([
+            {
+                id: "p2",
+                description: "a p2",
+                partNumber: "part2",
+            },
+            {
+                id: "p1",
+                description: "a p1",
+                partNumber: "part1",
+            },
+        ]);
+    });
+});

--- a/packages/graphql/tests/tck/issues/3394.test.ts
+++ b/packages/graphql/tests/tck/issues/3394.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import gql from "graphql-tag";
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/3394", () => {
+    let neoSchema: Neo4jGraphQL;
+
+    const typeDefs = `#graphql
+        type Product {
+            id: String! @alias(property: "fg_item_id")
+            description: String!
+            partNumber: ID! @alias(property: "fg_item")
+        }
+    `;
+
+    beforeAll(() => {
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("should sort by aliased field", async () => {
+        const query = gql`
+            query listProducts {
+                products(options: { sort: { partNumber: DESC } }) {
+                    id
+                    partNumber
+                    description
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:\`Product\`)
+            WITH *
+            ORDER BY this.fg_item DESC
+            RETURN this { id: this.fg_item_id, partNumber: this.fg_item, .description } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});

--- a/packages/graphql/tests/tck/issues/3394.test.ts
+++ b/packages/graphql/tests/tck/issues/3394.test.ts
@@ -25,6 +25,10 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
     let neoSchema: Neo4jGraphQL;
 
     const typeDefs = `#graphql
+        type Employee {
+            products: [Product!]! @relationship(type: "CAN_ACCESS", direction: OUT)
+        }
+
         type Product {
             id: String! @alias(property: "fg_item_id")
             description: String!
@@ -61,16 +65,14 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
     });
 
-    test("should sort by aliased field in connection", async () => {
+    test("should sort by aliased field in relationship", async () => {
         const query = gql`
             query listProducts {
-                productsConnection(sort: { partNumber: DESC }) {
-                    edges {
-                        node {
-                            id
-                            partNumber
-                            description
-                        }
+                employees {
+                    products(options: { sort: { partNumber: DESC } }) {
+                        id
+                        partNumber
+                        description
                     }
                 }
             }
@@ -79,18 +81,96 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
         const result = await translateQuery(neoSchema, query);
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this:\`Product\`)
-            WITH collect(this) AS edges
-            WITH edges, size(edges) AS totalCount
-            UNWIND edges AS this
-            WITH this, totalCount
-            WITH *
-            ORDER BY this.fg_item DESC
-            WITH { node: this { id: this.fg_item_id, partNumber: this.fg_item, .description } } AS edge, totalCount, this
-            WITH collect(edge) AS edges, totalCount
-            RETURN { edges: edges, totalCount: totalCount } AS this"
+            "MATCH (this:\`Employee\`)
+            CALL {
+                WITH this
+                MATCH (this)-[this0:CAN_ACCESS]->(this1:\`Product\`)
+                WITH this1 { id: this1.fg_item_id, partNumber: this1.fg_item, .description } AS this1
+                ORDER BY this1.partNumber DESC
+                RETURN collect(this1) AS var2
+            }
+            RETURN this { products: var2 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+    describe("Connection sort", () => {
+        test("should sort by aliased field in connection", async () => {
+            const query = gql`
+                query listProducts {
+                    productsConnection(sort: { partNumber: DESC }) {
+                        edges {
+                            node {
+                                id
+                                partNumber
+                                description
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                            "MATCH (this:\`Product\`)
+                            WITH collect(this) AS edges
+                            WITH edges, size(edges) AS totalCount
+                            UNWIND edges AS this
+                            WITH this, totalCount
+                            WITH *
+                            ORDER BY this.fg_item DESC
+                            WITH { node: this { id: this.fg_item_id, partNumber: this.fg_item, .description } } AS edge, totalCount, this
+                            WITH collect(edge) AS edges, totalCount
+                            RETURN { edges: edges, totalCount: totalCount } AS this"
+                    `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+        });
+
+        test("should sort by aliased field in nested connection", async () => {
+            const query = gql`
+                query listProducts {
+                    employees {
+                        productsConnection(sort: { node: { partNumber: DESC } }) {
+                            edges {
+                                node {
+                                    id
+                                    partNumber
+                                    description
+                                }
+                            }
+                        }
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:\`Employee\`)
+                CALL {
+                    WITH this
+                    MATCH (this)-[this0:CAN_ACCESS]->(this1:\`Product\`)
+                    WITH this0, this1
+                    ORDER BY this1.partNumber DESC
+                    WITH { node: { id: this1.fg_item_id, partNumber: this1.fg_item, description: this1.description } } AS edge
+                    WITH collect(edge) AS edges
+                    WITH edges, size(edges) AS totalCount
+                    CALL {
+                        WITH edges
+                        UNWIND edges AS edge
+                        WITH edge
+                        ORDER BY edge.node.partNumber DESC
+                        RETURN collect(edge) AS var2
+                    }
+                    WITH var2 AS edges, totalCount
+                    RETURN { edges: edges, totalCount: totalCount } AS var3
+                }
+                RETURN this { productsConnection: var3 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+        });
     });
 });


### PR DESCRIPTION
# Description
When sorting, we are using the options argument directly. This PR transforms the given fields to the DbFieldNames when needed to properly take `@alias` into account.

This PR adds a method `getFields` in Node which is not efficient and should be refactored into the SchemaModel


## Complexity

Complexity: Low

# Issue

Closes #3394 

