### PR TITLE
Update configuration.adoc

### DIFF
--- a/docs/modules/ROOT/pages/authentication-and-authorization/configuration.adoc
+++ b/docs/modules/ROOT/pages/authentication-and-authorization/configuration.adoc
@@ -20,10 +20,11 @@ const server = new ApolloServer({
 const { url } = await startStandaloneServer(server, {
     listen: { port: 4000 },
     context: async ({ req }) => ({
-        token: req.headers.Authorization,
+        token: req.headers.authorization,
     }),
 });
 ----
+Note the `context` function: Specify the `authorization` in the `req.headers` as all lowercase despite the HTTP header's initial capital letter.
 
 Optionally, if a custom decoding mechanism is required, that same header can be decoded and the resulting JWT payload put into the `jwt` field of the context.
 


### PR DESCRIPTION
The context should be fed with token: req.headers.authorization, not with req.headers.Authorization

# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity:

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
