### PR TITLE
Access control docs

### DIFF
--- a/docs/modules/ROOT/pages/directives.adoc
+++ b/docs/modules/ROOT/pages/directives.adoc
@@ -156,3 +156,15 @@ Reference: xref::type-definitions/indexes-and-constraints.adoc#type-definitions-
 The `@writeonly` directive marks fields as write-only.
 
 Reference: xref::type-definitions/access-control.adoc#type-definitions-access-control-writeonly[`@writeonly`]
+
+== `@selectable`
+
+The `@selectable` directive controls if the field will be available on queries and aggregations. 
+
+Reference: xref::type-definitions/access-control.adoc#type-definitions-access-control-selectable[`@selectable`]
+
+== `@settable`
+
+The `@settable` directive controls if the input field will be available on creation and update mutations. 
+
+Reference: xref::type-definitions/access-control.adoc#type-definitions-access-control-settable[`@settable`]

--- a/docs/modules/ROOT/pages/type-definitions/access-control.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/access-control.adoc
@@ -117,7 +117,7 @@ This directive controls if the field will be available on queries and aggregatio
 
 It has two arguments:
 
-* onRead: If disabled, this field will not be available on queries.
+* onRead: If disabled, this field will not be available on queries and subscriptions.
 * onAggregation: If disabled, aggregations will not be available for this field
 
 
@@ -161,4 +161,48 @@ type MovieAggregateSelection {
 }
 ----
 
+[[type-definitions-access-control-settable]]
+== `@settable`
 
+This directive controls if the input field will be available on creation and update mutations.
+
+It has two arguments:
+
+* onCreate: If disabled, this field will not be available to be set on creation.
+* onCreate: If disabled, this field will not be available to be set on update.
+
+=== Definition
+
+[source, graphql, indent=0]
+----
+"""Instructs @neo4j/graphql to generate this input field for mutation."""
+directive @settable(onCreate: Boolean! = true, onUpdate: Boolean! = true) on FIELD_DEFINITION
+----
+
+=== Usage
+
+With the following definition:
+
+[source, graphql, indent=0]
+----
+type Movie {
+    title: String!
+    description: String @settable(onCreate: true, onUpdate: false)
+}
+----
+
+The following input fields will be generated:
+
+[source, graphql, indent=0]
+----
+input MovieCreateInput {
+    description: String
+    title: String!
+}
+
+input MovieUpdateInput {
+    title: String
+}
+----
+
+This means the description can be set on creation, but it will not be available for update operations.

--- a/docs/modules/ROOT/pages/type-definitions/access-control.adoc
+++ b/docs/modules/ROOT/pages/type-definitions/access-control.adoc
@@ -109,3 +109,56 @@ This field will only feature in input types, and will not be available for query
 """Instructs @neo4j/graphql to only include a field in the generated input types for the object type within which the directive is applied, but exclude it from the object type itself."""
 directive @writeonly on FIELD_DEFINITION
 ----
+
+[[type-definitions-access-control-selectable]]
+== `@selectable`
+
+This directive controls if the field will be available on queries and aggregations. 
+
+It has two arguments:
+
+* onRead: If disabled, this field will not be available on queries.
+* onAggregation: If disabled, aggregations will not be available for this field
+
+
+=== Definition
+
+[source, graphql, indent=0]
+----
+"""Instructs @neo4j/graphql to generate this field for selectable fields."""
+directive @selectable(onRead: Boolean! = true, onAggregate: Boolean! = true) on FIELD_DEFINITION
+----
+
+=== Usage
+
+With the following definition:
+
+[source, graphql, indent=0]
+----
+type Movie {
+    title: String!
+    description: String @selectable(onRead: false, onAggregate: true)
+}
+----
+
+The type `Movie` in the resulting schema will look:
+
+[source, graphql, indent=0]
+----
+type Movie {
+    title: String!
+}
+----
+
+This means that descriptions cannot be queries, neither on top or nested levels. Aggregations, however, are available for both:
+
+[source, graphql, indent=0]
+----
+type MovieAggregateSelection {
+    count: Int!
+    description: StringAggregateSelectionNullable!
+    title: StringAggregateSelectionNonNullable!
+}
+----
+
+


### PR DESCRIPTION
# Description
This PR adds the documentation on `@selectable` and `@settable` directives (implemented in #3403 and #3404) and described in #3263 