### PR TITLE
Settable directive

### DIFF
--- a/packages/graphql/src/graphql/directives/index.ts
+++ b/packages/graphql/src/graphql/directives/index.ts
@@ -24,6 +24,7 @@ export { computedDirective } from "./computed";
 export { customResolverDirective } from "./customResolver";
 export { cypherDirective } from "./cypher";
 export { selectableDirective } from "./selectable";
+export { settableDirective } from "./settable";
 export { defaultDirective } from "./default";
 export { excludeDirective } from "./exclude";
 export { fulltextDirective } from "./fulltext";

--- a/packages/graphql/src/graphql/directives/settable.ts
+++ b/packages/graphql/src/graphql/directives/settable.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { DirectiveLocation, GraphQLBoolean, GraphQLDirective, GraphQLNonNull } from "graphql";
+
+export const settableDirective = new GraphQLDirective({
+    name: "settable",
+    description: "Instructs @neo4j/graphql to generate this field for mutations input.",
+    locations: [DirectiveLocation.FIELD_DEFINITION],
+    args: {
+        onCreate: {
+            description: "Generates this input field for create operations.",
+            type: new GraphQLNonNull(GraphQLBoolean),
+            defaultValue: true,
+        },
+        onUpdate: {
+            description: "Generates this input field for update operations.",
+            type: new GraphQLNonNull(GraphQLBoolean),
+            defaultValue: true,
+        },
+    },
+});

--- a/packages/graphql/src/graphql/directives/settable.ts
+++ b/packages/graphql/src/graphql/directives/settable.ts
@@ -21,7 +21,7 @@ import { DirectiveLocation, GraphQLBoolean, GraphQLDirective, GraphQLNonNull } f
 
 export const settableDirective = new GraphQLDirective({
     name: "settable",
-    description: "Instructs @neo4j/graphql to generate this field for mutations input.",
+    description: "Instructs @neo4j/graphql to generate this field for mutation inputs.",
     locations: [DirectiveLocation.FIELD_DEFINITION],
     args: {
         onCreate: {

--- a/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
@@ -223,15 +223,17 @@ function createRelationshipFields({
             where: `${rel.connectionPrefix}${upperFieldName}ConnectionWhere`,
         });
 
-        // Interface CreateInput does not require relationship input fields
-        // These are specified on the concrete nodes.
-        if (!(composeNode instanceof InterfaceTypeComposer)) {
-            nodeCreateInput.addFields({
-                [rel.fieldName]: {
-                    type: nodeFieldInputName,
-                    directives: deprecatedDirectives,
-                },
-            });
+        if (rel.settableOptions.onCreate) {
+            // Interface CreateInput does not require relationship input fields
+            // These are specified on the concrete nodes.
+            if (!(composeNode instanceof InterfaceTypeComposer)) {
+                nodeCreateInput.addFields({
+                    [rel.fieldName]: {
+                        type: nodeFieldInputName,
+                        directives: deprecatedDirectives,
+                    },
+                });
+            }
         }
 
         if (nestedOperations.has(RelationshipNestedOperationsOption.CONNECT_OR_CREATE)) {
@@ -255,7 +257,7 @@ function createRelationshipFields({
             }
         }
 
-        if (nestedOperations.has(RelationshipNestedOperationsOption.CREATE)) {
+        if (nestedOperations.has(RelationshipNestedOperationsOption.CREATE) && rel.settableOptions.onCreate) {
             const createName = `${rel.connectionPrefix}${upperFieldName}CreateFieldInput`;
             const create = rel.typeMeta.array ? `[${createName}!]` : createName;
             schemaComposer.getOrCreateITC(createName, (tc) => {
@@ -326,7 +328,7 @@ function createRelationshipFields({
             });
         }
 
-        if (nestedOperations.has(RelationshipNestedOperationsOption.UPDATE)) {
+        if (nestedOperations.has(RelationshipNestedOperationsOption.UPDATE) && rel.settableOptions.onUpdate) {
             const connectionUpdateInputName = `${rel.connectionPrefix}${upperFieldName}UpdateConnectionInput`;
 
             nodeUpdateInput.addFields({

--- a/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
@@ -257,7 +257,7 @@ function createRelationshipFields({
             }
         }
 
-        if (nestedOperations.has(RelationshipNestedOperationsOption.CREATE) && rel.settableOptions.onCreate) {
+        if (nestedOperations.has(RelationshipNestedOperationsOption.CREATE)) {
             const createName = `${rel.connectionPrefix}${upperFieldName}CreateFieldInput`;
             const create = rel.typeMeta.array ? `[${createName}!]` : createName;
             schemaComposer.getOrCreateITC(createName, (tc) => {
@@ -328,7 +328,7 @@ function createRelationshipFields({
             });
         }
 
-        if (nestedOperations.has(RelationshipNestedOperationsOption.UPDATE) && rel.settableOptions.onUpdate) {
+        if (nestedOperations.has(RelationshipNestedOperationsOption.UPDATE)) {
             const connectionUpdateInputName = `${rel.connectionPrefix}${upperFieldName}UpdateConnectionInput`;
 
             nodeUpdateInput.addFields({

--- a/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
@@ -327,8 +327,7 @@ function createRelationshipFields({
                 },
             });
         }
-
-        if (nestedOperations.has(RelationshipNestedOperationsOption.UPDATE)) {
+        if (nestedOperations.has(RelationshipNestedOperationsOption.UPDATE) && rel.settableOptions.onUpdate) {
             const connectionUpdateInputName = `${rel.connectionPrefix}${upperFieldName}UpdateConnectionInput`;
 
             nodeUpdateInput.addFields({

--- a/packages/graphql/src/schema/get-obj-field-meta.ts
+++ b/packages/graphql/src/schema/get-obj-field-meta.ts
@@ -60,6 +60,7 @@ import type {
     CustomResolverField,
     Neo4jGraphQLCallbacks,
     SelectableOptions,
+    SettableOptions,
 } from "../types";
 import parseValueNode from "./parse-value-node";
 import checkDirectiveCombinations from "./check-directive-combinations";
@@ -154,6 +155,7 @@ function getObjFieldMeta({
             const populatedByDirective = directives.find((x) => x.name.value === "populatedBy");
             const jwtClaimDirective = directives.find((x) => x.name.value === "jwtClaim");
             const selectableDirective = directives.find((x) => x.name.value === "selectable");
+            const settableDirective = directives.find((x) => x.name.value === "settable");
             const unique = getUniqueMeta(directives, obj, field.name.value);
 
             const fieldInterface = interfaces.find((x) => x.name.value === typeMeta.name);
@@ -167,6 +169,7 @@ function getObjFieldMeta({
                 dbPropertyName: field.name.value,
                 typeMeta,
                 selectableOptions: parseSelectableDirective(selectableDirective),
+                settableOptions: parseSettableDirective(settableDirective),
                 otherDirectives: (directives || []).filter(
                     (x) =>
                         ![
@@ -188,6 +191,7 @@ function getObjFieldMeta({
                             "populatedBy",
                             "jwtClaim",
                             "selectable",
+                            "settable",
                         ].includes(x.name.value)
                 ),
                 arguments: [...(field.arguments || [])],
@@ -310,6 +314,7 @@ function getObjFieldMeta({
                     fieldName: `${baseField.fieldName}Connection`,
                     relationshipTypeName,
                     selectableOptions: parseSelectableDirective(selectableDirective),
+                    settableOptions: parseSettableDirective(settableDirective),
                     typeMeta: {
                         name: connectionTypeName,
                         required: true,
@@ -671,5 +676,19 @@ function parseSelectableDirective(directive: DirectiveNode | undefined): Selecta
     return {
         onRead: args.onRead ?? defaultArguments.onRead,
         onAggregate: args.onAggregate ?? defaultArguments.onAggregate,
+    };
+}
+
+function parseSettableDirective(directive: DirectiveNode | undefined): SettableOptions {
+    const defaultArguments = {
+        onCreate: true,
+        onUpdate: true,
+    };
+
+    const args: Partial<SettableOptions> = directive ? parseArguments(directive) : {};
+
+    return {
+        onCreate: args.onCreate ?? defaultArguments.onCreate,
+        onUpdate: args.onUpdate ?? defaultArguments.onUpdate,
     };
 }

--- a/packages/graphql/src/schema/resolvers/subscriptions/where.test.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/where.test.ts
@@ -69,6 +69,10 @@ describe("subscriptionWhere", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                 },
@@ -124,6 +128,10 @@ describe("subscriptionWhere", () => {
                     selectableOptions: {
                         onRead: true,
                         onAggregate: false,
+                    },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
                     },
                     otherDirectives: [],
                     arguments: [],

--- a/packages/graphql/src/schema/to-compose.ts
+++ b/packages/graphql/src/schema/to-compose.ts
@@ -91,7 +91,8 @@ export function objectFieldsToCreateInputFields(fields: BaseField[]): Record<str
             const isAutogenerate = (f as PrimitiveField)?.autogenerate;
             const isCallback = (f as PrimitiveField)?.callback;
             const isTemporal = (f as TemporalField)?.timestamps;
-            return !isAutogenerate && !isCallback && !isTemporal;
+            const isSettable = f.settableOptions.onCreate;
+            return !isAutogenerate && !isCallback && !isTemporal && isSettable;
         })
         .reduce((res: Record<string, InputField>, f) => {
             const fieldType = f.typeMeta.input.create.pretty;
@@ -190,8 +191,10 @@ export function objectFieldsToUpdateInputFields(fields: BaseField[]): Record<str
         const deprecatedDirectives = graphqlDirectivesToCompose(
             f.otherDirectives.filter((directive) => directive.name.value === "deprecated")
         );
+
         const staticField = f.readonly || (f as PrimitiveField)?.autogenerate;
-        if (staticField) {
+        const isSettable = f.settableOptions.onUpdate;
+        if (staticField || !isSettable) {
             return res;
         }
 

--- a/packages/graphql/src/translate/create-auth-and-params.test.ts
+++ b/packages/graphql/src/translate/create-auth-and-params.test.ts
@@ -53,6 +53,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -124,6 +128,10 @@ describe("createAuthAndParams", () => {
                 selectableOptions: {
                     onRead: true,
                     onAggregate: false,
+                },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
                 },
                 otherDirectives: [],
                 arguments: [],
@@ -202,6 +210,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -271,6 +283,10 @@ describe("createAuthAndParams", () => {
                 selectableOptions: {
                     onRead: true,
                     onAggregate: false,
+                },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
                 },
                 otherDirectives: [],
                 arguments: [],
@@ -343,6 +359,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -413,6 +433,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -481,6 +505,10 @@ describe("createAuthAndParams", () => {
                 selectableOptions: {
                     onRead: true,
                     onAggregate: false,
+                },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
                 },
                 otherDirectives: [],
                 arguments: [],
@@ -563,6 +591,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -597,6 +629,10 @@ describe("createAuthAndParams", () => {
                         selectableOptions: {
                             onRead: true,
                             onAggregate: false,
+                        },
+                        settableOptions: {
+                            onCreate: true,
+                            onUpdate: true,
                         },
                         otherDirectives: [],
                         arguments: [],
@@ -671,6 +707,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -705,6 +745,10 @@ describe("createAuthAndParams", () => {
                         selectableOptions: {
                             onRead: true,
                             onAggregate: false,
+                        },
+                        settableOptions: {
+                            onCreate: true,
+                            onUpdate: true,
                         },
                         otherDirectives: [],
                         arguments: [],
@@ -780,6 +824,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -842,6 +890,10 @@ describe("createAuthAndParams", () => {
                     onRead: true,
                     onAggregate: false,
                 },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
+                },
                 otherDirectives: [],
                 arguments: [],
             };
@@ -903,6 +955,10 @@ describe("createAuthAndParams", () => {
                 selectableOptions: {
                     onRead: true,
                     onAggregate: false,
+                },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
                 },
                 otherDirectives: [],
                 arguments: [],
@@ -968,6 +1024,10 @@ describe("createAuthAndParams", () => {
                 selectableOptions: {
                     onRead: true,
                     onAggregate: false,
+                },
+                settableOptions: {
+                    onCreate: true,
+                    onUpdate: true,
                 },
                 otherDirectives: [],
                 arguments: [],

--- a/packages/graphql/src/translate/create-connect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.test.ts
@@ -64,6 +64,10 @@ describe("createConnectAndParams", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                     nestedOperations: defaultNestedOperations,

--- a/packages/graphql/src/translate/create-create-and-params.test.ts
+++ b/packages/graphql/src/translate/create-create-and-params.test.ts
@@ -63,6 +63,10 @@ describe("createCreateAndParams", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                 },

--- a/packages/graphql/src/translate/create-disconnect-and-params.test.ts
+++ b/packages/graphql/src/translate/create-disconnect-and-params.test.ts
@@ -60,6 +60,10 @@ describe("createDisconnectAndParams", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                     nestedOperations: defaultNestedOperations,

--- a/packages/graphql/src/translate/create-projection-and-params.test.ts
+++ b/packages/graphql/src/translate/create-projection-and-params.test.ts
@@ -69,6 +69,10 @@ describe("createProjectionAndParams", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                 },
@@ -134,6 +138,10 @@ describe("createProjectionAndParams", () => {
                     selectableOptions: {
                         onRead: true,
                         onAggregate: false,
+                    },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
                     },
                     otherDirectives: [],
                     arguments: [],

--- a/packages/graphql/src/translate/create-update-and-params.test.ts
+++ b/packages/graphql/src/translate/create-update-and-params.test.ts
@@ -52,6 +52,10 @@ describe("createUpdateAndParams", () => {
                 onRead: true,
                 onAggregate: false,
             },
+            settableOptions: {
+                onCreate: true,
+                onUpdate: true,
+            },
             otherDirectives: [],
             arguments: [],
         };

--- a/packages/graphql/src/translate/projection/elements/create-relationship-property-element.test.ts
+++ b/packages/graphql/src/translate/projection/elements/create-relationship-property-element.test.ts
@@ -58,6 +58,10 @@ describe("createRelationshipPropertyElement", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                     description: undefined,
@@ -93,6 +97,10 @@ describe("createRelationshipPropertyElement", () => {
                         onRead: true,
                         onAggregate: false,
                     },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
+                    },
                     otherDirectives: [],
                     arguments: [],
                     description: undefined,
@@ -127,6 +135,10 @@ describe("createRelationshipPropertyElement", () => {
                     selectableOptions: {
                         onRead: true,
                         onAggregate: false,
+                    },
+                    settableOptions: {
+                        onCreate: true,
+                        onUpdate: true,
                     },
                     otherDirectives: [],
                     arguments: [],

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -114,6 +114,11 @@ export type SelectableOptions = {
     onAggregate: boolean;
 };
 
+export type SettableOptions = {
+    onCreate: boolean;
+    onUpdate: boolean;
+};
+
 /**
  * Representation a ObjectTypeDefinitionNode field.
  */
@@ -130,6 +135,7 @@ export interface BaseField {
     dbPropertyName?: string;
     unique?: Unique;
     selectableOptions: SelectableOptions;
+    settableOptions: SettableOptions;
 }
 
 /**

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -1,0 +1,570 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { gql } from "graphql-tag";
+import { Neo4jGraphQL } from "../../../src";
+import { TestSubscriptionsMechanism } from "../../utils/TestSubscriptionsMechanism";
+
+describe("@settable", () => {
+    let subscriptionPlugin: TestSubscriptionsMechanism;
+
+    beforeAll(() => {
+        subscriptionPlugin = new TestSubscriptionsMechanism();
+    });
+
+    test("Disable create fields", async () => {
+        const typeDefs = gql`
+            type Movie {
+                title: String!
+                description: String @settable(onCreate: false, onUpdate: true)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              description: String
+              title: String!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              description: StringAggregateSelectionNullable!
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            input MovieCreateInput {
+              title: String!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              description: SortDirection
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              description: String
+              title: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              description: String
+              description_CONTAINS: String
+              description_ENDS_WITH: String
+              description_IN: [String]
+              description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_STARTS_WITH: String
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String!]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String!
+              shortest: String!
+            }
+
+            type StringAggregateSelectionNullable {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+
+    test("Disable update fields", async () => {
+        const typeDefs = gql`
+            type Movie {
+                title: String!
+                description: String @settable(onCreate: true, onUpdate: false)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              description: String
+              title: String!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              description: StringAggregateSelectionNullable!
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            input MovieCreateInput {
+              description: String
+              title: String!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              description: SortDirection
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              title: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              description: String
+              description_CONTAINS: String
+              description_ENDS_WITH: String
+              description_IN: [String]
+              description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_STARTS_WITH: String
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String!]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String!
+              shortest: String!
+            }
+
+            type StringAggregateSelectionNullable {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+
+    test("Disable create and update fields", async () => {
+        const typeDefs = gql`
+            type Movie {
+                title: String!
+                description: String @settable(onCreate: false, onUpdate: false)
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({ typeDefs, features: { subscriptions: subscriptionPlugin } });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+              subscription: Subscription
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            enum EventType {
+              CREATE
+              CREATE_RELATIONSHIP
+              DELETE
+              DELETE_RELATIONSHIP
+              UPDATE
+            }
+
+            type Movie {
+              description: String
+              title: String!
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              description: StringAggregateSelectionNullable!
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            input MovieCreateInput {
+              title: String!
+            }
+
+            type MovieCreatedEvent {
+              createdMovie: MovieEventPayload!
+              event: EventType!
+              timestamp: Float!
+            }
+
+            type MovieDeletedEvent {
+              deletedMovie: MovieEventPayload!
+              event: EventType!
+              timestamp: Float!
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            type MovieEventPayload {
+              description: String
+              title: String!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              description: SortDirection
+              title: SortDirection
+            }
+
+            input MovieSubscriptionWhere {
+              AND: [MovieSubscriptionWhere!]
+              NOT: MovieSubscriptionWhere
+              OR: [MovieSubscriptionWhere!]
+              description: String
+              description_CONTAINS: String
+              description_ENDS_WITH: String
+              description_IN: [String]
+              description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_STARTS_WITH: String
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            input MovieUpdateInput {
+              title: String
+            }
+
+            type MovieUpdatedEvent {
+              event: EventType!
+              previousState: MovieEventPayload!
+              timestamp: Float!
+              updatedMovie: MovieEventPayload!
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              description: String
+              description_CONTAINS: String
+              description_ENDS_WITH: String
+              description_IN: [String]
+              description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              description_STARTS_WITH: String
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String!]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteMovies(where: MovieWhere): DeleteInfo!
+              updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String!
+              shortest: String!
+            }
+
+            type StringAggregateSelectionNullable {
+              longest: String
+              shortest: String
+            }
+
+            type Subscription {
+              movieCreated(where: MovieSubscriptionWhere): MovieCreatedEvent!
+              movieDeleted(where: MovieSubscriptionWhere): MovieDeletedEvent!
+              movieUpdated(where: MovieSubscriptionWhere): MovieUpdatedEvent!
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -21,13 +21,13 @@ import { printSchemaWithDirectives } from "@graphql-tools/utils";
 import { lexicographicSortSchema } from "graphql/utilities";
 import { gql } from "graphql-tag";
 import { Neo4jGraphQL } from "../../../src";
-import { TestSubscriptionsMechanism } from "../../utils/TestSubscriptionsMechanism";
+import { TestSubscriptionsPlugin } from "../../utils/TestSubscriptionPlugin";
 
 describe("@settable", () => {
-    let subscriptionPlugin: TestSubscriptionsMechanism;
+    let subscriptionPlugin: TestSubscriptionsPlugin;
 
     beforeAll(() => {
-        subscriptionPlugin = new TestSubscriptionsMechanism();
+        subscriptionPlugin = new TestSubscriptionsPlugin();
     });
 
     test("Disable create fields", async () => {
@@ -353,7 +353,7 @@ describe("@settable", () => {
                 description: String @settable(onCreate: false, onUpdate: false)
             }
         `;
-        const neoSchema = new Neo4jGraphQL({ typeDefs, features: { subscriptions: subscriptionPlugin } });
+        const neoSchema = new Neo4jGraphQL({ typeDefs, plugins: { subscriptions: subscriptionPlugin } });
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
         expect(printedSchema).toMatchInlineSnapshot(`
             "schema {

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -636,6 +636,10 @@ describe("@settable", () => {
                   node_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
                 }
 
+                input ActorActedInCreateFieldInput {
+                  node: MovieCreateInput!
+                }
+
                 input ActorActedInDeleteFieldInput {
                   where: ActorActedInConnectionWhere
                 }
@@ -731,6 +735,7 @@ describe("@settable", () => {
 
                 input ActorActedInUpdateFieldInput {
                   connect: [ActorActedInConnectFieldInput!]
+                  create: [ActorActedInCreateFieldInput!]
                   delete: [ActorActedInDeleteFieldInput!]
                   disconnect: [ActorActedInDisconnectFieldInput!]
                   update: ActorActedInUpdateConnectionInput
@@ -780,6 +785,10 @@ describe("@settable", () => {
                   Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
                   \\"\\"\\"
                   sort: [ActorSort!]
+                }
+
+                input ActorRelationInput {
+                  actedIn: [ActorActedInCreateFieldInput!]
                 }
 
                 \\"\\"\\"
@@ -951,7 +960,7 @@ describe("@settable", () => {
                   createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
                   deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
                   deleteMovies(where: MovieWhere): DeleteInfo!
-                  updateActors(connect: ActorConnectInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+                  updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
                   updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
                 }
 
@@ -1174,6 +1183,19 @@ describe("@settable", () => {
                   node: Movie!
                 }
 
+                input ActorActedInUpdateConnectionInput {
+                  node: MovieUpdateInput
+                }
+
+                input ActorActedInUpdateFieldInput {
+                  connect: [ActorActedInConnectFieldInput!]
+                  create: [ActorActedInCreateFieldInput!]
+                  delete: [ActorActedInDeleteFieldInput!]
+                  disconnect: [ActorActedInDisconnectFieldInput!]
+                  update: ActorActedInUpdateConnectionInput
+                  where: ActorActedInConnectionWhere
+                }
+
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelectionNonNullable!
@@ -1232,6 +1254,7 @@ describe("@settable", () => {
                 }
 
                 input ActorUpdateInput {
+                  actedIn: [ActorActedInUpdateFieldInput!]
                   name: String
                 }
 

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -1183,19 +1183,6 @@ describe("@settable", () => {
                   node: Movie!
                 }
 
-                input ActorActedInUpdateConnectionInput {
-                  node: MovieUpdateInput
-                }
-
-                input ActorActedInUpdateFieldInput {
-                  connect: [ActorActedInConnectFieldInput!]
-                  create: [ActorActedInCreateFieldInput!]
-                  delete: [ActorActedInDeleteFieldInput!]
-                  disconnect: [ActorActedInDisconnectFieldInput!]
-                  update: ActorActedInUpdateConnectionInput
-                  where: ActorActedInConnectionWhere
-                }
-
                 type ActorAggregateSelection {
                   count: Int!
                   name: StringAggregateSelectionNonNullable!
@@ -1254,7 +1241,6 @@ describe("@settable", () => {
                 }
 
                 input ActorUpdateInput {
-                  actedIn: [ActorActedInUpdateFieldInput!]
                   name: String
                 }
 

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -32,7 +32,7 @@ describe("@settable", () => {
 
     test("Disable create fields", async () => {
         const typeDefs = gql`
-            type Movie {
+            type Movie @query(aggregate: true) {
                 title: String!
                 description: String @settable(onCreate: false, onUpdate: true)
             }
@@ -190,7 +190,7 @@ describe("@settable", () => {
 
     test("Disable update fields", async () => {
         const typeDefs = gql`
-            type Movie {
+            type Movie @query(aggregate: true) {
                 title: String!
                 description: String @settable(onCreate: true, onUpdate: false)
             }
@@ -348,7 +348,7 @@ describe("@settable", () => {
 
     test("Disable create and update fields", async () => {
         const typeDefs = gql`
-            type Movie {
+            type Movie @query(aggregate: true) {
                 title: String!
                 description: String @settable(onCreate: false, onUpdate: false)
             }
@@ -571,12 +571,12 @@ describe("@settable", () => {
     describe("Relationships", () => {
         test("Prevent relationship field creation", async () => {
             const typeDefs = gql`
-                type Movie {
+                type Movie @query(aggregate: true) {
                     title: String!
                     description: String
                 }
 
-                type Actor {
+                type Actor @query(aggregate: true) {
                     name: String!
                     actedIn: [Movie!]!
                         @relationship(type: "ACTED_IN", direction: OUT)
@@ -1011,12 +1011,12 @@ describe("@settable", () => {
 
         test("Prevent relationship field update", async () => {
             const typeDefs = gql`
-                type Movie {
+                type Movie @query(aggregate: true) {
                     title: String!
                     description: String
                 }
 
-                type Actor {
+                type Actor @query(aggregate: true) {
                     name: String!
                     actedIn: [Movie!]!
                         @relationship(type: "ACTED_IN", direction: OUT)

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -1458,5 +1458,1259 @@ describe("@settable", () => {
                 }"
             `);
         });
+
+        test("Prevent update on nested relationships", async () => {
+            const typeDefs = gql`
+                type Movie @query(aggregate: true) {
+                    title: String!
+                    description: String
+                    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                }
+
+                type Actor @query(aggregate: true) {
+                    name: String!
+                    actedIn: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT) @settable(onUpdate: false)
+                }
+            `;
+            const neoSchema = new Neo4jGraphQL({ typeDefs });
+            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+            expect(printedSchema).toMatchInlineSnapshot(`
+                "schema {
+                  query: Query
+                  mutation: Mutation
+                }
+
+                type Actor {
+                  actedIn(directed: Boolean = true, options: MovieOptions, where: MovieWhere): [Movie!]!
+                  actedInAggregate(directed: Boolean = true, where: MovieWhere): ActorMovieActedInAggregationSelection
+                  actedInConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorActedInConnectionSort!], where: ActorActedInConnectionWhere): ActorActedInConnection!
+                  name: String!
+                }
+
+                input ActorActedInAggregateInput {
+                  AND: [ActorActedInAggregateInput!]
+                  NOT: ActorActedInAggregateInput
+                  OR: [ActorActedInAggregateInput!]
+                  count: Int
+                  count_GT: Int
+                  count_GTE: Int
+                  count_LT: Int
+                  count_LTE: Int
+                  node: ActorActedInNodeAggregationWhereInput
+                }
+
+                input ActorActedInConnectFieldInput {
+                  connect: [MovieConnectInput!]
+                  \\"\\"\\"
+                  Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+                  \\"\\"\\"
+                  overwrite: Boolean! = true
+                  where: MovieConnectWhere
+                }
+
+                type ActorActedInConnection {
+                  edges: [ActorActedInRelationship!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                input ActorActedInConnectionSort {
+                  node: MovieSort
+                }
+
+                input ActorActedInConnectionWhere {
+                  AND: [ActorActedInConnectionWhere!]
+                  NOT: ActorActedInConnectionWhere
+                  OR: [ActorActedInConnectionWhere!]
+                  node: MovieWhere
+                  node_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                }
+
+                input ActorActedInCreateFieldInput {
+                  node: MovieCreateInput!
+                }
+
+                input ActorActedInDeleteFieldInput {
+                  delete: MovieDeleteInput
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInDisconnectFieldInput {
+                  disconnect: MovieDisconnectInput
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInFieldInput {
+                  connect: [ActorActedInConnectFieldInput!]
+                  create: [ActorActedInCreateFieldInput!]
+                }
+
+                input ActorActedInNodeAggregationWhereInput {
+                  AND: [ActorActedInNodeAggregationWhereInput!]
+                  NOT: ActorActedInNodeAggregationWhereInput
+                  OR: [ActorActedInNodeAggregationWhereInput!]
+                  description_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LENGTH_EQUAL: Float
+                  description_AVERAGE_LENGTH_GT: Float
+                  description_AVERAGE_LENGTH_GTE: Float
+                  description_AVERAGE_LENGTH_LT: Float
+                  description_AVERAGE_LENGTH_LTE: Float
+                  description_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LENGTH_EQUAL: Int
+                  description_LONGEST_LENGTH_GT: Int
+                  description_LONGEST_LENGTH_GTE: Int
+                  description_LONGEST_LENGTH_LT: Int
+                  description_LONGEST_LENGTH_LTE: Int
+                  description_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LENGTH_EQUAL: Int
+                  description_SHORTEST_LENGTH_GT: Int
+                  description_SHORTEST_LENGTH_GTE: Int
+                  description_SHORTEST_LENGTH_LT: Int
+                  description_SHORTEST_LENGTH_LTE: Int
+                  description_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LENGTH_EQUAL: Float
+                  title_AVERAGE_LENGTH_GT: Float
+                  title_AVERAGE_LENGTH_GTE: Float
+                  title_AVERAGE_LENGTH_LT: Float
+                  title_AVERAGE_LENGTH_LTE: Float
+                  title_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LENGTH_EQUAL: Int
+                  title_LONGEST_LENGTH_GT: Int
+                  title_LONGEST_LENGTH_GTE: Int
+                  title_LONGEST_LENGTH_LT: Int
+                  title_LONGEST_LENGTH_LTE: Int
+                  title_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LENGTH_EQUAL: Int
+                  title_SHORTEST_LENGTH_GT: Int
+                  title_SHORTEST_LENGTH_GTE: Int
+                  title_SHORTEST_LENGTH_LT: Int
+                  title_SHORTEST_LENGTH_LTE: Int
+                  title_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                }
+
+                type ActorActedInRelationship {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                type ActorAggregateSelection {
+                  count: Int!
+                  name: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorConnectInput {
+                  actedIn: [ActorActedInConnectFieldInput!]
+                }
+
+                input ActorConnectWhere {
+                  node: ActorWhere!
+                }
+
+                input ActorCreateInput {
+                  actedIn: ActorActedInFieldInput
+                  name: String!
+                }
+
+                input ActorDeleteInput {
+                  actedIn: [ActorActedInDeleteFieldInput!]
+                }
+
+                input ActorDisconnectInput {
+                  actedIn: [ActorActedInDisconnectFieldInput!]
+                }
+
+                type ActorEdge {
+                  cursor: String!
+                  node: Actor!
+                }
+
+                type ActorMovieActedInAggregationSelection {
+                  count: Int!
+                  node: ActorMovieActedInNodeAggregateSelection
+                }
+
+                type ActorMovieActedInNodeAggregateSelection {
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [ActorSort!]
+                }
+
+                input ActorRelationInput {
+                  actedIn: [ActorActedInCreateFieldInput!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+                \\"\\"\\"
+                input ActorSort {
+                  name: SortDirection
+                }
+
+                input ActorUpdateInput {
+                  name: String
+                }
+
+                input ActorWhere {
+                  AND: [ActorWhere!]
+                  NOT: ActorWhere
+                  OR: [ActorWhere!]
+                  actedIn: MovieWhere @deprecated(reason: \\"Use \`actedIn_SOME\` instead.\\")
+                  actedInAggregate: ActorActedInAggregateInput
+                  actedInConnection: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_SOME\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where all of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_ALL: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where none of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_NONE: ActorActedInConnectionWhere
+                  actedInConnection_NOT: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_NONE\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where one of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SINGLE: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where some of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SOME: ActorActedInConnectionWhere
+                  \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+                  actedIn_ALL: MovieWhere
+                  \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+                  actedIn_NONE: MovieWhere
+                  actedIn_NOT: MovieWhere @deprecated(reason: \\"Use \`actedIn_NONE\` instead.\\")
+                  \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+                  actedIn_SINGLE: MovieWhere
+                  \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+                  actedIn_SOME: MovieWhere
+                  name: String
+                  name_CONTAINS: String
+                  name_ENDS_WITH: String
+                  name_IN: [String!]
+                  name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_STARTS_WITH: String
+                }
+
+                type ActorsConnection {
+                  edges: [ActorEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type CreateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: CreateInfo!
+                }
+
+                type CreateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  relationshipsCreated: Int!
+                }
+
+                type CreateMoviesMutationResponse {
+                  info: CreateInfo!
+                  movies: [Movie!]!
+                }
+
+                type DeleteInfo {
+                  bookmark: String
+                  nodesDeleted: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type Movie {
+                  actors(directed: Boolean = true, options: ActorOptions, where: ActorWhere): [Actor!]!
+                  actorsAggregate(directed: Boolean = true, where: ActorWhere): MovieActorActorsAggregationSelection
+                  actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+                  description: String
+                  title: String!
+                }
+
+                type MovieActorActorsAggregationSelection {
+                  count: Int!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
+                type MovieActorActorsNodeAggregateSelection {
+                  name: StringAggregateSelectionNonNullable!
+                }
+
+                input MovieActorsAggregateInput {
+                  AND: [MovieActorsAggregateInput!]
+                  NOT: MovieActorsAggregateInput
+                  OR: [MovieActorsAggregateInput!]
+                  count: Int
+                  count_GT: Int
+                  count_GTE: Int
+                  count_LT: Int
+                  count_LTE: Int
+                  node: MovieActorsNodeAggregationWhereInput
+                }
+
+                input MovieActorsConnectFieldInput {
+                  connect: [ActorConnectInput!]
+                  \\"\\"\\"
+                  Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+                  \\"\\"\\"
+                  overwrite: Boolean! = true
+                  where: ActorConnectWhere
+                }
+
+                type MovieActorsConnection {
+                  edges: [MovieActorsRelationship!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                input MovieActorsConnectionSort {
+                  node: ActorSort
+                }
+
+                input MovieActorsConnectionWhere {
+                  AND: [MovieActorsConnectionWhere!]
+                  NOT: MovieActorsConnectionWhere
+                  OR: [MovieActorsConnectionWhere!]
+                  node: ActorWhere
+                  node_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                }
+
+                input MovieActorsCreateFieldInput {
+                  node: ActorCreateInput!
+                }
+
+                input MovieActorsDeleteFieldInput {
+                  delete: ActorDeleteInput
+                  where: MovieActorsConnectionWhere
+                }
+
+                input MovieActorsDisconnectFieldInput {
+                  disconnect: ActorDisconnectInput
+                  where: MovieActorsConnectionWhere
+                }
+
+                input MovieActorsFieldInput {
+                  connect: [MovieActorsConnectFieldInput!]
+                  create: [MovieActorsCreateFieldInput!]
+                }
+
+                input MovieActorsNodeAggregationWhereInput {
+                  AND: [MovieActorsNodeAggregationWhereInput!]
+                  NOT: MovieActorsNodeAggregationWhereInput
+                  OR: [MovieActorsNodeAggregationWhereInput!]
+                  name_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_LENGTH_EQUAL: Float
+                  name_AVERAGE_LENGTH_GT: Float
+                  name_AVERAGE_LENGTH_GTE: Float
+                  name_AVERAGE_LENGTH_LT: Float
+                  name_AVERAGE_LENGTH_LTE: Float
+                  name_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_LENGTH_EQUAL: Int
+                  name_LONGEST_LENGTH_GT: Int
+                  name_LONGEST_LENGTH_GTE: Int
+                  name_LONGEST_LENGTH_LT: Int
+                  name_LONGEST_LENGTH_LTE: Int
+                  name_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_LENGTH_EQUAL: Int
+                  name_SHORTEST_LENGTH_GT: Int
+                  name_SHORTEST_LENGTH_GTE: Int
+                  name_SHORTEST_LENGTH_LT: Int
+                  name_SHORTEST_LENGTH_LTE: Int
+                  name_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                }
+
+                type MovieActorsRelationship {
+                  cursor: String!
+                  node: Actor!
+                }
+
+                input MovieActorsUpdateConnectionInput {
+                  node: ActorUpdateInput
+                }
+
+                input MovieActorsUpdateFieldInput {
+                  connect: [MovieActorsConnectFieldInput!]
+                  create: [MovieActorsCreateFieldInput!]
+                  delete: [MovieActorsDeleteFieldInput!]
+                  disconnect: [MovieActorsDisconnectFieldInput!]
+                  update: MovieActorsUpdateConnectionInput
+                  where: MovieActorsConnectionWhere
+                }
+
+                type MovieAggregateSelection {
+                  count: Int!
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input MovieConnectInput {
+                  actors: [MovieActorsConnectFieldInput!]
+                }
+
+                input MovieConnectWhere {
+                  node: MovieWhere!
+                }
+
+                input MovieCreateInput {
+                  actors: MovieActorsFieldInput
+                  description: String
+                  title: String!
+                }
+
+                input MovieDeleteInput {
+                  actors: [MovieActorsDeleteFieldInput!]
+                }
+
+                input MovieDisconnectInput {
+                  actors: [MovieActorsDisconnectFieldInput!]
+                }
+
+                type MovieEdge {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                input MovieOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [MovieSort!]
+                }
+
+                input MovieRelationInput {
+                  actors: [MovieActorsCreateFieldInput!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+                \\"\\"\\"
+                input MovieSort {
+                  description: SortDirection
+                  title: SortDirection
+                }
+
+                input MovieUpdateInput {
+                  actors: [MovieActorsUpdateFieldInput!]
+                  description: String
+                  title: String
+                }
+
+                input MovieWhere {
+                  AND: [MovieWhere!]
+                  NOT: MovieWhere
+                  OR: [MovieWhere!]
+                  actors: ActorWhere @deprecated(reason: \\"Use \`actors_SOME\` instead.\\")
+                  actorsAggregate: MovieActorsAggregateInput
+                  actorsConnection: MovieActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_SOME\` instead.\\")
+                  \\"\\"\\"
+                  Return Movies where all of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_ALL: MovieActorsConnectionWhere
+                  \\"\\"\\"
+                  Return Movies where none of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_NONE: MovieActorsConnectionWhere
+                  actorsConnection_NOT: MovieActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_NONE\` instead.\\")
+                  \\"\\"\\"
+                  Return Movies where one of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_SINGLE: MovieActorsConnectionWhere
+                  \\"\\"\\"
+                  Return Movies where some of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_SOME: MovieActorsConnectionWhere
+                  \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
+                  actors_ALL: ActorWhere
+                  \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
+                  actors_NONE: ActorWhere
+                  actors_NOT: ActorWhere @deprecated(reason: \\"Use \`actors_NONE\` instead.\\")
+                  \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
+                  actors_SINGLE: ActorWhere
+                  \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
+                  actors_SOME: ActorWhere
+                  description: String
+                  description_CONTAINS: String
+                  description_ENDS_WITH: String
+                  description_IN: [String]
+                  description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_STARTS_WITH: String
+                  title: String
+                  title_CONTAINS: String
+                  title_ENDS_WITH: String
+                  title_IN: [String!]
+                  title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_STARTS_WITH: String
+                }
+
+                type MoviesConnection {
+                  edges: [MovieEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type Mutation {
+                  createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+                  deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+                  deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+                  updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+                  updateMovies(connect: MovieConnectInput, create: MovieRelationInput, delete: MovieDeleteInput, disconnect: MovieDisconnectInput, update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+                }
+
+                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+                type PageInfo {
+                  endCursor: String
+                  hasNextPage: Boolean!
+                  hasPreviousPage: Boolean!
+                  startCursor: String
+                }
+
+                type Query {
+                  actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+                  movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+                }
+
+                enum SortDirection {
+                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+                  ASC
+                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+                  DESC
+                }
+
+                type StringAggregateSelectionNonNullable {
+                  longest: String!
+                  shortest: String!
+                }
+
+                type StringAggregateSelectionNullable {
+                  longest: String
+                  shortest: String
+                }
+
+                type UpdateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: UpdateInfo!
+                }
+
+                type UpdateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  nodesDeleted: Int!
+                  relationshipsCreated: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type UpdateMoviesMutationResponse {
+                  info: UpdateInfo!
+                  movies: [Movie!]!
+                }"
+            `);
+        });
+
+        test("Prevent create on nested relationships", async () => {
+            const typeDefs = gql`
+                type Movie @query(aggregate: true) {
+                    title: String!
+                    description: String
+                    actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+                }
+
+                type Actor @query(aggregate: true) {
+                    name: String!
+                    actedIn: [Movie!]! @relationship(type: "ACTED_IN", direction: OUT) @settable(onCreate: false)
+                }
+            `;
+            const neoSchema = new Neo4jGraphQL({ typeDefs });
+            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+            expect(printedSchema).toMatchInlineSnapshot(`
+                "schema {
+                  query: Query
+                  mutation: Mutation
+                }
+
+                type Actor {
+                  actedIn(directed: Boolean = true, options: MovieOptions, where: MovieWhere): [Movie!]!
+                  actedInAggregate(directed: Boolean = true, where: MovieWhere): ActorMovieActedInAggregationSelection
+                  actedInConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorActedInConnectionSort!], where: ActorActedInConnectionWhere): ActorActedInConnection!
+                  name: String!
+                }
+
+                input ActorActedInAggregateInput {
+                  AND: [ActorActedInAggregateInput!]
+                  NOT: ActorActedInAggregateInput
+                  OR: [ActorActedInAggregateInput!]
+                  count: Int
+                  count_GT: Int
+                  count_GTE: Int
+                  count_LT: Int
+                  count_LTE: Int
+                  node: ActorActedInNodeAggregationWhereInput
+                }
+
+                input ActorActedInConnectFieldInput {
+                  connect: [MovieConnectInput!]
+                  \\"\\"\\"
+                  Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+                  \\"\\"\\"
+                  overwrite: Boolean! = true
+                  where: MovieConnectWhere
+                }
+
+                type ActorActedInConnection {
+                  edges: [ActorActedInRelationship!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                input ActorActedInConnectionSort {
+                  node: MovieSort
+                }
+
+                input ActorActedInConnectionWhere {
+                  AND: [ActorActedInConnectionWhere!]
+                  NOT: ActorActedInConnectionWhere
+                  OR: [ActorActedInConnectionWhere!]
+                  node: MovieWhere
+                  node_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                }
+
+                input ActorActedInCreateFieldInput {
+                  node: MovieCreateInput!
+                }
+
+                input ActorActedInDeleteFieldInput {
+                  delete: MovieDeleteInput
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInDisconnectFieldInput {
+                  disconnect: MovieDisconnectInput
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInNodeAggregationWhereInput {
+                  AND: [ActorActedInNodeAggregationWhereInput!]
+                  NOT: ActorActedInNodeAggregationWhereInput
+                  OR: [ActorActedInNodeAggregationWhereInput!]
+                  description_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LENGTH_EQUAL: Float
+                  description_AVERAGE_LENGTH_GT: Float
+                  description_AVERAGE_LENGTH_GTE: Float
+                  description_AVERAGE_LENGTH_LT: Float
+                  description_AVERAGE_LENGTH_LTE: Float
+                  description_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LENGTH_EQUAL: Int
+                  description_LONGEST_LENGTH_GT: Int
+                  description_LONGEST_LENGTH_GTE: Int
+                  description_LONGEST_LENGTH_LT: Int
+                  description_LONGEST_LENGTH_LTE: Int
+                  description_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LENGTH_EQUAL: Int
+                  description_SHORTEST_LENGTH_GT: Int
+                  description_SHORTEST_LENGTH_GTE: Int
+                  description_SHORTEST_LENGTH_LT: Int
+                  description_SHORTEST_LENGTH_LTE: Int
+                  description_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LENGTH_EQUAL: Float
+                  title_AVERAGE_LENGTH_GT: Float
+                  title_AVERAGE_LENGTH_GTE: Float
+                  title_AVERAGE_LENGTH_LT: Float
+                  title_AVERAGE_LENGTH_LTE: Float
+                  title_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LENGTH_EQUAL: Int
+                  title_LONGEST_LENGTH_GT: Int
+                  title_LONGEST_LENGTH_GTE: Int
+                  title_LONGEST_LENGTH_LT: Int
+                  title_LONGEST_LENGTH_LTE: Int
+                  title_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LENGTH_EQUAL: Int
+                  title_SHORTEST_LENGTH_GT: Int
+                  title_SHORTEST_LENGTH_GTE: Int
+                  title_SHORTEST_LENGTH_LT: Int
+                  title_SHORTEST_LENGTH_LTE: Int
+                  title_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                }
+
+                type ActorActedInRelationship {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                input ActorActedInUpdateConnectionInput {
+                  node: MovieUpdateInput
+                }
+
+                input ActorActedInUpdateFieldInput {
+                  connect: [ActorActedInConnectFieldInput!]
+                  create: [ActorActedInCreateFieldInput!]
+                  delete: [ActorActedInDeleteFieldInput!]
+                  disconnect: [ActorActedInDisconnectFieldInput!]
+                  update: ActorActedInUpdateConnectionInput
+                  where: ActorActedInConnectionWhere
+                }
+
+                type ActorAggregateSelection {
+                  count: Int!
+                  name: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorConnectInput {
+                  actedIn: [ActorActedInConnectFieldInput!]
+                }
+
+                input ActorConnectWhere {
+                  node: ActorWhere!
+                }
+
+                input ActorCreateInput {
+                  name: String!
+                }
+
+                input ActorDeleteInput {
+                  actedIn: [ActorActedInDeleteFieldInput!]
+                }
+
+                input ActorDisconnectInput {
+                  actedIn: [ActorActedInDisconnectFieldInput!]
+                }
+
+                type ActorEdge {
+                  cursor: String!
+                  node: Actor!
+                }
+
+                type ActorMovieActedInAggregationSelection {
+                  count: Int!
+                  node: ActorMovieActedInNodeAggregateSelection
+                }
+
+                type ActorMovieActedInNodeAggregateSelection {
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [ActorSort!]
+                }
+
+                input ActorRelationInput {
+                  actedIn: [ActorActedInCreateFieldInput!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+                \\"\\"\\"
+                input ActorSort {
+                  name: SortDirection
+                }
+
+                input ActorUpdateInput {
+                  actedIn: [ActorActedInUpdateFieldInput!]
+                  name: String
+                }
+
+                input ActorWhere {
+                  AND: [ActorWhere!]
+                  NOT: ActorWhere
+                  OR: [ActorWhere!]
+                  actedIn: MovieWhere @deprecated(reason: \\"Use \`actedIn_SOME\` instead.\\")
+                  actedInAggregate: ActorActedInAggregateInput
+                  actedInConnection: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_SOME\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where all of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_ALL: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where none of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_NONE: ActorActedInConnectionWhere
+                  actedInConnection_NOT: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_NONE\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where one of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SINGLE: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where some of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SOME: ActorActedInConnectionWhere
+                  \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+                  actedIn_ALL: MovieWhere
+                  \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+                  actedIn_NONE: MovieWhere
+                  actedIn_NOT: MovieWhere @deprecated(reason: \\"Use \`actedIn_NONE\` instead.\\")
+                  \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+                  actedIn_SINGLE: MovieWhere
+                  \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+                  actedIn_SOME: MovieWhere
+                  name: String
+                  name_CONTAINS: String
+                  name_ENDS_WITH: String
+                  name_IN: [String!]
+                  name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_STARTS_WITH: String
+                }
+
+                type ActorsConnection {
+                  edges: [ActorEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type CreateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: CreateInfo!
+                }
+
+                type CreateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  relationshipsCreated: Int!
+                }
+
+                type CreateMoviesMutationResponse {
+                  info: CreateInfo!
+                  movies: [Movie!]!
+                }
+
+                type DeleteInfo {
+                  bookmark: String
+                  nodesDeleted: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type Movie {
+                  actors(directed: Boolean = true, options: ActorOptions, where: ActorWhere): [Actor!]!
+                  actorsAggregate(directed: Boolean = true, where: ActorWhere): MovieActorActorsAggregationSelection
+                  actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+                  description: String
+                  title: String!
+                }
+
+                type MovieActorActorsAggregationSelection {
+                  count: Int!
+                  node: MovieActorActorsNodeAggregateSelection
+                }
+
+                type MovieActorActorsNodeAggregateSelection {
+                  name: StringAggregateSelectionNonNullable!
+                }
+
+                input MovieActorsAggregateInput {
+                  AND: [MovieActorsAggregateInput!]
+                  NOT: MovieActorsAggregateInput
+                  OR: [MovieActorsAggregateInput!]
+                  count: Int
+                  count_GT: Int
+                  count_GTE: Int
+                  count_LT: Int
+                  count_LTE: Int
+                  node: MovieActorsNodeAggregationWhereInput
+                }
+
+                input MovieActorsConnectFieldInput {
+                  connect: [ActorConnectInput!]
+                  \\"\\"\\"
+                  Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+                  \\"\\"\\"
+                  overwrite: Boolean! = true
+                  where: ActorConnectWhere
+                }
+
+                type MovieActorsConnection {
+                  edges: [MovieActorsRelationship!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                input MovieActorsConnectionSort {
+                  node: ActorSort
+                }
+
+                input MovieActorsConnectionWhere {
+                  AND: [MovieActorsConnectionWhere!]
+                  NOT: MovieActorsConnectionWhere
+                  OR: [MovieActorsConnectionWhere!]
+                  node: ActorWhere
+                  node_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                }
+
+                input MovieActorsCreateFieldInput {
+                  node: ActorCreateInput!
+                }
+
+                input MovieActorsDeleteFieldInput {
+                  delete: ActorDeleteInput
+                  where: MovieActorsConnectionWhere
+                }
+
+                input MovieActorsDisconnectFieldInput {
+                  disconnect: ActorDisconnectInput
+                  where: MovieActorsConnectionWhere
+                }
+
+                input MovieActorsFieldInput {
+                  connect: [MovieActorsConnectFieldInput!]
+                  create: [MovieActorsCreateFieldInput!]
+                }
+
+                input MovieActorsNodeAggregationWhereInput {
+                  AND: [MovieActorsNodeAggregationWhereInput!]
+                  NOT: MovieActorsNodeAggregationWhereInput
+                  OR: [MovieActorsNodeAggregationWhereInput!]
+                  name_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_LENGTH_EQUAL: Float
+                  name_AVERAGE_LENGTH_GT: Float
+                  name_AVERAGE_LENGTH_GTE: Float
+                  name_AVERAGE_LENGTH_LT: Float
+                  name_AVERAGE_LENGTH_LTE: Float
+                  name_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_LENGTH_EQUAL: Int
+                  name_LONGEST_LENGTH_GT: Int
+                  name_LONGEST_LENGTH_GTE: Int
+                  name_LONGEST_LENGTH_LT: Int
+                  name_LONGEST_LENGTH_LTE: Int
+                  name_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  name_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_LENGTH_EQUAL: Int
+                  name_SHORTEST_LENGTH_GT: Int
+                  name_SHORTEST_LENGTH_GTE: Int
+                  name_SHORTEST_LENGTH_LT: Int
+                  name_SHORTEST_LENGTH_LTE: Int
+                  name_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                }
+
+                type MovieActorsRelationship {
+                  cursor: String!
+                  node: Actor!
+                }
+
+                input MovieActorsUpdateConnectionInput {
+                  node: ActorUpdateInput
+                }
+
+                input MovieActorsUpdateFieldInput {
+                  connect: [MovieActorsConnectFieldInput!]
+                  create: [MovieActorsCreateFieldInput!]
+                  delete: [MovieActorsDeleteFieldInput!]
+                  disconnect: [MovieActorsDisconnectFieldInput!]
+                  update: MovieActorsUpdateConnectionInput
+                  where: MovieActorsConnectionWhere
+                }
+
+                type MovieAggregateSelection {
+                  count: Int!
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input MovieConnectInput {
+                  actors: [MovieActorsConnectFieldInput!]
+                }
+
+                input MovieConnectWhere {
+                  node: MovieWhere!
+                }
+
+                input MovieCreateInput {
+                  actors: MovieActorsFieldInput
+                  description: String
+                  title: String!
+                }
+
+                input MovieDeleteInput {
+                  actors: [MovieActorsDeleteFieldInput!]
+                }
+
+                input MovieDisconnectInput {
+                  actors: [MovieActorsDisconnectFieldInput!]
+                }
+
+                type MovieEdge {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                input MovieOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [MovieSort!]
+                }
+
+                input MovieRelationInput {
+                  actors: [MovieActorsCreateFieldInput!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+                \\"\\"\\"
+                input MovieSort {
+                  description: SortDirection
+                  title: SortDirection
+                }
+
+                input MovieUpdateInput {
+                  actors: [MovieActorsUpdateFieldInput!]
+                  description: String
+                  title: String
+                }
+
+                input MovieWhere {
+                  AND: [MovieWhere!]
+                  NOT: MovieWhere
+                  OR: [MovieWhere!]
+                  actors: ActorWhere @deprecated(reason: \\"Use \`actors_SOME\` instead.\\")
+                  actorsAggregate: MovieActorsAggregateInput
+                  actorsConnection: MovieActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_SOME\` instead.\\")
+                  \\"\\"\\"
+                  Return Movies where all of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_ALL: MovieActorsConnectionWhere
+                  \\"\\"\\"
+                  Return Movies where none of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_NONE: MovieActorsConnectionWhere
+                  actorsConnection_NOT: MovieActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_NONE\` instead.\\")
+                  \\"\\"\\"
+                  Return Movies where one of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_SINGLE: MovieActorsConnectionWhere
+                  \\"\\"\\"
+                  Return Movies where some of the related MovieActorsConnections match this filter
+                  \\"\\"\\"
+                  actorsConnection_SOME: MovieActorsConnectionWhere
+                  \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
+                  actors_ALL: ActorWhere
+                  \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
+                  actors_NONE: ActorWhere
+                  actors_NOT: ActorWhere @deprecated(reason: \\"Use \`actors_NONE\` instead.\\")
+                  \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
+                  actors_SINGLE: ActorWhere
+                  \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
+                  actors_SOME: ActorWhere
+                  description: String
+                  description_CONTAINS: String
+                  description_ENDS_WITH: String
+                  description_IN: [String]
+                  description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_STARTS_WITH: String
+                  title: String
+                  title_CONTAINS: String
+                  title_ENDS_WITH: String
+                  title_IN: [String!]
+                  title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_STARTS_WITH: String
+                }
+
+                type MoviesConnection {
+                  edges: [MovieEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type Mutation {
+                  createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+                  deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+                  deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+                  updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+                  updateMovies(connect: MovieConnectInput, create: MovieRelationInput, delete: MovieDeleteInput, disconnect: MovieDisconnectInput, update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+                }
+
+                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+                type PageInfo {
+                  endCursor: String
+                  hasNextPage: Boolean!
+                  hasPreviousPage: Boolean!
+                  startCursor: String
+                }
+
+                type Query {
+                  actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+                  movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+                }
+
+                enum SortDirection {
+                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+                  ASC
+                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+                  DESC
+                }
+
+                type StringAggregateSelectionNonNullable {
+                  longest: String!
+                  shortest: String!
+                }
+
+                type StringAggregateSelectionNullable {
+                  longest: String
+                  shortest: String
+                }
+
+                type UpdateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: UpdateInfo!
+                }
+
+                type UpdateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  nodesDeleted: Int!
+                  relationshipsCreated: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type UpdateMoviesMutationResponse {
+                  info: UpdateInfo!
+                  movies: [Movie!]!
+                }"
+            `);
+        });
     });
 });

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -567,4 +567,887 @@ describe("@settable", () => {
             }"
         `);
     });
+
+    describe("Relationships", () => {
+        test("Prevent relationship field creation", async () => {
+            const typeDefs = gql`
+                type Movie {
+                    title: String!
+                    description: String
+                }
+
+                type Actor {
+                    name: String!
+                    actedIn: [Movie!]!
+                        @relationship(type: "ACTED_IN", direction: OUT)
+                        @settable(onCreate: false, onUpdate: true)
+                }
+            `;
+            const neoSchema = new Neo4jGraphQL({ typeDefs });
+            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+            expect(printedSchema).toMatchInlineSnapshot(`
+                "schema {
+                  query: Query
+                  mutation: Mutation
+                }
+
+                type Actor {
+                  actedIn(directed: Boolean = true, options: MovieOptions, where: MovieWhere): [Movie!]!
+                  actedInAggregate(directed: Boolean = true, where: MovieWhere): ActorMovieActedInAggregationSelection
+                  actedInConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorActedInConnectionSort!], where: ActorActedInConnectionWhere): ActorActedInConnection!
+                  name: String!
+                }
+
+                input ActorActedInAggregateInput {
+                  AND: [ActorActedInAggregateInput!]
+                  NOT: ActorActedInAggregateInput
+                  OR: [ActorActedInAggregateInput!]
+                  count: Int
+                  count_GT: Int
+                  count_GTE: Int
+                  count_LT: Int
+                  count_LTE: Int
+                  node: ActorActedInNodeAggregationWhereInput
+                }
+
+                input ActorActedInConnectFieldInput {
+                  \\"\\"\\"
+                  Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+                  \\"\\"\\"
+                  overwrite: Boolean! = true
+                  where: MovieConnectWhere
+                }
+
+                type ActorActedInConnection {
+                  edges: [ActorActedInRelationship!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                input ActorActedInConnectionSort {
+                  node: MovieSort
+                }
+
+                input ActorActedInConnectionWhere {
+                  AND: [ActorActedInConnectionWhere!]
+                  NOT: ActorActedInConnectionWhere
+                  OR: [ActorActedInConnectionWhere!]
+                  node: MovieWhere
+                  node_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                }
+
+                input ActorActedInDeleteFieldInput {
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInDisconnectFieldInput {
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInNodeAggregationWhereInput {
+                  AND: [ActorActedInNodeAggregationWhereInput!]
+                  NOT: ActorActedInNodeAggregationWhereInput
+                  OR: [ActorActedInNodeAggregationWhereInput!]
+                  description_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LENGTH_EQUAL: Float
+                  description_AVERAGE_LENGTH_GT: Float
+                  description_AVERAGE_LENGTH_GTE: Float
+                  description_AVERAGE_LENGTH_LT: Float
+                  description_AVERAGE_LENGTH_LTE: Float
+                  description_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LENGTH_EQUAL: Int
+                  description_LONGEST_LENGTH_GT: Int
+                  description_LONGEST_LENGTH_GTE: Int
+                  description_LONGEST_LENGTH_LT: Int
+                  description_LONGEST_LENGTH_LTE: Int
+                  description_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LENGTH_EQUAL: Int
+                  description_SHORTEST_LENGTH_GT: Int
+                  description_SHORTEST_LENGTH_GTE: Int
+                  description_SHORTEST_LENGTH_LT: Int
+                  description_SHORTEST_LENGTH_LTE: Int
+                  description_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LENGTH_EQUAL: Float
+                  title_AVERAGE_LENGTH_GT: Float
+                  title_AVERAGE_LENGTH_GTE: Float
+                  title_AVERAGE_LENGTH_LT: Float
+                  title_AVERAGE_LENGTH_LTE: Float
+                  title_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LENGTH_EQUAL: Int
+                  title_LONGEST_LENGTH_GT: Int
+                  title_LONGEST_LENGTH_GTE: Int
+                  title_LONGEST_LENGTH_LT: Int
+                  title_LONGEST_LENGTH_LTE: Int
+                  title_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LENGTH_EQUAL: Int
+                  title_SHORTEST_LENGTH_GT: Int
+                  title_SHORTEST_LENGTH_GTE: Int
+                  title_SHORTEST_LENGTH_LT: Int
+                  title_SHORTEST_LENGTH_LTE: Int
+                  title_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                }
+
+                type ActorActedInRelationship {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                input ActorActedInUpdateConnectionInput {
+                  node: MovieUpdateInput
+                }
+
+                input ActorActedInUpdateFieldInput {
+                  connect: [ActorActedInConnectFieldInput!]
+                  delete: [ActorActedInDeleteFieldInput!]
+                  disconnect: [ActorActedInDisconnectFieldInput!]
+                  update: ActorActedInUpdateConnectionInput
+                  where: ActorActedInConnectionWhere
+                }
+
+                type ActorAggregateSelection {
+                  count: Int!
+                  name: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorConnectInput {
+                  actedIn: [ActorActedInConnectFieldInput!]
+                }
+
+                input ActorCreateInput {
+                  name: String!
+                }
+
+                input ActorDeleteInput {
+                  actedIn: [ActorActedInDeleteFieldInput!]
+                }
+
+                input ActorDisconnectInput {
+                  actedIn: [ActorActedInDisconnectFieldInput!]
+                }
+
+                type ActorEdge {
+                  cursor: String!
+                  node: Actor!
+                }
+
+                type ActorMovieActedInAggregationSelection {
+                  count: Int!
+                  node: ActorMovieActedInNodeAggregateSelection
+                }
+
+                type ActorMovieActedInNodeAggregateSelection {
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [ActorSort!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+                \\"\\"\\"
+                input ActorSort {
+                  name: SortDirection
+                }
+
+                input ActorUpdateInput {
+                  actedIn: [ActorActedInUpdateFieldInput!]
+                  name: String
+                }
+
+                input ActorWhere {
+                  AND: [ActorWhere!]
+                  NOT: ActorWhere
+                  OR: [ActorWhere!]
+                  actedIn: MovieWhere @deprecated(reason: \\"Use \`actedIn_SOME\` instead.\\")
+                  actedInAggregate: ActorActedInAggregateInput
+                  actedInConnection: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_SOME\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where all of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_ALL: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where none of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_NONE: ActorActedInConnectionWhere
+                  actedInConnection_NOT: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_NONE\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where one of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SINGLE: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where some of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SOME: ActorActedInConnectionWhere
+                  \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+                  actedIn_ALL: MovieWhere
+                  \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+                  actedIn_NONE: MovieWhere
+                  actedIn_NOT: MovieWhere @deprecated(reason: \\"Use \`actedIn_NONE\` instead.\\")
+                  \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+                  actedIn_SINGLE: MovieWhere
+                  \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+                  actedIn_SOME: MovieWhere
+                  name: String
+                  name_CONTAINS: String
+                  name_ENDS_WITH: String
+                  name_IN: [String!]
+                  name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_STARTS_WITH: String
+                }
+
+                type ActorsConnection {
+                  edges: [ActorEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type CreateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: CreateInfo!
+                }
+
+                type CreateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  relationshipsCreated: Int!
+                }
+
+                type CreateMoviesMutationResponse {
+                  info: CreateInfo!
+                  movies: [Movie!]!
+                }
+
+                type DeleteInfo {
+                  bookmark: String
+                  nodesDeleted: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type Movie {
+                  description: String
+                  title: String!
+                }
+
+                type MovieAggregateSelection {
+                  count: Int!
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input MovieConnectWhere {
+                  node: MovieWhere!
+                }
+
+                input MovieCreateInput {
+                  description: String
+                  title: String!
+                }
+
+                type MovieEdge {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                input MovieOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [MovieSort!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+                \\"\\"\\"
+                input MovieSort {
+                  description: SortDirection
+                  title: SortDirection
+                }
+
+                input MovieUpdateInput {
+                  description: String
+                  title: String
+                }
+
+                input MovieWhere {
+                  AND: [MovieWhere!]
+                  NOT: MovieWhere
+                  OR: [MovieWhere!]
+                  description: String
+                  description_CONTAINS: String
+                  description_ENDS_WITH: String
+                  description_IN: [String]
+                  description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_STARTS_WITH: String
+                  title: String
+                  title_CONTAINS: String
+                  title_ENDS_WITH: String
+                  title_IN: [String!]
+                  title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_STARTS_WITH: String
+                }
+
+                type MoviesConnection {
+                  edges: [MovieEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type Mutation {
+                  createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+                  deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+                  deleteMovies(where: MovieWhere): DeleteInfo!
+                  updateActors(connect: ActorConnectInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+                  updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+                }
+
+                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+                type PageInfo {
+                  endCursor: String
+                  hasNextPage: Boolean!
+                  hasPreviousPage: Boolean!
+                  startCursor: String
+                }
+
+                type Query {
+                  actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+                  movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+                }
+
+                enum SortDirection {
+                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+                  ASC
+                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+                  DESC
+                }
+
+                type StringAggregateSelectionNonNullable {
+                  longest: String!
+                  shortest: String!
+                }
+
+                type StringAggregateSelectionNullable {
+                  longest: String
+                  shortest: String
+                }
+
+                type UpdateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: UpdateInfo!
+                }
+
+                type UpdateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  nodesDeleted: Int!
+                  relationshipsCreated: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type UpdateMoviesMutationResponse {
+                  info: UpdateInfo!
+                  movies: [Movie!]!
+                }"
+            `);
+        });
+
+        test("Prevent relationship field update", async () => {
+            const typeDefs = gql`
+                type Movie {
+                    title: String!
+                    description: String
+                }
+
+                type Actor {
+                    name: String!
+                    actedIn: [Movie!]!
+                        @relationship(type: "ACTED_IN", direction: OUT)
+                        @settable(onCreate: true, onUpdate: false)
+                }
+            `;
+            const neoSchema = new Neo4jGraphQL({ typeDefs });
+            const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+            expect(printedSchema).toMatchInlineSnapshot(`
+                "schema {
+                  query: Query
+                  mutation: Mutation
+                }
+
+                type Actor {
+                  actedIn(directed: Boolean = true, options: MovieOptions, where: MovieWhere): [Movie!]!
+                  actedInAggregate(directed: Boolean = true, where: MovieWhere): ActorMovieActedInAggregationSelection
+                  actedInConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorActedInConnectionSort!], where: ActorActedInConnectionWhere): ActorActedInConnection!
+                  name: String!
+                }
+
+                input ActorActedInAggregateInput {
+                  AND: [ActorActedInAggregateInput!]
+                  NOT: ActorActedInAggregateInput
+                  OR: [ActorActedInAggregateInput!]
+                  count: Int
+                  count_GT: Int
+                  count_GTE: Int
+                  count_LT: Int
+                  count_LTE: Int
+                  node: ActorActedInNodeAggregationWhereInput
+                }
+
+                input ActorActedInConnectFieldInput {
+                  \\"\\"\\"
+                  Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+                  \\"\\"\\"
+                  overwrite: Boolean! = true
+                  where: MovieConnectWhere
+                }
+
+                type ActorActedInConnection {
+                  edges: [ActorActedInRelationship!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                input ActorActedInConnectionSort {
+                  node: MovieSort
+                }
+
+                input ActorActedInConnectionWhere {
+                  AND: [ActorActedInConnectionWhere!]
+                  NOT: ActorActedInConnectionWhere
+                  OR: [ActorActedInConnectionWhere!]
+                  node: MovieWhere
+                  node_NOT: MovieWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                }
+
+                input ActorActedInCreateFieldInput {
+                  node: MovieCreateInput!
+                }
+
+                input ActorActedInDeleteFieldInput {
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInDisconnectFieldInput {
+                  where: ActorActedInConnectionWhere
+                }
+
+                input ActorActedInFieldInput {
+                  connect: [ActorActedInConnectFieldInput!]
+                  create: [ActorActedInCreateFieldInput!]
+                }
+
+                input ActorActedInNodeAggregationWhereInput {
+                  AND: [ActorActedInNodeAggregationWhereInput!]
+                  NOT: ActorActedInNodeAggregationWhereInput
+                  OR: [ActorActedInNodeAggregationWhereInput!]
+                  description_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LENGTH_EQUAL: Float
+                  description_AVERAGE_LENGTH_GT: Float
+                  description_AVERAGE_LENGTH_GTE: Float
+                  description_AVERAGE_LENGTH_LT: Float
+                  description_AVERAGE_LENGTH_LTE: Float
+                  description_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LENGTH_EQUAL: Int
+                  description_LONGEST_LENGTH_GT: Int
+                  description_LONGEST_LENGTH_GTE: Int
+                  description_LONGEST_LENGTH_LT: Int
+                  description_LONGEST_LENGTH_LTE: Int
+                  description_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  description_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LENGTH_EQUAL: Int
+                  description_SHORTEST_LENGTH_GT: Int
+                  description_SHORTEST_LENGTH_GTE: Int
+                  description_SHORTEST_LENGTH_LT: Int
+                  description_SHORTEST_LENGTH_LTE: Int
+                  description_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  description_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LENGTH_EQUAL: Float
+                  title_AVERAGE_LENGTH_GT: Float
+                  title_AVERAGE_LENGTH_GTE: Float
+                  title_AVERAGE_LENGTH_LT: Float
+                  title_AVERAGE_LENGTH_LTE: Float
+                  title_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LENGTH_EQUAL: Int
+                  title_LONGEST_LENGTH_GT: Int
+                  title_LONGEST_LENGTH_GTE: Int
+                  title_LONGEST_LENGTH_LT: Int
+                  title_LONGEST_LENGTH_LTE: Int
+                  title_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+                  title_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LENGTH_EQUAL: Int
+                  title_SHORTEST_LENGTH_GT: Int
+                  title_SHORTEST_LENGTH_GTE: Int
+                  title_SHORTEST_LENGTH_LT: Int
+                  title_SHORTEST_LENGTH_LTE: Int
+                  title_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                  title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+                }
+
+                type ActorActedInRelationship {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                type ActorAggregateSelection {
+                  count: Int!
+                  name: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorConnectInput {
+                  actedIn: [ActorActedInConnectFieldInput!]
+                }
+
+                input ActorCreateInput {
+                  actedIn: ActorActedInFieldInput
+                  name: String!
+                }
+
+                input ActorDeleteInput {
+                  actedIn: [ActorActedInDeleteFieldInput!]
+                }
+
+                input ActorDisconnectInput {
+                  actedIn: [ActorActedInDisconnectFieldInput!]
+                }
+
+                type ActorEdge {
+                  cursor: String!
+                  node: Actor!
+                }
+
+                type ActorMovieActedInAggregationSelection {
+                  count: Int!
+                  node: ActorMovieActedInNodeAggregateSelection
+                }
+
+                type ActorMovieActedInNodeAggregateSelection {
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input ActorOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [ActorSort!]
+                }
+
+                input ActorRelationInput {
+                  actedIn: [ActorActedInCreateFieldInput!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+                \\"\\"\\"
+                input ActorSort {
+                  name: SortDirection
+                }
+
+                input ActorUpdateInput {
+                  name: String
+                }
+
+                input ActorWhere {
+                  AND: [ActorWhere!]
+                  NOT: ActorWhere
+                  OR: [ActorWhere!]
+                  actedIn: MovieWhere @deprecated(reason: \\"Use \`actedIn_SOME\` instead.\\")
+                  actedInAggregate: ActorActedInAggregateInput
+                  actedInConnection: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_SOME\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where all of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_ALL: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where none of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_NONE: ActorActedInConnectionWhere
+                  actedInConnection_NOT: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_NONE\` instead.\\")
+                  \\"\\"\\"
+                  Return Actors where one of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SINGLE: ActorActedInConnectionWhere
+                  \\"\\"\\"
+                  Return Actors where some of the related ActorActedInConnections match this filter
+                  \\"\\"\\"
+                  actedInConnection_SOME: ActorActedInConnectionWhere
+                  \\"\\"\\"Return Actors where all of the related Movies match this filter\\"\\"\\"
+                  actedIn_ALL: MovieWhere
+                  \\"\\"\\"Return Actors where none of the related Movies match this filter\\"\\"\\"
+                  actedIn_NONE: MovieWhere
+                  actedIn_NOT: MovieWhere @deprecated(reason: \\"Use \`actedIn_NONE\` instead.\\")
+                  \\"\\"\\"Return Actors where one of the related Movies match this filter\\"\\"\\"
+                  actedIn_SINGLE: MovieWhere
+                  \\"\\"\\"Return Actors where some of the related Movies match this filter\\"\\"\\"
+                  actedIn_SOME: MovieWhere
+                  name: String
+                  name_CONTAINS: String
+                  name_ENDS_WITH: String
+                  name_IN: [String!]
+                  name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  name_STARTS_WITH: String
+                }
+
+                type ActorsConnection {
+                  edges: [ActorEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type CreateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: CreateInfo!
+                }
+
+                type CreateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  relationshipsCreated: Int!
+                }
+
+                type CreateMoviesMutationResponse {
+                  info: CreateInfo!
+                  movies: [Movie!]!
+                }
+
+                type DeleteInfo {
+                  bookmark: String
+                  nodesDeleted: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type Movie {
+                  description: String
+                  title: String!
+                }
+
+                type MovieAggregateSelection {
+                  count: Int!
+                  description: StringAggregateSelectionNullable!
+                  title: StringAggregateSelectionNonNullable!
+                }
+
+                input MovieConnectWhere {
+                  node: MovieWhere!
+                }
+
+                input MovieCreateInput {
+                  description: String
+                  title: String!
+                }
+
+                type MovieEdge {
+                  cursor: String!
+                  node: Movie!
+                }
+
+                input MovieOptions {
+                  limit: Int
+                  offset: Int
+                  \\"\\"\\"
+                  Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+                  \\"\\"\\"
+                  sort: [MovieSort!]
+                }
+
+                \\"\\"\\"
+                Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+                \\"\\"\\"
+                input MovieSort {
+                  description: SortDirection
+                  title: SortDirection
+                }
+
+                input MovieUpdateInput {
+                  description: String
+                  title: String
+                }
+
+                input MovieWhere {
+                  AND: [MovieWhere!]
+                  NOT: MovieWhere
+                  OR: [MovieWhere!]
+                  description: String
+                  description_CONTAINS: String
+                  description_ENDS_WITH: String
+                  description_IN: [String]
+                  description_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  description_STARTS_WITH: String
+                  title: String
+                  title_CONTAINS: String
+                  title_ENDS_WITH: String
+                  title_IN: [String!]
+                  title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+                  title_STARTS_WITH: String
+                }
+
+                type MoviesConnection {
+                  edges: [MovieEdge!]!
+                  pageInfo: PageInfo!
+                  totalCount: Int!
+                }
+
+                type Mutation {
+                  createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+                  createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+                  deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+                  deleteMovies(where: MovieWhere): DeleteInfo!
+                  updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+                  updateMovies(update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+                }
+
+                \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+                type PageInfo {
+                  endCursor: String
+                  hasNextPage: Boolean!
+                  hasPreviousPage: Boolean!
+                  startCursor: String
+                }
+
+                type Query {
+                  actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+                  actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+                  actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+                  movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+                  moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+                  moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+                }
+
+                enum SortDirection {
+                  \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+                  ASC
+                  \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+                  DESC
+                }
+
+                type StringAggregateSelectionNonNullable {
+                  longest: String!
+                  shortest: String!
+                }
+
+                type StringAggregateSelectionNullable {
+                  longest: String
+                  shortest: String
+                }
+
+                type UpdateActorsMutationResponse {
+                  actors: [Actor!]!
+                  info: UpdateInfo!
+                }
+
+                type UpdateInfo {
+                  bookmark: String
+                  nodesCreated: Int!
+                  nodesDeleted: Int!
+                  relationshipsCreated: Int!
+                  relationshipsDeleted: Int!
+                }
+
+                type UpdateMoviesMutationResponse {
+                  info: UpdateInfo!
+                  movies: [Movie!]!
+                }"
+            `);
+        });
+    });
 });

--- a/packages/graphql/tests/utils/builders/relation-field-builder.ts
+++ b/packages/graphql/tests/utils/builders/relation-field-builder.ts
@@ -38,6 +38,10 @@ export class RelationFieldBuilder extends Builder<RelationField, RelationField> 
                 onRead: true,
                 onAggregate: true,
             },
+            settableOptions: {
+                onCreate: true,
+                onUpdate: true,
+            },
             otherDirectives: [],
             arguments: [],
             inherited: false,


### PR DESCRIPTION
# Description
> This PR depends on #3403 

Adds `@settable` directive defined in https://github.com/neo4j/graphql/discussions/3263

This directive has the following options:
* onCreate
* onUpdate

Setting these values will disable the generation of the GraphQL input fields for create operations and update operations


## Complexity


Complexity: Medium