### PR TITLE
Refactor: remove unused Neo4jGraphQLCypherBuilderError

### DIFF
--- a/packages/graphql/src/classes/Error.ts
+++ b/packages/graphql/src/classes/Error.ts
@@ -60,16 +60,6 @@ export class Neo4jGraphQLConstraintValidationError extends Neo4jGraphQLError {
     }
 }
 
-export class Neo4jGraphQLCypherBuilderError extends Neo4jGraphQLError {
-    readonly name;
-
-    constructor(message: string) {
-        super(message);
-
-        Object.defineProperty(this, "name", { value: "Neo4jGraphQLCypherQueryBuilderError" });
-    }
-}
-
 export class Neo4jGraphQLRelationshipValidationError extends Neo4jGraphQLError {
     readonly name;
 
@@ -79,6 +69,7 @@ export class Neo4jGraphQLRelationshipValidationError extends Neo4jGraphQLError {
         Object.defineProperty(this, "name", { value: "Neo4jGraphQLRelationshipValidationError" });
     }
 }
+
 export class Neo4jGraphQLSchemaValidationError extends Neo4jGraphQLError {
     readonly name;
 


### PR DESCRIPTION
# Description

This Neo4jGraphQLCypherBuilderError class is no longer used, I assume it was part of the code that was moved out to the separate Cypherbuilder package.

## Complexity

Low