### PR TITLE
Is array relationships

### DIFF
--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -228,6 +228,7 @@ function generateRelationshipField(
         const fields = (propertyInterface.fields || []).map((field) => generateAttribute(field));
         attributes = filterTruthy(fields);
     }
+
     return new Relationship({
         name: fieldName,
         type: type as string,
@@ -235,6 +236,7 @@ function generateRelationshipField(
         source,
         target: relatedToEntity,
         direction: direction as RelationshipDirection,
+        isArray: Boolean(fieldTypeMeta.array),
     });
 }
 

--- a/packages/graphql/src/schema-model/relationship/Relationship.ts
+++ b/packages/graphql/src/schema-model/relationship/Relationship.ts
@@ -32,6 +32,7 @@ export class Relationship {
     public readonly source: ConcreteEntity; // Origin field of relationship
     public readonly target: Entity;
     public readonly direction: RelationshipDirection;
+    public readonly isArray: boolean;
 
     /**Note: Required for now to infer the types without ResolveTree */
     public get connectionFieldTypename(): string {
@@ -59,6 +60,7 @@ export class Relationship {
         source,
         target,
         direction,
+        isArray,
     }: {
         name: string;
         type: string;
@@ -66,12 +68,14 @@ export class Relationship {
         source: ConcreteEntity;
         target: Entity;
         direction: RelationshipDirection;
+        isArray: boolean;
     }) {
         this.type = type;
         this.source = source;
         this.target = target;
         this.name = name;
         this.direction = direction;
+        this.isArray = isArray;
 
         for (const attribute of attributes) {
             this.addAttribute(attribute);
@@ -86,6 +90,7 @@ export class Relationship {
             source: this.source,
             target: this.target,
             direction: this.direction,
+            isArray: this.isArray,
         });
     }
 

--- a/packages/graphql/src/translate/queryAST/ast/fields/OperationField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/OperationField.ts
@@ -33,7 +33,7 @@ export class OperationField extends Field {
 
     public getProjectionField(): Record<string, Cypher.Expr> {
         if (!this.projectionExpr) {
-            throw new Error("Projection expression of operation not availabe (has transpiled been called)?");
+            throw new Error("Projection expression of operation not available (has transpiled been called)?");
         }
         return { [this.alias]: this.projectionExpr };
     }

--- a/packages/graphql/src/translate/queryAST/ast/filters/Filter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/Filter.ts
@@ -38,6 +38,8 @@ export type WhereOperator =
     | `NOT_${ArrayWhereOperator}`
     | RelationshipWhereOperator;
 
+export type FilterOperator = WhereOperator | "EQ";
+
 export type LogicalOperators = "NOT" | "AND" | "OR";
 
 const RELATIONSHIP_OPERATORS = ["ALL", "NONE", "SINGLE", "SOME"] as const;
@@ -48,4 +50,8 @@ export function isRelationshipOperator(operator: string): operator is Relationsh
 
 export abstract class Filter extends QueryASTNode {
     public abstract getPredicate(variable: Cypher.Variable): Cypher.Predicate | undefined;
+
+    public getSubqueries(_parentNode: Cypher.Node): Cypher.Clause[] {
+        return [];
+    }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/LogicalFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/LogicalFilter.ts
@@ -32,6 +32,10 @@ export class LogicalFilter extends Filter {
         this.children = filters;
     }
 
+    public getSubqueries(parentNode: Cypher.Node): Cypher.Clause[] {
+        return this.children.flatMap((c) => c.getSubqueries(parentNode));
+    }
+
     public getPredicate(target: Cypher.Variable): Cypher.Predicate | undefined {
         const predicates = filterTruthy(this.children.map((f) => f.getPredicate(target)));
 

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationFilter.ts
@@ -6,12 +6,6 @@ import { getRelationshipDirection } from "../../../utils/get-relationship-direct
 import type { ConcreteEntity } from "../../../../../schema-model/entity/ConcreteEntity";
 import type { AggregationPropertyFilter } from "./AggregationPropertyFilter";
 
-type FiltersContructor = {
-    node: AggregationPropertyFilter[];
-    edge: AggregationPropertyFilter[];
-    filters: CountFilter[]; // Top filters
-};
-
 export class AggregationFilter extends Filter {
     private relationship: Relationship;
 

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationFilter.ts
@@ -1,0 +1,96 @@
+import Cypher from "@neo4j/cypher-builder";
+import { Filter } from "../Filter";
+import type { Relationship } from "../../../../../schema-model/relationship/Relationship";
+import type { CountFilter } from "./CountFilter";
+import { getRelationshipDirection } from "../../../utils/get-relationship-direction";
+import type { ConcreteEntity } from "../../../../../schema-model/entity/ConcreteEntity";
+import type { AggregationPropertyFilter } from "./AggregationPropertyFilter";
+
+type FiltersContructor = {
+    node: AggregationPropertyFilter[];
+    edge: AggregationPropertyFilter[];
+    filters: CountFilter[]; // Top filters
+};
+
+export class AggregationFilter extends Filter {
+    private relationship: Relationship;
+
+    private filters: CountFilter[] = [];
+    private nodeFilters: AggregationPropertyFilter[] = [];
+    private edgeFilters: AggregationPropertyFilter[] = [];
+
+    private subqueryVariables: Array<Cypher.Variable> = [];
+
+    constructor(relationship: Relationship) {
+        super();
+        this.relationship = relationship;
+    }
+
+    public addFilter(filter: CountFilter) {
+        this.filters.push(filter);
+    }
+
+    public addNodeFilters(filters: AggregationPropertyFilter[]) {
+        this.nodeFilters.push(...filters);
+    }
+
+    public addEdgeFilters(filters: AggregationPropertyFilter[]) {
+        this.edgeFilters.push(...filters);
+    }
+
+    public getSubqueries(parentNode: Cypher.Node): Cypher.Clause[] {
+        const relatedEntity = this.relationship.target as ConcreteEntity;
+        const relatedNode = new Cypher.Node({
+            labels: relatedEntity.labels,
+        });
+
+        const pattern = this.createRelationshipPattern(parentNode, relatedNode);
+
+        const predicates = Cypher.or(...this.filters.map((f) => f.getPredicate(relatedNode)));
+        const nodePredicates = Cypher.or(...this.nodeFilters.map((f) => f.getPredicate(relatedNode)));
+        const edgePredicates = Cypher.or(...this.edgeFilters.map((f) => f.getPredicate(relatedNode)));
+
+        const returnColumns: Cypher.ProjectionColumn[] = [];
+
+        if (predicates) {
+            const newVar = new Cypher.Variable();
+            this.subqueryVariables.push(newVar);
+            returnColumns.push([predicates, newVar]);
+        }
+        if (nodePredicates) {
+            const newVar = new Cypher.Variable();
+            this.subqueryVariables.push(newVar);
+            returnColumns.push([nodePredicates, newVar]);
+        }
+        if (edgePredicates) {
+            const newVar = new Cypher.Variable();
+            this.subqueryVariables.push(newVar);
+            returnColumns.push([edgePredicates, newVar]);
+        }
+
+        if (returnColumns.length === 0) return []; // Maybe throw?
+
+        const subquery = new Cypher.Match(pattern).return(...returnColumns);
+
+        return [subquery];
+    }
+
+    public getPredicate(variable: Cypher.Variable): Cypher.Predicate | undefined {
+        const trueLiteral = new Cypher.Literal(true);
+        const subqueryPredicates = this.subqueryVariables.map((v) => Cypher.eq(v, trueLiteral));
+        return Cypher.and(...subqueryPredicates);
+    }
+
+    // Duplicate from relationship filters
+    private createRelationshipPattern(parentNode: Cypher.Node, relatedNode: Cypher.Node): Cypher.Pattern {
+        return new Cypher.Pattern(parentNode)
+            .withoutLabels()
+            .related(
+                new Cypher.Relationship({
+                    type: this.relationship.type,
+                })
+            )
+            .withDirection(getRelationshipDirection(this.relationship))
+            .to(relatedNode);
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
@@ -1,0 +1,34 @@
+import Cypher from "@neo4j/cypher-builder";
+import type { Attribute } from "../../../../../schema-model/attribute/Attribute";
+import type { AggregationLogicalOperator } from "../../../factory/parsers/parse-where-field";
+
+export class AggregationPropertyFilter {
+    protected attribute: Attribute;
+    protected comparisonValue: unknown;
+
+    protected logicalOperator: AggregationLogicalOperator;
+
+    constructor({
+        attribute,
+        logicalOperator,
+        comparisonValue,
+    }: {
+        attribute: Attribute;
+        logicalOperator: AggregationLogicalOperator;
+        comparisonValue: unknown;
+    }) {
+        this.attribute = attribute;
+        this.comparisonValue = comparisonValue;
+        this.logicalOperator = logicalOperator;
+    }
+
+    public getPredicate(variable: Cypher.Variable): Cypher.Predicate | undefined {
+        const comparisonVar = new Cypher.Variable();
+        const property = variable.property(this.attribute.name);
+        return Cypher.any(
+            comparisonVar,
+            Cypher.collect(property),
+            Cypher.eq(comparisonVar, new Cypher.Param(this.comparisonValue))
+        );
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
@@ -1,34 +1,104 @@
 import Cypher from "@neo4j/cypher-builder";
-import type { Attribute } from "../../../../../schema-model/attribute/Attribute";
-import type { AggregationLogicalOperator } from "../../../factory/parsers/parse-where-field";
+import { AttributeType, type Attribute } from "../../../../../schema-model/attribute/Attribute";
+import type { AggregationLogicalOperator, AggregationOperator } from "../../../factory/parsers/parse-where-field";
 
 export class AggregationPropertyFilter {
     protected attribute: Attribute;
     protected comparisonValue: unknown;
 
     protected logicalOperator: AggregationLogicalOperator;
+    private aggregationOperator: AggregationOperator | undefined;
 
     constructor({
         attribute,
         logicalOperator,
         comparisonValue,
+        aggregationOperator,
     }: {
         attribute: Attribute;
         logicalOperator: AggregationLogicalOperator;
         comparisonValue: unknown;
+        aggregationOperator: AggregationOperator | undefined;
     }) {
         this.attribute = attribute;
         this.comparisonValue = comparisonValue;
         this.logicalOperator = logicalOperator;
+        this.aggregationOperator = aggregationOperator;
     }
 
     public getPredicate(variable: Cypher.Variable): Cypher.Predicate | undefined {
         const comparisonVar = new Cypher.Variable();
         const property = variable.property(this.attribute.name);
-        return Cypher.any(
-            comparisonVar,
-            Cypher.collect(property),
-            Cypher.eq(comparisonVar, new Cypher.Param(this.comparisonValue))
-        );
+
+        if (this.aggregationOperator) {
+            const aggrOperation = this.getAggregateOperation(Cypher.size(property), this.aggregationOperator);
+            return this.createBaseOperation({
+                operator: this.logicalOperator,
+                property: aggrOperation,
+                param: new Cypher.Param(this.comparisonValue),
+            });
+        } else {
+            let listExpr: Cypher.Expr;
+
+            if (this.logicalOperator !== "EQUAL" && this.attribute.type === AttributeType.String) {
+                listExpr = Cypher.collect(Cypher.size(property));
+            } else {
+                listExpr = Cypher.collect(property);
+            }
+
+            const comparisonOperation = this.createBaseOperation({
+                operator: this.logicalOperator,
+                property: comparisonVar,
+                param: new Cypher.Param(this.comparisonValue),
+            });
+
+            return Cypher.any(comparisonVar, listExpr, comparisonOperation);
+        }
+    }
+
+    private getAggregateOperation(
+        property: Cypher.Property | Cypher.Function,
+        aggregationOperator: string
+    ): Cypher.Function {
+        switch (aggregationOperator) {
+            case "AVERAGE":
+                return Cypher.avg(property);
+            case "MIN":
+            case "SHORTEST":
+                return Cypher.min(property);
+            case "MAX":
+            case "LONGEST":
+                return Cypher.max(property);
+            case "SUM":
+                return Cypher.sum(property);
+            default:
+                throw new Error(`Invalid operator ${aggregationOperator}`);
+        }
+    }
+
+    /** Returns the default operation for a given filter */
+    protected createBaseOperation({
+        operator,
+        property,
+        param,
+    }: {
+        operator: AggregationLogicalOperator;
+        property: Cypher.Expr;
+        param: Cypher.Expr;
+    }): Cypher.ComparisonOp {
+        switch (operator) {
+            case "LT":
+                return Cypher.lt(property, param);
+            case "LTE":
+                return Cypher.lte(property, param);
+            case "GT":
+                return Cypher.gt(property, param);
+            case "GTE":
+                return Cypher.gte(property, param);
+            case "EQUAL":
+                return Cypher.eq(property, param);
+            default:
+                throw new Error(`Invalid operator ${operator}`);
+        }
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/AggregationPropertyFilter.ts
@@ -1,8 +1,9 @@
 import Cypher from "@neo4j/cypher-builder";
 import { AttributeType, type Attribute } from "../../../../../schema-model/attribute/Attribute";
 import type { AggregationLogicalOperator, AggregationOperator } from "../../../factory/parsers/parse-where-field";
+import { Filter } from "../Filter";
 
-export class AggregationPropertyFilter {
+export class AggregationPropertyFilter extends Filter {
     protected attribute: Attribute;
     protected comparisonValue: unknown;
 
@@ -20,6 +21,7 @@ export class AggregationPropertyFilter {
         comparisonValue: unknown;
         aggregationOperator: AggregationOperator | undefined;
     }) {
+        super();
         this.attribute = attribute;
         this.comparisonValue = comparisonValue;
         this.logicalOperator = logicalOperator;
@@ -31,7 +33,13 @@ export class AggregationPropertyFilter {
         const property = variable.property(this.attribute.name);
 
         if (this.aggregationOperator) {
-            const aggrOperation = this.getAggregateOperation(Cypher.size(property), this.aggregationOperator);
+            let propertyExpr: Cypher.Expr = property;
+
+            if (this.attribute.type === AttributeType.String) {
+                propertyExpr = Cypher.size(property);
+            }
+
+            const aggrOperation = this.getAggregateOperation(propertyExpr, this.aggregationOperator);
             return this.createBaseOperation({
                 operator: this.logicalOperator,
                 property: aggrOperation,

--- a/packages/graphql/src/translate/queryAST/ast/filters/aggregation/CountFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/aggregation/CountFilter.ts
@@ -1,0 +1,92 @@
+import Cypher from "@neo4j/cypher-builder";
+import type { FilterOperator } from "../Filter";
+
+export class CountFilter {
+    protected comparisonValue: unknown;
+    protected operator: FilterOperator;
+    protected isNot: boolean; // _NOT is deprecated
+
+    constructor({
+        isNot,
+        operator,
+        comparisonValue,
+    }: {
+        operator: FilterOperator;
+        isNot: boolean;
+        comparisonValue: unknown;
+    }) {
+        this.comparisonValue = comparisonValue;
+        this.operator = operator;
+        this.isNot = isNot;
+    }
+    // private targetNodeFilters: ConnectionNodeFilter[] = [];
+
+    // private relationshipFilters: ConnectionEdgeFilter[] = [];
+
+    // private relationship: Relationship;
+    // private operator: RelationshipWhereOperator;
+
+    // private isNot: boolean;
+
+    // constructor({
+    //     relationship,
+    //     operator,
+    //     isNot,
+    // }: {
+    //     relationship: Relationship;
+    //     operator: RelationshipWhereOperator | undefined;
+    //     isNot: boolean;
+    // }) {
+    //     super();
+    //     this.relationship = relationship;
+    //     this.isNot = isNot;
+    //     this.operator = operator || "SOME";
+    // }
+
+    public getPredicate(variable: Cypher.Variable): Cypher.Predicate | undefined {
+        return this.createBaseOperation({
+            operator: this.operator,
+            expr: Cypher.count(variable),
+            param: new Cypher.Param(this.comparisonValue),
+        });
+    }
+
+    /** Returns the default operation for a given filter */
+    // NOTE: duplicate from property filter
+    protected createBaseOperation({
+        operator,
+        expr,
+        param,
+    }: {
+        operator: FilterOperator;
+        expr: Cypher.Expr;
+        param: Cypher.Expr;
+    }): Cypher.ComparisonOp {
+        switch (operator) {
+            case "LT":
+                return Cypher.lt(expr, param);
+            case "LTE":
+                return Cypher.lte(expr, param);
+            case "GT":
+                return Cypher.gt(expr, param);
+            case "GTE":
+                return Cypher.gte(expr, param);
+            case "ENDS_WITH":
+                return Cypher.endsWith(expr, param);
+            case "STARTS_WITH":
+                return Cypher.startsWith(expr, param);
+            case "MATCHES":
+                return Cypher.matches(expr, param);
+            case "CONTAINS":
+                return Cypher.contains(expr, param);
+            case "IN":
+                return Cypher.in(expr, param);
+            case "INCLUDES":
+                return Cypher.in(param, expr);
+            case "EQ":
+                return Cypher.eq(expr, param);
+            default:
+                throw new Error(`Invalid operator ${operator}`);
+        }
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/filters/property-filters/PropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/property-filters/PropertyFilter.ts
@@ -19,9 +19,8 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { Attribute } from "../../../../../schema-model/attribute/Attribute";
-import { Filter, type WhereOperator } from "../Filter";
-
-type FilterOperator = WhereOperator | "EQ";
+import type { FilterOperator } from "../Filter";
+import { Filter } from "../Filter";
 
 export class PropertyFilter extends Filter {
     protected attribute: Attribute;

--- a/packages/graphql/src/translate/queryAST/ast/operations/AggregationOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/AggregationOperation.ts
@@ -153,14 +153,7 @@ export class AggregationOperation extends Operation {
         return Cypher.and(...this.filters.map((f) => f.getPredicate(target)));
     }
 
-    // TODO: remove
-    public transpile2({ returnVariable, parentNode }: OperationTranspileOptions): Cypher.Clause[] {
-        // Return variable is not really used here
-        return this.transpileNestedRelationship(this.entity as Relationship, { returnVariable, parentNode });
-    }
-
     public transpile({ returnVariable, parentNode }: OperationTranspileOptions): OperationTranspileResult {
-        // return Cypher.concat(...this.transpile2({ returnVariable, parentNode }));
         const clauses = this.transpileNestedRelationship(this.entity as Relationship, { returnVariable, parentNode });
         return {
             clauses,

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -318,6 +318,7 @@ export class FilterFactory {
                 attribute: attr,
                 comparisonValue: value,
                 logicalOperator: logicalOperator || "EQUAL",
+                aggregationOperator: aggregationOperator,
             });
         });
     }

--- a/packages/graphql/src/translate/queryAST/factory/parsers/parse-where-field.ts
+++ b/packages/graphql/src/translate/queryAST/factory/parsers/parse-where-field.ts
@@ -61,3 +61,31 @@ export function parseConnectionWhereFields(key: string): ConnectionWhereArgField
         isNot,
     };
 }
+
+export const aggregationFieldRegEx =
+    /(?<fieldName>[_A-Za-z]\w*?)(?:_(?<aggregationOperator>AVERAGE|MAX|MIN|SUM|SHORTEST|LONGEST))?(?:_LENGTH)?(?:_(?<logicalOperator>EQUAL|GT|GTE|LT|LTE))?$/;
+
+export type AggregationOperator = "AVERAGE" | "SHORTEST" | "LONGEST" | "MIN" | "MAX" | "SUM";
+export type AggregationLogicalOperator = "EQUAL" | "GT" | "GTE" | "LT" | "LTE";
+
+export type AggregationFieldRegexGroups = {
+    fieldName: string;
+    aggregationOperator?: AggregationOperator;
+    logicalOperator?: AggregationLogicalOperator;
+};
+
+export function parseAggregationWhereFields(field: string): AggregationFieldRegexGroups {
+    const match = aggregationFieldRegEx.exec(field);
+
+    const matchGroups = match?.groups as {
+        fieldName: string;
+        aggregationOperator?: string;
+        logicalOperator?: string;
+    };
+
+    return {
+        fieldName: matchGroups.fieldName,
+        aggregationOperator: matchGroups.aggregationOperator as AggregationOperator | undefined,
+        logicalOperator: matchGroups.logicalOperator as AggregationLogicalOperator | undefined,
+    };
+}

--- a/packages/graphql/src/utils/utils.ts
+++ b/packages/graphql/src/utils/utils.ts
@@ -63,7 +63,7 @@ export function asArray<T>(raw: T | Array<T> | undefined | null): Array<T> {
 }
 
 /** Filter all elements in an array, only leaving truthy values */
-export function filterTruthy<T>(arr: Array<T | null | undefined>): Array<T> {
+export function filterTruthy<T>(arr: Array<T | null | undefined | void>): Array<T> {
     return arr.filter((v): v is T => !!v);
 }
 

--- a/packages/graphql/tests/tck/aggregations/where/composite.test.ts
+++ b/packages/graphql/tests/tck/aggregations/where/composite.test.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import type { DocumentNode } from "graphql";
+import { Neo4jGraphQL } from "../../../../src";
+import { formatCypher, translateQuery, formatParams } from "../../utils/tck-test-utils";
+
+describe("Cypher Aggregations where with count and node", () => {
+    let typeDefs: DocumentNode;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = gql`
+            type User {
+                name: String!
+            }
+
+            type Post {
+                content: String!
+                likes: [User!]! @relationship(type: "LIKES", direction: IN)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("Equality Count and node", async () => {
+        const query = gql`
+            {
+                posts(where: { likesAggregate: { count: 10, node: { name_EQUAL: "potato" } } }) {
+                    content
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query);
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "MATCH (this:Post)
+            CALL {
+                WITH this
+                MATCH (this)<-[this0:LIKES]-(this1:User)
+                RETURN count(this1) = $param0 AS var2, any(var3 IN collect(this1.name) WHERE var3 = $param1) AS var4
+            }
+            WITH *
+            WHERE (var2 = true AND var4 = true)
+            RETURN this { .content } AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"param0\\": {
+                    \\"low\\": 10,
+                    \\"high\\": 0
+                },
+                \\"param1\\": \\"potato\\"
+            }"
+        `);
+    });
+});


### PR DESCRIPTION
This PR depends on #3737 

Add `head` on relationship queries that are not arrays

Before:
Test Suites: 102 failed, 135 passed, 237 total
Tests:       282 failed, 968 passed, 1250 total

After:
Test Suites: 101 failed, 136 passed, 237 total
Tests:       277 failed, 973 passed, 1250 total