### PR TITLE
Fix use of unnormalized type name in generation

### DIFF
--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -2798,7 +2798,7 @@ describe("generate", () => {
                 args?: any;
                 context?: any;
                 rootValue?: any;
-              }): Promise<FAQ[]>;
+              }): Promise<Faq[]>;
               public create(args: {
                 input: FaqCreateInput[];
                 selectionSet?: string | DocumentNode | SelectionSetNode;
@@ -2857,7 +2857,7 @@ describe("generate", () => {
                 args?: any;
                 context?: any;
                 rootValue?: any;
-              }): Promise<FAQEntry[]>;
+              }): Promise<FaqEntry[]>;
               public create(args: {
                 input: FaqEntryCreateInput[];
                 selectionSet?: string | DocumentNode | SelectionSetNode;

--- a/packages/ogm/src/generate.ts
+++ b/packages/ogm/src/generate.ts
@@ -186,7 +186,7 @@ async function generate(options: IGenerateOptions): Promise<undefined | string> 
                     args?: any;
                     context?: any;
                     rootValue?: any;
-                }): Promise<${node.name}[]>
+                }): Promise<${normalizedNodeName}[]>
                 public create(args: {
                     input: ${normalizedNodeName}CreateInput[];
                     selectionSet?: string | DocumentNode | SelectionSetNode;


### PR DESCRIPTION
# Description

Not sure what has gone on here, but this issue is also present on `dev` and not just on the 4.0.0 branch as reported.

## Complexity

Complexity: Low

# Issue

Closes #3723
