### PR TITLE
Toolbox: Ensure no additional commas are added to the editor value

### DIFF
--- a/.changeset/tender-rats-reflect.md
+++ b/.changeset/tender-rats-reflect.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-toolbox": patch
+---
+
+fix: ensure no additional commas are added to the editor value

--- a/packages/graphql-toolbox/src/modules/EditorView/utils.ts
+++ b/packages/graphql-toolbox/src/modules/EditorView/utils.ts
@@ -22,8 +22,8 @@ import type { GraphQLSchema } from "graphql";
 import { parse } from "graphql";
 import { getComplexity, simpleEstimator } from "graphql-query-complexity";
 import pluginBabel from "prettier/plugins/babel";
-import pluginGraphQL from "prettier/plugins/graphql";
 import pluginEstree from "prettier/plugins/estree.mjs"; // Explicitly import .mjs file
+import pluginGraphQL from "prettier/plugins/graphql";
 import prettier from "prettier/standalone";
 
 export enum ParserOptions {
@@ -33,6 +33,7 @@ export enum ParserOptions {
 
 export const formatCode = (editorView: EditorView, parserOption: ParserOptions): void => {
     const selection = editorView.state.selection;
+    // eslint-disable-next-line @typescript-eslint/no-base-to-string
     const value = editorView.state.doc.toString();
 
     let options = {};

--- a/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
+++ b/packages/graphql-toolbox/src/modules/SchemaView/SchemaView.tsx
@@ -193,7 +193,8 @@ export const SchemaView = ({ onSchemaChange }: Props) => {
 
     const onSubmit = () => {
         if (!editorView) return;
-        const value = Array.from(editorView?.state.doc).toString();
+        // eslint-disable-next-line @typescript-eslint/no-base-to-string
+        const value = editorView?.state.doc.toString();
         if (value) {
             buildSchema(value).catch(() => null);
         }


### PR DESCRIPTION
# Description

According to https://codemirror.net/docs/migration/ using .toString() on editorView.state.doc is the preferred method to get the document as a string.

## Complexity

Low