### PR TITLE
Simplify the programmatic toggle for debug logging

### DIFF
--- a/.changeset/new-comics-retire.md
+++ b/.changeset/new-comics-retire.md
@@ -1,0 +1,6 @@
+---
+"@neo4j/graphql": major
+"@neo4j/graphql-ogm": major
+---
+
+Programmatic toggling of debug logging is now done using the `debug` option of the constructor.

--- a/docs/modules/ROOT/pages/migration/v4-migration/index.adoc
+++ b/docs/modules/ROOT/pages/migration/v4-migration/index.adoc
@@ -880,3 +880,61 @@ await startStandaloneServer(server, {
 ----
 
 The `bookmarks` key has been removed because it is no longer needed with the bookmark manager of the newer driver.
+
+=== Debug logging
+
+The programmatic toggle for debug logging has been moved from `config.enableDebug` to simply `debug`.
+
+An example of `enableDebug`:
+
+[source, javascript, indent=0]
+----
+const { Neo4jGraphQL } = require("@neo4j/graphql");
+const neo4j = require("neo4j-driver");
+const { ApolloServer } = require("apollo-server");
+
+const typeDefs = `
+    type Movie {
+        title: String!
+    }
+`;
+
+const driver = neo4j.driver(
+    "bolt://localhost:7687",
+    neo4j.auth.basic("neo4j", "password")
+);
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    config: {
+      enableDebug: true,
+    }
+});
+----
+
+This now becomes:
+
+[source, javascript, indent=0]
+----
+const { Neo4jGraphQL } = require("@neo4j/graphql");
+const neo4j = require("neo4j-driver");
+const { ApolloServer } = require("apollo-server");
+
+const typeDefs = `
+    type Movie {
+        title: String!
+    }
+`;
+
+const driver = neo4j.driver(
+    "bolt://localhost:7687",
+    neo4j.auth.basic("neo4j", "password")
+);
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    debug: true,
+});
+----

--- a/docs/modules/ROOT/pages/troubleshooting.adoc
+++ b/docs/modules/ROOT/pages/troubleshooting.adoc
@@ -10,6 +10,8 @@ This chapter contains common troubleshooting steps. Additionally, there is a sec
 
 `@neo4j/graphql` uses the https://www.npmjs.com/package/debug[`debug`] library for debug-level logging. You can turn on all debug logging by setting the environment variable `DEBUG` to `@neo4j/graphql:*` when running. For example:
 
+==== Command line
+
 [source, bash, indent=0]
 ----
 DEBUG=@neo4j/graphql:* node src/index.js
@@ -21,6 +23,34 @@ Alternatively, if you are debugging a particular functionality, you can specify 
 2. `@neo4j/graphql:auth` - Logs the status of authorization header and token extraction, and decoding of JWT
 3. `@neo4j/graphql:graphql` - Logs the GraphQL query and variables
 4. `@neo4j/graphql:execute` - Logs the Cypher and Cypher paramaters before execution, and summary of execution
+
+==== Constructor
+
+You can also enable all debug logging in the library by setting the `debug` argument to `true` in the constructor.
+
+[source, javascript, indent=0]
+----
+const { Neo4jGraphQL } = require("@neo4j/graphql");
+const neo4j = require("neo4j-driver");
+const { ApolloServer } = require("apollo-server");
+
+const typeDefs = `
+    type Movie {
+        title: String!
+    }
+`;
+
+const driver = neo4j.driver(
+    "bolt://localhost:7687",
+    neo4j.auth.basic("neo4j", "password")
+);
+
+const neoSchema = new Neo4jGraphQL({
+    typeDefs,
+    driver,
+    debug: true,
+});
+----
 
 === For `@neo4j/introspector`
 

--- a/packages/graphql-toolbox/src/modules/EditorView/EditorView.tsx
+++ b/packages/graphql-toolbox/src/modules/EditorView/EditorView.tsx
@@ -27,7 +27,8 @@ import { graphql } from "graphql";
 
 import { tracking } from "../../analytics/tracking";
 import { Extension } from "../../components/Filename";
-import { EDITOR_PARAMS_INPUT, EDITOR_RESPONSE_OUTPUT } from "../../constants";
+import { DEFAULT_DATABASE_NAME, EDITOR_PARAMS_INPUT, EDITOR_RESPONSE_OUTPUT } from "../../constants";
+import { AuthContext } from "../../contexts/auth";
 import { Screen } from "../../contexts/screen";
 import { SettingsContext } from "../../contexts/settings";
 import { useStore } from "../../store";
@@ -47,6 +48,7 @@ export interface Props {
 
 export const EditorView = ({ schema }: Props) => {
     const store = useStore();
+    const auth = useContext(AuthContext);
     const settings = useContext(SettingsContext);
     const [loading, setLoading] = useState<boolean>(false);
     const [showDocs, setShowDocs] = useState<boolean>(false);
@@ -68,7 +70,11 @@ export const EditorView = ({ schema }: Props) => {
                 const response = await graphql({
                     schema: schema,
                     source: override || useStore.getState().getActiveTab().query || "",
-                    contextValue: {},
+                    contextValue: {
+                        sessionConfig: {
+                            database: auth.selectedDatabaseName || DEFAULT_DATABASE_NAME,
+                        },
+                    },
                     variableValues: safeParse(useStore.getState().getActiveTab().variables, {}),
                 });
 

--- a/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
+++ b/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
@@ -123,11 +123,6 @@ export const SchemaView = ({ onSchemaChange }: Props) => {
                     driver: auth.driver,
                     features,
                     debug: useStore.getState().enableDebug,
-                    config: {
-                        sessionConfig: {
-                            database: auth.selectedDatabaseName || DEFAULT_DATABASE_NAME,
-                        },
-                    },
                 };
 
                 const neoSchema = new Neo4jGraphQL(options);

--- a/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
+++ b/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
@@ -122,8 +122,8 @@ export const SchemaView = ({ onSchemaChange }: Props) => {
                     typeDefs,
                     driver: auth.driver,
                     features,
+                    debug: useStore.getState().enableDebug,
                     config: {
-                        enableDebug: useStore.getState().enableDebug,
                         sessionConfig: {
                             database: auth.selectedDatabaseName || DEFAULT_DATABASE_NAME,
                         },

--- a/packages/graphql/src/classes/Neo4jGraphQL.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.ts
@@ -57,7 +57,6 @@ import { Neo4jGraphQLAuthorization } from "./authorization/Neo4jGraphQLAuthoriza
 import { Neo4jGraphQLSubscriptionsDefaultMechanism } from "./Neo4jGraphQLSubscriptionsDefaultMechanism";
 
 export interface Neo4jGraphQLConfig {
-    enableDebug?: boolean;
     startupValidation?: StartupValidationConfig;
     cypherQueryOptions?: CypherQueryOptions;
 }
@@ -74,6 +73,7 @@ export interface Neo4jGraphQLConstructor {
     features?: Neo4jFeaturesSettings;
     config?: Neo4jGraphQLConfig;
     driver?: Driver;
+    debug?: boolean;
 }
 
 export const defaultValidationConfig: ValidationConfig = {
@@ -107,8 +107,10 @@ class Neo4jGraphQL {
 
     private authorization?: Neo4jGraphQLAuthorization;
 
+    private debug?: boolean;
+
     constructor(input: Neo4jGraphQLConstructor) {
-        const { config = {}, driver, features, typeDefs, resolvers } = input;
+        const { config = {}, driver, features, typeDefs, resolvers, debug } = input;
 
         this.driver = driver;
         this.config = config;
@@ -116,6 +118,8 @@ class Neo4jGraphQL {
 
         this.typeDefs = typeDefs;
         this.resolvers = resolvers;
+
+        this.debug = debug;
 
         this.checkEnableDebug();
 
@@ -271,8 +275,8 @@ class Neo4jGraphQL {
     }
 
     private checkEnableDebug(): void {
-        if (this.config.enableDebug === true || this.config.enableDebug === false) {
-            if (this.config.enableDebug) {
+        if (this.debug === true || this.debug === false) {
+            if (this.debug) {
                 Debug.enable(DEBUG_ALL);
             } else {
                 Debug.disable();


### PR DESCRIPTION
# Description

Programmatic toggling of debug logging is done using:

```gql
const neoSchema = new Neo4jGraphQL({
    typeDefs,
    driver,
    debug: true,
});
```

This further reduces the `config` object, which honestly I think we should just be rid of.

## Complexity

Complexity: Low
