### PR TITLE
Fix non-relative import in the OGM

### DIFF
--- a/.changeset/funny-items-drive.md
+++ b/.changeset/funny-items-drive.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-ogm": patch
+---
+
+Fix non-relative import in the OGM

--- a/packages/ogm/src/classes/Model.ts
+++ b/packages/ogm/src/classes/Model.ts
@@ -20,7 +20,7 @@
 import type { DocumentNode, GraphQLSchema, SelectionSetNode } from "graphql";
 import { graphql, parse, print } from "graphql";
 import type { GraphQLOptionsArg, GraphQLWhereArg, DeleteInfo } from "../types";
-import type { Neo4jGraphQLContext } from "@neo4j/graphql/src";
+import type { Neo4jGraphQLContext } from "@neo4j/graphql";
 
 type Neo4jGraphQLOGMContext = Omit<Neo4jGraphQLContext, "jwt" | "token">;
 


### PR DESCRIPTION
# Description

A import of `@neo4j/graphql/src` has snuck into the OGM, preventing it's use.

To be merged urgently for immediate release.

## Complexity

Complexity: Low
