### PR TITLE
Improve the checking for non-existent parameters when evaluating authorization rules

### DIFF
--- a/.changeset/young-ligers-poke.md
+++ b/.changeset/young-ligers-poke.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Improve the checking for non-existent parameters when evaluating authorization rules

--- a/packages/graphql/src/schema/resolvers/wrapper.ts
+++ b/packages/graphql/src/schema/resolvers/wrapper.ts
@@ -118,7 +118,6 @@ export const wrapResolver =
                         jwtParam: new Cypher.NamedParam("jwt", jwt),
                         isAuthenticatedParam: new Cypher.NamedParam("isAuthenticated", isAuthenticated),
                         claims: jwtPayloadFieldsMap,
-                        jwtDefault: new Cypher.NamedParam("jwtDefault", {}),
                     };
                 } catch (e) {
                     const isAuthenticated = false;
@@ -126,7 +125,6 @@ export const wrapResolver =
                         isAuthenticated,
                         jwtParam: new Cypher.NamedParam("jwt", {}),
                         isAuthenticatedParam: new Cypher.NamedParam("isAuthenticated", isAuthenticated),
-                        jwtDefault: new Cypher.NamedParam("jwtDefault", {}),
                     };
                 }
             }
@@ -152,7 +150,6 @@ export const wrapResolver =
                 jwt,
                 jwtParam: new Cypher.NamedParam("jwt", jwt),
                 isAuthenticatedParam: new Cypher.NamedParam("isAuthenticated", isAuthenticated),
-                jwtDefault: new Cypher.NamedParam("jwtDefault", {}),
             };
         }
 

--- a/packages/graphql/src/translate/authorization/utils/populate-where-params.test.ts
+++ b/packages/graphql/src/translate/authorization/utils/populate-where-params.test.ts
@@ -25,7 +25,6 @@ import { populateWhereParams } from "./populate-where-params";
 describe("populateWhereParams", () => {
     let context: Context;
     let jwtParam: Cypher.Param;
-    let jwtDefault: Cypher.Param;
 
     beforeAll(() => {
         const jwt = {
@@ -39,14 +38,12 @@ describe("populateWhereParams", () => {
         };
 
         jwtParam = new Cypher.Param(jwt);
-        jwtDefault = new Cypher.Param({});
 
         context = new ContextBuilder({
             authorization: {
                 jwtParam,
                 isAuthenticated: true,
                 isAuthenticatedParam: new Cypher.Param(true),
-                jwtDefault,
             },
         }).instance();
     });
@@ -57,7 +54,7 @@ describe("populateWhereParams", () => {
         };
 
         expect(populateWhereParams({ where, context })).toEqual({
-            id: Cypher.coalesce(jwtParam.property("sub"), jwtDefault),
+            id: jwtParam.property("sub"),
         });
     });
 
@@ -67,7 +64,7 @@ describe("populateWhereParams", () => {
         };
 
         expect(populateWhereParams({ where, context })).toEqual({
-            id: Cypher.coalesce(jwtParam.property("some", "other", "claim"), jwtDefault),
+            id: jwtParam.property("some", "other", "claim"),
         });
     });
 
@@ -80,7 +77,7 @@ describe("populateWhereParams", () => {
 
         expect(populateWhereParams({ where, context })).toEqual({
             user: {
-                id: Cypher.coalesce(jwtParam.property("sub"), jwtDefault),
+                id: jwtParam.property("sub"),
             },
         });
     });
@@ -105,12 +102,12 @@ describe("populateWhereParams", () => {
             AND: [
                 {
                     user: {
-                        id: Cypher.coalesce(jwtParam.property("sub"), jwtDefault),
+                        id: jwtParam.property("sub"),
                     },
                 },
                 {
                     user: {
-                        role_IN: Cypher.coalesce(jwtParam.property("roles"), jwtDefault),
+                        role_IN: jwtParam.property("roles"),
                     },
                 },
             ],
@@ -159,26 +156,26 @@ describe("populateWhereParams", () => {
                             AND: [
                                 {
                                     user: {
-                                        id: Cypher.coalesce(jwtParam.property("sub"), jwtDefault),
+                                        id: jwtParam.property("sub"),
                                     },
                                 },
                                 {
                                     user: {
-                                        role_IN: Cypher.coalesce(jwtParam.property("roles"), jwtDefault),
+                                        role_IN: jwtParam.property("roles"),
                                     },
                                 },
                             ],
                         },
                         {
                             user: {
-                                role_IN: Cypher.coalesce(jwtParam.property("roles"), jwtDefault),
+                                role_IN: jwtParam.property("roles"),
                             },
                         },
                     ],
                 },
                 {
                     user: {
-                        role_IN: Cypher.coalesce(jwtParam.property("roles"), jwtDefault),
+                        role_IN: jwtParam.property("roles"),
                     },
                 },
             ],

--- a/packages/graphql/src/translate/authorization/utils/populate-where-params.ts
+++ b/packages/graphql/src/translate/authorization/utils/populate-where-params.ts
@@ -39,12 +39,7 @@ export function populateWhereParams({ where, context }: { where: GraphQLWhereArg
 
                 const jwtProperty = context.authorization.jwtParam.property(...(mappedPath || path).split("."));
 
-                // coalesce jwt parameter values to be an empty map which can be evaluated in a boolean expression
-                // this is because comparing against null will always produce null, which results in errors in apoc.util.validatePredicate
-                // comparing a node property against a map will always results in false, because maps cannot be used as properties
-                const coalesce = Cypher.coalesce(jwtProperty, context.authorization.jwtDefault);
-
-                parsed[k] = coalesce;
+                parsed[k] = jwtProperty;
             } else if (v.startsWith("$context")) {
                 const path = v.substring(9);
                 const contextValueParameter = new Cypher.Param(dotProp.get(context, path));

--- a/packages/graphql/src/translate/authorization/where/create-authorization-where-predicate.ts
+++ b/packages/graphql/src/translate/authorization/where/create-authorization-where-predicate.ts
@@ -74,6 +74,7 @@ export function createAuthorizationWherePredicate({
                 whereInput: populateWhereParams({ where: value, context }),
                 targetElement: target,
                 useExistExpr,
+                checkParameterExistence: true,
             });
 
             if (predicate) {

--- a/packages/graphql/src/translate/where/create-where-predicate.ts
+++ b/packages/graphql/src/translate/where/create-where-predicate.ts
@@ -33,12 +33,14 @@ export function createWherePredicate({
     context,
     element,
     useExistExpr = true,
+    checkParameterExistence,
 }: {
     targetElement: Cypher.Variable;
     whereInput: GraphQLWhereArg;
     context: Context;
     element: GraphElement;
     useExistExpr?: boolean;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     const whereFields = Object.entries(whereInput);
     const predicates: Cypher.Predicate[] = [];
@@ -51,6 +53,8 @@ export function createWherePredicate({
                 targetElement,
                 context,
                 value: asArray(value),
+                useExistExpr,
+                checkParameterExistence,
             });
             if (predicate) {
                 predicates.push(predicate);
@@ -66,6 +70,7 @@ export function createWherePredicate({
             targetElement,
             context,
             useExistExpr,
+            checkParameterExistence,
         });
         if (predicate) {
             predicates.push(predicate);
@@ -87,12 +92,16 @@ function createNestedPredicate({
     targetElement,
     context,
     value,
+    useExistExpr,
+    checkParameterExistence,
 }: {
     key: LogicalOperator;
     element: GraphElement;
     targetElement: Cypher.Variable;
     context: Context;
     value: Array<GraphQLWhereArg>;
+    useExistExpr?: boolean;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     const nested: Cypher.Predicate[] = [];
     let subqueries: Cypher.CompositeClause | undefined;
@@ -103,6 +112,8 @@ function createNestedPredicate({
             element,
             targetElement,
             context,
+            useExistExpr,
+            checkParameterExistence,
         });
         if (predicate) {
             nested.push(predicate);

--- a/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-connection-operation.ts
@@ -36,6 +36,7 @@ export function createConnectionOperation({
     parentNode,
     operator,
     useExistExpr = true,
+    checkParameterExistence,
 }: {
     connectionField: ConnectionField;
     value: any;
@@ -43,6 +44,7 @@ export function createConnectionOperation({
     parentNode: Cypher.Node;
     operator: string | undefined;
     useExistExpr?: boolean;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     let nodeEntries: Record<string, any>;
 
@@ -99,6 +101,7 @@ export function createConnectionOperation({
             whereOperator: operator as WhereOperator,
             refEdge: contextRelationship,
             useExistExpr,
+            checkParameterExistence,
         });
 
         operations.push(predicate);
@@ -119,6 +122,7 @@ export function createConnectionWherePropertyOperation({
     node,
     edge,
     useExistExpr = true,
+    checkParameterExistence,
 }: {
     whereInput: ConnectionWhereArg;
     context: Context;
@@ -127,6 +131,7 @@ export function createConnectionWherePropertyOperation({
     edgeRef: Cypher.Variable;
     targetNode: Cypher.Node;
     useExistExpr?: boolean;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     const preComputedSubqueriesResult: (Cypher.CompositeClause | undefined)[] = [];
     const params: (Cypher.Predicate | undefined)[] = [];
@@ -142,6 +147,7 @@ export function createConnectionWherePropertyOperation({
                     node,
                     edge,
                     useExistExpr,
+                    checkParameterExistence,
                 });
                 subOperations.push(predicate);
                 if (preComputedSubqueries && !preComputedSubqueries.empty)
@@ -161,6 +167,7 @@ export function createConnectionWherePropertyOperation({
                 context,
                 element: edge,
                 useExistExpr,
+                checkParameterExistence,
             });
 
             params.push(result);
@@ -189,6 +196,7 @@ export function createConnectionWherePropertyOperation({
                 context,
                 element: node,
                 useExistExpr,
+                checkParameterExistence,
             });
 
             // NOTE: _NOT is handled by the size()=0

--- a/packages/graphql/src/translate/where/property-operations/create-property-where.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-property-where.ts
@@ -128,6 +128,7 @@ export function createPropertyWhere({
                 value,
                 isNot,
                 useExistExpr,
+                checkParameterExistence,
             });
         }
 
@@ -140,6 +141,7 @@ export function createPropertyWhere({
                 parentNode: targetElement as Cypher.Node,
                 operator,
                 useExistExpr,
+                checkParameterExistence,
             });
         }
 

--- a/packages/graphql/src/translate/where/property-operations/create-relationship-operation.ts
+++ b/packages/graphql/src/translate/where/property-operations/create-relationship-operation.ts
@@ -36,6 +36,7 @@ export function createRelationshipOperation({
     value,
     isNot,
     useExistExpr = true,
+    checkParameterExistence,
 }: {
     relationField: RelationField;
     context: Context;
@@ -44,6 +45,7 @@ export function createRelationshipOperation({
     value: GraphQLWhereArg;
     isNot: boolean;
     useExistExpr?: boolean;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     const refNode = context.nodes.find((n) => n.name === relationField.typeMeta.name);
     if (!refNode) throw new Error("Relationship filters must reference nodes");
@@ -83,6 +85,7 @@ export function createRelationshipOperation({
         whereInput: value,
         whereOperator: operator as WhereOperator,
         useExistExpr,
+        checkParameterExistence,
     });
 }
 
@@ -98,6 +101,7 @@ export function createRelationPredicate({
     whereOperator,
     refEdge,
     useExistExpr = true,
+    checkParameterExistence,
 }: {
     parentNode: Cypher.Node;
     targetNode: Cypher.Node;
@@ -110,6 +114,7 @@ export function createRelationPredicate({
     whereOperator: WhereOperator;
     refEdge?: Relationship;
     useExistExpr?: boolean;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     let labelsOfNodesImplementingInterface: string[] | undefined;
     let labels = refNode.getLabels(context);
@@ -151,6 +156,7 @@ export function createRelationPredicate({
               targetNode,
               edgeRef: targetRelationship,
               useExistExpr,
+              checkParameterExistence,
           })
         : createWherePredicate({
               whereInput,
@@ -158,6 +164,7 @@ export function createRelationPredicate({
               element: refNode,
               context,
               useExistExpr,
+              checkParameterExistence,
           });
 
     if (orOperatorMultipleNodeLabels) {
@@ -181,6 +188,7 @@ export function createRelationPredicate({
             context,
             refNode,
             refEdge,
+            checkParameterExistence,
         });
     }
 
@@ -285,6 +293,7 @@ function createRelationPredicateWithSubqueries({
     context,
     whereInput,
     refEdge,
+    checkParameterExistence,
 }: {
     parentNode: Cypher.Node;
     targetNode: Cypher.Node;
@@ -297,6 +306,7 @@ function createRelationPredicateWithSubqueries({
     context: Context;
     whereInput: any;
     refEdge?: Relationship;
+    checkParameterExistence?: boolean;
 }): PredicateReturn {
     const matchPattern = new Cypher.Match(targetPattern);
     const subqueryWith = new Cypher.With("*");
@@ -325,12 +335,14 @@ function createRelationPredicateWithSubqueries({
                       node: refNode,
                       targetNode,
                       edgeRef: targetRelationship,
+                      checkParameterExistence,
                   })
                 : createWherePredicate({
                       whereInput,
                       targetElement: targetNode,
                       element: refNode,
                       context,
+                      checkParameterExistence,
                   });
 
             if (notNoneInnerPredicates.predicate && notNoneInnerPredicates.preComputedSubqueries) {
@@ -347,6 +359,7 @@ function createRelationPredicateWithSubqueries({
                         refNode,
                         context,
                         refEdge,
+                        checkParameterExistence,
                     });
                 return {
                     predicate: Cypher.and(notExistsPredicate, Cypher.eq(returnVar, new Cypher.Literal(true))),

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -46,7 +46,6 @@ type AuthorizationContext = {
     isAuthenticated: boolean;
     isAuthenticatedParam: Cypher.Param;
     claims?: Map<string, string>;
-    jwtDefault: Cypher.Param;
 };
 
 export interface Context extends Neo4jGraphQLContext {

--- a/packages/graphql/tests/tck/aggregations/auth.test.ts
+++ b/packages/graphql/tests/tck/aggregations/auth.test.ts
@@ -85,7 +85,7 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN { count: count(this) }"
         `);
 
@@ -95,8 +95,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -116,7 +115,7 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.name = $param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])))
+            WHERE (this.name = $param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])))
             RETURN { count: count(this) }"
         `);
 
@@ -127,8 +126,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -151,9 +149,9 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { imdbRatingInt: { min: min(this.imdbRatingInt), max: max(this.imdbRatingInt) } }"
         `);
 
@@ -163,8 +161,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -187,9 +184,9 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { imdbRatingFloat: { min: min(this.imdbRatingFloat), max: max(this.imdbRatingFloat) } }"
         `);
 
@@ -199,8 +196,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -223,9 +219,9 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { imdbRatingBigInt: { min: min(this.imdbRatingBigInt), max: max(this.imdbRatingBigInt) } }"
         `);
 
@@ -235,8 +231,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -259,9 +254,9 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { id: { shortest: min(this.id), longest: max(this.id) } }"
         `);
 
@@ -271,8 +266,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -295,9 +289,9 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { name: { shortest:
                                         reduce(aggVar = collect(this.name)[0], current IN collect(this.name) |
                                             CASE
@@ -321,8 +315,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -345,9 +338,9 @@ describe("Cypher Aggregations with Auth", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN { createdAt: { min: apoc.date.convertFormat(toString(min(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), max: apoc.date.convertFormat(toString(max(this.createdAt)), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") } }"
         `);
 
@@ -357,8 +350,7 @@ describe("Cypher Aggregations with Auth", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
@@ -120,7 +120,7 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } AS this"
         `);
 
@@ -132,8 +132,7 @@ describe("Cypher Auth Allow", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -155,9 +154,9 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .password } AS this"
         `);
 
@@ -169,8 +168,7 @@ describe("Cypher Auth Allow", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -195,14 +193,14 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -217,8 +215,7 @@ describe("Cypher Auth Allow", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -244,11 +241,11 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)<-[this1:HAS_POST]-(this2:\`User\`)
-                WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this2.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this2.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this2 { .password } AS this2
                 RETURN head(collect(this2)) AS var3
             }
@@ -263,8 +260,7 @@ describe("Cypher Auth Allow", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -291,21 +287,21 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.id = $param3 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 CALL {
                     WITH this1
                     MATCH (this1)-[this3:HAS_COMMENT]->(this4:\`Comment\`)
                     OPTIONAL MATCH (this4)<-[:HAS_COMMENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE (this4.id = $param5 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this4 { .content } AS this4
                     RETURN collect(this4) AS var6
                 }
@@ -325,9 +321,8 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param4\\": \\"1\\",
-                \\"param5\\": \\"1\\"
+                \\"param3\\": \\"1\\",
+                \\"param4\\": \\"1\\"
             }"
         `);
     });
@@ -351,7 +346,7 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.id = $this_update_id
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -366,7 +361,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"old-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -392,9 +386,9 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.password = $this_update_password
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -409,7 +403,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_password\\": \\"new-password\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -437,12 +430,12 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             	WITH this
             	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.id = $this_update_creator0_id
             	RETURN count(*) AS update_this_creator0
             }
@@ -467,7 +460,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_creator0_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -498,14 +490,14 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             	WITH this
             	MATCH (this)<-[this_has_post0_relationship:HAS_POST]-(this_creator0:User)
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_creator0
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_creator0.password = $this_update_creator0_password
             	RETURN count(*) AS update_this_creator0
             }
@@ -530,7 +522,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_creator0_password\\": \\"new-password\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -554,7 +545,7 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             DETACH DELETE this"
         `);
 
@@ -567,8 +558,7 @@ describe("Cypher Auth Allow", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"user-id\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -590,12 +580,12 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
             OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -616,7 +606,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_deleteUsers\\": {
                     \\"args\\": {
                         \\"delete\\": {
@@ -656,14 +645,14 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -687,7 +676,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"post-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
@@ -735,7 +723,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_COMMENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             WITH this
@@ -744,7 +732,7 @@ describe("Cypher Auth Allow", () => {
             WITH *, count(authorization_this0) AS creatorCount
             OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization_this1:\`User\`)
             WITH *, count(authorization_this1) AS creatorCount
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this1.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
             	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
@@ -757,7 +745,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
             OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_post0_disconnect0_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_post0_disconnect0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
             	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
@@ -797,7 +785,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0\\": \\"user-id\\",
                 \\"updateComments\\": {
                     \\"args\\": {
@@ -842,14 +829,14 @@ describe("Cypher Auth Allow", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -879,7 +866,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_connect_posts0_node_param0\\": \\"post-id\\",
                 \\"resolvedCallbacks\\": {}
             }"

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
@@ -200,7 +200,7 @@ describe("Cypher Auth Allow", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -241,7 +241,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)<-[this1:HAS_POST]-(this2:\`User\`)
@@ -294,14 +294,14 @@ describe("Cypher Auth Allow", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.id = $param3 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.id = $param3 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 CALL {
                     WITH this1
                     MATCH (this1)-[this3:HAS_COMMENT]->(this4:\`Comment\`)
                     OPTIONAL MATCH (this4)<-[:HAS_COMMENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this4.id = $param4 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this4 { .content } AS this4
                     RETURN collect(this4) AS var6
                 }
@@ -430,7 +430,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             	WITH this
@@ -490,7 +490,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             	WITH this
@@ -585,7 +585,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
             OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -652,7 +652,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -723,7 +723,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_COMMENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
             CALL {
             WITH this
@@ -732,7 +732,7 @@ describe("Cypher Auth Allow", () => {
             WITH *, count(authorization_this0) AS creatorCount
             OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization_this1:\`User\`)
             WITH *, count(authorization_this1) AS creatorCount
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this1.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
             	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
@@ -745,7 +745,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
             OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_post0_disconnect0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_post0_disconnect0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
             	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
@@ -836,7 +836,7 @@ describe("Cypher Auth Allow", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -109,7 +109,7 @@ describe("@auth allow on specific interface implementation", () => {
                     OPTIONAL MATCH (this4)<-[:HAS_CONTENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this4
                     RETURN this4 AS var2
                 }
@@ -127,8 +127,7 @@ describe("@auth allow on specific interface implementation", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -171,11 +170,11 @@ describe("@auth allow on specific interface implementation", () => {
                     OPTIONAL MATCH (this4)<-[:HAS_CONTENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     CALL {
                         WITH this4
                         MATCH (this4)-[this6:HAS_COMMENT]->(this7:\`Comment\`)
-                        WHERE this7.id = $param6
+                        WHERE this7.id = $param5
                         WITH this7 { .content } AS this7
                         RETURN collect(this7) AS var8
                     }
@@ -200,8 +199,7 @@ describe("@auth allow on specific interface implementation", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param6\\": \\"1\\"
+                \\"param5\\": \\"1\\"
             }"
         `);
     });
@@ -263,7 +261,7 @@ describe("@auth allow on specific interface implementation", () => {
             	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
@@ -291,7 +289,7 @@ describe("@auth allow on specific interface implementation", () => {
                     OPTIONAL MATCH (update_this4)<-[:HAS_CONTENT]-(update_this5:\`User\`)
                     WITH *, count(update_this5) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND update_this5.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND update_this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH update_this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS update_this4
                     RETURN update_this4 AS update_var2
                 }
@@ -310,7 +308,6 @@ describe("@auth allow on specific interface implementation", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"param0\\": \\"user-id\\",
                 \\"this_update_content0_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
@@ -349,7 +346,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
             OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -386,8 +383,7 @@ describe("@auth allow on specific interface implementation", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"user-id\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -430,7 +426,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -456,7 +452,6 @@ describe("@auth allow on specific interface implementation", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {
@@ -523,7 +518,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -536,7 +531,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
             	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
@@ -564,7 +559,6 @@ describe("@auth allow on specific interface implementation", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0\\": \\"comment-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
@@ -647,7 +641,7 @@ describe("@auth allow on specific interface implementation", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -679,7 +673,6 @@ describe("@auth allow on specific interface implementation", () => {
                     ],
                     \\"sub\\": \\"user-id\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -109,7 +109,7 @@ describe("@auth allow on specific interface implementation", () => {
                     OPTIONAL MATCH (this4)<-[:HAS_CONTENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this4
                     RETURN this4 AS var2
                 }
@@ -170,7 +170,7 @@ describe("@auth allow on specific interface implementation", () => {
                     OPTIONAL MATCH (this4)<-[:HAS_CONTENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this4.id = $param2 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     CALL {
                         WITH this4
                         MATCH (this4)-[this6:HAS_COMMENT]->(this7:\`Comment\`)
@@ -261,7 +261,7 @@ describe("@auth allow on specific interface implementation", () => {
             	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
@@ -289,7 +289,7 @@ describe("@auth allow on specific interface implementation", () => {
                     OPTIONAL MATCH (update_this4)<-[:HAS_CONTENT]-(update_this5:\`User\`)
                     WITH *, count(update_this5) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND update_this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND update_this5.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH update_this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS update_this4
                     RETURN update_this4 AS update_var2
                 }
@@ -346,7 +346,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
             OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -426,7 +426,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -518,7 +518,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -531,7 +531,7 @@ describe("@auth allow on specific interface implementation", () => {
             OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
             	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
@@ -641,7 +641,7 @@ describe("@auth allow on specific interface implementation", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/bind.test.ts
@@ -187,7 +187,7 @@ describe("Cypher Auth Allow", () => {
                     OPTIONAL MATCH (create_this5)<-[:HAS_POST]-(create_this13:\`User\`)
                     WITH *, count(create_this13) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND create_this13.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND create_this13.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH create_this5
                     CALL {
                     	WITH create_this5
@@ -422,7 +422,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_connect_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_connect_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_creator_User
             }
             WITH *
@@ -488,7 +488,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_disconnect_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_disconnect_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_creator_User
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/bind.test.ts
@@ -99,7 +99,7 @@ describe("Cypher Auth Allow", () => {
                     create_this1.id = create_var0.id,
                     create_this1.name = create_var0.name
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this1.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
@@ -120,7 +120,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -181,14 +180,14 @@ describe("Cypher Auth Allow", () => {
                             create_this10.id = create_var8.id
                         MERGE (create_this5)<-[create_this11:HAS_POST]-(create_this10)
                         WITH *
-                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this10.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this10.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                         RETURN collect(NULL) AS create_var12
                     }
                     WITH *
                     OPTIONAL MATCH (create_this5)<-[:HAS_POST]-(create_this13:\`User\`)
                     WITH *, count(create_this13) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND create_this13.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND create_this13.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH create_this5
                     CALL {
                     	WITH create_this5
@@ -200,7 +199,7 @@ describe("Cypher Auth Allow", () => {
                     RETURN collect(NULL) AS create_var14
                 }
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this1.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN create_this1
             }
             RETURN collect(create_this1 { .id }) AS data"
@@ -237,7 +236,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -264,7 +262,7 @@ describe("Cypher Auth Allow", () => {
             WHERE this.id = $param0
             SET this.id = $this_update_id
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -279,7 +277,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -323,7 +320,7 @@ describe("Cypher Auth Allow", () => {
             		MATCH (this_posts0)<-[this_posts0_has_post0_relationship:HAS_POST]-(this_posts0_creator0:User)
             		SET this_posts0_creator0.id = $this_update_posts0_creator0_id
             		WITH this, this_posts0, this_posts0_creator0
-            		WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_posts0_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_posts0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             		RETURN count(*) AS update_this_posts0_creator0
             	}
             	WITH this, this_posts0
@@ -337,7 +334,7 @@ describe("Cypher Auth Allow", () => {
             	RETURN count(*) AS update_this_posts0
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -353,7 +350,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"update\\": {
@@ -426,7 +422,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_connect_creator0_node.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_connect_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_creator_User
             }
             WITH *
@@ -452,7 +448,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -493,7 +488,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_disconnect_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_disconnect_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_creator_User
             }
             WITH *
@@ -519,7 +514,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updatePosts\\": {
                     \\"args\\": {
                         \\"disconnect\\": {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -135,7 +135,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this0_contentPost0_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             MERGE (this0)-[:HAS_CONTENT]->(this0_contentPost0_node)
             WITH this0, this0_contentPost0_node
             CALL {
@@ -329,7 +329,7 @@ describe("Cypher Auth Allow", () => {
             	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
             	WITH *
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
@@ -452,7 +452,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_content_Post
             }
             WITH *
@@ -529,7 +529,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_content_Post
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -129,13 +129,13 @@ describe("Cypher Auth Allow", () => {
             CREATE (this0_contentPost0_node_creator0_node:User)
             SET this0_contentPost0_node_creator0_node.id = $this0_contentPost0_node_creator0_node_id
             WITH this0, this0_contentPost0_node, this0_contentPost0_node_creator0_node
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this0_contentPost0_node_creator0_node.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             MERGE (this0_contentPost0_node)<-[:HAS_CONTENT]-(this0_contentPost0_node_creator0_node)
             WITH this0, this0_contentPost0_node
             OPTIONAL MATCH (this0_contentPost0_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             MERGE (this0)-[:HAS_CONTENT]->(this0_contentPost0_node)
             WITH this0, this0_contentPost0_node
             CALL {
@@ -146,7 +146,7 @@ describe("Cypher Auth Allow", () => {
             	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
             }
             WITH this0
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             RETURN [ this0 { .id } ] AS data"
@@ -165,7 +165,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -218,7 +217,7 @@ describe("Cypher Auth Allow", () => {
             CREATE (this0_contentComment0_node_creator0_node:User)
             SET this0_contentComment0_node_creator0_node.id = $this0_contentComment0_node_creator0_node_id
             WITH this0, this0_contentComment0_node, this0_contentComment0_node_creator0_node
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this0_contentComment0_node_creator0_node.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0_contentComment0_node_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             MERGE (this0_contentComment0_node)<-[:HAS_CONTENT]-(this0_contentComment0_node_creator0_node)
             MERGE (this0)-[:HAS_CONTENT]->(this0_contentComment0_node)
             WITH this0, this0_contentComment0_node
@@ -230,7 +229,7 @@ describe("Cypher Auth Allow", () => {
             	RETURN c AS this0_contentComment0_node_creator_User_unique_ignored
             }
             WITH this0
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             RETURN [ this0 { .id } ] AS data"
@@ -249,7 +248,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -296,7 +294,7 @@ describe("Cypher Auth Allow", () => {
             		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
             		SET this_content0_creator0.id = $this_update_content0_creator0_id
             		WITH this, this_content0, this_content0_creator0
-            		WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_content0_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_content0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             		RETURN count(*) AS update_this_content0_creator0
             	}
             	WITH this, this_content0
@@ -324,14 +322,14 @@ describe("Cypher Auth Allow", () => {
             		MATCH (this_content0)<-[this_content0_has_content0_relationship:HAS_CONTENT]-(this_content0_creator0:User)
             		SET this_content0_creator0.id = $this_update_content0_creator0_id
             		WITH this, this_content0, this_content0_creator0
-            		WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this_content0_creator0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            		WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_content0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             		RETURN count(*) AS update_this_content0_creator0
             	}
             	WITH this, this_content0
             	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
             	WITH *
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
@@ -345,7 +343,7 @@ describe("Cypher Auth Allow", () => {
             RETURN count(*) AS update_this_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -361,7 +359,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"update\\": {
@@ -431,7 +428,7 @@ describe("Cypher Auth Allow", () => {
             	}
             WITH this, this_connect_content0_node
             WITH this, this_connect_content0_node
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	RETURN count(*) AS connect_this_connect_content_Comment
             }
             CALL {
@@ -455,7 +452,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_content_Post
             }
             WITH *
@@ -473,7 +470,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_connect_content1_node_param0\\": \\"content-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -515,7 +511,7 @@ describe("Cypher Auth Allow", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_content0
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN count(*) AS disconnect_this_disconnect_content_Comment
             }
             CALL {
@@ -533,7 +529,7 @@ describe("Cypher Auth Allow", () => {
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_content_Post
             }
             WITH *
@@ -551,7 +547,6 @@ describe("Cypher Auth Allow", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"content-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -98,7 +98,7 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } AS this"
         `);
 
@@ -111,9 +111,8 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\"
             }"
         `);
     });
@@ -135,7 +134,7 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN this { .id } AS this"
         `);
 
@@ -149,9 +148,8 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param4\\": \\"user\\",
-                \\"param5\\": \\"admin\\"
+                \\"param3\\": \\"user\\",
+                \\"param4\\": \\"admin\\"
             }"
         `);
     });
@@ -176,11 +174,11 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -196,11 +194,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"user\\",
-                \\"param6\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"user\\",
+                \\"param5\\": \\"admin\\"
             }"
         `);
     });
@@ -229,11 +226,11 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -251,11 +248,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"user\\",
-                \\"param6\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"user\\",
+                \\"param5\\": \\"admin\\"
             }"
         `);
     });
@@ -284,11 +280,11 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.id = $param5 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND $param7 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -306,12 +302,11 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"some-id\\",
-                \\"param6\\": \\"user\\",
-                \\"param7\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"some-id\\",
+                \\"param5\\": \\"user\\",
+                \\"param6\\": \\"admin\\"
             }"
         `);
     });
@@ -336,11 +331,11 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.content = $param5 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND $param7 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.content = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -356,12 +351,11 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"cool\\",
-                \\"param6\\": \\"user\\",
-                \\"param7\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"cool\\",
+                \\"param5\\": \\"user\\",
+                \\"param6\\": \\"admin\\"
             }"
         `);
     });
@@ -388,13 +382,13 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
                     WITH *
                     MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var3
                 }
@@ -413,11 +407,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"user\\",
-                \\"param6\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"user\\",
+                \\"param5\\": \\"admin\\"
             }"
         `);
     });
@@ -448,13 +441,13 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -474,11 +467,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"user\\",
-                \\"param6\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"user\\",
+                \\"param5\\": \\"admin\\"
             }"
         `);
     });
@@ -509,13 +501,13 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE (this1.id = $param5 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $param6 IN $jwt.roles)) OR ($isAuthenticated = true AND $param7 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -535,12 +527,11 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"param5\\": \\"some-id\\",
-                \\"param6\\": \\"user\\",
-                \\"param7\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"param4\\": \\"some-id\\",
+                \\"param5\\": \\"user\\",
+                \\"param6\\": \\"admin\\"
             }"
         `);
     });
@@ -564,10 +555,10 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.name = $this_update_name
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -580,12 +571,11 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
                 \\"this_update_name\\": \\"Bob\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -610,10 +600,10 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.name = $this_update_name
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -627,12 +617,11 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param4\\": \\"user\\",
-                \\"param5\\": \\"admin\\",
+                \\"param3\\": \\"user\\",
+                \\"param4\\": \\"admin\\",
                 \\"this_update_name\\": \\"Bob\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -660,15 +649,15 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
             	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_posts0
             	CALL {
             		WITH this_posts0
@@ -680,12 +669,12 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS update_this_posts0
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
             CALL {
                 WITH this
                 MATCH (this)-[update_this0:HAS_POST]->(update_this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(update_this2 IN [(update_this1)<-[:HAS_POST]-(update_this2:\`User\`) WHERE update_this2.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $update_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $update_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(update_this2 IN [(update_this1)<-[:HAS_POST]-(update_this2:\`User\`) WHERE update_this2.id = $jwt.sub | 1] WHERE true) AND $update_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $update_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH update_this1 { .id } AS update_this1
                 RETURN collect(update_this1) AS update_var3
             }
@@ -701,13 +690,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"update_param3\\": \\"user\\",
-                \\"update_param4\\": \\"admin\\",
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
+                \\"update_param2\\": \\"user\\",
+                \\"update_param3\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
                 \\"this_update_posts0_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -731,7 +719,7 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             DETACH DELETE this"
         `);
 
@@ -744,9 +732,8 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\"
             }"
         `);
     });
@@ -768,10 +755,10 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -791,11 +778,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\"
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\"
             }"
         `);
     });
@@ -830,7 +816,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this0.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -845,11 +831,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this0.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post
             }
             WITH this0
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this0.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             RETURN [ this0 { .id } ] AS data"
@@ -867,11 +853,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -912,7 +897,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this0.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -927,11 +912,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this0.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post
             }
             WITH this0
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this0.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             RETURN [ this0 { .id } ] AS data"
@@ -950,11 +935,10 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -979,12 +963,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -999,11 +983,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_posts0_connect0_node
             WITH this, this_posts0_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_posts0_connect_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1016,13 +1000,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1047,12 +1030,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1067,11 +1050,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_posts0_connect0_node
             WITH this, this_posts0_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_posts0_connect_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1084,14 +1067,13 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
                 \\"this_posts0_connect0_node_param0\\": \\"new-id\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1116,12 +1098,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1136,7 +1118,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post
             }
             WITH *
@@ -1152,13 +1134,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1183,12 +1164,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1203,7 +1184,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post
             }
             WITH *
@@ -1219,14 +1200,13 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
                 \\"this_connect_posts0_node_param0\\": \\"some-id\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1251,12 +1231,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1265,11 +1245,11 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_posts0_disconnect0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_posts0_disconnect_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1282,13 +1262,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1313,12 +1292,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1327,11 +1306,11 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_posts0_disconnect0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_posts0_disconnect_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1344,14 +1323,13 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
                 \\"updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0\\": \\"new-id\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"update\\": {
@@ -1395,12 +1373,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1409,7 +1387,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *
@@ -1425,13 +1403,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {
@@ -1467,12 +1444,12 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1481,7 +1458,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (this.id = coalesce($jwt.sub, $jwtDefault) AND $authorization_param3 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = coalesce($jwt.sub, $jwtDefault) | 1] WHERE true) AND $authorization_param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *
@@ -1497,14 +1474,13 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"user\\",
-                \\"param4\\": \\"admin\\",
+                \\"param2\\": \\"user\\",
+                \\"param3\\": \\"admin\\",
                 \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"some-id\\",
-                \\"authorization_param3\\": \\"user\\",
-                \\"authorization_param4\\": \\"admin\\",
-                \\"authorization_param5\\": \\"user\\",
-                \\"authorization_param6\\": \\"admin\\",
+                \\"authorization_param2\\": \\"user\\",
+                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization_param4\\": \\"user\\",
+                \\"authorization_param5\\": \\"admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -178,7 +178,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -230,7 +230,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -284,7 +284,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -335,7 +335,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                WHERE (this1.content = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.content = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -388,7 +388,7 @@ describe("Cypher Auth Where with Roles", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var3
                 }
@@ -447,7 +447,7 @@ describe("Cypher Auth Where with Roles", () => {
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -507,7 +507,7 @@ describe("Cypher Auth Where with Roles", () => {
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
-                    WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE this2.id = $jwt.sub | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -654,10 +654,10 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_posts0
             	CALL {
             		WITH this_posts0
@@ -674,7 +674,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
                 WITH this
                 MATCH (this)-[update_this0:HAS_POST]->(update_this1:\`Post\`)
-                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(update_this2 IN [(update_this1)<-[:HAS_POST]-(update_this2:\`User\`) WHERE update_this2.id = $jwt.sub | 1] WHERE true) AND $update_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $update_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(update_this2 IN [(update_this1)<-[:HAS_POST]-(update_this2:\`User\`) WHERE ($jwt.sub IS NOT NULL AND update_this2.id = $jwt.sub) | 1] WHERE true) AND $update_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $update_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH update_this1 { .id } AS update_this1
                 RETURN collect(update_this1) AS update_var3
             }
@@ -758,7 +758,7 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -816,7 +816,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -831,7 +831,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post
             }
             WITH this0
@@ -897,7 +897,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -912,7 +912,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post
             }
             WITH this0
@@ -968,7 +968,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -983,7 +983,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_posts0_connect0_node
             WITH this, this_posts0_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_posts0_connect_Post
             }
             WITH this
@@ -1035,7 +1035,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1050,7 +1050,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_posts0_connect0_node
             WITH this, this_posts0_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_posts0_connect_Post
             }
             WITH this
@@ -1103,7 +1103,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1118,7 +1118,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post
             }
             WITH *
@@ -1169,7 +1169,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1184,7 +1184,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post
             }
             WITH *
@@ -1236,7 +1236,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1245,7 +1245,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_posts0_disconnect0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_posts0_disconnect_Post
             }
             WITH this
@@ -1297,7 +1297,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1306,7 +1306,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_posts0_disconnect0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_posts0_disconnect_Post
             }
             WITH this
@@ -1378,7 +1378,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1387,7 +1387,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *
@@ -1449,7 +1449,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1458,7 +1458,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS _
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE authorization_this0.id = $jwt.sub | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND $authorization_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $authorization_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -109,7 +109,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub))
             RETURN this { .id } AS this"
         `);
 
@@ -121,8 +121,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -144,7 +143,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)))
             RETURN this { .id } AS this"
         `);
 
@@ -157,8 +156,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -183,7 +181,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 CALL {
@@ -197,7 +195,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this4)<-[:HAS_CONTENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = coalesce($jwt.sub, $jwtDefault)))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub))
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS this4
                     RETURN this4 AS var2
                 }
@@ -215,8 +213,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -245,7 +242,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 CALL {
@@ -259,7 +256,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:\`User\`)
                     WITH *, count(this4) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this4.id = coalesce($jwt.sub, $jwtDefault)))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this4.id = $jwt.sub))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
@@ -278,8 +275,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -308,13 +304,13 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_CONTENT]->(this1:\`Comment\`)
-                    WHERE this1.id = $param3
+                    WHERE this1.id = $param2
                     WITH { node: { __resolveType: \\"Comment\\", __id: id(this1) } } AS edge
                     RETURN edge
                     UNION
@@ -323,7 +319,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:\`User\`)
                     WITH *, count(this4) AS creatorCount
                     WITH *
-                    WHERE (this3.id = $param4 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this4.id = coalesce($jwt.sub, $jwtDefault))))
+                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this4.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
@@ -343,9 +339,8 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"some-id\\",
-                \\"param4\\": \\"some-id\\"
+                \\"param2\\": \\"some-id\\",
+                \\"param3\\": \\"some-id\\"
             }"
         `);
     });
@@ -369,7 +364,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub))
             SET this.content = $this_update_content
             WITH *
             CALL {
@@ -391,7 +386,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_content\\": \\"Bob\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -417,7 +411,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)))
             SET this.content = $this_update_content
             WITH *
             CALL {
@@ -440,7 +434,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_content\\": \\"Bob\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -464,7 +457,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	 WITH this
@@ -493,7 +486,7 @@ describe("Cypher Auth Where", () => {
             	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault)))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
@@ -519,7 +512,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_content0_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -543,7 +535,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub))
             DETACH DELETE this"
         `);
 
@@ -555,8 +547,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -578,7 +569,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)))
             DETACH DELETE this"
         `);
 
@@ -591,8 +582,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -612,7 +602,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             OPTIONAL MATCH (this)-[this_content_Comment0_relationship:HAS_CONTENT]->(this_content_Comment0:Comment)
             WITH this, collect(DISTINCT this_content_Comment0) AS this_content_Comment0_to_delete
@@ -626,7 +616,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
             OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -645,8 +635,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -679,7 +668,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE ($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault))
+            	WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -700,7 +689,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
             OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -733,7 +722,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -772,7 +760,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_content_connect0_node:Comment)
-            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND ($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault))
+            	WHERE this0_content_connect0_node.id = $this0_content_connect0_node_param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -793,7 +781,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
             OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -827,7 +815,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this0_content_connect1_node_param0\\": \\"post-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -851,7 +838,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	 WITH this
@@ -859,7 +846,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            	WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -885,7 +872,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
             OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -915,7 +902,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -938,7 +924,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	 WITH this
@@ -946,7 +932,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Comment)
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -972,7 +958,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
             OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1002,7 +988,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_content0_connect0_node_param0\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -1026,12 +1011,12 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            	WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
@@ -1052,7 +1037,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1081,7 +1066,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1104,12 +1088,12 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_content0_node:Comment)
-            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            	WHERE this_connect_content0_node.id = $this_connect_content0_node_param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content0_node) as connectedNodes, collect(this) as parentNodes
@@ -1130,7 +1114,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1159,7 +1143,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_connect_content0_node_param0\\": \\"some-id\\",
                 \\"this_connect_content1_node_param0\\": \\"some-id\\",
                 \\"resolvedCallbacks\\": {}
@@ -1184,7 +1167,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	 WITH this
@@ -1192,7 +1175,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1212,7 +1195,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
             OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1236,7 +1219,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1259,7 +1241,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	 WITH this
@@ -1267,7 +1249,7 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Comment)
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1287,7 +1269,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
             OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1311,7 +1293,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_update_content0_disconnect0_where_Comment_this_content0_disconnect0param0\\": \\"new-id\\",
                 \\"updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0\\": \\"new-id\\",
                 \\"updateUsers\\": {
@@ -1355,12 +1336,12 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1375,7 +1356,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1398,7 +1379,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {
@@ -1432,12 +1412,12 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Comment)
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1452,7 +1432,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1475,7 +1455,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_disconnect_content0_where_Comment_this_disconnect_content0param0\\": \\"some-id\\",
                 \\"updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0\\": \\"some-id\\",
                 \\"updateUsers\\": {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -109,7 +109,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
             RETURN this { .id } AS this"
         `);
 
@@ -143,7 +143,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)))
+            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))))
             RETURN this { .id } AS this"
         `);
 
@@ -195,7 +195,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this4)<-[:HAS_CONTENT]-(this5:\`User\`)
                     WITH *, count(this5) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this5.id = $jwt.sub))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)))
                     WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS this4
                     RETURN this4 AS var2
                 }
@@ -256,7 +256,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:\`User\`)
                     WITH *, count(this4) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this4.id = $jwt.sub))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
@@ -319,7 +319,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:\`User\`)
                     WITH *, count(this4) AS creatorCount
                     WITH *
-                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this4.id = $jwt.sub)))
+                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
@@ -364,7 +364,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
             SET this.content = $this_update_content
             WITH *
             CALL {
@@ -411,7 +411,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)))
+            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))))
             SET this.content = $this_update_content
             WITH *
             CALL {
@@ -486,7 +486,7 @@ describe("Cypher Auth Where", () => {
             	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
             	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
@@ -535,7 +535,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)))
             DETACH DELETE this"
         `);
 
@@ -569,7 +569,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)<-[:HAS_CONTENT]-(this0:\`User\`)
             WITH *, count(this0) AS creatorCount
             WITH *
-            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this0.id = $jwt.sub)))
+            WHERE (this.content = $param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub))))
             DETACH DELETE this"
         `);
 
@@ -616,7 +616,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
             OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
             WITH this, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -689,7 +689,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
             OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -781,7 +781,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
             OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -872,7 +872,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
             OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -958,7 +958,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
             OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1037,7 +1037,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1114,7 +1114,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_connect_content1_node:Post)
             OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1195,7 +1195,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
             OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1269,7 +1269,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
             OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1356,7 +1356,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1432,7 +1432,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
             OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -90,7 +90,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             RETURN this { .id } AS this"
         `);
 
@@ -102,8 +102,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -125,7 +124,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.name = $param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             RETURN this { .id } AS this"
         `);
 
@@ -138,8 +137,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -164,14 +162,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault)))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -186,8 +184,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -216,14 +213,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault)))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -240,8 +237,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -270,14 +266,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))))
+                WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -295,8 +291,7 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"some-id\\"
+                \\"param2\\": \\"some-id\\"
             }"
         `);
     });
@@ -321,14 +316,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.content = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))))
+                WHERE (this1.content = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -344,8 +339,7 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"cool\\"
+                \\"param2\\": \\"cool\\"
             }"
         `);
     });
@@ -372,7 +366,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 CALL {
@@ -381,7 +375,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault)))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
                     WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var3
                 }
@@ -399,8 +393,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -431,7 +424,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 CALL {
@@ -440,7 +433,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault)))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -459,8 +452,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -491,7 +483,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             CALL {
                 WITH this
                 CALL {
@@ -500,7 +492,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE (this1.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))))
+                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -520,8 +512,7 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param3\\": \\"some-id\\"
+                \\"param2\\": \\"some-id\\"
             }"
         `);
     });
@@ -545,7 +536,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             SET this.name = $this_update_name
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -559,7 +550,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_name\\": \\"Bob\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -585,7 +575,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.name = $param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             SET this.name = $this_update_name
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
@@ -600,7 +590,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_name\\": \\"Bob\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -629,14 +618,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
             	OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault)))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
             	CALL {
@@ -655,7 +644,7 @@ describe("Cypher Auth Where", () => {
                 OPTIONAL MATCH (update_this1)<-[:HAS_POST]-(update_this2:\`User\`)
                 WITH *, count(update_this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND update_this2.id = coalesce($jwt.sub, $jwtDefault)))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND update_this2.id = $jwt.sub))
                 WITH update_this1 { .id } AS update_this1
                 RETURN collect(update_this1) AS update_var3
             }
@@ -671,7 +660,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_posts0_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -695,7 +683,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             DETACH DELETE this"
         `);
 
@@ -707,8 +695,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -730,7 +717,7 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE (this.name = $param0 AND ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE (this.name = $param0 AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             DETACH DELETE this"
         `);
 
@@ -743,8 +730,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -766,12 +752,12 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
             OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault)))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -790,8 +776,7 @@ describe("Cypher Auth Where", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -828,7 +813,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
             OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -861,7 +846,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -904,7 +888,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
             OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -938,7 +922,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -963,14 +946,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
             OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -998,7 +981,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1023,14 +1005,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
             OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1058,7 +1040,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_posts0_connect0_node_param0\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -1084,14 +1065,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1120,7 +1101,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1145,14 +1125,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1181,7 +1161,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_connect_posts0_node_param0\\": \\"some-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -1207,14 +1186,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
             OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1236,7 +1215,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1261,14 +1239,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
             OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1290,7 +1268,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0\\": \\"new-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
@@ -1335,14 +1312,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1365,7 +1342,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {
@@ -1401,14 +1377,14 @@ describe("Cypher Auth Where", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault))
+            WHERE ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub))
             WITH this
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = coalesce($jwt.sub, $jwtDefault))))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1431,7 +1407,6 @@ describe("Cypher Auth Where", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"some-id\\",
                 \\"updateUsers\\": {
                     \\"args\\": {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -169,7 +169,7 @@ describe("Cypher Auth Where", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -220,7 +220,7 @@ describe("Cypher Auth Where", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -273,7 +273,7 @@ describe("Cypher Auth Where", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)))
+                WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -323,7 +323,7 @@ describe("Cypher Auth Where", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.content = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)))
+                WHERE (this1.content = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }
@@ -375,7 +375,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                     WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
                     RETURN this1 AS var3
                 }
@@ -433,7 +433,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -492,7 +492,7 @@ describe("Cypher Auth Where", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)))
+                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -625,7 +625,7 @@ describe("Cypher Auth Where", () => {
             	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
             	OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
             	CALL {
@@ -644,7 +644,7 @@ describe("Cypher Auth Where", () => {
                 OPTIONAL MATCH (update_this1)<-[:HAS_POST]-(update_this2:\`User\`)
                 WITH *, count(update_this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND update_this2.id = $jwt.sub))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND update_this2.id = $jwt.sub)))
                 WITH update_this1 { .id } AS update_this1
                 RETURN collect(update_this1) AS update_var3
             }
@@ -757,7 +757,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
             OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub))
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
             WITH this, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -813,7 +813,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
             OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -888,7 +888,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
             OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -953,7 +953,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
             OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1012,7 +1012,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
             OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1072,7 +1072,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1132,7 +1132,7 @@ describe("Cypher Auth Where", () => {
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
             OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1193,7 +1193,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
             OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1246,7 +1246,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
             OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1319,7 +1319,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1384,7 +1384,7 @@ describe("Cypher Auth Where", () => {
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
             OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:\`User\`)
             WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND authorization_this0.id = $jwt.sub)))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -99,7 +99,7 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     CALL {
                         WITH this1
                         MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -90,7 +90,7 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
@@ -99,11 +99,11 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                     WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     CALL {
                         WITH this1
                         MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)
-                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this4.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                         WITH { node: { name: this4.name } } AS edge
                         WITH collect(edge) AS edges
                         WITH edges, size(edges) AS totalCount
@@ -125,8 +125,7 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
@@ -87,7 +87,7 @@ describe("Cypher Auth Projection On Connections", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -145,7 +145,7 @@ describe("Cypher Auth Projection On Connections", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this1
                     MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
@@ -80,14 +80,14 @@ describe("Cypher Auth Projection On Connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -102,8 +102,7 @@ describe("Cypher Auth Projection On Connections", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -139,18 +138,18 @@ describe("Cypher Auth Projection On Connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Post\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`User\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this1
                     MATCH (this1:\`Post\`)<-[this3:HAS_POST]-(this4:\`User\`)
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this4.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { node: { name: this4.name } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount
@@ -170,8 +169,7 @@ describe("Cypher Auth Projection On Connections", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
@@ -100,7 +100,7 @@ describe("Auth projections for interface relationship fields", () => {
                     UNION
                     WITH *
                     MATCH (this)-[this3:ACTED_IN]->(this4:\`Series\`)
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this4.episodes = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.episodes = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
                     RETURN this4 AS var2
                 }
@@ -116,8 +116,7 @@ describe("Auth projections for interface relationship fields", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/authorization/projection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection.test.ts
@@ -69,10 +69,10 @@ describe("Cypher Auth Projection", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.id = $this_update_id
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -85,7 +85,6 @@ describe("Cypher Auth Projection", () => {
                     ],
                     \\"sub\\": \\"super_admin\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this_update_id\\": \\"new-id\\",
                 \\"resolvedCallbacks\\": {}
             }"
@@ -109,7 +108,7 @@ describe("Cypher Auth Projection", () => {
         });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param3 AS create_var1
+            "UNWIND $create_param2 AS create_var1
             CALL {
                 WITH create_var1
                 CREATE (create_this0:\`User\`)
@@ -118,7 +117,7 @@ describe("Cypher Auth Projection", () => {
                 RETURN create_this0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(create_this0 { .id }) AS data"
         `);
 
@@ -131,8 +130,7 @@ describe("Cypher Auth Projection", () => {
                     ],
                     \\"sub\\": \\"super_admin\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"create_param3\\": [
+                \\"create_param2\\": [
                     {
                         \\"id\\": \\"id-1\\"
                     },

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -76,14 +76,14 @@ describe("Cypher Auth Projection On Connections", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Person\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:\`Comment\`)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`Person\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = coalesce($jwt.sub, $jwtDefault))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
@@ -98,8 +98,7 @@ describe("Cypher Auth Projection On Connections", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -83,7 +83,7 @@ describe("Cypher Auth Projection On Connections", () => {
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:\`Person\`)
                 WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount

--- a/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth.test.ts
@@ -84,7 +84,7 @@ describe("Node Directive", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`Person\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this { .id } AS this"
         `);
 
@@ -96,8 +96,7 @@ describe("Node Directive", () => {
                         \\"admin\\"
                     ],
                     \\"sub\\": \\"id-01\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });

--- a/packages/graphql/tests/tck/fulltext/auth.test.ts
+++ b/packages/graphql/tests/tck/fulltext/auth.test.ts
@@ -77,7 +77,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE this0.id = $jwt.sub | 1]) > 0))
+                WHERE ($param1 IN labels(this) AND ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0))
                 RETURN this { .title } AS this"
             `);
 
@@ -132,7 +132,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE this0.id = $jwt.sub | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -189,7 +189,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE NOT (this0.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE NOT ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -248,7 +248,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE this0.id = $jwt.sub | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -310,7 +310,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE NOT (this0.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE NOT ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -373,7 +373,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this0:DIRECTED]-(this1:\`Person\`) WHERE this0.year = $param3 | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this0:DIRECTED]-(this1:\`Person\`) WHERE ($param3 IS NOT NULL AND this0.year = $param3) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -433,7 +433,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this0:DIRECTED]-(this1:\`Person\`) WHERE NOT (this0.year = $param3) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this0:DIRECTED]-(this1:\`Person\`) WHERE NOT ($param3 IS NOT NULL AND this0.year = $param3) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -489,7 +489,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE this0.id = $jwt.sub
+                    WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
                 }))
                 RETURN this { .title } AS this"
             `);
@@ -547,7 +547,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE this0.id = $jwt.sub
+                    WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -607,10 +607,10 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE this0.id = $jwt.sub
+                    WHERE ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
                 } AND NOT (EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE NOT (this0.id = $jwt.sub)
+                    WHERE NOT ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)
                 }))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -672,7 +672,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE this1.id = $jwt.sub
+                    WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -737,10 +737,10 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE this1.id = $jwt.sub
+                    WHERE ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
                 } AND NOT (EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE NOT (this1.id = $jwt.sub)
+                    WHERE NOT ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)
                 }))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -806,7 +806,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE this0.year = $param3
+                    WHERE ($param3 IS NOT NULL AND this0.year = $param3)
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -869,10 +869,10 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE this0.year = $param3
+                    WHERE ($param3 IS NOT NULL AND this0.year = $param3)
                 } AND NOT (EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE NOT (this0.year = $param3)
+                    WHERE NOT ($param3 IS NOT NULL AND this0.year = $param3)
                 }))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);

--- a/packages/graphql/tests/tck/fulltext/auth.test.ts
+++ b/packages/graphql/tests/tck/fulltext/auth.test.ts
@@ -77,7 +77,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE this0.id = coalesce($jwt.sub, $jwtDefault) | 1]) > 0))
+                WHERE ($param1 IN labels(this) AND ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE this0.id = $jwt.sub | 1]) > 0))
                 RETURN this { .title } AS this"
             `);
 
@@ -88,7 +88,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -133,7 +132,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE this0.id = coalesce($jwt.sub, $jwtDefault) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE this0.id = $jwt.sub | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -144,7 +143,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -191,7 +189,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE NOT (this0.id = coalesce($jwt.sub, $jwtDefault)) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[:DIRECTED]-(this0:\`Person\`) WHERE NOT (this0.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -202,7 +200,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -251,7 +248,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE this0.id = coalesce($jwt.sub, $jwtDefault) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE this0.id = $jwt.sub | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -262,7 +259,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -314,7 +310,7 @@ describe("Cypher -> fulltext -> Auth", () => {
             expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
                 "CALL db.index.fulltext.queryNodes(\\"MovieTitle\\", $param0) YIELD node AS this
                 WITH *
-                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE NOT (this0.id = coalesce($jwt.sub, $jwtDefault)) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this)<-[this1:DIRECTED]-(this0:\`Person\`) WHERE NOT (this0.id = $jwt.sub) | 1]) = 0), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
 
@@ -325,7 +321,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -494,7 +489,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE this0.id = coalesce($jwt.sub, $jwtDefault)
+                    WHERE this0.id = $jwt.sub
                 }))
                 RETURN this { .title } AS this"
             `);
@@ -506,7 +501,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -553,7 +547,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE this0.id = coalesce($jwt.sub, $jwtDefault)
+                    WHERE this0.id = $jwt.sub
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -565,7 +559,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -614,10 +607,10 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE this0.id = coalesce($jwt.sub, $jwtDefault)
+                    WHERE this0.id = $jwt.sub
                 } AND NOT (EXISTS {
                     MATCH (this)<-[:DIRECTED]-(this0:\`Person\`)
-                    WHERE NOT (this0.id = coalesce($jwt.sub, $jwtDefault))
+                    WHERE NOT (this0.id = $jwt.sub)
                 }))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -629,7 +622,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -680,7 +672,7 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE this1.id = coalesce($jwt.sub, $jwtDefault)
+                    WHERE this1.id = $jwt.sub
                 }), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -692,7 +684,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }
@@ -746,10 +737,10 @@ describe("Cypher -> fulltext -> Auth", () => {
                 WITH *
                 WHERE ($param1 IN labels(this) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE this1.id = coalesce($jwt.sub, $jwtDefault)
+                    WHERE this1.id = $jwt.sub
                 } AND NOT (EXISTS {
                     MATCH (this)<-[this0:DIRECTED]-(this1:\`Person\`)
-                    WHERE NOT (this1.id = coalesce($jwt.sub, $jwtDefault))
+                    WHERE NOT (this1.id = $jwt.sub)
                 }))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 RETURN this { .title } AS this"
             `);
@@ -761,7 +752,6 @@ describe("Cypher -> fulltext -> Auth", () => {
                     "roles": Array [],
                     "sub": "my-sub",
                   },
-                  "jwtDefault": Object {},
                   "param0": "something AND something",
                   "param1": "Movie",
                 }

--- a/packages/graphql/tests/tck/issues/1132.test.ts
+++ b/packages/graphql/tests/tck/issues/1132.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_targets0_node:Target)
-            	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this_connect_targets0_node.id = $this_connect_targets0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_targets0_node) as connectedNodes, collect(this) as parentNodes
@@ -94,7 +94,6 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"1\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -143,7 +142,7 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_targets0_rel:HAS_TARGET]->(this_disconnect_targets0:Target)
-            WHERE this_disconnect_targets0.id = $updateSources_args_disconnect_targets0_where_Target_this_disconnect_targets0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE this_disconnect_targets0.id = $updateSources_args_disconnect_targets0_where_Target_this_disconnect_targets0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_targets0, this_disconnect_targets0_rel, this
             	WITH collect(this_disconnect_targets0) as this_disconnect_targets0, this_disconnect_targets0_rel, this
@@ -165,7 +164,6 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"1\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"updateSources\\": {
                     \\"args\\": {
                         \\"disconnect\\": {

--- a/packages/graphql/tests/tck/issues/2789.test.ts
+++ b/packages/graphql/tests/tck/issues/2789.test.ts
@@ -54,14 +54,14 @@ describe("https://github.com/neo4j/graphql/issues/2789", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:\`User\`)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = $param1), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($param1 IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = $authorization_param1), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization_param1 IS NOT NULL AND this.id = $authorization_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.password = $this_update_password
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = $authorization_param1), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = $authorization_param1), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization_param1 IS NOT NULL AND this.id = $authorization_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization_param1 IS NOT NULL AND this.id = $authorization_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this.id = $update_param1), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($update_param1 IS NOT NULL AND this.id = $update_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .password }) AS data"
         `);
 

--- a/packages/graphql/tests/tck/issues/2812.test.ts
+++ b/packages/graphql/tests/tck/issues/2812.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param3 AS create_var4
+            "UNWIND $create_param2 AS create_var4
             CALL {
                 WITH create_var4
                 CREATE (create_this0:\`Movie\`)
@@ -100,17 +100,17 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         create_this8.id = randomUUID()
                     MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
                     WITH *
-                    WHERE (apoc.util.validatePredicate((create_var6.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate((create_var6.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (apoc.util.validatePredicate((create_var6.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate((create_var6.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     RETURN collect(NULL) AS create_var10
                 }
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param6 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param5 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN create_this0
             }
             CALL {
                 WITH create_this0
                 MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this2.nodeCreatedBy = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this2.nodeCreatedBy = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
@@ -128,8 +128,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                     ],
                     \\"sub\\": \\"User\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"create_param3\\": [
+                \\"create_param2\\": [
                     {
                         \\"id\\": \\"1\\",
                         \\"actors\\": {
@@ -158,9 +157,9 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         }
                     }
                 ],
-                \\"create_param4\\": \\"role-A\\",
-                \\"create_param5\\": \\"role-B\\",
-                \\"create_param6\\": \\"admin\\",
+                \\"create_param3\\": \\"role-A\\",
+                \\"create_param4\\": \\"role-B\\",
+                \\"create_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -193,7 +192,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param3 AS create_var4
+            "UNWIND $create_param2 AS create_var4
             CALL {
                 WITH create_var4
                 CREATE (create_this0:\`Movie\`)
@@ -213,17 +212,17 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         create_this8.id = randomUUID()
                     MERGE (create_this0)<-[create_this9:ACTED_IN]-(create_this8)
                     WITH *
-                    WHERE (apoc.util.validatePredicate((create_var6.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate((create_var6.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (apoc.util.validatePredicate((create_var6.fieldA IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate((create_var6.fieldB IS NOT NULL AND NOT ($isAuthenticated = true AND $create_param4 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     RETURN collect(NULL) AS create_var10
                 }
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param6 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param5 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN create_this0
             }
             CALL {
                 WITH create_this0
                 MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this2.nodeCreatedBy = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this2.nodeCreatedBy = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
@@ -241,8 +240,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                     ],
                     \\"sub\\": \\"User\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"create_param3\\": [
+                \\"create_param2\\": [
                     {
                         \\"id\\": \\"1\\",
                         \\"actors\\": {
@@ -273,9 +271,9 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         }
                     }
                 ],
-                \\"create_param4\\": \\"role-A\\",
-                \\"create_param5\\": \\"role-B\\",
-                \\"create_param6\\": \\"admin\\",
+                \\"create_param3\\": \\"role-A\\",
+                \\"create_param4\\": \\"role-B\\",
+                \\"create_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -304,7 +302,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param3 AS create_var4
+            "UNWIND $create_param2 AS create_var4
             CALL {
                 WITH create_var4
                 CREATE (create_this0:\`Movie\`)
@@ -324,13 +322,13 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                     RETURN collect(NULL) AS create_var10
                 }
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param4 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param3 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 RETURN create_this0
             }
             CALL {
                 WITH create_this0
                 MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this2.nodeCreatedBy = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this2.nodeCreatedBy = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
@@ -348,8 +346,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                     ],
                     \\"sub\\": \\"User\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"create_param3\\": [
+                \\"create_param2\\": [
                     {
                         \\"id\\": \\"1\\",
                         \\"actors\\": {
@@ -376,7 +373,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
                         }
                     }
                 ],
-                \\"create_param4\\": \\"admin\\",
+                \\"create_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
@@ -146,7 +146,7 @@ describe("Batch Create, Auth", () => {
         const result = await translateQuery(neoSchema, query, { token });
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "UNWIND $create_param3 AS create_var4
+            "UNWIND $create_param2 AS create_var4
             CALL {
                 WITH create_var4
                 CREATE (create_this0:\`Movie\`)
@@ -175,7 +175,7 @@ describe("Batch Create, Auth", () => {
                     RETURN collect(NULL) AS create_var10
                 }
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param4 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $create_param3 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this0
                 CALL {
                 	WITH create_this0
@@ -189,7 +189,7 @@ describe("Batch Create, Auth", () => {
             CALL {
                 WITH create_this0
                 MATCH (create_this0)<-[create_this1:ACTED_IN]-(create_this2:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this2.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this2.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this2 { .name } AS create_this2
                 RETURN collect(create_this2) AS create_var3
             }
@@ -203,8 +203,7 @@ describe("Batch Create, Auth", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"1\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"create_param3\\": [
+                \\"create_param2\\": [
                     {
                         \\"id\\": \\"1\\",
                         \\"actors\\": {
@@ -242,7 +241,7 @@ describe("Batch Create, Auth", () => {
                         }
                     }
                 ],
-                \\"create_param4\\": \\"admin\\",
+                \\"create_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -369,7 +368,7 @@ describe("Batch Create, Auth", () => {
             CALL {
             	WITH this3
             	OPTIONAL MATCH (this3_actors_connect0_node:Actor)
-            	WHERE this3_actors_connect0_node.id = $this3_actors_connect0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this3_actors_connect0_node.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this3_actors_connect0_node.id = $this3_actors_connect0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this3_actors_connect0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this3_actors_connect0_node) as connectedNodes, collect(this3) as parentNodes
@@ -430,7 +429,7 @@ describe("Batch Create, Auth", () => {
             CALL {
                 WITH this0
                 MATCH (this0)<-[create_this3:ACTED_IN]-(create_this4:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this4.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this4 { .name } AS create_this4
                 RETURN collect(create_this4) AS create_var5
             }
@@ -443,7 +442,7 @@ describe("Batch Create, Auth", () => {
             CALL {
                 WITH this1
                 MATCH (this1)<-[create_this9:ACTED_IN]-(create_this10:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this10.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this10.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this10 { .name } AS create_this10
                 RETURN collect(create_this10) AS create_var11
             }
@@ -456,7 +455,7 @@ describe("Batch Create, Auth", () => {
             CALL {
                 WITH this2
                 MATCH (this2)<-[create_this15:ACTED_IN]-(create_this16:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this16.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this16.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this16 { .name } AS create_this16
                 RETURN collect(create_this16) AS create_var17
             }
@@ -469,7 +468,7 @@ describe("Batch Create, Auth", () => {
             CALL {
                 WITH this3
                 MATCH (this3)<-[create_this21:ACTED_IN]-(create_this22:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this22.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this22.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this22 { .name } AS create_this22
                 RETURN collect(create_this22) AS create_var23
             }
@@ -482,7 +481,7 @@ describe("Batch Create, Auth", () => {
             CALL {
                 WITH this4
                 MATCH (this4)<-[create_this27:ACTED_IN]-(create_this28:\`Actor\`)
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_this28.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND create_this28.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH create_this28 { .name } AS create_this28
                 RETURN collect(create_this28) AS create_var29
             }
@@ -496,7 +495,6 @@ describe("Batch Create, Auth", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"1\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this0_id\\": \\"1\\",
                 \\"this0_actors0_node_name\\": \\"actor 1\\",
                 \\"this0_actors0_relationship_year\\": {

--- a/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
+++ b/packages/graphql/tests/tck/rfcs/rfc-022.test.ts
@@ -200,7 +200,7 @@ describe("tck/rfs/022 subquery projection", () => {
                 CALL {
                     WITH this
                     MATCH (this)<-[this0:ACTED_IN]-(this1:\`Person\`)
-                    WHERE (this1.name = $param1 AND (($isAuthenticated = true AND this1.name = $param3) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (this1.name = coalesce($jwt.test, $jwtDefault) AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])))
+                    WHERE (this1.name = $param1 AND (($isAuthenticated = true AND ($param3 IS NOT NULL AND this1.name = $param3)) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.test IS NOT NULL AND this1.name = $jwt.test) AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])))
                     WITH this1 { .name } AS this1
                     RETURN collect(this1) AS var2
                 }
@@ -220,8 +220,7 @@ describe("tck/rfs/022 subquery projection", () => {
                         \\"roles\\": [],
                         \\"test\\": \\"my-test\\"
                     },
-                    \\"jwtDefault\\": {},
-                    \\"param6\\": \\"admin\\"
+                    \\"param5\\": \\"admin\\"
                 }"
             `);
         });

--- a/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create-auth.test.ts
@@ -81,7 +81,7 @@ describe("Subscriptions metadata on create", () => {
             SET this0.id = $this0_id
             WITH meta + { event: \\"create\\", id: id(this0), properties: { old: null, new: this0 { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this0
             WITH this0, meta
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this0.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0, meta AS this0_meta
             }
             CALL {
@@ -90,7 +90,7 @@ describe("Subscriptions metadata on create", () => {
             SET this1.id = $this1_id
             WITH meta + { event: \\"create\\", id: id(this1), properties: { old: null, new: this1 { .* } }, timestamp: timestamp(), typename: \\"Actor\\" } AS meta, this1
             WITH this1, meta
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this1.id = coalesce($jwt.sub, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this1.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this1, meta AS this1_meta
             }
             WITH this0, this1, this0_meta + this1_meta AS meta
@@ -105,7 +105,6 @@ describe("Subscriptions metadata on create", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"super_admin\\"
                 },
-                \\"jwtDefault\\": {},
                 \\"this1_id\\": \\"2\\",
                 \\"resolvedCallbacks\\": {}
             }"

--- a/packages/graphql/tests/tck/union.test.ts
+++ b/packages/graphql/tests/tck/union.test.ts
@@ -79,7 +79,7 @@ describe("Cypher Union", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:SEARCH]->(this1:\`Genre\`)
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this1.name = coalesce($jwt.jwtAllowedNamesExample, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
@@ -100,8 +100,7 @@ describe("Cypher Union", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"jwtAllowedNamesExample\\": \\"Horror\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -129,7 +128,7 @@ describe("Cypher Union", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:SEARCH]->(this1:\`Genre\`)
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this1.name = coalesce($jwt.jwtAllowedNamesExample, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
@@ -150,8 +149,7 @@ describe("Cypher Union", () => {
                 \\"jwt\\": {
                     \\"roles\\": [],
                     \\"jwtAllowedNamesExample\\": \\"Horror\\"
-                },
-                \\"jwtDefault\\": {}
+                }
             }"
         `);
     });
@@ -186,19 +184,19 @@ describe("Cypher Union", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:SEARCH]->(this1:\`Genre\`)
-                    WHERE (this1.name = $param1 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND this1.name = coalesce($jwt.jwtAllowedNamesExample, $jwtDefault)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this1.name = $param1 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.jwtAllowedNamesExample IS NOT NULL AND this1.name = $jwt.jwtAllowedNamesExample)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH this1 { __resolveType: \\"Genre\\", __id: id(this), .name } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:SEARCH]->(this4:\`Movie\`)
-                    WHERE this4.title = $param5
+                    WHERE this4.title = $param4
                     WITH this4 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
-                SKIP $param6
-                LIMIT $param7
+                SKIP $param5
+                LIMIT $param6
                 RETURN collect(var2) AS var2
             }
             RETURN this { search: var2 } AS this"
@@ -213,13 +211,12 @@ describe("Cypher Union", () => {
                     \\"roles\\": [],
                     \\"jwtAllowedNamesExample\\": \\"Horror\\"
                 },
-                \\"jwtDefault\\": {},
-                \\"param5\\": \\"The Matrix\\",
-                \\"param6\\": {
+                \\"param4\\": \\"The Matrix\\",
+                \\"param5\\": {
                     \\"low\\": 1,
                     \\"high\\": 0
                 },
-                \\"param7\\": {
+                \\"param6\\": {
                     \\"low\\": 10,
                     \\"high\\": 0
                 }

--- a/packages/graphql/tests/utils/builders/context-builder.ts
+++ b/packages/graphql/tests/utils/builders/context-builder.ts
@@ -59,7 +59,6 @@ export class ContextBuilder extends Builder<Context, Context> {
                 jwtParam: new Cypher.Param({}),
                 isAuthenticated: true,
                 isAuthenticatedParam: new Cypher.Param(true),
-                jwtDefault: new Cypher.Param({}),
             },
             ...newOptions,
         });


### PR DESCRIPTION
# Description

Address the following issue reported on Discord:

> Hi, I started to play around with the new  `@authorization` directive using 3.23.0. Our jwt object that is passed to the executed query contains a list of stores where the user is admin.
> What we want to achieve is that the admin user is only able to query clients that belong to their stores. The authorization directive looks like this:
> `@authorization(validate: [{when: [BEFORE], where: {node: {config: {store_IN: "$jwt.storeAdmins"}}}}])`
> However this will throw an error when a graphql query is executed: `Type mismatch: expected List<T> but was Any, Map, Node or Relationship`
>
> The issue seems to be that the validatePredicate cypher that is generated is using COALESCE for the store_IN condition: `WHERE this0.store IN coalesce($jwt.storeAdmins, $jwtDefault)`
> $jwtDefault is an empty object so `this0.store IN coalesce($jwt.storeAdmins, $jwtDefault)` will throw an error when it is used with an _IN filter.
>
> This behavior can be easily checked in neo4j browser as well:
> ```
> :params {
>   jwt: {
>    adminStores: ["www.acme.com"]
>   },
>   jwtDefault: {}
> }
> ```
>
> This will execute: `return "www.acme.com" in coalesce($jwt.adminStores, [])`
> This will throw error: `return "www.acme.com" in coalesce($jwt.adminStores, $jwtDefault)`
>
> Do you have any recommendation how to handle this? 
>
> Great work btw, I really love the improvements I see so far around the new authorization directive!

## Complexity

Complexity: Medium
