### PR TITLE
Update @tsconfig/node16 to version 16.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "release": "yarn build && changeset publish"
     },
     "devDependencies": {
-        "@tsconfig/node16": "1.0.4",
+        "@tsconfig/node16": "16.1.1",
         "@typescript-eslint/eslint-plugin": "6.4.1",
         "@typescript-eslint/parser": "6.4.1",
         "concurrently": "8.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7707,10 +7707,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node16@npm:1.0.4":
-  version: 1.0.4
-  resolution: "@tsconfig/node16@npm:1.0.4"
-  checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
+"@tsconfig/node16@npm:16.1.1":
+  version: 16.1.1
+  resolution: "@tsconfig/node16@npm:16.1.1"
+  checksum: 26d83db06866083b543e73eda33585464362fd0835229b9a5b1185f0353b9b5db9ca4f66a4be53d4ec5d4c219be42b0a7582f8bcc7268f2f77b1c643375e490f
   languageName: node
   linkType: hard
 
@@ -22336,7 +22336,7 @@ __metadata:
   dependencies:
     "@changesets/changelog-github": 0.4.8
     "@changesets/cli": 2.26.2
-    "@tsconfig/node16": 1.0.4
+    "@tsconfig/node16": 16.1.1
     "@typescript-eslint/eslint-plugin": 6.4.1
     "@typescript-eslint/parser": 6.4.1
     concurrently: 8.2.1


### PR DESCRIPTION
# Description

Nightly builds are failing due to a tsconfig misconfiguration of the `moduleResolution` field. This PR updates the dependency @tsconfig/node16 to version 16.1.1 which includes the required changes.

## Complexity

Low