### PR TITLE
introduce aggregate argument to the relationship directive

### DIFF
--- a/packages/graphql/src/graphql/directives/relationship.ts
+++ b/packages/graphql/src/graphql/directives/relationship.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { DirectiveLocation, GraphQLDirective, GraphQLList, GraphQLNonNull, GraphQLString } from "graphql";
+import { DirectiveLocation, GraphQLBoolean, GraphQLDirective, GraphQLList, GraphQLNonNull, GraphQLString } from "graphql";
 import { RelationshipNestedOperationsOption, RelationshipQueryDirectionOption } from "../../constants";
 import { RelationshipDirectionEnum } from "./arguments/enums/RelationshipDirection";
 import { RelationshipNestedOperationsEnum } from "./arguments/enums/RelationshipNestedOperations";
@@ -57,6 +57,10 @@ export const relationshipDirective = new GraphQLDirective({
             type: new GraphQLNonNull(new GraphQLList(new GraphQLNonNull(RelationshipNestedOperationsEnum))),
             defaultValue: defaultNestedOperations,
             description: "Prevent all but these operations from being generated for this relationship",
+        },
+        aggregate: {
+            type: GraphQLBoolean,
+            defaultValue: true,
         },
     },
 });

--- a/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
+++ b/packages/graphql/src/schema/create-relationship-fields/create-relationship-fields.ts
@@ -207,14 +207,15 @@ function createRelationshipFields({
                 };
 
                 const aggregationFieldsArgs = addDirectedArgument(aggregationFieldsBaseArgs, rel);
-
-                composeNode.addFields({
-                    [`${rel.fieldName}Aggregate`]: {
-                        type: aggregationTypeObject,
-                        args: aggregationFieldsArgs,
-                        directives: deprecatedDirectives,
-                    },
-                });
+                if (rel.aggregate) {
+                    composeNode.addFields({
+                        [`${rel.fieldName}Aggregate`]: {
+                            type: aggregationTypeObject,
+                            args: aggregationFieldsArgs,
+                            directives: deprecatedDirectives,
+                        },
+                    });
+                }
             }
         }
 

--- a/packages/graphql/src/schema/get-relationship-meta.ts
+++ b/packages/graphql/src/schema/get-relationship-meta.ts
@@ -17,10 +17,11 @@
  * limitations under the License.
  */
 
-import type { ArgumentNode, FieldDefinitionNode, StringValueNode } from "graphql";
+import type { ArgumentNode, DirectiveNode, FieldDefinitionNode, StringValueNode } from "graphql";
 import { Kind } from "graphql";
 import { RelationshipNestedOperationsOption, RelationshipQueryDirectionOption } from "../constants";
-import { defaultNestedOperations } from "../graphql/directives/relationship";
+import { defaultNestedOperations, relationshipDirective } from "../graphql/directives/relationship";
+import { getArgumentValues } from "../utils/get-argument-values";
 
 type RelationshipDirection = "IN" | "OUT";
 
@@ -30,6 +31,7 @@ type RelationshipMeta = {
     properties?: string;
     queryDirection: RelationshipQueryDirectionOption;
     nestedOperations: RelationshipNestedOperationsOption[];
+    aggregate: boolean;
 };
 
 function getRelationshipMeta(
@@ -42,107 +44,11 @@ function getRelationshipMeta(
     if (!directive) {
         return undefined;
     }
-
-    if (!directive.arguments) {
-        throw new Error("@relationship has no arguments");
-    }
-
-    // Fail earlier if required arguments are missing: direction, type
-    const direction = getDirection(directive.arguments);
-    const type = getType(directive.arguments);
-
-    // Optional arguments
-    const queryDirection = getQueryDirection(directive.arguments);
-    const properties = getProperties(directive.arguments);
-    const nestedOperations = getNestedOperations(directive.arguments);
-
-    return {
-        direction,
-        type,
-        properties,
-        queryDirection,
-        nestedOperations,
-    };
+    return getRelationshipDirectiveArguments(directive);
 }
 
-function getType(directiveArguments: Readonly<ArgumentNode[]>) {
-    const typeArg = directiveArguments.find((x) => x.name.value === "type");
-    if (!typeArg) {
-        throw new Error("@relationship type required");
-    }
-    if (typeArg.value.kind !== Kind.STRING) {
-        throw new Error("@relationship type not a string");
-    }
-
-    return typeArg.value.value;
-}
-
-function getProperties(directiveArguments: Readonly<ArgumentNode[]>) {
-    const propertiesArg = directiveArguments.find((x) => x.name.value === "properties");
-    if (propertiesArg && propertiesArg.value.kind !== Kind.STRING) {
-        throw new Error("@relationship properties not a string");
-    }
-    return (propertiesArg?.value as StringValueNode)?.value;
-}
-
-function getDirection(directiveArguments: Readonly<ArgumentNode[]>): RelationshipDirection {
-    const directionArg = directiveArguments.find((x) => x.name.value === "direction");
-    if (!directionArg) {
-        throw new Error("@relationship direction required");
-    }
-    if (directionArg.value.kind !== Kind.ENUM) {
-        throw new Error("@relationship direction not a enum");
-    }
-    if (!["IN", "OUT"].includes(directionArg.value.value)) {
-        throw new Error("@relationship direction invalid");
-    }
-
-    return directionArg.value.value as RelationshipDirection;
-}
-
-function getQueryDirection(directiveArguments: Readonly<ArgumentNode[]>): RelationshipQueryDirectionOption {
-    const queryDirectionArg = directiveArguments.find((x) => x.name.value === "queryDirection");
-    let queryDirection = RelationshipQueryDirectionOption.DEFAULT_DIRECTED;
-
-    if (queryDirectionArg) {
-        if (queryDirectionArg.value.kind !== Kind.ENUM) {
-            throw new Error("@relationship queryDirection not an enum");
-        }
-
-        const queryDirectionValue = RelationshipQueryDirectionOption[queryDirectionArg.value.value];
-        if (!Object.values(RelationshipQueryDirectionOption).includes(queryDirectionValue)) {
-            throw new Error("@relationship queryDirection invalid");
-        }
-        queryDirection = queryDirectionArg.value.value as RelationshipQueryDirectionOption;
-    }
-    return queryDirection;
-}
-
-function getNestedOperations(directiveArguments: Readonly<ArgumentNode[]>): RelationshipNestedOperationsOption[] {
-    const nestedOperations: RelationshipNestedOperationsOption[] = [];
-
-    const nestedOperationsArg = directiveArguments.find((x) => x.name.value === "nestedOperations");
-
-    if (!nestedOperationsArg) {
-        return defaultNestedOperations;
-    }
-
-    if (nestedOperationsArg.value.kind !== Kind.LIST) {
-        throw new Error("@relationship nestedOperations not a list");
-    }
-
-    for (const [index, nestedOperationsArgValue] of nestedOperationsArg.value.values.entries()) {
-        if (nestedOperationsArgValue.kind !== Kind.ENUM) {
-            throw new Error(`@relationship nestedOperations value at index position ${index} not an enum`);
-        }
-
-        const nestedOperationsValue = RelationshipNestedOperationsOption[nestedOperationsArgValue.value];
-        if (!Object.values(RelationshipNestedOperationsOption).includes(nestedOperationsValue)) {
-            throw new Error(`@relationship nestedOperations value at index position ${index} invalid`);
-        }
-        nestedOperations.push(nestedOperationsValue);
-    }
-    return nestedOperations;
+function getRelationshipDirectiveArguments(directiveNode: DirectiveNode): RelationshipMeta {
+    return  getArgumentValues(relationshipDirective, directiveNode) as RelationshipMeta;
 }
 
 export default getRelationshipMeta;

--- a/packages/graphql/src/schema/get-relationship-meta.ts
+++ b/packages/graphql/src/schema/get-relationship-meta.ts
@@ -17,10 +17,9 @@
  * limitations under the License.
  */
 
-import type { ArgumentNode, DirectiveNode, FieldDefinitionNode, StringValueNode } from "graphql";
-import { Kind } from "graphql";
-import { RelationshipNestedOperationsOption, RelationshipQueryDirectionOption } from "../constants";
-import { defaultNestedOperations, relationshipDirective } from "../graphql/directives/relationship";
+import type { DirectiveNode, FieldDefinitionNode } from "graphql";
+import type { RelationshipNestedOperationsOption, RelationshipQueryDirectionOption } from "../constants";
+import { relationshipDirective } from "../graphql/directives/relationship";
 import { getArgumentValues } from "../utils/get-argument-values";
 
 type RelationshipDirection = "IN" | "OUT";
@@ -48,7 +47,7 @@ function getRelationshipMeta(
 }
 
 function getRelationshipDirectiveArguments(directiveNode: DirectiveNode): RelationshipMeta {
-    return  getArgumentValues(relationshipDirective, directiveNode) as RelationshipMeta;
+    return getArgumentValues(relationshipDirective, directiveNode) as RelationshipMeta;
 }
 
 export default getRelationshipMeta;

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -151,6 +151,7 @@ export interface RelationField extends BaseField {
     interface?: InterfaceField;
     queryDirection: RelationshipQueryDirectionOption;
     nestedOperations: RelationshipNestedOperationsOption[];
+    aggregate: boolean;
 }
 
 export interface ConnectionField extends BaseField {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -1,0 +1,539 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import { Neo4jGraphQL } from "../../../src";
+import type { GraphQLObjectType } from "graphql";
+import { lexicographicSortSchema } from "graphql";
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+
+describe("@relationship directive, aggregate argument", () => {
+    test("the default behavior should enable nested aggregation (this will change in 4.0)", async () => {
+        const typeDefs = gql`
+            type Actor {
+                username: String!
+                password: String!
+            }
+
+            type Movie {
+                title: String
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const schema = await neoSchema.getSchema();
+        const movieType = schema.getType("Movie") as GraphQLObjectType;
+        expect(movieType).toBeDefined();
+
+        const movieFields = movieType.getFields();
+        const movieActorsAggregate = movieFields["actorsAggregate"];
+        expect(movieActorsAggregate).toBeDefined();
+    });
+
+    test("should disable nested aggregation", async () => {
+        const typeDefs = gql`
+            type Actor {
+                username: String!
+                password: String!
+            }
+
+            type Movie {
+                title: String
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, aggregate: false)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const schema = await neoSchema.getSchema();
+        const movieType = schema.getType("Movie") as GraphQLObjectType;
+        expect(movieType).toBeDefined();
+
+        const movieFields = movieType.getFields();
+        const movieActorsAggregate = movieFields["actorsAggregate"];
+        expect(movieActorsAggregate).toBeUndefined();
+    });
+
+    test("should enable nested aggregation", async () => {
+        const typeDefs = gql`
+            type Actor {
+                username: String!
+                password: String!
+            }
+
+            type Movie {
+                title: String
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, aggregate: true)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const schema = await neoSchema.getSchema();
+        const movieType = schema.getType("Movie") as GraphQLObjectType;
+        expect(movieType).toBeDefined();
+
+        const movieFields = movieType.getFields();
+        const movieActorsAggregate = movieFields["actorsAggregate"];
+        expect(movieActorsAggregate).toBeDefined();
+    });
+
+    test("snapshot test with aggregate argument set as false", async () => {
+        const typeDefs = gql`
+            type Actor {
+                username: String!
+                password: String!
+            }
+
+            type Movie {
+                title: String
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, aggregate: false)
+            }
+        `;
+
+        const neoSchema = new Neo4jGraphQL({ typeDefs });
+        const schema = await neoSchema.getSchema();
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(schema));
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            type Actor {
+              password: String!
+              username: String!
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              password: StringAggregateSelectionNonNullable!
+              username: StringAggregateSelectionNonNullable!
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              password: String!
+              username: String!
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ActorSort!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              password: SortDirection
+              username: SortDirection
+            }
+
+            input ActorUpdateInput {
+              password: String
+              username: String
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              password: String
+              password_CONTAINS: String
+              password_ENDS_WITH: String
+              password_IN: [String!]
+              password_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              password_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              password_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              password_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              password_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              password_STARTS_WITH: String
+              username: String
+              username_CONTAINS: String
+              username_ENDS_WITH: String
+              username_IN: [String!]
+              username_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              username_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              username_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              username_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              username_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              username_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            type CreateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type DeleteInfo {
+              bookmark: String
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type Movie {
+              actors(directed: Boolean = true, options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [MovieActorsConnectionSort!], where: MovieActorsConnectionWhere): MovieActorsConnection!
+              title: String
+            }
+
+            input MovieActorsAggregateInput {
+              AND: [MovieActorsAggregateInput!]
+              NOT: MovieActorsAggregateInput
+              OR: [MovieActorsAggregateInput!]
+              count: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              node: MovieActorsNodeAggregationWhereInput
+            }
+
+            input MovieActorsConnectFieldInput {
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: ActorConnectWhere
+            }
+
+            type MovieActorsConnection {
+              edges: [MovieActorsRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input MovieActorsConnectionSort {
+              node: ActorSort
+            }
+
+            input MovieActorsConnectionWhere {
+              AND: [MovieActorsConnectionWhere!]
+              NOT: MovieActorsConnectionWhere
+              OR: [MovieActorsConnectionWhere!]
+              node: ActorWhere
+              node_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+            }
+
+            input MovieActorsCreateFieldInput {
+              node: ActorCreateInput!
+            }
+
+            input MovieActorsDeleteFieldInput {
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsDisconnectFieldInput {
+              where: MovieActorsConnectionWhere
+            }
+
+            input MovieActorsFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+            }
+
+            input MovieActorsNodeAggregationWhereInput {
+              AND: [MovieActorsNodeAggregationWhereInput!]
+              NOT: MovieActorsNodeAggregationWhereInput
+              OR: [MovieActorsNodeAggregationWhereInput!]
+              password_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_AVERAGE_LENGTH_EQUAL: Float
+              password_AVERAGE_LENGTH_GT: Float
+              password_AVERAGE_LENGTH_GTE: Float
+              password_AVERAGE_LENGTH_LT: Float
+              password_AVERAGE_LENGTH_LTE: Float
+              password_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              password_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              password_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              password_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_LONGEST_LENGTH_EQUAL: Int
+              password_LONGEST_LENGTH_GT: Int
+              password_LONGEST_LENGTH_GTE: Int
+              password_LONGEST_LENGTH_LT: Int
+              password_LONGEST_LENGTH_LTE: Int
+              password_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              password_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              password_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_SHORTEST_LENGTH_EQUAL: Int
+              password_SHORTEST_LENGTH_GT: Int
+              password_SHORTEST_LENGTH_GTE: Int
+              password_SHORTEST_LENGTH_LT: Int
+              password_SHORTEST_LENGTH_LTE: Int
+              password_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              password_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_AVERAGE_LENGTH_EQUAL: Float
+              username_AVERAGE_LENGTH_GT: Float
+              username_AVERAGE_LENGTH_GTE: Float
+              username_AVERAGE_LENGTH_LT: Float
+              username_AVERAGE_LENGTH_LTE: Float
+              username_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              username_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              username_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              username_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_LONGEST_LENGTH_EQUAL: Int
+              username_LONGEST_LENGTH_GT: Int
+              username_LONGEST_LENGTH_GTE: Int
+              username_LONGEST_LENGTH_LT: Int
+              username_LONGEST_LENGTH_LTE: Int
+              username_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              username_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              username_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_SHORTEST_LENGTH_EQUAL: Int
+              username_SHORTEST_LENGTH_GT: Int
+              username_SHORTEST_LENGTH_GTE: Int
+              username_SHORTEST_LENGTH_LT: Int
+              username_SHORTEST_LENGTH_LTE: Int
+              username_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              username_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+            }
+
+            type MovieActorsRelationship {
+              cursor: String!
+              node: Actor!
+            }
+
+            input MovieActorsUpdateConnectionInput {
+              node: ActorUpdateInput
+            }
+
+            input MovieActorsUpdateFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+              delete: [MovieActorsDeleteFieldInput!]
+              disconnect: [MovieActorsDisconnectFieldInput!]
+              update: MovieActorsUpdateConnectionInput
+              where: MovieActorsConnectionWhere
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              title: StringAggregateSelectionNullable!
+            }
+
+            input MovieConnectInput {
+              actors: [MovieActorsConnectFieldInput!]
+            }
+
+            input MovieCreateInput {
+              actors: MovieActorsFieldInput
+              title: String
+            }
+
+            input MovieDeleteInput {
+              actors: [MovieActorsDeleteFieldInput!]
+            }
+
+            input MovieDisconnectInput {
+              actors: [MovieActorsDisconnectFieldInput!]
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            input MovieRelationInput {
+              actors: [MovieActorsCreateFieldInput!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actors: [MovieActorsUpdateFieldInput!]
+              title: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actors: ActorWhere @deprecated(reason: \\"Use \`actors_SOME\` instead.\\")
+              actorsAggregate: MovieActorsAggregateInput
+              actorsConnection: MovieActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_SOME\` instead.\\")
+              \\"\\"\\"
+              Return Movies where all of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_ALL: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_NONE: MovieActorsConnectionWhere
+              actorsConnection_NOT: MovieActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_NONE\` instead.\\")
+              \\"\\"\\"
+              Return Movies where one of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SINGLE: MovieActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related MovieActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SOME: MovieActorsConnectionWhere
+              \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
+              actors_ALL: ActorWhere
+              \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
+              actors_NONE: ActorWhere
+              actors_NOT: ActorWhere @deprecated(reason: \\"Use \`actors_NONE\` instead.\\")
+              \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
+              actors_SINGLE: ActorWhere
+              \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
+              actors_SOME: ActorWhere
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              deleteActors(where: ActorWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              updateActors(update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateMovies(connect: MovieConnectInput, create: MovieRelationInput, delete: MovieDeleteInput, disconnect: MovieDisconnectInput, update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+            }
+
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String!
+              shortest: String!
+            }
+
+            type StringAggregateSelectionNullable {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            type UpdateInfo {
+              bookmark: String
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
# Description

This PR introduces the aggregate argument to the @relationship directive, It also removes the unnecessary code from get-relationship-meta by delegating the parse and the validation logic to GraphQL-JS.

## Complexity

Complexity: low


# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
