### PR TITLE
Refined normalization of user type definitions

### DIFF
--- a/.changeset/khaki-mayflies-float.md
+++ b/.changeset/khaki-mayflies-float.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graphql": major
+"@neo4j/graphql-ogm": major
+---
+
+The Neo4j GraphQL Library now only accepts a `string`, `DocumentNode` or an array containing these types. A callback function returning these is also accepted. This is a reduction from `TypeSource` which also included types such as `GraphQLSchema` and `DefinitionNode`, which would have resulted in unexpected behaviour if passed in.


### PR DESCRIPTION
# Description

Introduces a private method, `normalizeTypeDefinitions`, which maps to the "Type Definitions Normalization" stage of the schema generation lifecycle.

This is less "potentially destructive" than the current approach, which blindly calls `mergeTypeDefs`. This new approach only does this if necessary, and will perform the least processing possible.

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low