### PR TITLE
Preserve library casing in OGM

### DIFF
--- a/.changeset/quick-items-laugh.md
+++ b/.changeset/quick-items-laugh.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-ogm": patch
+---
+
+Preserve library generated casing when generating TypeScript types using the OGM.

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -2827,7 +2827,7 @@ describe("generate", () => {
               public aggregate(args: {
                 where?: FaqWhere;
 
-                aggregate: FaqAggregateSelectionInput;
+                aggregate: FAQAggregateSelectionInput;
                 context?: any;
                 rootValue?: any;
               }): Promise<FaqAggregateSelection>;
@@ -2886,7 +2886,7 @@ describe("generate", () => {
               public aggregate(args: {
                 where?: FaqEntryWhere;
 
-                aggregate: FaqEntryAggregateSelectionInput;
+                aggregate: FAQEntryAggregateSelectionInput;
                 context?: any;
                 rootValue?: any;
               }): Promise<FaqEntryAggregateSelection>;

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -22,6 +22,7 @@ import * as fs from "fs";
 import * as path from "path";
 import generate from "./generate";
 import { OGM } from "./index";
+import gql from "graphql-tag";
 
 describe("generate", () => {
     const filesToDelete: string[] = [];
@@ -80,19 +81,19 @@ describe("generate", () => {
               usersAggregate: UserAggregateSelection;
             };
 
-            export type QueryUsersArgs = {
+            export type QueryusersArgs = {
               where?: InputMaybe<UserWhere>;
               options?: InputMaybe<UserOptions>;
             };
 
-            export type QueryUsersConnectionArgs = {
+            export type QueryusersConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<UserWhere>;
               sort?: InputMaybe<Array<InputMaybe<UserSort>>>;
             };
 
-            export type QueryUsersAggregateArgs = {
+            export type QueryusersAggregateArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
@@ -103,24 +104,24 @@ describe("generate", () => {
               updateUsers: UpdateUsersMutationResponse;
             };
 
-            export type MutationCreateUsersArgs = {
+            export type MutationcreateUsersArgs = {
               input: Array<UserCreateInput>;
             };
 
-            export type MutationDeleteUsersArgs = {
+            export type MutationdeleteUsersArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
-            export type MutationUpdateUsersArgs = {
+            export type MutationupdateUsersArgs = {
               where?: InputMaybe<UserWhere>;
               update?: InputMaybe<UserUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              Asc = \\"ASC\\",
+              ASC = \\"ASC\\",
               /** Sort by field values in descending order. */
-              Desc = \\"DESC\\",
+              DESC = \\"DESC\\",
             }
 
             export type CreateInfo = {
@@ -349,7 +350,7 @@ describe("generate", () => {
               usersAggregate: UserAggregateSelection;
             };
 
-            export type QueryUsersFulltextUserNameArgs = {
+            export type QueryusersFulltextUserNameArgs = {
               phrase: Scalars[\\"String\\"];
               where?: InputMaybe<UserFulltextWhere>;
               sort?: InputMaybe<Array<UserFulltextSort>>;
@@ -357,13 +358,13 @@ describe("generate", () => {
               offset?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type QueryUsersArgs = {
+            export type QueryusersArgs = {
               where?: InputMaybe<UserWhere>;
               options?: InputMaybe<UserOptions>;
               fulltext?: InputMaybe<UserFulltext>;
             };
 
-            export type QueryUsersConnectionArgs = {
+            export type QueryusersConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<UserWhere>;
@@ -371,7 +372,7 @@ describe("generate", () => {
               fulltext?: InputMaybe<UserFulltext>;
             };
 
-            export type QueryUsersAggregateArgs = {
+            export type QueryusersAggregateArgs = {
               where?: InputMaybe<UserWhere>;
               fulltext?: InputMaybe<UserFulltext>;
             };
@@ -383,24 +384,24 @@ describe("generate", () => {
               updateUsers: UpdateUsersMutationResponse;
             };
 
-            export type MutationCreateUsersArgs = {
+            export type MutationcreateUsersArgs = {
               input: Array<UserCreateInput>;
             };
 
-            export type MutationDeleteUsersArgs = {
+            export type MutationdeleteUsersArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
-            export type MutationUpdateUsersArgs = {
+            export type MutationupdateUsersArgs = {
               where?: InputMaybe<UserWhere>;
               update?: InputMaybe<UserUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              Asc = \\"ASC\\",
+              ASC = \\"ASC\\",
               /** Sort by field values in descending order. */
-              Desc = \\"DESC\\",
+              DESC = \\"DESC\\",
             }
 
             export type CreateInfo = {
@@ -669,19 +670,19 @@ describe("generate", () => {
               usersAggregate: UserAggregateSelection;
             };
 
-            export type QueryUsersArgs = {
+            export type QueryusersArgs = {
               where?: InputMaybe<UserWhere>;
               options?: InputMaybe<UserOptions>;
             };
 
-            export type QueryUsersConnectionArgs = {
+            export type QueryusersConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<UserWhere>;
               sort?: InputMaybe<Array<InputMaybe<UserSort>>>;
             };
 
-            export type QueryUsersAggregateArgs = {
+            export type QueryusersAggregateArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
@@ -692,24 +693,24 @@ describe("generate", () => {
               updateUsers: UpdateUsersMutationResponse;
             };
 
-            export type MutationCreateUsersArgs = {
+            export type MutationcreateUsersArgs = {
               input: Array<UserCreateInput>;
             };
 
-            export type MutationDeleteUsersArgs = {
+            export type MutationdeleteUsersArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
-            export type MutationUpdateUsersArgs = {
+            export type MutationupdateUsersArgs = {
               where?: InputMaybe<UserWhere>;
               update?: InputMaybe<UserUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              Asc = \\"ASC\\",
+              ASC = \\"ASC\\",
               /** Sort by field values in descending order. */
-              Desc = \\"DESC\\",
+              DESC = \\"DESC\\",
             }
 
             export type CreateInfo = {
@@ -945,35 +946,35 @@ describe("generate", () => {
               peopleAggregate: PersonAggregateSelection;
             };
 
-            export type QueryMoviesArgs = {
+            export type QuerymoviesArgs = {
               where?: InputMaybe<MovieWhere>;
               options?: InputMaybe<MovieOptions>;
             };
 
-            export type QueryMoviesConnectionArgs = {
+            export type QuerymoviesConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<MovieWhere>;
               sort?: InputMaybe<Array<InputMaybe<MovieSort>>>;
             };
 
-            export type QueryMoviesAggregateArgs = {
+            export type QuerymoviesAggregateArgs = {
               where?: InputMaybe<MovieWhere>;
             };
 
-            export type QueryPeopleArgs = {
+            export type QuerypeopleArgs = {
               where?: InputMaybe<PersonWhere>;
               options?: InputMaybe<PersonOptions>;
             };
 
-            export type QueryPeopleConnectionArgs = {
+            export type QuerypeopleConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<PersonWhere>;
               sort?: InputMaybe<Array<InputMaybe<PersonSort>>>;
             };
 
-            export type QueryPeopleAggregateArgs = {
+            export type QuerypeopleAggregateArgs = {
               where?: InputMaybe<PersonWhere>;
             };
 
@@ -987,16 +988,16 @@ describe("generate", () => {
               updatePeople: UpdatePeopleMutationResponse;
             };
 
-            export type MutationCreateMoviesArgs = {
+            export type MutationcreateMoviesArgs = {
               input: Array<MovieCreateInput>;
             };
 
-            export type MutationDeleteMoviesArgs = {
+            export type MutationdeleteMoviesArgs = {
               where?: InputMaybe<MovieWhere>;
               delete?: InputMaybe<MovieDeleteInput>;
             };
 
-            export type MutationUpdateMoviesArgs = {
+            export type MutationupdateMoviesArgs = {
               where?: InputMaybe<MovieWhere>;
               update?: InputMaybe<MovieUpdateInput>;
               connect?: InputMaybe<MovieConnectInput>;
@@ -1005,24 +1006,24 @@ describe("generate", () => {
               delete?: InputMaybe<MovieDeleteInput>;
             };
 
-            export type MutationCreatePeopleArgs = {
+            export type MutationcreatePeopleArgs = {
               input: Array<PersonCreateInput>;
             };
 
-            export type MutationDeletePeopleArgs = {
+            export type MutationdeletePeopleArgs = {
               where?: InputMaybe<PersonWhere>;
             };
 
-            export type MutationUpdatePeopleArgs = {
+            export type MutationupdatePeopleArgs = {
               where?: InputMaybe<PersonWhere>;
               update?: InputMaybe<PersonUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              Asc = \\"ASC\\",
+              ASC = \\"ASC\\",
               /** Sort by field values in descending order. */
-              Desc = \\"DESC\\",
+              DESC = \\"DESC\\",
             }
 
             export type ActedIn = {
@@ -1071,18 +1072,18 @@ describe("generate", () => {
               actorsConnection: MovieActorsConnection;
             };
 
-            export type MovieActorsArgs = {
+            export type MovieactorsArgs = {
               where?: InputMaybe<PersonWhere>;
               options?: InputMaybe<PersonOptions>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type MovieActorsAggregateArgs = {
+            export type MovieactorsAggregateArgs = {
               where?: InputMaybe<PersonWhere>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type MovieActorsConnectionArgs = {
+            export type MovieactorsConnectionArgs = {
               where?: InputMaybe<MovieActorsConnectionWhere>;
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
@@ -1654,5 +1655,1248 @@ describe("generate", () => {
                 ogm,
             })
         ).rejects.toThrow("outFile or noWrite required");
+    });
+
+    test("https://github.com/neo4j/graphql/issues/3539", async () => {
+        const typeDefs = gql`
+            type FAQ {
+                id: ID! @id
+                activated: Boolean!
+                name: String!
+                entries: [FAQEntry!]!
+                    @relationship(type: "FAQ_ENTRY_IN_FAQ", properties: "FaqEntryInFaq", direction: IN)
+            }
+
+            type FAQEntry {
+                id: ID! @id
+                title: String!
+                body: String!
+                inFAQs: [FAQ!]! @relationship(type: "FAQ_ENTRY_IN_FAQ", properties: "FaqEntryInFaq", direction: OUT)
+            }
+
+            interface FaqEntryInFaq @relationshipProperties {
+                position: Int
+            }
+        `;
+
+        const ogm = new OGM({
+            typeDefs,
+            // @ts-ignore
+            driver: {},
+        });
+
+        const generated = (await generate({
+            ogm,
+            noWrite: true,
+        })) as string;
+
+        expect(generated).toMatchInlineSnapshot(`
+            "import type { SelectionSetNode, DocumentNode } from \\"graphql\\";
+            export type Maybe<T> = T | null;
+            export type InputMaybe<T> = Maybe<T>;
+            export type Exact<T extends { [key: string]: unknown }> = {
+              [K in keyof T]: T[K];
+            };
+            export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
+              [SubKey in K]?: Maybe<T[SubKey]>;
+            };
+            export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
+              [SubKey in K]: Maybe<T[SubKey]>;
+            };
+            /** All built-in and custom scalars, mapped to their actual values */
+            export type Scalars = {
+              /** The \`ID\` scalar type represents a unique identifier, often used to refetch an object or as key for a cache. The ID type appears in a JSON response as a String; however, it is not intended to be human-readable. When expected as an input type, any string (such as \`\\"4\\"\`) or integer (such as \`4\`) input value will be accepted as an ID. */
+              ID: string;
+              /** The \`String\` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text. */
+              String: string;
+              /** The \`Boolean\` scalar type represents \`true\` or \`false\`. */
+              Boolean: boolean;
+              /** The \`Int\` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. */
+              Int: number;
+              /** The \`Float\` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). */
+              Float: number;
+            };
+
+            export type Query = {
+              __typename?: \\"Query\\";
+              faqs: Array<FAQ>;
+              faqsConnection: FaqsConnection;
+              faqsAggregate: FAQAggregateSelection;
+              faqEntries: Array<FAQEntry>;
+              faqEntriesConnection: FaqEntriesConnection;
+              faqEntriesAggregate: FAQEntryAggregateSelection;
+            };
+
+            export type QueryfaqsArgs = {
+              where?: InputMaybe<FAQWhere>;
+              options?: InputMaybe<FAQOptions>;
+            };
+
+            export type QueryfaqsConnectionArgs = {
+              first?: InputMaybe<Scalars[\\"Int\\"]>;
+              after?: InputMaybe<Scalars[\\"String\\"]>;
+              where?: InputMaybe<FAQWhere>;
+              sort?: InputMaybe<Array<InputMaybe<FAQSort>>>;
+            };
+
+            export type QueryfaqsAggregateArgs = {
+              where?: InputMaybe<FAQWhere>;
+            };
+
+            export type QueryfaqEntriesArgs = {
+              where?: InputMaybe<FAQEntryWhere>;
+              options?: InputMaybe<FAQEntryOptions>;
+            };
+
+            export type QueryfaqEntriesConnectionArgs = {
+              first?: InputMaybe<Scalars[\\"Int\\"]>;
+              after?: InputMaybe<Scalars[\\"String\\"]>;
+              where?: InputMaybe<FAQEntryWhere>;
+              sort?: InputMaybe<Array<InputMaybe<FAQEntrySort>>>;
+            };
+
+            export type QueryfaqEntriesAggregateArgs = {
+              where?: InputMaybe<FAQEntryWhere>;
+            };
+
+            export type Mutation = {
+              __typename?: \\"Mutation\\";
+              createFaqs: CreateFaqsMutationResponse;
+              deleteFaqs: DeleteInfo;
+              updateFaqs: UpdateFaqsMutationResponse;
+              createFaqEntries: CreateFaqEntriesMutationResponse;
+              deleteFaqEntries: DeleteInfo;
+              updateFaqEntries: UpdateFaqEntriesMutationResponse;
+            };
+
+            export type MutationcreateFaqsArgs = {
+              input: Array<FAQCreateInput>;
+            };
+
+            export type MutationdeleteFaqsArgs = {
+              where?: InputMaybe<FAQWhere>;
+              delete?: InputMaybe<FAQDeleteInput>;
+            };
+
+            export type MutationupdateFaqsArgs = {
+              where?: InputMaybe<FAQWhere>;
+              update?: InputMaybe<FAQUpdateInput>;
+              connect?: InputMaybe<FAQConnectInput>;
+              disconnect?: InputMaybe<FAQDisconnectInput>;
+              create?: InputMaybe<FAQRelationInput>;
+              delete?: InputMaybe<FAQDeleteInput>;
+              connectOrCreate?: InputMaybe<FAQConnectOrCreateInput>;
+            };
+
+            export type MutationcreateFaqEntriesArgs = {
+              input: Array<FAQEntryCreateInput>;
+            };
+
+            export type MutationdeleteFaqEntriesArgs = {
+              where?: InputMaybe<FAQEntryWhere>;
+              delete?: InputMaybe<FAQEntryDeleteInput>;
+            };
+
+            export type MutationupdateFaqEntriesArgs = {
+              where?: InputMaybe<FAQEntryWhere>;
+              update?: InputMaybe<FAQEntryUpdateInput>;
+              connect?: InputMaybe<FAQEntryConnectInput>;
+              disconnect?: InputMaybe<FAQEntryDisconnectInput>;
+              create?: InputMaybe<FAQEntryRelationInput>;
+              delete?: InputMaybe<FAQEntryDeleteInput>;
+              connectOrCreate?: InputMaybe<FAQEntryConnectOrCreateInput>;
+            };
+
+            export enum SortDirection {
+              /** Sort by field values in ascending order. */
+              ASC = \\"ASC\\",
+              /** Sort by field values in descending order. */
+              DESC = \\"DESC\\",
+            }
+
+            export type FaqEntryInFaq = {
+              position?: Maybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type CreateFaqEntriesMutationResponse = {
+              __typename?: \\"CreateFaqEntriesMutationResponse\\";
+              info: CreateInfo;
+              faqEntries: Array<FAQEntry>;
+            };
+
+            export type CreateFaqsMutationResponse = {
+              __typename?: \\"CreateFaqsMutationResponse\\";
+              info: CreateInfo;
+              faqs: Array<FAQ>;
+            };
+
+            export type CreateInfo = {
+              __typename?: \\"CreateInfo\\";
+              bookmark?: Maybe<Scalars[\\"String\\"]>;
+              nodesCreated: Scalars[\\"Int\\"];
+              relationshipsCreated: Scalars[\\"Int\\"];
+            };
+
+            export type DeleteInfo = {
+              __typename?: \\"DeleteInfo\\";
+              bookmark?: Maybe<Scalars[\\"String\\"]>;
+              nodesDeleted: Scalars[\\"Int\\"];
+              relationshipsDeleted: Scalars[\\"Int\\"];
+            };
+
+            export type FAQ = {
+              __typename?: \\"FAQ\\";
+              id: Scalars[\\"ID\\"];
+              activated: Scalars[\\"Boolean\\"];
+              name: Scalars[\\"String\\"];
+              entries: Array<FAQEntry>;
+              entriesAggregate?: Maybe<FAQFAQEntryEntriesAggregationSelection>;
+              entriesConnection: FAQEntriesConnection;
+            };
+
+            export type FAQentriesArgs = {
+              where?: InputMaybe<FAQEntryWhere>;
+              options?: InputMaybe<FAQEntryOptions>;
+              directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
+            };
+
+            export type FAQentriesAggregateArgs = {
+              where?: InputMaybe<FAQEntryWhere>;
+              directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
+            };
+
+            export type FAQentriesConnectionArgs = {
+              where?: InputMaybe<FAQEntriesConnectionWhere>;
+              first?: InputMaybe<Scalars[\\"Int\\"]>;
+              after?: InputMaybe<Scalars[\\"String\\"]>;
+              directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
+              sort?: InputMaybe<Array<FAQEntriesConnectionSort>>;
+            };
+
+            export type FAQAggregateSelection = {
+              __typename?: \\"FAQAggregateSelection\\";
+              count: Scalars[\\"Int\\"];
+              id: IDAggregateSelectionNonNullable;
+              name: StringAggregateSelectionNonNullable;
+            };
+
+            export type FAQEdge = {
+              __typename?: \\"FAQEdge\\";
+              cursor: Scalars[\\"String\\"];
+              node: FAQ;
+            };
+
+            export type FaqEntriesConnection = {
+              __typename?: \\"FaqEntriesConnection\\";
+              totalCount: Scalars[\\"Int\\"];
+              pageInfo: PageInfo;
+              edges: Array<FAQEntryEdge>;
+            };
+
+            export type FAQEntriesConnection = {
+              __typename?: \\"FAQEntriesConnection\\";
+              edges: Array<FAQEntriesRelationship>;
+              totalCount: Scalars[\\"Int\\"];
+              pageInfo: PageInfo;
+            };
+
+            export type FAQEntriesRelationship = FaqEntryInFaq & {
+              __typename?: \\"FAQEntriesRelationship\\";
+              cursor: Scalars[\\"String\\"];
+              node: FAQEntry;
+              position?: Maybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntry = {
+              __typename?: \\"FAQEntry\\";
+              id: Scalars[\\"ID\\"];
+              title: Scalars[\\"String\\"];
+              body: Scalars[\\"String\\"];
+              inFAQs: Array<FAQ>;
+              inFAQsAggregate?: Maybe<FAQEntryFAQInFAQsAggregationSelection>;
+              inFAQsConnection: FAQEntryInFAQsConnection;
+            };
+
+            export type FAQEntryinFAQsArgs = {
+              where?: InputMaybe<FAQWhere>;
+              options?: InputMaybe<FAQOptions>;
+              directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
+            };
+
+            export type FAQEntryinFAQsAggregateArgs = {
+              where?: InputMaybe<FAQWhere>;
+              directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
+            };
+
+            export type FAQEntryinFAQsConnectionArgs = {
+              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              first?: InputMaybe<Scalars[\\"Int\\"]>;
+              after?: InputMaybe<Scalars[\\"String\\"]>;
+              directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
+              sort?: InputMaybe<Array<FAQEntryInFAQsConnectionSort>>;
+            };
+
+            export type FAQEntryAggregateSelection = {
+              __typename?: \\"FAQEntryAggregateSelection\\";
+              count: Scalars[\\"Int\\"];
+              id: IDAggregateSelectionNonNullable;
+              title: StringAggregateSelectionNonNullable;
+              body: StringAggregateSelectionNonNullable;
+            };
+
+            export type FAQEntryEdge = {
+              __typename?: \\"FAQEntryEdge\\";
+              cursor: Scalars[\\"String\\"];
+              node: FAQEntry;
+            };
+
+            export type FAQEntryFAQInFAQsAggregationSelection = {
+              __typename?: \\"FAQEntryFAQInFAQsAggregationSelection\\";
+              count: Scalars[\\"Int\\"];
+              node?: Maybe<FAQEntryFAQInFAQsNodeAggregateSelection>;
+              edge?: Maybe<FAQEntryFAQInFAQsEdgeAggregateSelection>;
+            };
+
+            export type FAQEntryFAQInFAQsEdgeAggregateSelection = {
+              __typename?: \\"FAQEntryFAQInFAQsEdgeAggregateSelection\\";
+              position: IntAggregateSelectionNullable;
+            };
+
+            export type FAQEntryFAQInFAQsNodeAggregateSelection = {
+              __typename?: \\"FAQEntryFAQInFAQsNodeAggregateSelection\\";
+              id: IDAggregateSelectionNonNullable;
+              name: StringAggregateSelectionNonNullable;
+            };
+
+            export type FAQEntryInFAQsConnection = {
+              __typename?: \\"FAQEntryInFAQsConnection\\";
+              edges: Array<FAQEntryInFAQsRelationship>;
+              totalCount: Scalars[\\"Int\\"];
+              pageInfo: PageInfo;
+            };
+
+            export type FAQEntryInFAQsRelationship = FaqEntryInFaq & {
+              __typename?: \\"FAQEntryInFAQsRelationship\\";
+              cursor: Scalars[\\"String\\"];
+              node: FAQ;
+              position?: Maybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQFAQEntryEntriesAggregationSelection = {
+              __typename?: \\"FAQFAQEntryEntriesAggregationSelection\\";
+              count: Scalars[\\"Int\\"];
+              node?: Maybe<FAQFAQEntryEntriesNodeAggregateSelection>;
+              edge?: Maybe<FAQFAQEntryEntriesEdgeAggregateSelection>;
+            };
+
+            export type FAQFAQEntryEntriesEdgeAggregateSelection = {
+              __typename?: \\"FAQFAQEntryEntriesEdgeAggregateSelection\\";
+              position: IntAggregateSelectionNullable;
+            };
+
+            export type FAQFAQEntryEntriesNodeAggregateSelection = {
+              __typename?: \\"FAQFAQEntryEntriesNodeAggregateSelection\\";
+              id: IDAggregateSelectionNonNullable;
+              title: StringAggregateSelectionNonNullable;
+              body: StringAggregateSelectionNonNullable;
+            };
+
+            export type FaqsConnection = {
+              __typename?: \\"FaqsConnection\\";
+              totalCount: Scalars[\\"Int\\"];
+              pageInfo: PageInfo;
+              edges: Array<FAQEdge>;
+            };
+
+            export type IDAggregateSelectionNonNullable = {
+              __typename?: \\"IDAggregateSelectionNonNullable\\";
+              shortest: Scalars[\\"ID\\"];
+              longest: Scalars[\\"ID\\"];
+            };
+
+            export type IntAggregateSelectionNullable = {
+              __typename?: \\"IntAggregateSelectionNullable\\";
+              max?: Maybe<Scalars[\\"Int\\"]>;
+              min?: Maybe<Scalars[\\"Int\\"]>;
+              average?: Maybe<Scalars[\\"Float\\"]>;
+              sum?: Maybe<Scalars[\\"Int\\"]>;
+            };
+
+            /** Pagination information (Relay) */
+            export type PageInfo = {
+              __typename?: \\"PageInfo\\";
+              hasNextPage: Scalars[\\"Boolean\\"];
+              hasPreviousPage: Scalars[\\"Boolean\\"];
+              startCursor?: Maybe<Scalars[\\"String\\"]>;
+              endCursor?: Maybe<Scalars[\\"String\\"]>;
+            };
+
+            export type StringAggregateSelectionNonNullable = {
+              __typename?: \\"StringAggregateSelectionNonNullable\\";
+              shortest: Scalars[\\"String\\"];
+              longest: Scalars[\\"String\\"];
+            };
+
+            export type UpdateFaqEntriesMutationResponse = {
+              __typename?: \\"UpdateFaqEntriesMutationResponse\\";
+              info: UpdateInfo;
+              faqEntries: Array<FAQEntry>;
+            };
+
+            export type UpdateFaqsMutationResponse = {
+              __typename?: \\"UpdateFaqsMutationResponse\\";
+              info: UpdateInfo;
+              faqs: Array<FAQ>;
+            };
+
+            export type UpdateInfo = {
+              __typename?: \\"UpdateInfo\\";
+              bookmark?: Maybe<Scalars[\\"String\\"]>;
+              nodesCreated: Scalars[\\"Int\\"];
+              nodesDeleted: Scalars[\\"Int\\"];
+              relationshipsCreated: Scalars[\\"Int\\"];
+              relationshipsDeleted: Scalars[\\"Int\\"];
+            };
+
+            export type FAQConnectInput = {
+              entries?: InputMaybe<Array<FAQEntriesConnectFieldInput>>;
+            };
+
+            export type FAQConnectOrCreateInput = {
+              entries?: InputMaybe<Array<FAQEntriesConnectOrCreateFieldInput>>;
+            };
+
+            export type FAQConnectOrCreateWhere = {
+              node: FAQUniqueWhere;
+            };
+
+            export type FAQConnectWhere = {
+              node: FAQWhere;
+            };
+
+            export type FAQCreateInput = {
+              activated: Scalars[\\"Boolean\\"];
+              name: Scalars[\\"String\\"];
+              entries?: InputMaybe<FAQEntriesFieldInput>;
+            };
+
+            export type FAQDeleteInput = {
+              entries?: InputMaybe<Array<FAQEntriesDeleteFieldInput>>;
+            };
+
+            export type FAQDisconnectInput = {
+              entries?: InputMaybe<Array<FAQEntriesDisconnectFieldInput>>;
+            };
+
+            export type FAQEntriesAggregateInput = {
+              count?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              AND?: InputMaybe<Array<FAQEntriesAggregateInput>>;
+              OR?: InputMaybe<Array<FAQEntriesAggregateInput>>;
+              NOT?: InputMaybe<FAQEntriesAggregateInput>;
+              node?: InputMaybe<FAQEntriesNodeAggregationWhereInput>;
+              edge?: InputMaybe<FAQEntriesEdgeAggregationWhereInput>;
+            };
+
+            export type FAQEntriesConnectFieldInput = {
+              where?: InputMaybe<FAQEntryConnectWhere>;
+              connect?: InputMaybe<Array<FAQEntryConnectInput>>;
+              edge?: InputMaybe<FaqEntryInFaqCreateInput>;
+              /** Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0. */
+              overwrite?: Scalars[\\"Boolean\\"];
+            };
+
+            export type FAQEntriesConnectionSort = {
+              edge?: InputMaybe<FaqEntryInFaqSort>;
+              node?: InputMaybe<FAQEntrySort>;
+            };
+
+            export type FAQEntriesConnectionWhere = {
+              AND?: InputMaybe<Array<FAQEntriesConnectionWhere>>;
+              OR?: InputMaybe<Array<FAQEntriesConnectionWhere>>;
+              NOT?: InputMaybe<FAQEntriesConnectionWhere>;
+              edge?: InputMaybe<FaqEntryInFaqWhere>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              edge_NOT?: InputMaybe<FaqEntryInFaqWhere>;
+              node?: InputMaybe<FAQEntryWhere>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              node_NOT?: InputMaybe<FAQEntryWhere>;
+            };
+
+            export type FAQEntriesConnectOrCreateFieldInput = {
+              where: FAQEntryConnectOrCreateWhere;
+              onCreate: FAQEntriesConnectOrCreateFieldInputOnCreate;
+            };
+
+            export type FAQEntriesConnectOrCreateFieldInputOnCreate = {
+              node: FAQEntryOnCreateInput;
+              edge?: InputMaybe<FaqEntryInFaqCreateInput>;
+            };
+
+            export type FAQEntriesCreateFieldInput = {
+              node: FAQEntryCreateInput;
+              edge?: InputMaybe<FaqEntryInFaqCreateInput>;
+            };
+
+            export type FAQEntriesDeleteFieldInput = {
+              where?: InputMaybe<FAQEntriesConnectionWhere>;
+              delete?: InputMaybe<FAQEntryDeleteInput>;
+            };
+
+            export type FAQEntriesDisconnectFieldInput = {
+              where?: InputMaybe<FAQEntriesConnectionWhere>;
+              disconnect?: InputMaybe<FAQEntryDisconnectInput>;
+            };
+
+            export type FAQEntriesEdgeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FAQEntriesEdgeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FAQEntriesEdgeAggregationWhereInput>>;
+              NOT?: InputMaybe<FAQEntriesEdgeAggregationWhereInput>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntriesFieldInput = {
+              connectOrCreate?: InputMaybe<Array<FAQEntriesConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FAQEntriesCreateFieldInput>>;
+              connect?: InputMaybe<Array<FAQEntriesConnectFieldInput>>;
+            };
+
+            export type FAQEntriesNodeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FAQEntriesNodeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FAQEntriesNodeAggregationWhereInput>>;
+              NOT?: InputMaybe<FAQEntriesNodeAggregationWhereInput>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              id_EQUAL?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              title_EQUAL?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_LONGEST_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_SHORTEST_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              title_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              title_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_AVERAGE_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_LONGEST_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_SHORTEST_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_AVERAGE_LENGTH_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              title_LONGEST_LENGTH_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_SHORTEST_LENGTH_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              title_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_AVERAGE_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_LONGEST_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_SHORTEST_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              title_LONGEST_LENGTH_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              title_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_AVERAGE_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_LONGEST_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_SHORTEST_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_AVERAGE_LENGTH_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              title_LONGEST_LENGTH_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_SHORTEST_LENGTH_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              title_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_AVERAGE_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_LONGEST_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              title_SHORTEST_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              title_LONGEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              title_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              body_EQUAL?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_LONGEST_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_SHORTEST_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              body_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              body_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_AVERAGE_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_LONGEST_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_SHORTEST_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_AVERAGE_LENGTH_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              body_LONGEST_LENGTH_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_SHORTEST_LENGTH_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              body_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_AVERAGE_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_LONGEST_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_SHORTEST_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              body_LONGEST_LENGTH_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              body_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_AVERAGE_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_LONGEST_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_SHORTEST_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_AVERAGE_LENGTH_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              body_LONGEST_LENGTH_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_SHORTEST_LENGTH_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              body_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_AVERAGE_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_LONGEST_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              body_SHORTEST_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              body_LONGEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              body_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntriesUpdateConnectionInput = {
+              node?: InputMaybe<FAQEntryUpdateInput>;
+              edge?: InputMaybe<FaqEntryInFaqUpdateInput>;
+            };
+
+            export type FAQEntriesUpdateFieldInput = {
+              where?: InputMaybe<FAQEntriesConnectionWhere>;
+              connectOrCreate?: InputMaybe<Array<FAQEntriesConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FAQEntriesCreateFieldInput>>;
+              connect?: InputMaybe<Array<FAQEntriesConnectFieldInput>>;
+              update?: InputMaybe<FAQEntriesUpdateConnectionInput>;
+              delete?: InputMaybe<Array<FAQEntriesDeleteFieldInput>>;
+              disconnect?: InputMaybe<Array<FAQEntriesDisconnectFieldInput>>;
+            };
+
+            export type FAQEntryConnectInput = {
+              inFAQs?: InputMaybe<Array<FAQEntryInFAQsConnectFieldInput>>;
+            };
+
+            export type FAQEntryConnectOrCreateInput = {
+              inFAQs?: InputMaybe<Array<FAQEntryInFAQsConnectOrCreateFieldInput>>;
+            };
+
+            export type FAQEntryConnectOrCreateWhere = {
+              node: FAQEntryUniqueWhere;
+            };
+
+            export type FAQEntryConnectWhere = {
+              node: FAQEntryWhere;
+            };
+
+            export type FAQEntryCreateInput = {
+              title: Scalars[\\"String\\"];
+              body: Scalars[\\"String\\"];
+              inFAQs?: InputMaybe<FAQEntryInFAQsFieldInput>;
+            };
+
+            export type FAQEntryDeleteInput = {
+              inFAQs?: InputMaybe<Array<FAQEntryInFAQsDeleteFieldInput>>;
+            };
+
+            export type FAQEntryDisconnectInput = {
+              inFAQs?: InputMaybe<Array<FAQEntryInFAQsDisconnectFieldInput>>;
+            };
+
+            export type FaqEntryInFaqCreateInput = {
+              position?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntryInFAQsAggregateInput = {
+              count?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              count_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              AND?: InputMaybe<Array<FAQEntryInFAQsAggregateInput>>;
+              OR?: InputMaybe<Array<FAQEntryInFAQsAggregateInput>>;
+              NOT?: InputMaybe<FAQEntryInFAQsAggregateInput>;
+              node?: InputMaybe<FAQEntryInFAQsNodeAggregationWhereInput>;
+              edge?: InputMaybe<FAQEntryInFAQsEdgeAggregationWhereInput>;
+            };
+
+            export type FAQEntryInFAQsConnectFieldInput = {
+              where?: InputMaybe<FAQConnectWhere>;
+              connect?: InputMaybe<Array<FAQConnectInput>>;
+              edge?: InputMaybe<FaqEntryInFaqCreateInput>;
+              /** Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0. */
+              overwrite?: Scalars[\\"Boolean\\"];
+            };
+
+            export type FAQEntryInFAQsConnectionSort = {
+              edge?: InputMaybe<FaqEntryInFaqSort>;
+              node?: InputMaybe<FAQSort>;
+            };
+
+            export type FAQEntryInFAQsConnectionWhere = {
+              AND?: InputMaybe<Array<FAQEntryInFAQsConnectionWhere>>;
+              OR?: InputMaybe<Array<FAQEntryInFAQsConnectionWhere>>;
+              NOT?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              edge?: InputMaybe<FaqEntryInFaqWhere>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              edge_NOT?: InputMaybe<FaqEntryInFaqWhere>;
+              node?: InputMaybe<FAQWhere>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              node_NOT?: InputMaybe<FAQWhere>;
+            };
+
+            export type FAQEntryInFAQsConnectOrCreateFieldInput = {
+              where: FAQConnectOrCreateWhere;
+              onCreate: FAQEntryInFAQsConnectOrCreateFieldInputOnCreate;
+            };
+
+            export type FAQEntryInFAQsConnectOrCreateFieldInputOnCreate = {
+              node: FAQOnCreateInput;
+              edge?: InputMaybe<FaqEntryInFaqCreateInput>;
+            };
+
+            export type FAQEntryInFAQsCreateFieldInput = {
+              node: FAQCreateInput;
+              edge?: InputMaybe<FaqEntryInFaqCreateInput>;
+            };
+
+            export type FAQEntryInFAQsDeleteFieldInput = {
+              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              delete?: InputMaybe<FAQDeleteInput>;
+            };
+
+            export type FAQEntryInFAQsDisconnectFieldInput = {
+              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              disconnect?: InputMaybe<FAQDisconnectInput>;
+            };
+
+            export type FAQEntryInFAQsEdgeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FAQEntryInFAQsEdgeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FAQEntryInFAQsEdgeAggregationWhereInput>>;
+              NOT?: InputMaybe<FAQEntryInFAQsEdgeAggregationWhereInput>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              position_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_AVERAGE_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              position_MIN_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_MAX_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_SUM_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntryInFAQsFieldInput = {
+              connectOrCreate?: InputMaybe<Array<FAQEntryInFAQsConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FAQEntryInFAQsCreateFieldInput>>;
+              connect?: InputMaybe<Array<FAQEntryInFAQsConnectFieldInput>>;
+            };
+
+            export type FAQEntryInFAQsNodeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FAQEntryInFAQsNodeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FAQEntryInFAQsNodeAggregationWhereInput>>;
+              NOT?: InputMaybe<FAQEntryInFAQsNodeAggregationWhereInput>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              id_EQUAL?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              name_EQUAL?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_LONGEST_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_SHORTEST_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_AVERAGE_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
+              name_LONGEST_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_SHORTEST_LENGTH_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              name_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_AVERAGE_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_LONGEST_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_SHORTEST_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_AVERAGE_LENGTH_GT?: InputMaybe<Scalars[\\"Float\\"]>;
+              name_LONGEST_LENGTH_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_SHORTEST_LENGTH_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              name_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_AVERAGE_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_LONGEST_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_SHORTEST_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_AVERAGE_LENGTH_GTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              name_LONGEST_LENGTH_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_SHORTEST_LENGTH_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              name_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_AVERAGE_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_LONGEST_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_SHORTEST_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_AVERAGE_LENGTH_LT?: InputMaybe<Scalars[\\"Float\\"]>;
+              name_LONGEST_LENGTH_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_SHORTEST_LENGTH_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
+              name_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_AVERAGE_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_LONGEST_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Please use the explicit _LENGTH version for string aggregation. */
+              name_SHORTEST_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_AVERAGE_LENGTH_LTE?: InputMaybe<Scalars[\\"Float\\"]>;
+              name_LONGEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              name_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FaqEntryInFaqSort = {
+              position?: InputMaybe<SortDirection>;
+            };
+
+            export type FAQEntryInFAQsUpdateConnectionInput = {
+              node?: InputMaybe<FAQUpdateInput>;
+              edge?: InputMaybe<FaqEntryInFaqUpdateInput>;
+            };
+
+            export type FAQEntryInFAQsUpdateFieldInput = {
+              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              connectOrCreate?: InputMaybe<Array<FAQEntryInFAQsConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FAQEntryInFAQsCreateFieldInput>>;
+              connect?: InputMaybe<Array<FAQEntryInFAQsConnectFieldInput>>;
+              update?: InputMaybe<FAQEntryInFAQsUpdateConnectionInput>;
+              delete?: InputMaybe<Array<FAQEntryInFAQsDeleteFieldInput>>;
+              disconnect?: InputMaybe<Array<FAQEntryInFAQsDisconnectFieldInput>>;
+            };
+
+            export type FaqEntryInFaqUpdateInput = {
+              position?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_INCREMENT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_DECREMENT?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FaqEntryInFaqWhere = {
+              OR?: InputMaybe<Array<FaqEntryInFaqWhere>>;
+              AND?: InputMaybe<Array<FaqEntryInFaqWhere>>;
+              NOT?: InputMaybe<FaqEntryInFaqWhere>;
+              position?: InputMaybe<Scalars[\\"Int\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              position_NOT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_IN?: InputMaybe<Array<InputMaybe<Scalars[\\"Int\\"]>>>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              position_NOT_IN?: InputMaybe<Array<InputMaybe<Scalars[\\"Int\\"]>>>;
+              position_LT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_GT?: InputMaybe<Scalars[\\"Int\\"]>;
+              position_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntryOnCreateInput = {
+              title: Scalars[\\"String\\"];
+              body: Scalars[\\"String\\"];
+            };
+
+            export type FAQEntryOptions = {
+              /** Specify one or more FAQEntrySort objects to sort FaqEntries by. The sorts will be applied in the order in which they are arranged in the array. */
+              sort?: InputMaybe<Array<FAQEntrySort>>;
+              limit?: InputMaybe<Scalars[\\"Int\\"]>;
+              offset?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQEntryRelationInput = {
+              inFAQs?: InputMaybe<Array<FAQEntryInFAQsCreateFieldInput>>;
+            };
+
+            /** Fields to sort FaqEntries by. The order in which sorts are applied is not guaranteed when specifying many fields in one FAQEntrySort object. */
+            export type FAQEntrySort = {
+              id?: InputMaybe<SortDirection>;
+              title?: InputMaybe<SortDirection>;
+              body?: InputMaybe<SortDirection>;
+            };
+
+            export type FAQEntryUniqueWhere = {
+              id?: InputMaybe<Scalars[\\"ID\\"]>;
+            };
+
+            export type FAQEntryUpdateInput = {
+              title?: InputMaybe<Scalars[\\"String\\"]>;
+              body?: InputMaybe<Scalars[\\"String\\"]>;
+              inFAQs?: InputMaybe<Array<FAQEntryInFAQsUpdateFieldInput>>;
+            };
+
+            export type FAQEntryWhere = {
+              OR?: InputMaybe<Array<FAQEntryWhere>>;
+              AND?: InputMaybe<Array<FAQEntryWhere>>;
+              NOT?: InputMaybe<FAQEntryWhere>;
+              id?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT?: InputMaybe<Scalars[\\"ID\\"]>;
+              id_IN?: InputMaybe<Array<Scalars[\\"ID\\"]>>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_IN?: InputMaybe<Array<Scalars[\\"ID\\"]>>;
+              id_CONTAINS?: InputMaybe<Scalars[\\"ID\\"]>;
+              id_STARTS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              id_ENDS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_CONTAINS?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_STARTS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              title?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              title_NOT?: InputMaybe<Scalars[\\"String\\"]>;
+              title_IN?: InputMaybe<Array<Scalars[\\"String\\"]>>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              title_NOT_IN?: InputMaybe<Array<Scalars[\\"String\\"]>>;
+              title_CONTAINS?: InputMaybe<Scalars[\\"String\\"]>;
+              title_STARTS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              title_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              title_NOT_CONTAINS?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              title_NOT_STARTS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              title_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              body?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              body_NOT?: InputMaybe<Scalars[\\"String\\"]>;
+              body_IN?: InputMaybe<Array<Scalars[\\"String\\"]>>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              body_NOT_IN?: InputMaybe<Array<Scalars[\\"String\\"]>>;
+              body_CONTAINS?: InputMaybe<Scalars[\\"String\\"]>;
+              body_STARTS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              body_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              body_NOT_CONTAINS?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              body_NOT_STARTS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              body_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Use \`inFAQs_SOME\` instead. */
+              inFAQs?: InputMaybe<FAQWhere>;
+              /** @deprecated Use \`inFAQs_NONE\` instead. */
+              inFAQs_NOT?: InputMaybe<FAQWhere>;
+              inFAQsAggregate?: InputMaybe<FAQEntryInFAQsAggregateInput>;
+              /** Return FAQEntries where all of the related FAQS match this filter */
+              inFAQs_ALL?: InputMaybe<FAQWhere>;
+              /** Return FAQEntries where none of the related FAQS match this filter */
+              inFAQs_NONE?: InputMaybe<FAQWhere>;
+              /** Return FAQEntries where one of the related FAQS match this filter */
+              inFAQs_SINGLE?: InputMaybe<FAQWhere>;
+              /** Return FAQEntries where some of the related FAQS match this filter */
+              inFAQs_SOME?: InputMaybe<FAQWhere>;
+              /** @deprecated Use \`inFAQsConnection_SOME\` instead. */
+              inFAQsConnection?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              /** @deprecated Use \`inFAQsConnection_NONE\` instead. */
+              inFAQsConnection_NOT?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              /** Return FAQEntries where all of the related FAQEntryInFAQsConnections match this filter */
+              inFAQsConnection_ALL?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              /** Return FAQEntries where none of the related FAQEntryInFAQsConnections match this filter */
+              inFAQsConnection_NONE?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              /** Return FAQEntries where one of the related FAQEntryInFAQsConnections match this filter */
+              inFAQsConnection_SINGLE?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              /** Return FAQEntries where some of the related FAQEntryInFAQsConnections match this filter */
+              inFAQsConnection_SOME?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+            };
+
+            export type FAQOnCreateInput = {
+              activated: Scalars[\\"Boolean\\"];
+              name: Scalars[\\"String\\"];
+            };
+
+            export type FAQOptions = {
+              /** Specify one or more FAQSort objects to sort Faqs by. The sorts will be applied in the order in which they are arranged in the array. */
+              sort?: InputMaybe<Array<FAQSort>>;
+              limit?: InputMaybe<Scalars[\\"Int\\"]>;
+              offset?: InputMaybe<Scalars[\\"Int\\"]>;
+            };
+
+            export type FAQRelationInput = {
+              entries?: InputMaybe<Array<FAQEntriesCreateFieldInput>>;
+            };
+
+            /** Fields to sort Faqs by. The order in which sorts are applied is not guaranteed when specifying many fields in one FAQSort object. */
+            export type FAQSort = {
+              id?: InputMaybe<SortDirection>;
+              activated?: InputMaybe<SortDirection>;
+              name?: InputMaybe<SortDirection>;
+            };
+
+            export type FAQUniqueWhere = {
+              id?: InputMaybe<Scalars[\\"ID\\"]>;
+            };
+
+            export type FAQUpdateInput = {
+              activated?: InputMaybe<Scalars[\\"Boolean\\"]>;
+              name?: InputMaybe<Scalars[\\"String\\"]>;
+              entries?: InputMaybe<Array<FAQEntriesUpdateFieldInput>>;
+            };
+
+            export type FAQWhere = {
+              OR?: InputMaybe<Array<FAQWhere>>;
+              AND?: InputMaybe<Array<FAQWhere>>;
+              NOT?: InputMaybe<FAQWhere>;
+              id?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT?: InputMaybe<Scalars[\\"ID\\"]>;
+              id_IN?: InputMaybe<Array<Scalars[\\"ID\\"]>>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_IN?: InputMaybe<Array<Scalars[\\"ID\\"]>>;
+              id_CONTAINS?: InputMaybe<Scalars[\\"ID\\"]>;
+              id_STARTS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              id_ENDS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_CONTAINS?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_STARTS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              id_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"ID\\"]>;
+              activated?: InputMaybe<Scalars[\\"Boolean\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              activated_NOT?: InputMaybe<Scalars[\\"Boolean\\"]>;
+              name?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              name_NOT?: InputMaybe<Scalars[\\"String\\"]>;
+              name_IN?: InputMaybe<Array<Scalars[\\"String\\"]>>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              name_NOT_IN?: InputMaybe<Array<Scalars[\\"String\\"]>>;
+              name_CONTAINS?: InputMaybe<Scalars[\\"String\\"]>;
+              name_STARTS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              name_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              name_NOT_CONTAINS?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              name_NOT_STARTS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
+              name_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
+              /** @deprecated Use \`entries_SOME\` instead. */
+              entries?: InputMaybe<FAQEntryWhere>;
+              /** @deprecated Use \`entries_NONE\` instead. */
+              entries_NOT?: InputMaybe<FAQEntryWhere>;
+              entriesAggregate?: InputMaybe<FAQEntriesAggregateInput>;
+              /** Return FAQS where all of the related FAQEntries match this filter */
+              entries_ALL?: InputMaybe<FAQEntryWhere>;
+              /** Return FAQS where none of the related FAQEntries match this filter */
+              entries_NONE?: InputMaybe<FAQEntryWhere>;
+              /** Return FAQS where one of the related FAQEntries match this filter */
+              entries_SINGLE?: InputMaybe<FAQEntryWhere>;
+              /** Return FAQS where some of the related FAQEntries match this filter */
+              entries_SOME?: InputMaybe<FAQEntryWhere>;
+              /** @deprecated Use \`entriesConnection_SOME\` instead. */
+              entriesConnection?: InputMaybe<FAQEntriesConnectionWhere>;
+              /** @deprecated Use \`entriesConnection_NONE\` instead. */
+              entriesConnection_NOT?: InputMaybe<FAQEntriesConnectionWhere>;
+              /** Return FAQS where all of the related FAQEntriesConnections match this filter */
+              entriesConnection_ALL?: InputMaybe<FAQEntriesConnectionWhere>;
+              /** Return FAQS where none of the related FAQEntriesConnections match this filter */
+              entriesConnection_NONE?: InputMaybe<FAQEntriesConnectionWhere>;
+              /** Return FAQS where one of the related FAQEntriesConnections match this filter */
+              entriesConnection_SINGLE?: InputMaybe<FAQEntriesConnectionWhere>;
+              /** Return FAQS where some of the related FAQEntriesConnections match this filter */
+              entriesConnection_SOME?: InputMaybe<FAQEntriesConnectionWhere>;
+            };
+
+            export interface IDAggregateInputNonNullable {
+              shortest?: boolean;
+              longest?: boolean;
+            }
+            export interface StringAggregateInputNonNullable {
+              shortest?: boolean;
+              longest?: boolean;
+            }
+            export interface FAQAggregateSelectionInput {
+              count?: boolean;
+              id?: IDAggregateInputNonNullable;
+              name?: StringAggregateInputNonNullable;
+            }
+
+            export declare class FAQModel {
+              public find(args?: {
+                where?: FAQWhere;
+
+                options?: FAQOptions;
+                selectionSet?: string | DocumentNode | SelectionSetNode;
+                args?: any;
+                context?: any;
+                rootValue?: any;
+              }): Promise<FAQ[]>;
+              public create(args: {
+                input: FAQCreateInput[];
+                selectionSet?: string | DocumentNode | SelectionSetNode;
+                args?: any;
+                context?: any;
+                rootValue?: any;
+              }): Promise<CreateFaqsMutationResponse>;
+              public update(args: {
+                where?: FAQWhere;
+                update?: FAQUpdateInput;
+                connect?: FAQConnectInput;
+                disconnect?: FAQDisconnectInput;
+                create?: FAQCreateInput;
+                connectOrCreate?: FAQConnectOrCreateInput;
+                selectionSet?: string | DocumentNode | SelectionSetNode;
+                args?: any;
+                context?: any;
+                rootValue?: any;
+              }): Promise<UpdateFaqsMutationResponse>;
+              public delete(args: {
+                where?: FAQWhere;
+                delete?: FAQDeleteInput;
+                context?: any;
+                rootValue?: any;
+              }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
+              public aggregate(args: {
+                where?: FAQWhere;
+
+                aggregate: FAQAggregateSelectionInput;
+                context?: any;
+                rootValue?: any;
+              }): Promise<FAQAggregateSelection>;
+            }
+
+            export interface IDAggregateInputNonNullable {
+              shortest?: boolean;
+              longest?: boolean;
+            }
+            export interface StringAggregateInputNonNullable {
+              shortest?: boolean;
+              longest?: boolean;
+            }
+            export interface FAQEntryAggregateSelectionInput {
+              count?: boolean;
+              id?: IDAggregateInputNonNullable;
+              title?: StringAggregateInputNonNullable;
+              body?: StringAggregateInputNonNullable;
+            }
+
+            export declare class FAQEntryModel {
+              public find(args?: {
+                where?: FAQEntryWhere;
+
+                options?: FAQEntryOptions;
+                selectionSet?: string | DocumentNode | SelectionSetNode;
+                args?: any;
+                context?: any;
+                rootValue?: any;
+              }): Promise<FAQEntry[]>;
+              public create(args: {
+                input: FAQEntryCreateInput[];
+                selectionSet?: string | DocumentNode | SelectionSetNode;
+                args?: any;
+                context?: any;
+                rootValue?: any;
+              }): Promise<CreateFaqEntriesMutationResponse>;
+              public update(args: {
+                where?: FAQEntryWhere;
+                update?: FAQEntryUpdateInput;
+                connect?: FAQEntryConnectInput;
+                disconnect?: FAQEntryDisconnectInput;
+                create?: FAQEntryCreateInput;
+                connectOrCreate?: FAQEntryConnectOrCreateInput;
+                selectionSet?: string | DocumentNode | SelectionSetNode;
+                args?: any;
+                context?: any;
+                rootValue?: any;
+              }): Promise<UpdateFaqEntriesMutationResponse>;
+              public delete(args: {
+                where?: FAQEntryWhere;
+                delete?: FAQEntryDeleteInput;
+                context?: any;
+                rootValue?: any;
+              }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
+              public aggregate(args: {
+                where?: FAQEntryWhere;
+
+                aggregate: FAQEntryAggregateSelectionInput;
+                context?: any;
+                rootValue?: any;
+              }): Promise<FAQEntryAggregateSelection>;
+            }
+
+            export interface ModelMap {
+              FAQ: FAQModel;
+              FAQEntry: FAQEntryModel;
+            }
+            "
+        `);
     });
 });

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -81,19 +81,19 @@ describe("generate", () => {
               usersAggregate: UserAggregateSelection;
             };
 
-            export type QueryusersArgs = {
+            export type QueryUsersArgs = {
               where?: InputMaybe<UserWhere>;
               options?: InputMaybe<UserOptions>;
             };
 
-            export type QueryusersConnectionArgs = {
+            export type QueryUsersConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<UserWhere>;
               sort?: InputMaybe<Array<InputMaybe<UserSort>>>;
             };
 
-            export type QueryusersAggregateArgs = {
+            export type QueryUsersAggregateArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
@@ -104,24 +104,24 @@ describe("generate", () => {
               updateUsers: UpdateUsersMutationResponse;
             };
 
-            export type MutationcreateUsersArgs = {
+            export type MutationCreateUsersArgs = {
               input: Array<UserCreateInput>;
             };
 
-            export type MutationdeleteUsersArgs = {
+            export type MutationDeleteUsersArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
-            export type MutationupdateUsersArgs = {
+            export type MutationUpdateUsersArgs = {
               where?: InputMaybe<UserWhere>;
               update?: InputMaybe<UserUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              ASC = \\"ASC\\",
+              Asc = \\"ASC\\",
               /** Sort by field values in descending order. */
-              DESC = \\"DESC\\",
+              Desc = \\"DESC\\",
             }
 
             export type CreateInfo = {
@@ -350,7 +350,7 @@ describe("generate", () => {
               usersAggregate: UserAggregateSelection;
             };
 
-            export type QueryusersFulltextUserNameArgs = {
+            export type QueryUsersFulltextUserNameArgs = {
               phrase: Scalars[\\"String\\"];
               where?: InputMaybe<UserFulltextWhere>;
               sort?: InputMaybe<Array<UserFulltextSort>>;
@@ -358,13 +358,13 @@ describe("generate", () => {
               offset?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type QueryusersArgs = {
+            export type QueryUsersArgs = {
               where?: InputMaybe<UserWhere>;
               options?: InputMaybe<UserOptions>;
               fulltext?: InputMaybe<UserFulltext>;
             };
 
-            export type QueryusersConnectionArgs = {
+            export type QueryUsersConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<UserWhere>;
@@ -372,7 +372,7 @@ describe("generate", () => {
               fulltext?: InputMaybe<UserFulltext>;
             };
 
-            export type QueryusersAggregateArgs = {
+            export type QueryUsersAggregateArgs = {
               where?: InputMaybe<UserWhere>;
               fulltext?: InputMaybe<UserFulltext>;
             };
@@ -384,24 +384,24 @@ describe("generate", () => {
               updateUsers: UpdateUsersMutationResponse;
             };
 
-            export type MutationcreateUsersArgs = {
+            export type MutationCreateUsersArgs = {
               input: Array<UserCreateInput>;
             };
 
-            export type MutationdeleteUsersArgs = {
+            export type MutationDeleteUsersArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
-            export type MutationupdateUsersArgs = {
+            export type MutationUpdateUsersArgs = {
               where?: InputMaybe<UserWhere>;
               update?: InputMaybe<UserUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              ASC = \\"ASC\\",
+              Asc = \\"ASC\\",
               /** Sort by field values in descending order. */
-              DESC = \\"DESC\\",
+              Desc = \\"DESC\\",
             }
 
             export type CreateInfo = {
@@ -670,19 +670,19 @@ describe("generate", () => {
               usersAggregate: UserAggregateSelection;
             };
 
-            export type QueryusersArgs = {
+            export type QueryUsersArgs = {
               where?: InputMaybe<UserWhere>;
               options?: InputMaybe<UserOptions>;
             };
 
-            export type QueryusersConnectionArgs = {
+            export type QueryUsersConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<UserWhere>;
               sort?: InputMaybe<Array<InputMaybe<UserSort>>>;
             };
 
-            export type QueryusersAggregateArgs = {
+            export type QueryUsersAggregateArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
@@ -693,24 +693,24 @@ describe("generate", () => {
               updateUsers: UpdateUsersMutationResponse;
             };
 
-            export type MutationcreateUsersArgs = {
+            export type MutationCreateUsersArgs = {
               input: Array<UserCreateInput>;
             };
 
-            export type MutationdeleteUsersArgs = {
+            export type MutationDeleteUsersArgs = {
               where?: InputMaybe<UserWhere>;
             };
 
-            export type MutationupdateUsersArgs = {
+            export type MutationUpdateUsersArgs = {
               where?: InputMaybe<UserWhere>;
               update?: InputMaybe<UserUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              ASC = \\"ASC\\",
+              Asc = \\"ASC\\",
               /** Sort by field values in descending order. */
-              DESC = \\"DESC\\",
+              Desc = \\"DESC\\",
             }
 
             export type CreateInfo = {
@@ -946,35 +946,35 @@ describe("generate", () => {
               peopleAggregate: PersonAggregateSelection;
             };
 
-            export type QuerymoviesArgs = {
+            export type QueryMoviesArgs = {
               where?: InputMaybe<MovieWhere>;
               options?: InputMaybe<MovieOptions>;
             };
 
-            export type QuerymoviesConnectionArgs = {
+            export type QueryMoviesConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<MovieWhere>;
               sort?: InputMaybe<Array<InputMaybe<MovieSort>>>;
             };
 
-            export type QuerymoviesAggregateArgs = {
+            export type QueryMoviesAggregateArgs = {
               where?: InputMaybe<MovieWhere>;
             };
 
-            export type QuerypeopleArgs = {
+            export type QueryPeopleArgs = {
               where?: InputMaybe<PersonWhere>;
               options?: InputMaybe<PersonOptions>;
             };
 
-            export type QuerypeopleConnectionArgs = {
+            export type QueryPeopleConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               where?: InputMaybe<PersonWhere>;
               sort?: InputMaybe<Array<InputMaybe<PersonSort>>>;
             };
 
-            export type QuerypeopleAggregateArgs = {
+            export type QueryPeopleAggregateArgs = {
               where?: InputMaybe<PersonWhere>;
             };
 
@@ -988,16 +988,16 @@ describe("generate", () => {
               updatePeople: UpdatePeopleMutationResponse;
             };
 
-            export type MutationcreateMoviesArgs = {
+            export type MutationCreateMoviesArgs = {
               input: Array<MovieCreateInput>;
             };
 
-            export type MutationdeleteMoviesArgs = {
+            export type MutationDeleteMoviesArgs = {
               where?: InputMaybe<MovieWhere>;
               delete?: InputMaybe<MovieDeleteInput>;
             };
 
-            export type MutationupdateMoviesArgs = {
+            export type MutationUpdateMoviesArgs = {
               where?: InputMaybe<MovieWhere>;
               update?: InputMaybe<MovieUpdateInput>;
               connect?: InputMaybe<MovieConnectInput>;
@@ -1006,24 +1006,24 @@ describe("generate", () => {
               delete?: InputMaybe<MovieDeleteInput>;
             };
 
-            export type MutationcreatePeopleArgs = {
+            export type MutationCreatePeopleArgs = {
               input: Array<PersonCreateInput>;
             };
 
-            export type MutationdeletePeopleArgs = {
+            export type MutationDeletePeopleArgs = {
               where?: InputMaybe<PersonWhere>;
             };
 
-            export type MutationupdatePeopleArgs = {
+            export type MutationUpdatePeopleArgs = {
               where?: InputMaybe<PersonWhere>;
               update?: InputMaybe<PersonUpdateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              ASC = \\"ASC\\",
+              Asc = \\"ASC\\",
               /** Sort by field values in descending order. */
-              DESC = \\"DESC\\",
+              Desc = \\"DESC\\",
             }
 
             export type ActedIn = {
@@ -1072,18 +1072,18 @@ describe("generate", () => {
               actorsConnection: MovieActorsConnection;
             };
 
-            export type MovieactorsArgs = {
+            export type MovieActorsArgs = {
               where?: InputMaybe<PersonWhere>;
               options?: InputMaybe<PersonOptions>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type MovieactorsAggregateArgs = {
+            export type MovieActorsAggregateArgs = {
               where?: InputMaybe<PersonWhere>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type MovieactorsConnectionArgs = {
+            export type MovieActorsConnectionArgs = {
               where?: InputMaybe<MovieActorsConnectionWhere>;
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
@@ -1719,44 +1719,44 @@ describe("generate", () => {
 
             export type Query = {
               __typename?: \\"Query\\";
-              faqs: Array<FAQ>;
+              faqs: Array<Faq>;
               faqsConnection: FaqsConnection;
-              faqsAggregate: FAQAggregateSelection;
-              faqEntries: Array<FAQEntry>;
+              faqsAggregate: FaqAggregateSelection;
+              faqEntries: Array<FaqEntry>;
               faqEntriesConnection: FaqEntriesConnection;
-              faqEntriesAggregate: FAQEntryAggregateSelection;
+              faqEntriesAggregate: FaqEntryAggregateSelection;
             };
 
-            export type QueryfaqsArgs = {
-              where?: InputMaybe<FAQWhere>;
-              options?: InputMaybe<FAQOptions>;
+            export type QueryFaqsArgs = {
+              where?: InputMaybe<FaqWhere>;
+              options?: InputMaybe<FaqOptions>;
             };
 
-            export type QueryfaqsConnectionArgs = {
+            export type QueryFaqsConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
-              where?: InputMaybe<FAQWhere>;
-              sort?: InputMaybe<Array<InputMaybe<FAQSort>>>;
+              where?: InputMaybe<FaqWhere>;
+              sort?: InputMaybe<Array<InputMaybe<FaqSort>>>;
             };
 
-            export type QueryfaqsAggregateArgs = {
-              where?: InputMaybe<FAQWhere>;
+            export type QueryFaqsAggregateArgs = {
+              where?: InputMaybe<FaqWhere>;
             };
 
-            export type QueryfaqEntriesArgs = {
-              where?: InputMaybe<FAQEntryWhere>;
-              options?: InputMaybe<FAQEntryOptions>;
+            export type QueryFaqEntriesArgs = {
+              where?: InputMaybe<FaqEntryWhere>;
+              options?: InputMaybe<FaqEntryOptions>;
             };
 
-            export type QueryfaqEntriesConnectionArgs = {
+            export type QueryFaqEntriesConnectionArgs = {
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
-              where?: InputMaybe<FAQEntryWhere>;
-              sort?: InputMaybe<Array<InputMaybe<FAQEntrySort>>>;
+              where?: InputMaybe<FaqEntryWhere>;
+              sort?: InputMaybe<Array<InputMaybe<FaqEntrySort>>>;
             };
 
-            export type QueryfaqEntriesAggregateArgs = {
-              where?: InputMaybe<FAQEntryWhere>;
+            export type QueryFaqEntriesAggregateArgs = {
+              where?: InputMaybe<FaqEntryWhere>;
             };
 
             export type Mutation = {
@@ -1769,49 +1769,49 @@ describe("generate", () => {
               updateFaqEntries: UpdateFaqEntriesMutationResponse;
             };
 
-            export type MutationcreateFaqsArgs = {
-              input: Array<FAQCreateInput>;
+            export type MutationCreateFaqsArgs = {
+              input: Array<FaqCreateInput>;
             };
 
-            export type MutationdeleteFaqsArgs = {
-              where?: InputMaybe<FAQWhere>;
-              delete?: InputMaybe<FAQDeleteInput>;
+            export type MutationDeleteFaqsArgs = {
+              where?: InputMaybe<FaqWhere>;
+              delete?: InputMaybe<FaqDeleteInput>;
             };
 
-            export type MutationupdateFaqsArgs = {
-              where?: InputMaybe<FAQWhere>;
-              update?: InputMaybe<FAQUpdateInput>;
-              connect?: InputMaybe<FAQConnectInput>;
-              disconnect?: InputMaybe<FAQDisconnectInput>;
-              create?: InputMaybe<FAQRelationInput>;
-              delete?: InputMaybe<FAQDeleteInput>;
-              connectOrCreate?: InputMaybe<FAQConnectOrCreateInput>;
+            export type MutationUpdateFaqsArgs = {
+              where?: InputMaybe<FaqWhere>;
+              update?: InputMaybe<FaqUpdateInput>;
+              connect?: InputMaybe<FaqConnectInput>;
+              disconnect?: InputMaybe<FaqDisconnectInput>;
+              create?: InputMaybe<FaqRelationInput>;
+              delete?: InputMaybe<FaqDeleteInput>;
+              connectOrCreate?: InputMaybe<FaqConnectOrCreateInput>;
             };
 
-            export type MutationcreateFaqEntriesArgs = {
-              input: Array<FAQEntryCreateInput>;
+            export type MutationCreateFaqEntriesArgs = {
+              input: Array<FaqEntryCreateInput>;
             };
 
-            export type MutationdeleteFaqEntriesArgs = {
-              where?: InputMaybe<FAQEntryWhere>;
-              delete?: InputMaybe<FAQEntryDeleteInput>;
+            export type MutationDeleteFaqEntriesArgs = {
+              where?: InputMaybe<FaqEntryWhere>;
+              delete?: InputMaybe<FaqEntryDeleteInput>;
             };
 
-            export type MutationupdateFaqEntriesArgs = {
-              where?: InputMaybe<FAQEntryWhere>;
-              update?: InputMaybe<FAQEntryUpdateInput>;
-              connect?: InputMaybe<FAQEntryConnectInput>;
-              disconnect?: InputMaybe<FAQEntryDisconnectInput>;
-              create?: InputMaybe<FAQEntryRelationInput>;
-              delete?: InputMaybe<FAQEntryDeleteInput>;
-              connectOrCreate?: InputMaybe<FAQEntryConnectOrCreateInput>;
+            export type MutationUpdateFaqEntriesArgs = {
+              where?: InputMaybe<FaqEntryWhere>;
+              update?: InputMaybe<FaqEntryUpdateInput>;
+              connect?: InputMaybe<FaqEntryConnectInput>;
+              disconnect?: InputMaybe<FaqEntryDisconnectInput>;
+              create?: InputMaybe<FaqEntryRelationInput>;
+              delete?: InputMaybe<FaqEntryDeleteInput>;
+              connectOrCreate?: InputMaybe<FaqEntryConnectOrCreateInput>;
             };
 
             export enum SortDirection {
               /** Sort by field values in ascending order. */
-              ASC = \\"ASC\\",
+              Asc = \\"ASC\\",
               /** Sort by field values in descending order. */
-              DESC = \\"DESC\\",
+              Desc = \\"DESC\\",
             }
 
             export type FaqEntryInFaq = {
@@ -1821,13 +1821,13 @@ describe("generate", () => {
             export type CreateFaqEntriesMutationResponse = {
               __typename?: \\"CreateFaqEntriesMutationResponse\\";
               info: CreateInfo;
-              faqEntries: Array<FAQEntry>;
+              faqEntries: Array<FaqEntry>;
             };
 
             export type CreateFaqsMutationResponse = {
               __typename?: \\"CreateFaqsMutationResponse\\";
               info: CreateInfo;
-              faqs: Array<FAQ>;
+              faqs: Array<Faq>;
             };
 
             export type CreateInfo = {
@@ -1844,159 +1844,159 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"];
             };
 
-            export type FAQ = {
+            export type Faq = {
               __typename?: \\"FAQ\\";
               id: Scalars[\\"ID\\"];
               activated: Scalars[\\"Boolean\\"];
               name: Scalars[\\"String\\"];
-              entries: Array<FAQEntry>;
-              entriesAggregate?: Maybe<FAQFAQEntryEntriesAggregationSelection>;
-              entriesConnection: FAQEntriesConnection;
+              entries: Array<FaqEntry>;
+              entriesAggregate?: Maybe<FaqfaqEntryEntriesAggregationSelection>;
+              entriesConnection: FaqEntriesConnection;
             };
 
-            export type FAQentriesArgs = {
-              where?: InputMaybe<FAQEntryWhere>;
-              options?: InputMaybe<FAQEntryOptions>;
+            export type FaqEntriesArgs = {
+              where?: InputMaybe<FaqEntryWhere>;
+              options?: InputMaybe<FaqEntryOptions>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type FAQentriesAggregateArgs = {
-              where?: InputMaybe<FAQEntryWhere>;
+            export type FaqEntriesAggregateArgs = {
+              where?: InputMaybe<FaqEntryWhere>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type FAQentriesConnectionArgs = {
-              where?: InputMaybe<FAQEntriesConnectionWhere>;
+            export type FaqEntriesConnectionArgs = {
+              where?: InputMaybe<FaqEntriesConnectionWhere>;
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
-              sort?: InputMaybe<Array<FAQEntriesConnectionSort>>;
+              sort?: InputMaybe<Array<FaqEntriesConnectionSort>>;
             };
 
-            export type FAQAggregateSelection = {
+            export type FaqAggregateSelection = {
               __typename?: \\"FAQAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              id: IDAggregateSelectionNonNullable;
+              id: IdAggregateSelectionNonNullable;
               name: StringAggregateSelectionNonNullable;
             };
 
-            export type FAQEdge = {
+            export type FaqEdge = {
               __typename?: \\"FAQEdge\\";
               cursor: Scalars[\\"String\\"];
-              node: FAQ;
+              node: Faq;
             };
 
             export type FaqEntriesConnection = {
               __typename?: \\"FaqEntriesConnection\\";
               totalCount: Scalars[\\"Int\\"];
               pageInfo: PageInfo;
-              edges: Array<FAQEntryEdge>;
+              edges: Array<FaqEntryEdge>;
             };
 
-            export type FAQEntriesConnection = {
+            export type FaqEntriesConnection = {
               __typename?: \\"FAQEntriesConnection\\";
-              edges: Array<FAQEntriesRelationship>;
+              edges: Array<FaqEntriesRelationship>;
               totalCount: Scalars[\\"Int\\"];
               pageInfo: PageInfo;
             };
 
-            export type FAQEntriesRelationship = FaqEntryInFaq & {
+            export type FaqEntriesRelationship = FaqEntryInFaq & {
               __typename?: \\"FAQEntriesRelationship\\";
               cursor: Scalars[\\"String\\"];
-              node: FAQEntry;
+              node: FaqEntry;
               position?: Maybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntry = {
+            export type FaqEntry = {
               __typename?: \\"FAQEntry\\";
               id: Scalars[\\"ID\\"];
               title: Scalars[\\"String\\"];
               body: Scalars[\\"String\\"];
-              inFAQs: Array<FAQ>;
-              inFAQsAggregate?: Maybe<FAQEntryFAQInFAQsAggregationSelection>;
-              inFAQsConnection: FAQEntryInFAQsConnection;
+              inFAQs: Array<Faq>;
+              inFAQsAggregate?: Maybe<FaqEntryFaqInFaQsAggregationSelection>;
+              inFAQsConnection: FaqEntryInFaQsConnection;
             };
 
-            export type FAQEntryinFAQsArgs = {
-              where?: InputMaybe<FAQWhere>;
-              options?: InputMaybe<FAQOptions>;
+            export type FaqEntryInFaQsArgs = {
+              where?: InputMaybe<FaqWhere>;
+              options?: InputMaybe<FaqOptions>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type FAQEntryinFAQsAggregateArgs = {
-              where?: InputMaybe<FAQWhere>;
+            export type FaqEntryInFaQsAggregateArgs = {
+              where?: InputMaybe<FaqWhere>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
             };
 
-            export type FAQEntryinFAQsConnectionArgs = {
-              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+            export type FaqEntryInFaQsConnectionArgs = {
+              where?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               first?: InputMaybe<Scalars[\\"Int\\"]>;
               after?: InputMaybe<Scalars[\\"String\\"]>;
               directed?: InputMaybe<Scalars[\\"Boolean\\"]>;
-              sort?: InputMaybe<Array<FAQEntryInFAQsConnectionSort>>;
+              sort?: InputMaybe<Array<FaqEntryInFaQsConnectionSort>>;
             };
 
-            export type FAQEntryAggregateSelection = {
+            export type FaqEntryAggregateSelection = {
               __typename?: \\"FAQEntryAggregateSelection\\";
               count: Scalars[\\"Int\\"];
-              id: IDAggregateSelectionNonNullable;
+              id: IdAggregateSelectionNonNullable;
               title: StringAggregateSelectionNonNullable;
               body: StringAggregateSelectionNonNullable;
             };
 
-            export type FAQEntryEdge = {
+            export type FaqEntryEdge = {
               __typename?: \\"FAQEntryEdge\\";
               cursor: Scalars[\\"String\\"];
-              node: FAQEntry;
+              node: FaqEntry;
             };
 
-            export type FAQEntryFAQInFAQsAggregationSelection = {
+            export type FaqEntryFaqInFaQsAggregationSelection = {
               __typename?: \\"FAQEntryFAQInFAQsAggregationSelection\\";
               count: Scalars[\\"Int\\"];
-              node?: Maybe<FAQEntryFAQInFAQsNodeAggregateSelection>;
-              edge?: Maybe<FAQEntryFAQInFAQsEdgeAggregateSelection>;
+              node?: Maybe<FaqEntryFaqInFaQsNodeAggregateSelection>;
+              edge?: Maybe<FaqEntryFaqInFaQsEdgeAggregateSelection>;
             };
 
-            export type FAQEntryFAQInFAQsEdgeAggregateSelection = {
+            export type FaqEntryFaqInFaQsEdgeAggregateSelection = {
               __typename?: \\"FAQEntryFAQInFAQsEdgeAggregateSelection\\";
               position: IntAggregateSelectionNullable;
             };
 
-            export type FAQEntryFAQInFAQsNodeAggregateSelection = {
+            export type FaqEntryFaqInFaQsNodeAggregateSelection = {
               __typename?: \\"FAQEntryFAQInFAQsNodeAggregateSelection\\";
-              id: IDAggregateSelectionNonNullable;
+              id: IdAggregateSelectionNonNullable;
               name: StringAggregateSelectionNonNullable;
             };
 
-            export type FAQEntryInFAQsConnection = {
+            export type FaqEntryInFaQsConnection = {
               __typename?: \\"FAQEntryInFAQsConnection\\";
-              edges: Array<FAQEntryInFAQsRelationship>;
+              edges: Array<FaqEntryInFaQsRelationship>;
               totalCount: Scalars[\\"Int\\"];
               pageInfo: PageInfo;
             };
 
-            export type FAQEntryInFAQsRelationship = FaqEntryInFaq & {
+            export type FaqEntryInFaQsRelationship = FaqEntryInFaq & {
               __typename?: \\"FAQEntryInFAQsRelationship\\";
               cursor: Scalars[\\"String\\"];
-              node: FAQ;
+              node: Faq;
               position?: Maybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQFAQEntryEntriesAggregationSelection = {
+            export type FaqfaqEntryEntriesAggregationSelection = {
               __typename?: \\"FAQFAQEntryEntriesAggregationSelection\\";
               count: Scalars[\\"Int\\"];
-              node?: Maybe<FAQFAQEntryEntriesNodeAggregateSelection>;
-              edge?: Maybe<FAQFAQEntryEntriesEdgeAggregateSelection>;
+              node?: Maybe<FaqfaqEntryEntriesNodeAggregateSelection>;
+              edge?: Maybe<FaqfaqEntryEntriesEdgeAggregateSelection>;
             };
 
-            export type FAQFAQEntryEntriesEdgeAggregateSelection = {
+            export type FaqfaqEntryEntriesEdgeAggregateSelection = {
               __typename?: \\"FAQFAQEntryEntriesEdgeAggregateSelection\\";
               position: IntAggregateSelectionNullable;
             };
 
-            export type FAQFAQEntryEntriesNodeAggregateSelection = {
+            export type FaqfaqEntryEntriesNodeAggregateSelection = {
               __typename?: \\"FAQFAQEntryEntriesNodeAggregateSelection\\";
-              id: IDAggregateSelectionNonNullable;
+              id: IdAggregateSelectionNonNullable;
               title: StringAggregateSelectionNonNullable;
               body: StringAggregateSelectionNonNullable;
             };
@@ -2005,10 +2005,10 @@ describe("generate", () => {
               __typename?: \\"FaqsConnection\\";
               totalCount: Scalars[\\"Int\\"];
               pageInfo: PageInfo;
-              edges: Array<FAQEdge>;
+              edges: Array<FaqEdge>;
             };
 
-            export type IDAggregateSelectionNonNullable = {
+            export type IdAggregateSelectionNonNullable = {
               __typename?: \\"IDAggregateSelectionNonNullable\\";
               shortest: Scalars[\\"ID\\"];
               longest: Scalars[\\"ID\\"];
@@ -2040,13 +2040,13 @@ describe("generate", () => {
             export type UpdateFaqEntriesMutationResponse = {
               __typename?: \\"UpdateFaqEntriesMutationResponse\\";
               info: UpdateInfo;
-              faqEntries: Array<FAQEntry>;
+              faqEntries: Array<FaqEntry>;
             };
 
             export type UpdateFaqsMutationResponse = {
               __typename?: \\"UpdateFaqsMutationResponse\\";
               info: UpdateInfo;
-              faqs: Array<FAQ>;
+              faqs: Array<Faq>;
             };
 
             export type UpdateInfo = {
@@ -2058,103 +2058,103 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"];
             };
 
-            export type FAQConnectInput = {
-              entries?: InputMaybe<Array<FAQEntriesConnectFieldInput>>;
+            export type FaqConnectInput = {
+              entries?: InputMaybe<Array<FaqEntriesConnectFieldInput>>;
             };
 
-            export type FAQConnectOrCreateInput = {
-              entries?: InputMaybe<Array<FAQEntriesConnectOrCreateFieldInput>>;
+            export type FaqConnectOrCreateInput = {
+              entries?: InputMaybe<Array<FaqEntriesConnectOrCreateFieldInput>>;
             };
 
-            export type FAQConnectOrCreateWhere = {
-              node: FAQUniqueWhere;
+            export type FaqConnectOrCreateWhere = {
+              node: FaqUniqueWhere;
             };
 
-            export type FAQConnectWhere = {
-              node: FAQWhere;
+            export type FaqConnectWhere = {
+              node: FaqWhere;
             };
 
-            export type FAQCreateInput = {
+            export type FaqCreateInput = {
               activated: Scalars[\\"Boolean\\"];
               name: Scalars[\\"String\\"];
-              entries?: InputMaybe<FAQEntriesFieldInput>;
+              entries?: InputMaybe<FaqEntriesFieldInput>;
             };
 
-            export type FAQDeleteInput = {
-              entries?: InputMaybe<Array<FAQEntriesDeleteFieldInput>>;
+            export type FaqDeleteInput = {
+              entries?: InputMaybe<Array<FaqEntriesDeleteFieldInput>>;
             };
 
-            export type FAQDisconnectInput = {
-              entries?: InputMaybe<Array<FAQEntriesDisconnectFieldInput>>;
+            export type FaqDisconnectInput = {
+              entries?: InputMaybe<Array<FaqEntriesDisconnectFieldInput>>;
             };
 
-            export type FAQEntriesAggregateInput = {
+            export type FaqEntriesAggregateInput = {
               count?: InputMaybe<Scalars[\\"Int\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
-              AND?: InputMaybe<Array<FAQEntriesAggregateInput>>;
-              OR?: InputMaybe<Array<FAQEntriesAggregateInput>>;
-              NOT?: InputMaybe<FAQEntriesAggregateInput>;
-              node?: InputMaybe<FAQEntriesNodeAggregationWhereInput>;
-              edge?: InputMaybe<FAQEntriesEdgeAggregationWhereInput>;
+              AND?: InputMaybe<Array<FaqEntriesAggregateInput>>;
+              OR?: InputMaybe<Array<FaqEntriesAggregateInput>>;
+              NOT?: InputMaybe<FaqEntriesAggregateInput>;
+              node?: InputMaybe<FaqEntriesNodeAggregationWhereInput>;
+              edge?: InputMaybe<FaqEntriesEdgeAggregationWhereInput>;
             };
 
-            export type FAQEntriesConnectFieldInput = {
-              where?: InputMaybe<FAQEntryConnectWhere>;
-              connect?: InputMaybe<Array<FAQEntryConnectInput>>;
+            export type FaqEntriesConnectFieldInput = {
+              where?: InputMaybe<FaqEntryConnectWhere>;
+              connect?: InputMaybe<Array<FaqEntryConnectInput>>;
               edge?: InputMaybe<FaqEntryInFaqCreateInput>;
               /** Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0. */
               overwrite?: Scalars[\\"Boolean\\"];
             };
 
-            export type FAQEntriesConnectionSort = {
+            export type FaqEntriesConnectionSort = {
               edge?: InputMaybe<FaqEntryInFaqSort>;
-              node?: InputMaybe<FAQEntrySort>;
+              node?: InputMaybe<FaqEntrySort>;
             };
 
-            export type FAQEntriesConnectionWhere = {
-              AND?: InputMaybe<Array<FAQEntriesConnectionWhere>>;
-              OR?: InputMaybe<Array<FAQEntriesConnectionWhere>>;
-              NOT?: InputMaybe<FAQEntriesConnectionWhere>;
+            export type FaqEntriesConnectionWhere = {
+              AND?: InputMaybe<Array<FaqEntriesConnectionWhere>>;
+              OR?: InputMaybe<Array<FaqEntriesConnectionWhere>>;
+              NOT?: InputMaybe<FaqEntriesConnectionWhere>;
               edge?: InputMaybe<FaqEntryInFaqWhere>;
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
               edge_NOT?: InputMaybe<FaqEntryInFaqWhere>;
-              node?: InputMaybe<FAQEntryWhere>;
+              node?: InputMaybe<FaqEntryWhere>;
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-              node_NOT?: InputMaybe<FAQEntryWhere>;
+              node_NOT?: InputMaybe<FaqEntryWhere>;
             };
 
-            export type FAQEntriesConnectOrCreateFieldInput = {
-              where: FAQEntryConnectOrCreateWhere;
-              onCreate: FAQEntriesConnectOrCreateFieldInputOnCreate;
+            export type FaqEntriesConnectOrCreateFieldInput = {
+              where: FaqEntryConnectOrCreateWhere;
+              onCreate: FaqEntriesConnectOrCreateFieldInputOnCreate;
             };
 
-            export type FAQEntriesConnectOrCreateFieldInputOnCreate = {
-              node: FAQEntryOnCreateInput;
+            export type FaqEntriesConnectOrCreateFieldInputOnCreate = {
+              node: FaqEntryOnCreateInput;
               edge?: InputMaybe<FaqEntryInFaqCreateInput>;
             };
 
-            export type FAQEntriesCreateFieldInput = {
-              node: FAQEntryCreateInput;
+            export type FaqEntriesCreateFieldInput = {
+              node: FaqEntryCreateInput;
               edge?: InputMaybe<FaqEntryInFaqCreateInput>;
             };
 
-            export type FAQEntriesDeleteFieldInput = {
-              where?: InputMaybe<FAQEntriesConnectionWhere>;
-              delete?: InputMaybe<FAQEntryDeleteInput>;
+            export type FaqEntriesDeleteFieldInput = {
+              where?: InputMaybe<FaqEntriesConnectionWhere>;
+              delete?: InputMaybe<FaqEntryDeleteInput>;
             };
 
-            export type FAQEntriesDisconnectFieldInput = {
-              where?: InputMaybe<FAQEntriesConnectionWhere>;
-              disconnect?: InputMaybe<FAQEntryDisconnectInput>;
+            export type FaqEntriesDisconnectFieldInput = {
+              where?: InputMaybe<FaqEntriesConnectionWhere>;
+              disconnect?: InputMaybe<FaqEntryDisconnectInput>;
             };
 
-            export type FAQEntriesEdgeAggregationWhereInput = {
-              AND?: InputMaybe<Array<FAQEntriesEdgeAggregationWhereInput>>;
-              OR?: InputMaybe<Array<FAQEntriesEdgeAggregationWhereInput>>;
-              NOT?: InputMaybe<FAQEntriesEdgeAggregationWhereInput>;
+            export type FaqEntriesEdgeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FaqEntriesEdgeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FaqEntriesEdgeAggregationWhereInput>>;
+              NOT?: InputMaybe<FaqEntriesEdgeAggregationWhereInput>;
               /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
               position_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
               position_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
@@ -2187,16 +2187,16 @@ describe("generate", () => {
               position_SUM_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntriesFieldInput = {
-              connectOrCreate?: InputMaybe<Array<FAQEntriesConnectOrCreateFieldInput>>;
-              create?: InputMaybe<Array<FAQEntriesCreateFieldInput>>;
-              connect?: InputMaybe<Array<FAQEntriesConnectFieldInput>>;
+            export type FaqEntriesFieldInput = {
+              connectOrCreate?: InputMaybe<Array<FaqEntriesConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FaqEntriesCreateFieldInput>>;
+              connect?: InputMaybe<Array<FaqEntriesConnectFieldInput>>;
             };
 
-            export type FAQEntriesNodeAggregationWhereInput = {
-              AND?: InputMaybe<Array<FAQEntriesNodeAggregationWhereInput>>;
-              OR?: InputMaybe<Array<FAQEntriesNodeAggregationWhereInput>>;
-              NOT?: InputMaybe<FAQEntriesNodeAggregationWhereInput>;
+            export type FaqEntriesNodeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FaqEntriesNodeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FaqEntriesNodeAggregationWhereInput>>;
+              NOT?: InputMaybe<FaqEntriesNodeAggregationWhereInput>;
               /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
               id_EQUAL?: InputMaybe<Scalars[\\"ID\\"]>;
               /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
@@ -2311,122 +2311,122 @@ describe("generate", () => {
               body_SHORTEST_LENGTH_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntriesUpdateConnectionInput = {
-              node?: InputMaybe<FAQEntryUpdateInput>;
+            export type FaqEntriesUpdateConnectionInput = {
+              node?: InputMaybe<FaqEntryUpdateInput>;
               edge?: InputMaybe<FaqEntryInFaqUpdateInput>;
             };
 
-            export type FAQEntriesUpdateFieldInput = {
-              where?: InputMaybe<FAQEntriesConnectionWhere>;
-              connectOrCreate?: InputMaybe<Array<FAQEntriesConnectOrCreateFieldInput>>;
-              create?: InputMaybe<Array<FAQEntriesCreateFieldInput>>;
-              connect?: InputMaybe<Array<FAQEntriesConnectFieldInput>>;
-              update?: InputMaybe<FAQEntriesUpdateConnectionInput>;
-              delete?: InputMaybe<Array<FAQEntriesDeleteFieldInput>>;
-              disconnect?: InputMaybe<Array<FAQEntriesDisconnectFieldInput>>;
+            export type FaqEntriesUpdateFieldInput = {
+              where?: InputMaybe<FaqEntriesConnectionWhere>;
+              connectOrCreate?: InputMaybe<Array<FaqEntriesConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FaqEntriesCreateFieldInput>>;
+              connect?: InputMaybe<Array<FaqEntriesConnectFieldInput>>;
+              update?: InputMaybe<FaqEntriesUpdateConnectionInput>;
+              delete?: InputMaybe<Array<FaqEntriesDeleteFieldInput>>;
+              disconnect?: InputMaybe<Array<FaqEntriesDisconnectFieldInput>>;
             };
 
-            export type FAQEntryConnectInput = {
-              inFAQs?: InputMaybe<Array<FAQEntryInFAQsConnectFieldInput>>;
+            export type FaqEntryConnectInput = {
+              inFAQs?: InputMaybe<Array<FaqEntryInFaQsConnectFieldInput>>;
             };
 
-            export type FAQEntryConnectOrCreateInput = {
-              inFAQs?: InputMaybe<Array<FAQEntryInFAQsConnectOrCreateFieldInput>>;
+            export type FaqEntryConnectOrCreateInput = {
+              inFAQs?: InputMaybe<Array<FaqEntryInFaQsConnectOrCreateFieldInput>>;
             };
 
-            export type FAQEntryConnectOrCreateWhere = {
-              node: FAQEntryUniqueWhere;
+            export type FaqEntryConnectOrCreateWhere = {
+              node: FaqEntryUniqueWhere;
             };
 
-            export type FAQEntryConnectWhere = {
-              node: FAQEntryWhere;
+            export type FaqEntryConnectWhere = {
+              node: FaqEntryWhere;
             };
 
-            export type FAQEntryCreateInput = {
+            export type FaqEntryCreateInput = {
               title: Scalars[\\"String\\"];
               body: Scalars[\\"String\\"];
-              inFAQs?: InputMaybe<FAQEntryInFAQsFieldInput>;
+              inFAQs?: InputMaybe<FaqEntryInFaQsFieldInput>;
             };
 
-            export type FAQEntryDeleteInput = {
-              inFAQs?: InputMaybe<Array<FAQEntryInFAQsDeleteFieldInput>>;
+            export type FaqEntryDeleteInput = {
+              inFAQs?: InputMaybe<Array<FaqEntryInFaQsDeleteFieldInput>>;
             };
 
-            export type FAQEntryDisconnectInput = {
-              inFAQs?: InputMaybe<Array<FAQEntryInFAQsDisconnectFieldInput>>;
+            export type FaqEntryDisconnectInput = {
+              inFAQs?: InputMaybe<Array<FaqEntryInFaQsDisconnectFieldInput>>;
             };
 
             export type FaqEntryInFaqCreateInput = {
               position?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntryInFAQsAggregateInput = {
+            export type FaqEntryInFaQsAggregateInput = {
               count?: InputMaybe<Scalars[\\"Int\\"]>;
               count_LT?: InputMaybe<Scalars[\\"Int\\"]>;
               count_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
               count_GT?: InputMaybe<Scalars[\\"Int\\"]>;
               count_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
-              AND?: InputMaybe<Array<FAQEntryInFAQsAggregateInput>>;
-              OR?: InputMaybe<Array<FAQEntryInFAQsAggregateInput>>;
-              NOT?: InputMaybe<FAQEntryInFAQsAggregateInput>;
-              node?: InputMaybe<FAQEntryInFAQsNodeAggregationWhereInput>;
-              edge?: InputMaybe<FAQEntryInFAQsEdgeAggregationWhereInput>;
+              AND?: InputMaybe<Array<FaqEntryInFaQsAggregateInput>>;
+              OR?: InputMaybe<Array<FaqEntryInFaQsAggregateInput>>;
+              NOT?: InputMaybe<FaqEntryInFaQsAggregateInput>;
+              node?: InputMaybe<FaqEntryInFaQsNodeAggregationWhereInput>;
+              edge?: InputMaybe<FaqEntryInFaQsEdgeAggregationWhereInput>;
             };
 
-            export type FAQEntryInFAQsConnectFieldInput = {
-              where?: InputMaybe<FAQConnectWhere>;
-              connect?: InputMaybe<Array<FAQConnectInput>>;
+            export type FaqEntryInFaQsConnectFieldInput = {
+              where?: InputMaybe<FaqConnectWhere>;
+              connect?: InputMaybe<Array<FaqConnectInput>>;
               edge?: InputMaybe<FaqEntryInFaqCreateInput>;
               /** Whether or not to overwrite any matching relationship with the new properties. Will default to \`false\` in 4.0.0. */
               overwrite?: Scalars[\\"Boolean\\"];
             };
 
-            export type FAQEntryInFAQsConnectionSort = {
+            export type FaqEntryInFaQsConnectionSort = {
               edge?: InputMaybe<FaqEntryInFaqSort>;
-              node?: InputMaybe<FAQSort>;
+              node?: InputMaybe<FaqSort>;
             };
 
-            export type FAQEntryInFAQsConnectionWhere = {
-              AND?: InputMaybe<Array<FAQEntryInFAQsConnectionWhere>>;
-              OR?: InputMaybe<Array<FAQEntryInFAQsConnectionWhere>>;
-              NOT?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+            export type FaqEntryInFaQsConnectionWhere = {
+              AND?: InputMaybe<Array<FaqEntryInFaQsConnectionWhere>>;
+              OR?: InputMaybe<Array<FaqEntryInFaQsConnectionWhere>>;
+              NOT?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               edge?: InputMaybe<FaqEntryInFaqWhere>;
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
               edge_NOT?: InputMaybe<FaqEntryInFaqWhere>;
-              node?: InputMaybe<FAQWhere>;
+              node?: InputMaybe<FaqWhere>;
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
-              node_NOT?: InputMaybe<FAQWhere>;
+              node_NOT?: InputMaybe<FaqWhere>;
             };
 
-            export type FAQEntryInFAQsConnectOrCreateFieldInput = {
-              where: FAQConnectOrCreateWhere;
-              onCreate: FAQEntryInFAQsConnectOrCreateFieldInputOnCreate;
+            export type FaqEntryInFaQsConnectOrCreateFieldInput = {
+              where: FaqConnectOrCreateWhere;
+              onCreate: FaqEntryInFaQsConnectOrCreateFieldInputOnCreate;
             };
 
-            export type FAQEntryInFAQsConnectOrCreateFieldInputOnCreate = {
-              node: FAQOnCreateInput;
+            export type FaqEntryInFaQsConnectOrCreateFieldInputOnCreate = {
+              node: FaqOnCreateInput;
               edge?: InputMaybe<FaqEntryInFaqCreateInput>;
             };
 
-            export type FAQEntryInFAQsCreateFieldInput = {
-              node: FAQCreateInput;
+            export type FaqEntryInFaQsCreateFieldInput = {
+              node: FaqCreateInput;
               edge?: InputMaybe<FaqEntryInFaqCreateInput>;
             };
 
-            export type FAQEntryInFAQsDeleteFieldInput = {
-              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
-              delete?: InputMaybe<FAQDeleteInput>;
+            export type FaqEntryInFaQsDeleteFieldInput = {
+              where?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
+              delete?: InputMaybe<FaqDeleteInput>;
             };
 
-            export type FAQEntryInFAQsDisconnectFieldInput = {
-              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
-              disconnect?: InputMaybe<FAQDisconnectInput>;
+            export type FaqEntryInFaQsDisconnectFieldInput = {
+              where?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
+              disconnect?: InputMaybe<FaqDisconnectInput>;
             };
 
-            export type FAQEntryInFAQsEdgeAggregationWhereInput = {
-              AND?: InputMaybe<Array<FAQEntryInFAQsEdgeAggregationWhereInput>>;
-              OR?: InputMaybe<Array<FAQEntryInFAQsEdgeAggregationWhereInput>>;
-              NOT?: InputMaybe<FAQEntryInFAQsEdgeAggregationWhereInput>;
+            export type FaqEntryInFaQsEdgeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FaqEntryInFaQsEdgeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FaqEntryInFaQsEdgeAggregationWhereInput>>;
+              NOT?: InputMaybe<FaqEntryInFaQsEdgeAggregationWhereInput>;
               /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
               position_EQUAL?: InputMaybe<Scalars[\\"Int\\"]>;
               position_AVERAGE_EQUAL?: InputMaybe<Scalars[\\"Float\\"]>;
@@ -2459,16 +2459,16 @@ describe("generate", () => {
               position_SUM_LTE?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntryInFAQsFieldInput = {
-              connectOrCreate?: InputMaybe<Array<FAQEntryInFAQsConnectOrCreateFieldInput>>;
-              create?: InputMaybe<Array<FAQEntryInFAQsCreateFieldInput>>;
-              connect?: InputMaybe<Array<FAQEntryInFAQsConnectFieldInput>>;
+            export type FaqEntryInFaQsFieldInput = {
+              connectOrCreate?: InputMaybe<Array<FaqEntryInFaQsConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FaqEntryInFaQsCreateFieldInput>>;
+              connect?: InputMaybe<Array<FaqEntryInFaQsConnectFieldInput>>;
             };
 
-            export type FAQEntryInFAQsNodeAggregationWhereInput = {
-              AND?: InputMaybe<Array<FAQEntryInFAQsNodeAggregationWhereInput>>;
-              OR?: InputMaybe<Array<FAQEntryInFAQsNodeAggregationWhereInput>>;
-              NOT?: InputMaybe<FAQEntryInFAQsNodeAggregationWhereInput>;
+            export type FaqEntryInFaQsNodeAggregationWhereInput = {
+              AND?: InputMaybe<Array<FaqEntryInFaQsNodeAggregationWhereInput>>;
+              OR?: InputMaybe<Array<FaqEntryInFaQsNodeAggregationWhereInput>>;
+              NOT?: InputMaybe<FaqEntryInFaQsNodeAggregationWhereInput>;
               /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
               id_EQUAL?: InputMaybe<Scalars[\\"ID\\"]>;
               /** @deprecated Aggregation filters that are not relying on an aggregating function will be deprecated. */
@@ -2532,19 +2532,19 @@ describe("generate", () => {
               position?: InputMaybe<SortDirection>;
             };
 
-            export type FAQEntryInFAQsUpdateConnectionInput = {
-              node?: InputMaybe<FAQUpdateInput>;
+            export type FaqEntryInFaQsUpdateConnectionInput = {
+              node?: InputMaybe<FaqUpdateInput>;
               edge?: InputMaybe<FaqEntryInFaqUpdateInput>;
             };
 
-            export type FAQEntryInFAQsUpdateFieldInput = {
-              where?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
-              connectOrCreate?: InputMaybe<Array<FAQEntryInFAQsConnectOrCreateFieldInput>>;
-              create?: InputMaybe<Array<FAQEntryInFAQsCreateFieldInput>>;
-              connect?: InputMaybe<Array<FAQEntryInFAQsConnectFieldInput>>;
-              update?: InputMaybe<FAQEntryInFAQsUpdateConnectionInput>;
-              delete?: InputMaybe<Array<FAQEntryInFAQsDeleteFieldInput>>;
-              disconnect?: InputMaybe<Array<FAQEntryInFAQsDisconnectFieldInput>>;
+            export type FaqEntryInFaQsUpdateFieldInput = {
+              where?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
+              connectOrCreate?: InputMaybe<Array<FaqEntryInFaQsConnectOrCreateFieldInput>>;
+              create?: InputMaybe<Array<FaqEntryInFaQsCreateFieldInput>>;
+              connect?: InputMaybe<Array<FaqEntryInFaQsConnectFieldInput>>;
+              update?: InputMaybe<FaqEntryInFaQsUpdateConnectionInput>;
+              delete?: InputMaybe<Array<FaqEntryInFaQsDeleteFieldInput>>;
+              disconnect?: InputMaybe<Array<FaqEntryInFaQsDisconnectFieldInput>>;
             };
 
             export type FaqEntryInFaqUpdateInput = {
@@ -2569,43 +2569,43 @@ describe("generate", () => {
               position_GTE?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntryOnCreateInput = {
+            export type FaqEntryOnCreateInput = {
               title: Scalars[\\"String\\"];
               body: Scalars[\\"String\\"];
             };
 
-            export type FAQEntryOptions = {
+            export type FaqEntryOptions = {
               /** Specify one or more FAQEntrySort objects to sort FaqEntries by. The sorts will be applied in the order in which they are arranged in the array. */
-              sort?: InputMaybe<Array<FAQEntrySort>>;
+              sort?: InputMaybe<Array<FaqEntrySort>>;
               limit?: InputMaybe<Scalars[\\"Int\\"]>;
               offset?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQEntryRelationInput = {
-              inFAQs?: InputMaybe<Array<FAQEntryInFAQsCreateFieldInput>>;
+            export type FaqEntryRelationInput = {
+              inFAQs?: InputMaybe<Array<FaqEntryInFaQsCreateFieldInput>>;
             };
 
             /** Fields to sort FaqEntries by. The order in which sorts are applied is not guaranteed when specifying many fields in one FAQEntrySort object. */
-            export type FAQEntrySort = {
+            export type FaqEntrySort = {
               id?: InputMaybe<SortDirection>;
               title?: InputMaybe<SortDirection>;
               body?: InputMaybe<SortDirection>;
             };
 
-            export type FAQEntryUniqueWhere = {
+            export type FaqEntryUniqueWhere = {
               id?: InputMaybe<Scalars[\\"ID\\"]>;
             };
 
-            export type FAQEntryUpdateInput = {
+            export type FaqEntryUpdateInput = {
               title?: InputMaybe<Scalars[\\"String\\"]>;
               body?: InputMaybe<Scalars[\\"String\\"]>;
-              inFAQs?: InputMaybe<Array<FAQEntryInFAQsUpdateFieldInput>>;
+              inFAQs?: InputMaybe<Array<FaqEntryInFaQsUpdateFieldInput>>;
             };
 
-            export type FAQEntryWhere = {
-              OR?: InputMaybe<Array<FAQEntryWhere>>;
-              AND?: InputMaybe<Array<FAQEntryWhere>>;
-              NOT?: InputMaybe<FAQEntryWhere>;
+            export type FaqEntryWhere = {
+              OR?: InputMaybe<Array<FaqEntryWhere>>;
+              AND?: InputMaybe<Array<FaqEntryWhere>>;
+              NOT?: InputMaybe<FaqEntryWhere>;
               id?: InputMaybe<Scalars[\\"ID\\"]>;
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
               id_NOT?: InputMaybe<Scalars[\\"ID\\"]>;
@@ -2652,69 +2652,69 @@ describe("generate", () => {
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
               body_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
               /** @deprecated Use \`inFAQs_SOME\` instead. */
-              inFAQs?: InputMaybe<FAQWhere>;
+              inFAQs?: InputMaybe<FaqWhere>;
               /** @deprecated Use \`inFAQs_NONE\` instead. */
-              inFAQs_NOT?: InputMaybe<FAQWhere>;
-              inFAQsAggregate?: InputMaybe<FAQEntryInFAQsAggregateInput>;
+              inFAQs_NOT?: InputMaybe<FaqWhere>;
+              inFAQsAggregate?: InputMaybe<FaqEntryInFaQsAggregateInput>;
               /** Return FAQEntries where all of the related FAQS match this filter */
-              inFAQs_ALL?: InputMaybe<FAQWhere>;
+              inFAQs_ALL?: InputMaybe<FaqWhere>;
               /** Return FAQEntries where none of the related FAQS match this filter */
-              inFAQs_NONE?: InputMaybe<FAQWhere>;
+              inFAQs_NONE?: InputMaybe<FaqWhere>;
               /** Return FAQEntries where one of the related FAQS match this filter */
-              inFAQs_SINGLE?: InputMaybe<FAQWhere>;
+              inFAQs_SINGLE?: InputMaybe<FaqWhere>;
               /** Return FAQEntries where some of the related FAQS match this filter */
-              inFAQs_SOME?: InputMaybe<FAQWhere>;
+              inFAQs_SOME?: InputMaybe<FaqWhere>;
               /** @deprecated Use \`inFAQsConnection_SOME\` instead. */
-              inFAQsConnection?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              inFAQsConnection?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               /** @deprecated Use \`inFAQsConnection_NONE\` instead. */
-              inFAQsConnection_NOT?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              inFAQsConnection_NOT?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               /** Return FAQEntries where all of the related FAQEntryInFAQsConnections match this filter */
-              inFAQsConnection_ALL?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              inFAQsConnection_ALL?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               /** Return FAQEntries where none of the related FAQEntryInFAQsConnections match this filter */
-              inFAQsConnection_NONE?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              inFAQsConnection_NONE?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               /** Return FAQEntries where one of the related FAQEntryInFAQsConnections match this filter */
-              inFAQsConnection_SINGLE?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              inFAQsConnection_SINGLE?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
               /** Return FAQEntries where some of the related FAQEntryInFAQsConnections match this filter */
-              inFAQsConnection_SOME?: InputMaybe<FAQEntryInFAQsConnectionWhere>;
+              inFAQsConnection_SOME?: InputMaybe<FaqEntryInFaQsConnectionWhere>;
             };
 
-            export type FAQOnCreateInput = {
+            export type FaqOnCreateInput = {
               activated: Scalars[\\"Boolean\\"];
               name: Scalars[\\"String\\"];
             };
 
-            export type FAQOptions = {
+            export type FaqOptions = {
               /** Specify one or more FAQSort objects to sort Faqs by. The sorts will be applied in the order in which they are arranged in the array. */
-              sort?: InputMaybe<Array<FAQSort>>;
+              sort?: InputMaybe<Array<FaqSort>>;
               limit?: InputMaybe<Scalars[\\"Int\\"]>;
               offset?: InputMaybe<Scalars[\\"Int\\"]>;
             };
 
-            export type FAQRelationInput = {
-              entries?: InputMaybe<Array<FAQEntriesCreateFieldInput>>;
+            export type FaqRelationInput = {
+              entries?: InputMaybe<Array<FaqEntriesCreateFieldInput>>;
             };
 
             /** Fields to sort Faqs by. The order in which sorts are applied is not guaranteed when specifying many fields in one FAQSort object. */
-            export type FAQSort = {
+            export type FaqSort = {
               id?: InputMaybe<SortDirection>;
               activated?: InputMaybe<SortDirection>;
               name?: InputMaybe<SortDirection>;
             };
 
-            export type FAQUniqueWhere = {
+            export type FaqUniqueWhere = {
               id?: InputMaybe<Scalars[\\"ID\\"]>;
             };
 
-            export type FAQUpdateInput = {
+            export type FaqUpdateInput = {
               activated?: InputMaybe<Scalars[\\"Boolean\\"]>;
               name?: InputMaybe<Scalars[\\"String\\"]>;
-              entries?: InputMaybe<Array<FAQEntriesUpdateFieldInput>>;
+              entries?: InputMaybe<Array<FaqEntriesUpdateFieldInput>>;
             };
 
-            export type FAQWhere = {
-              OR?: InputMaybe<Array<FAQWhere>>;
-              AND?: InputMaybe<Array<FAQWhere>>;
-              NOT?: InputMaybe<FAQWhere>;
+            export type FaqWhere = {
+              OR?: InputMaybe<Array<FaqWhere>>;
+              AND?: InputMaybe<Array<FaqWhere>>;
+              NOT?: InputMaybe<FaqWhere>;
               id?: InputMaybe<Scalars[\\"ID\\"]>;
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
               id_NOT?: InputMaybe<Scalars[\\"ID\\"]>;
@@ -2749,33 +2749,33 @@ describe("generate", () => {
               /** @deprecated Negation filters will be deprecated, use the NOT operator to achieve the same behavior */
               name_NOT_ENDS_WITH?: InputMaybe<Scalars[\\"String\\"]>;
               /** @deprecated Use \`entries_SOME\` instead. */
-              entries?: InputMaybe<FAQEntryWhere>;
+              entries?: InputMaybe<FaqEntryWhere>;
               /** @deprecated Use \`entries_NONE\` instead. */
-              entries_NOT?: InputMaybe<FAQEntryWhere>;
-              entriesAggregate?: InputMaybe<FAQEntriesAggregateInput>;
+              entries_NOT?: InputMaybe<FaqEntryWhere>;
+              entriesAggregate?: InputMaybe<FaqEntriesAggregateInput>;
               /** Return FAQS where all of the related FAQEntries match this filter */
-              entries_ALL?: InputMaybe<FAQEntryWhere>;
+              entries_ALL?: InputMaybe<FaqEntryWhere>;
               /** Return FAQS where none of the related FAQEntries match this filter */
-              entries_NONE?: InputMaybe<FAQEntryWhere>;
+              entries_NONE?: InputMaybe<FaqEntryWhere>;
               /** Return FAQS where one of the related FAQEntries match this filter */
-              entries_SINGLE?: InputMaybe<FAQEntryWhere>;
+              entries_SINGLE?: InputMaybe<FaqEntryWhere>;
               /** Return FAQS where some of the related FAQEntries match this filter */
-              entries_SOME?: InputMaybe<FAQEntryWhere>;
+              entries_SOME?: InputMaybe<FaqEntryWhere>;
               /** @deprecated Use \`entriesConnection_SOME\` instead. */
-              entriesConnection?: InputMaybe<FAQEntriesConnectionWhere>;
+              entriesConnection?: InputMaybe<FaqEntriesConnectionWhere>;
               /** @deprecated Use \`entriesConnection_NONE\` instead. */
-              entriesConnection_NOT?: InputMaybe<FAQEntriesConnectionWhere>;
+              entriesConnection_NOT?: InputMaybe<FaqEntriesConnectionWhere>;
               /** Return FAQS where all of the related FAQEntriesConnections match this filter */
-              entriesConnection_ALL?: InputMaybe<FAQEntriesConnectionWhere>;
+              entriesConnection_ALL?: InputMaybe<FaqEntriesConnectionWhere>;
               /** Return FAQS where none of the related FAQEntriesConnections match this filter */
-              entriesConnection_NONE?: InputMaybe<FAQEntriesConnectionWhere>;
+              entriesConnection_NONE?: InputMaybe<FaqEntriesConnectionWhere>;
               /** Return FAQS where one of the related FAQEntriesConnections match this filter */
-              entriesConnection_SINGLE?: InputMaybe<FAQEntriesConnectionWhere>;
+              entriesConnection_SINGLE?: InputMaybe<FaqEntriesConnectionWhere>;
               /** Return FAQS where some of the related FAQEntriesConnections match this filter */
-              entriesConnection_SOME?: InputMaybe<FAQEntriesConnectionWhere>;
+              entriesConnection_SOME?: InputMaybe<FaqEntriesConnectionWhere>;
             };
 
-            export interface IDAggregateInputNonNullable {
+            export interface IdAggregateInputNonNullable {
               shortest?: boolean;
               longest?: boolean;
             }
@@ -2785,55 +2785,55 @@ describe("generate", () => {
             }
             export interface FAQAggregateSelectionInput {
               count?: boolean;
-              id?: IDAggregateInputNonNullable;
+              id?: IdAggregateInputNonNullable;
               name?: StringAggregateInputNonNullable;
             }
 
             export declare class FAQModel {
               public find(args?: {
-                where?: FAQWhere;
+                where?: FaqWhere;
 
-                options?: FAQOptions;
+                options?: FaqOptions;
                 selectionSet?: string | DocumentNode | SelectionSetNode;
                 args?: any;
                 context?: any;
                 rootValue?: any;
               }): Promise<FAQ[]>;
               public create(args: {
-                input: FAQCreateInput[];
+                input: FaqCreateInput[];
                 selectionSet?: string | DocumentNode | SelectionSetNode;
                 args?: any;
                 context?: any;
                 rootValue?: any;
               }): Promise<CreateFaqsMutationResponse>;
               public update(args: {
-                where?: FAQWhere;
-                update?: FAQUpdateInput;
-                connect?: FAQConnectInput;
-                disconnect?: FAQDisconnectInput;
-                create?: FAQCreateInput;
-                connectOrCreate?: FAQConnectOrCreateInput;
+                where?: FaqWhere;
+                update?: FaqUpdateInput;
+                connect?: FaqConnectInput;
+                disconnect?: FaqDisconnectInput;
+                create?: FaqCreateInput;
+                connectOrCreate?: FaqConnectOrCreateInput;
                 selectionSet?: string | DocumentNode | SelectionSetNode;
                 args?: any;
                 context?: any;
                 rootValue?: any;
               }): Promise<UpdateFaqsMutationResponse>;
               public delete(args: {
-                where?: FAQWhere;
-                delete?: FAQDeleteInput;
+                where?: FaqWhere;
+                delete?: FaqDeleteInput;
                 context?: any;
                 rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
-                where?: FAQWhere;
+                where?: FaqWhere;
 
-                aggregate: FAQAggregateSelectionInput;
+                aggregate: FaqAggregateSelectionInput;
                 context?: any;
                 rootValue?: any;
-              }): Promise<FAQAggregateSelection>;
+              }): Promise<FaqAggregateSelection>;
             }
 
-            export interface IDAggregateInputNonNullable {
+            export interface IdAggregateInputNonNullable {
               shortest?: boolean;
               longest?: boolean;
             }
@@ -2843,53 +2843,53 @@ describe("generate", () => {
             }
             export interface FAQEntryAggregateSelectionInput {
               count?: boolean;
-              id?: IDAggregateInputNonNullable;
+              id?: IdAggregateInputNonNullable;
               title?: StringAggregateInputNonNullable;
               body?: StringAggregateInputNonNullable;
             }
 
             export declare class FAQEntryModel {
               public find(args?: {
-                where?: FAQEntryWhere;
+                where?: FaqEntryWhere;
 
-                options?: FAQEntryOptions;
+                options?: FaqEntryOptions;
                 selectionSet?: string | DocumentNode | SelectionSetNode;
                 args?: any;
                 context?: any;
                 rootValue?: any;
               }): Promise<FAQEntry[]>;
               public create(args: {
-                input: FAQEntryCreateInput[];
+                input: FaqEntryCreateInput[];
                 selectionSet?: string | DocumentNode | SelectionSetNode;
                 args?: any;
                 context?: any;
                 rootValue?: any;
               }): Promise<CreateFaqEntriesMutationResponse>;
               public update(args: {
-                where?: FAQEntryWhere;
-                update?: FAQEntryUpdateInput;
-                connect?: FAQEntryConnectInput;
-                disconnect?: FAQEntryDisconnectInput;
-                create?: FAQEntryCreateInput;
-                connectOrCreate?: FAQEntryConnectOrCreateInput;
+                where?: FaqEntryWhere;
+                update?: FaqEntryUpdateInput;
+                connect?: FaqEntryConnectInput;
+                disconnect?: FaqEntryDisconnectInput;
+                create?: FaqEntryCreateInput;
+                connectOrCreate?: FaqEntryConnectOrCreateInput;
                 selectionSet?: string | DocumentNode | SelectionSetNode;
                 args?: any;
                 context?: any;
                 rootValue?: any;
               }): Promise<UpdateFaqEntriesMutationResponse>;
               public delete(args: {
-                where?: FAQEntryWhere;
-                delete?: FAQEntryDeleteInput;
+                where?: FaqEntryWhere;
+                delete?: FaqEntryDeleteInput;
                 context?: any;
                 rootValue?: any;
               }): Promise<{ nodesDeleted: number; relationshipsDeleted: number }>;
               public aggregate(args: {
-                where?: FAQEntryWhere;
+                where?: FaqEntryWhere;
 
-                aggregate: FAQEntryAggregateSelectionInput;
+                aggregate: FaqEntryAggregateSelectionInput;
                 context?: any;
                 rootValue?: any;
-              }): Promise<FAQEntryAggregateSelection>;
+              }): Promise<FaqEntryAggregateSelection>;
             }
 
             export interface ModelMap {

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -136,7 +136,7 @@ async function generate(options: IGenerateOptions): Promise<undefined | string> 
     await options.ogm.init();
 
     const config: Types.GenerateOptions = {
-        config: {},
+        config: { namingConvention: "keep" },
         plugins: [
             {
                 typescript: {},

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -26,6 +26,7 @@ import prettier from "prettier";
 import type { OGM } from "./index";
 import { getReferenceNode } from "./utils";
 import { upperFirst } from "./utils/upper-first";
+import camelcase from "camelcase";
 
 export interface IGenerateOptions {
     /**
@@ -136,7 +137,7 @@ async function generate(options: IGenerateOptions): Promise<undefined | string> 
     await options.ogm.init();
 
     const config: Types.GenerateOptions = {
-        config: { namingConvention: "keep" },
+        config: {},
         plugins: [
             {
                 typescript: {},
@@ -172,52 +173,53 @@ async function generate(options: IGenerateOptions): Promise<undefined | string> 
         });
 
         const nodeHasConnectOrCreate = hasConnectOrCreate(node, options.ogm);
+        const normalizedNodeName = upperFirst(node.singular);
         const model = `
             ${Object.values(aggregationInput[1]).join("\n")}
             ${aggregationInput[0]}
 
             export declare class ${modelName} {
                 public find(args?: {
-                    where?: ${node.name}Where;
-                    ${hasFulltextArg ? `fulltext?: ${node.name}Fulltext;` : ""}
-                    options?: ${node.name}Options;
+                    where?: ${normalizedNodeName}Where;
+                    ${hasFulltextArg ? `fulltext?: ${normalizedNodeName}Fulltext;` : ""}
+                    options?: ${normalizedNodeName}Options;
                     selectionSet?: string | DocumentNode | SelectionSetNode;
                     args?: any;
                     context?: any;
                     rootValue?: any;
                 }): Promise<${node.name}[]>
                 public create(args: {
-                    input: ${node.name}CreateInput[];
+                    input: ${normalizedNodeName}CreateInput[];
                     selectionSet?: string | DocumentNode | SelectionSetNode;
                     args?: any;
                     context?: any;
                     rootValue?: any;
                 }): Promise<Create${upperFirst(node.plural)}MutationResponse>
                 public update(args: {
-                    where?: ${node.name}Where;
-                    update?: ${node.name}UpdateInput;
-                    ${node.relationFields.length ? `connect?: ${node.name}ConnectInput` : ""}
-                    ${node.relationFields.length ? `disconnect?: ${node.name}DisconnectInput` : ""}
-                    ${node.relationFields.length ? `create?: ${node.name}CreateInput` : ""}
-                    ${nodeHasConnectOrCreate ? `connectOrCreate?: ${node.name}ConnectOrCreateInput` : ""}
+                    where?: ${normalizedNodeName}Where;
+                    update?: ${normalizedNodeName}UpdateInput;
+                    ${node.relationFields.length ? `connect?: ${normalizedNodeName}ConnectInput` : ""}
+                    ${node.relationFields.length ? `disconnect?: ${normalizedNodeName}DisconnectInput` : ""}
+                    ${node.relationFields.length ? `create?: ${normalizedNodeName}CreateInput` : ""}
+                    ${nodeHasConnectOrCreate ? `connectOrCreate?: ${normalizedNodeName}ConnectOrCreateInput` : ""}
                     selectionSet?: string | DocumentNode | SelectionSetNode;
                     args?: any;
                     context?: any;
                     rootValue?: any;
                 }): Promise<Update${upperFirst(node.plural)}MutationResponse>
                 public delete(args: {
-                    where?: ${node.name}Where;
-                    ${node.relationFields.length ? `delete?: ${node.name}DeleteInput` : ""}
+                    where?: ${normalizedNodeName}Where;
+                    ${node.relationFields.length ? `delete?: ${normalizedNodeName}DeleteInput` : ""}
                     context?: any;
                     rootValue?: any;
                 }): Promise<{ nodesDeleted: number; relationshipsDeleted: number; }>
                 public aggregate(args: {
-                    where?: ${node.name}Where;
-                    ${hasFulltextArg ? `fulltext?: ${node.name}Fulltext;` : ""}
-                    aggregate: ${node.name}AggregateSelectionInput;
+                    where?: ${normalizedNodeName}Where;
+                    ${hasFulltextArg ? `fulltext?: ${normalizedNodeName}Fulltext;` : ""}
+                    aggregate: ${normalizedNodeName}AggregateSelectionInput;
                     context?: any;
                     rootValue?: any;
-                }): Promise<${node.name}AggregateSelection>
+                }): Promise<${normalizedNodeName}AggregateSelection>
             }
         `;
 

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -26,7 +26,6 @@ import prettier from "prettier";
 import type { OGM } from "./index";
 import { getReferenceNode } from "./utils";
 import { upperFirst } from "./utils/upper-first";
-import camelcase from "camelcase";
 
 export interface IGenerateOptions {
     /**
@@ -216,7 +215,7 @@ async function generate(options: IGenerateOptions): Promise<undefined | string> 
                 public aggregate(args: {
                     where?: ${normalizedNodeName}Where;
                     ${hasFulltextArg ? `fulltext?: ${normalizedNodeName}Fulltext;` : ""}
-                    aggregate: ${normalizedNodeName}AggregateSelectionInput;
+                    aggregate: ${node.name}AggregateSelectionInput;
                     context?: any;
                     rootValue?: any;
                 }): Promise<${normalizedNodeName}AggregateSelection>


### PR DESCRIPTION
# Description

This PR opts to keep the casing generated by the library when using GraphQL Codegen.

## Complexity

Complexity: Low

# Issue

Closes #3539

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
