### PR TITLE
Fix property escaping in MERGE operation

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -92,7 +92,7 @@
         "@graphql-tools/resolvers-composition": "^6.5.3",
         "@graphql-tools/schema": "9.0.19",
         "@graphql-tools/utils": "^9.0.0",
-        "@neo4j/cypher-builder": "~0.5.1",
+        "@neo4j/cypher-builder": "~0.5.3",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "deep-equal": "^2.0.5",

--- a/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-alias.test.ts
+++ b/packages/graphql/tests/tck/connections/connect-or-create/connect-or-create-alias.test.ts
@@ -93,7 +93,7 @@ describe("Connect or create with @alias", () => {
             WITH this
             CALL {
                 WITH this
-                MERGE (this_isInPublication0_connectOrCreate0:\`Concept\`:\`Resource\` { $_uri: $this_isInPublication0_connectOrCreate_param0 })
+                MERGE (this_isInPublication0_connectOrCreate0:\`Concept\`:\`Resource\` { \`$_uri\`: $this_isInPublication0_connectOrCreate_param0 })
                 ON CREATE SET
                     this_isInPublication0_connectOrCreate0.\`$_uri\` = $this_isInPublication0_connectOrCreate_param1,
                     this_isInPublication0_connectOrCreate0.prefLabel = $this_isInPublication0_connectOrCreate_param2
@@ -102,7 +102,7 @@ describe("Connect or create with @alias", () => {
             WITH this
             CALL {
                 WITH this
-                MERGE (this_isInPublication1_connectOrCreate0:\`Concept\`:\`Resource\` { $_uri: $this_isInPublication1_connectOrCreate_param0 })
+                MERGE (this_isInPublication1_connectOrCreate0:\`Concept\`:\`Resource\` { \`$_uri\`: $this_isInPublication1_connectOrCreate_param0 })
                 ON CREATE SET
                     this_isInPublication1_connectOrCreate0.\`$_uri\` = $this_isInPublication1_connectOrCreate_param1,
                     this_isInPublication1_connectOrCreate0.prefLabel = $this_isInPublication1_connectOrCreate_param2

--- a/yarn.lock
+++ b/yarn.lock
@@ -3167,10 +3167,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:~0.5.1":
-  version: 0.5.2
-  resolution: "@neo4j/cypher-builder@npm:0.5.2"
-  checksum: 4d0728b15bb8d389ada511474908670cce35ff6fb88c83a8b94a4d818f165502b96356470196aa7bc77bc71240fe7fe61bef00b9caf619585bd972c871493590
+"@neo4j/cypher-builder@npm:~0.5.3":
+  version: 0.5.3
+  resolution: "@neo4j/cypher-builder@npm:0.5.3"
+  checksum: 1e3ecdcd66f26671a13f0562e0f877fb35a5e5744b7c226b382a39e46511a8d3b5f641e79a510b4f2ee9648b6087f0df5ec7ca82135bc2173527d7a3673c00c3
   languageName: node
   linkType: hard
 
@@ -3331,7 +3331,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": ^6.5.3
     "@graphql-tools/schema": 9.0.19
     "@graphql-tools/utils": ^9.0.0
-    "@neo4j/cypher-builder": ~0.5.1
+    "@neo4j/cypher-builder": ~0.5.3
     "@neo4j/graphql-plugin-auth": ^2.2.0
     "@types/deep-equal": 1.0.1
     "@types/is-uuid": 1.0.0


### PR DESCRIPTION
# Description
Update `@neo4j/cypher-builder` to `0.5.3` to fix an escaping issue that was causing the tests to fail