### PR TITLE
Toolbox: Fix prettify

### DIFF
--- a/packages/graphql-toolbox/src/modules/EditorView/QueryEditor.tsx
+++ b/packages/graphql-toolbox/src/modules/EditorView/QueryEditor.tsx
@@ -37,6 +37,7 @@ import {
 import { graphql as graphqlExtension } from "cm6-graphql";
 import { EditorView } from "codemirror";
 import type { GraphQLSchema } from "graphql";
+import type { ReactElement } from "react";
 import { dracula, tomorrow } from "thememirror";
 
 import { Extension, FileName } from "../../components/Filename";
@@ -47,7 +48,7 @@ import { formatCode, handleEditorDisableState, ParserOptions } from "./utils";
 
 export interface Props {
     loading: boolean;
-    buttons: any;
+    buttons: ReactElement;
     editorView: EditorView | null;
     setEditorView: React.Dispatch<React.SetStateAction<EditorView | null>>;
     onSubmit: (override?: string) => Promise<void>;

--- a/packages/graphql-toolbox/src/modules/EditorView/QueryEditor.tsx
+++ b/packages/graphql-toolbox/src/modules/EditorView/QueryEditor.tsx
@@ -110,11 +110,12 @@ export const QueryEditor = ({ loading, buttons, editorView, setEditorView, onSub
                     },
                 },
                 {
-                    key: "Shift-Mod-L",
+                    key: "Mod-m",
                     run: (view) => {
                         formatCode(view, ParserOptions.GRAPH_QL);
                         return true;
                     },
+                    preventDefault: true,
                 },
             ])
         ),

--- a/packages/graphql-toolbox/src/modules/EditorView/ResponseEditor.tsx
+++ b/packages/graphql-toolbox/src/modules/EditorView/ResponseEditor.tsx
@@ -103,7 +103,7 @@ export const ResponseEditor = ({ id, loading, fileExtension, fileName, value, bo
             const selection = editorView.state.selection;
             editorView.dispatch({
                 changes: { from: 0, to: editorView.state.doc.length, insert: value },
-                selection: value.length > selection.mainIndex ? undefined : selection,
+                selection: selection.main.to > value.length ? undefined : selection,
             });
             formatCode(editorView, ParserOptions.JSON);
         }

--- a/packages/graphql-toolbox/src/modules/EditorView/VariablesEditor.tsx
+++ b/packages/graphql-toolbox/src/modules/EditorView/VariablesEditor.tsx
@@ -23,7 +23,7 @@ import { closeBrackets } from "@codemirror/autocomplete";
 import { indentWithTab } from "@codemirror/commands";
 import { javascript } from "@codemirror/lang-javascript";
 import { bracketMatching, foldGutter, indentOnInput } from "@codemirror/language";
-import { Annotation, StateEffect } from "@codemirror/state";
+import { Annotation, Prec, StateEffect } from "@codemirror/state";
 import type { ViewUpdate } from "@codemirror/view";
 import {
     drawSelection,
@@ -34,13 +34,15 @@ import {
     keymap,
     lineNumbers,
 } from "@codemirror/view";
+import { Button } from "@neo4j-ndl/react";
+import classNames from "classnames";
 import { dracula, tomorrow } from "thememirror";
 
 import type { Extension } from "../../components/Filename";
 import { FileName } from "../../components/Filename";
 import { Theme, ThemeContext } from "../../contexts/theme";
 import { useStore } from "../../store";
-import { handleEditorDisableState } from "./utils";
+import { formatCode, handleEditorDisableState, ParserOptions } from "./utils";
 
 export interface Props {
     id: string;
@@ -58,6 +60,11 @@ export const VariablesEditor = ({ id, loading, fileExtension, fileName, borderRa
     const elementRef = useRef<HTMLDivElement | null>(null);
     const [editorView, setEditorView] = useState<EditorView | null>(null);
     const [value, setValue] = useState<string>();
+
+    const formatTheCode = (): void => {
+        if (!editorView) return;
+        formatCode(editorView, ParserOptions.GRAPH_QL);
+    };
 
     // Taken from https://github.com/uiwjs/react-codemirror/blob/master/core/src/useCodeMirror.ts
     const updateListener = EditorView.updateListener.of((vu: ViewUpdate) => {
@@ -89,6 +96,18 @@ export const VariablesEditor = ({ id, loading, fileExtension, fileName, borderRa
         javascript(),
         EditorView.lineWrapping,
         keymap.of([indentWithTab]),
+        Prec.highest(
+            keymap.of([
+                {
+                    key: "Mod-m",
+                    run: () => {
+                        formatTheCode();
+                        return true;
+                    },
+                    preventDefault: true,
+                },
+            ])
+        ),
         theme.theme === Theme.LIGHT ? tomorrow : dracula,
         updateListener,
     ];
@@ -141,7 +160,27 @@ export const VariablesEditor = ({ id, loading, fileExtension, fileName, borderRa
 
     return (
         <div style={{ width: "100%", height: "100%" }}>
-            <FileName extension={fileExtension} name={fileName} borderRadiusTop={borderRadiusTop}></FileName>
+            <FileName
+                extension={fileExtension}
+                name={fileName}
+                borderRadiusTop={borderRadiusTop}
+                rightButtons={
+                    <Button
+                        aria-label="Prettify code"
+                        className={classNames(
+                            "mr-2",
+                            theme.theme === Theme.LIGHT ? "ndl-theme-light" : "ndl-theme-dark"
+                        )}
+                        color="neutral"
+                        fill="outlined"
+                        size="small"
+                        onClick={formatTheCode}
+                        disabled={loading}
+                    >
+                        Prettify
+                    </Button>
+                }
+            />
             <div id={id} className={theme.theme === Theme.LIGHT ? "cm-light" : "cm-dark"} ref={elementRef} />
         </div>
     );

--- a/packages/graphql-toolbox/src/modules/EditorView/utils.ts
+++ b/packages/graphql-toolbox/src/modules/EditorView/utils.ts
@@ -53,12 +53,16 @@ export const formatCode = (editorView: EditorView, parserOption: ParserOptions):
             break;
     }
 
-    const formatted = prettier.format(value, options);
+    try {
+        const formatted = prettier.format(value, options);
 
-    editorView.dispatch({
-        changes: { from: 0, to: editorView.state.doc.length, insert: formatted },
-        selection: selection.main.to > formatted.length ? undefined : selection,
-    });
+        editorView.dispatch({
+            changes: { from: 0, to: editorView.state.doc.length, insert: formatted },
+            selection: selection.main.to > formatted.length ? undefined : selection,
+        });
+    } catch (e: unknown) {
+        return;
+    }
 };
 
 export const handleEditorDisableState = (editorViewRef: HTMLDivElement | null, loading: boolean): void => {

--- a/packages/graphql-toolbox/src/modules/EditorView/utils.ts
+++ b/packages/graphql-toolbox/src/modules/EditorView/utils.ts
@@ -54,9 +54,10 @@ export const formatCode = (editorView: EditorView, parserOption: ParserOptions):
     }
 
     const formatted = prettier.format(value, options);
+
     editorView.dispatch({
         changes: { from: 0, to: editorView.state.doc.length, insert: formatted },
-        selection: formatted.length > selection.mainIndex ? undefined : selection,
+        selection: selection.main.to > formatted.length ? undefined : selection,
     });
 };
 

--- a/packages/graphql-toolbox/src/modules/SchemaView/SchemaEditor.tsx
+++ b/packages/graphql-toolbox/src/modules/SchemaView/SchemaEditor.tsx
@@ -24,7 +24,7 @@ import { defaultKeymap, history, historyKeymap, indentWithTab } from "@codemirro
 import { bracketMatching, foldGutter, foldKeymap, indentOnInput } from "@codemirror/language";
 import { lintKeymap } from "@codemirror/lint";
 import { highlightSelectionMatches, searchKeymap } from "@codemirror/search";
-import { EditorState, StateEffect } from "@codemirror/state";
+import { EditorState, Prec, StateEffect } from "@codemirror/state";
 import {
     drawSelection,
     dropCursor,
@@ -99,6 +99,18 @@ export const SchemaEditor = ({
             ...completionKeymap,
             ...lintKeymap,
         ]),
+        Prec.highest(
+            keymap.of([
+                {
+                    key: "Mod-m",
+                    run: () => {
+                        formatTheCode();
+                        return true;
+                    },
+                    preventDefault: true,
+                },
+            ])
+        ),
         foldGutter({
             closedText: "▶",
             openText: "▼",


### PR DESCRIPTION
# Description

Fixes various things to do with prettifying.

You can now prettify the params (VariablesEditor)
You can now prettify using Mod-m (Mod being ctrl on Windows/Linux, cmd on Mac) on all views.
Fixes selection position when prettifying
No longer logs errors when trying to prettify text which is not able to be prettified.

## Complexity

Low