### PR TITLE
Fix schema generation using interface relationships and subscriptions

### DIFF
--- a/.changeset/spicy-mugs-jog.md
+++ b/.changeset/spicy-mugs-jog.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-toolbox": patch
+---
+
+chore: Toolbox - bump prettier to v3 and adjust usage. prettier.format() is an async call now.

--- a/packages/graphql-toolbox/package.json
+++ b/packages/graphql-toolbox/package.json
@@ -63,7 +63,7 @@
         "graphql-query-complexity": "0.12.0",
         "markdown-it": "13.0.1",
         "neo4j-driver": "5.10.0",
-        "prettier": "2.8.8",
+        "prettier": "3.0.0",
         "process": "0.11.10",
         "react": "18.2.0",
         "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4323,7 +4323,7 @@ __metadata:
     parse5: 7.1.2
     postcss: 8.4.26
     postcss-loader: 7.3.3
-    prettier: 2.8.8
+    prettier: 3.0.0
     process: 0.11.10
     randomstring: 1.3.0
     react: 18.2.0
@@ -24411,6 +24411,15 @@ __metadata:
   bin:
     prettier: bin-prettier.js
   checksum: b49e409431bf129dd89238d64299ba80717b57ff5a6d1c1a8b1a28b590d998a34e083fa13573bc732bb8d2305becb4c9a4407f8486c81fa7d55100eb08263cf8
+  languageName: node
+  linkType: hard
+
+"prettier@npm:3.0.0":
+  version: 3.0.0
+  resolution: "prettier@npm:3.0.0"
+  bin:
+    prettier: bin/prettier.cjs
+  checksum: 6a832876a1552dc58330d2467874e5a0b46b9ccbfc5d3531eb69d15684743e7f83dc9fbd202db6270446deba9c82b79d24383d09924c462b457136a759425e33
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Description

Fix schema generation using interface relationships and subscriptions.

We were adding relationship fields into interface event payloads for nested relationships, which subscriptions does not support.

Some changes to an unrelated schema test because that test contains types which only contain relationships.

## Complexity

Complexity: Low

# Issue

Closes #3439
