### PR TITLE
Feature: pass through transaction metadata

### DIFF
--- a/.changeset/yellow-humans-notice.md
+++ b/.changeset/yellow-humans-notice.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Add the ability to pass through arbitrary database transaction metadata into the request context

--- a/packages/graphql/src/classes/Executor.ts
+++ b/packages/graphql/src/classes/Executor.ts
@@ -83,6 +83,7 @@ export type ExecutorConstructorParam = {
     cypherQueryOptions?: CypherQueryOptions;
     sessionConfig?: SessionConfig;
     cypherParams?: Record<string, unknown>;
+    transactionMetadata?: Record<string, unknown>;
 };
 
 export type Neo4jGraphQLSessionConfig = Pick<SessionConfig, "database" | "impersonatedUser" | "auth">;
@@ -100,14 +101,22 @@ export class Executor {
     private sessionConfig: SessionConfig | undefined;
 
     private cypherParams: Record<string, unknown>;
+    private transactionMetadata: Record<string, unknown>;
 
-    constructor({ executionContext, cypherQueryOptions, sessionConfig, cypherParams = {} }: ExecutorConstructorParam) {
+    constructor({
+        executionContext,
+        cypherQueryOptions,
+        sessionConfig,
+        cypherParams = {},
+        transactionMetadata = {},
+    }: ExecutorConstructorParam) {
         this.executionContext = executionContext;
         this.cypherQueryOptions = cypherQueryOptions;
         this.lastBookmark = null;
         this.cypherQueryOptions = cypherQueryOptions;
         this.sessionConfig = sessionConfig;
         this.cypherParams = cypherParams;
+        this.transactionMetadata = transactionMetadata;
     }
 
     public async execute(
@@ -187,6 +196,7 @@ export class Executor {
 
         const transactionConfig: TransactionConfig = {
             metadata: {
+                ...this.transactionMetadata,
                 app,
                 type: "user-transpiled",
             },

--- a/packages/graphql/src/schema/resolvers/composition/wrap-query-and-mutation.ts
+++ b/packages/graphql/src/schema/resolvers/composition/wrap-query-and-mutation.ts
@@ -111,6 +111,7 @@ export const wrapQueryAndMutation =
             cypherQueryOptions: context.cypherQueryOptions,
             sessionConfig: context.sessionConfig,
             cypherParams: context.cypherParams,
+            transactionMetadata: context.transactionMetadata,
         });
 
         if (dbInfo) {

--- a/packages/graphql/src/types/neo4j-graphql-context.ts
+++ b/packages/graphql/src/types/neo4j-graphql-context.ts
@@ -34,7 +34,7 @@ export interface Neo4jGraphQLContext extends Neo4jGraphQLContextInterface {
      * ```
      * This can be referred to like `@cypher(statement: "RETURN $title AS title", columnName: "title")`.
      */
-    cypherParams?: Record<string, any>;
+    cypherParams?: Record<string, unknown>;
     /**
      * Configures which {@link https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/ | Cypher query options} to use when executing the translated query.
      */
@@ -47,4 +47,10 @@ export interface Neo4jGraphQLContext extends Neo4jGraphQLContextInterface {
      * Configuration that will be used during session construction if a driver was passed into the library on construction or if {@link executionContext} is an instance of a driver.
      */
     sessionConfig?: Neo4jGraphQLSessionConfig;
+    /**
+     * Attach metadata to the database transaction.
+     * This can be used to output information to the query log not related to the query itself.
+     * Will be ignored if {@link executionContext} is an instance of a transaction.
+     */
+    transactionMetadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
# Description

The context field `transactionMetadata` can be used to pass through arbitrary information into the database transaction metadata.

## Complexity

Complexity: Low
