### PR TITLE
Remove unused exports now defined in OGM

### DIFF
--- a/.changeset/moody-crews-march.md
+++ b/.changeset/moody-crews-march.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+Remove unused `DeleteInfo`, `GraphQLSortArg`, `GraphQLOptionsArg` and `GraphQLWhereArg` type exports.

--- a/packages/graphql/src/index.ts
+++ b/packages/graphql/src/index.ts
@@ -26,15 +26,7 @@ import * as directives from "./graphql/directives";
 import * as scalars from "./graphql/scalars";
 const objects = { Point, CartesianPoint };
 
-import {
-    DeleteInfo,
-    GraphQLOptionsArg,
-    GraphQLSortArg,
-    GraphQLWhereArg,
-    Neo4jGraphQLSubscriptionsMechanism,
-    Node,
-    SubscriptionsEvent,
-} from "./types";
+import { Neo4jGraphQLSubscriptionsMechanism, Node, SubscriptionsEvent } from "./types";
 
 /**
  * Core library functionality.
@@ -49,7 +41,7 @@ export { directives, scalars, objects };
 /**
  * Exports for usage by the OGM.
  */
-export { DeleteInfo, GraphQLOptionsArg, GraphQLSortArg, GraphQLWhereArg, Node };
+export { Node };
 
 /**
  * Allows for the implementation of custom subscriptions mechanisms.

--- a/packages/ogm/src/types.ts
+++ b/packages/ogm/src/types.ts
@@ -1,1 +1,53 @@
-export { GraphQLOptionsArg, GraphQLWhereArg, DeleteInfo, GraphQLSortArg } from "@neo4j/graphql";
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Integer } from "neo4j-driver";
+
+/**
+ * Whats returned when deleting nodes
+ */
+export interface DeleteInfo {
+    nodesDeleted: number;
+    relationshipsDeleted: number;
+}
+
+export interface GraphQLSortArg {
+    [field: string]: "ASC" | "DESC";
+}
+
+/**
+ * Representation of the options arg
+ * passed to resolvers.
+ */
+export interface GraphQLOptionsArg {
+    limit?: number | Integer;
+    offset?: number | Integer;
+    sort?: GraphQLSortArg[];
+}
+
+/**
+ * Representation of the where arg
+ * passed to resolvers.
+ */
+export interface GraphQLWhereArg {
+    [k: string]: any;
+    AND?: GraphQLWhereArg[];
+    OR?: GraphQLWhereArg[];
+    NOT?: GraphQLWhereArg;
+}


### PR DESCRIPTION
# Description

As part of cleanup towards 4.0.0, remove OGM dependency on library exports.

## Complexity

Complexity: Low
