### PR TITLE
Add generic types to parseArguments

### DIFF
--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -346,7 +346,7 @@ function generateConcreteEntity(
 function getLabels(entityDefinition: ObjectTypeDefinitionNode): string[] {
     const nodeDirectiveUsage = findDirective(entityDefinition.directives, nodeDirective.name);
     if (nodeDirectiveUsage) {
-        const nodeArguments = parseArguments(nodeDirective, nodeDirectiveUsage) as { labels?: string[] };
+        const nodeArguments = parseArguments<{ labels?: string[] }>(nodeDirective, nodeDirectiveUsage);
         if (nodeArguments.labels?.length) {
             return nodeArguments.labels;
         }

--- a/packages/graphql/src/schema-model/parser/annotations-parser/custom-resolver-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/custom-resolver-annotation.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { customResolverDirective } from "../../../graphql/directives";
 import { CustomResolverAnnotation } from "../../annotation/CustomResolverAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { customResolverDirective } from "../../../graphql/directives";
 
 export function parseCustomResolverAnnotation(directive: DirectiveNode): CustomResolverAnnotation {
-    const { requires } = parseArguments(customResolverDirective, directive) as { requires: string };
+    const { requires } = parseArguments<{ requires: string }>(customResolverDirective, directive);
 
     return new CustomResolverAnnotation({
         requires,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/filterable-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/filterable-annotation.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { filterableDirective } from "../../../graphql/directives";
 import { FilterableAnnotation } from "../../annotation/FilterableAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { filterableDirective } from "../../../graphql/directives";
 
 export function parseFilterableAnnotation(directive: DirectiveNode): FilterableAnnotation {
-    const { byValue, byAggregate } = parseArguments(filterableDirective, directive) as {
+    const { byValue, byAggregate } = parseArguments<{
         byValue: boolean;
         byAggregate: boolean;
-    };
+    }>(filterableDirective, directive);
 
     return new FilterableAnnotation({
         byAggregate,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/full-text-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/full-text-annotation.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { fulltextDirective } from "../../../graphql/directives";
 import type { FullTextField } from "../../annotation/FullTextAnnotation";
 import { FullTextAnnotation } from "../../annotation/FullTextAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { fulltextDirective } from "../../../graphql/directives";
 
 export function parseFullTextAnnotation(directive: DirectiveNode): FullTextAnnotation {
-    const { indexes } = parseArguments(fulltextDirective, directive) as { indexes: FullTextField[] };
+    const { indexes } = parseArguments<{ indexes: FullTextField[] }>(fulltextDirective, directive);
 
     return new FullTextAnnotation({
         indexes,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/jwt-claim-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/jwt-claim-annotation.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { jwtClaim } from "../../../graphql/directives";
 import { JWTClaimAnnotation } from "../../annotation/JWTClaimAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { jwtClaim } from "../../../graphql/directives";
 
 export function parseJWTClaimAnnotation(directive: DirectiveNode): JWTClaimAnnotation {
-    const { path } = parseArguments(jwtClaim, directive) as { path: string };
+    const { path } = parseArguments<{ path: string }>(jwtClaim, directive);
 
     return new JWTClaimAnnotation({
         path,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/limit-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/limit-annotation.ts
@@ -19,16 +19,16 @@
 
 import type { DirectiveNode } from "graphql";
 import { Neo4jGraphQLSchemaValidationError } from "../../../classes";
+import { limitDirective } from "../../../graphql/directives";
 import { LimitAnnotation } from "../../annotation/LimitAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { limitDirective } from "../../../graphql/directives";
 
 export function parseLimitAnnotation(directive: DirectiveNode): LimitAnnotation {
-    const { default: _default, max } = parseArguments(limitDirective, directive) as {
+    const { default: _default, max } = parseArguments<{
         default?: number;
         max?: number;
         resolvable: boolean;
-    };
+    }>(limitDirective, directive);
     if (_default && typeof _default !== "number") {
         throw new Neo4jGraphQLSchemaValidationError(`@limit default must be a number`);
     }

--- a/packages/graphql/src/schema-model/parser/annotations-parser/plural-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/plural-annotation.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { pluralDirective } from "../../../graphql/directives";
 import { PluralAnnotation } from "../../annotation/PluralAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { pluralDirective } from "../../../graphql/directives";
 
 export function parsePluralAnnotation(directive: DirectiveNode): PluralAnnotation {
-    const { value } = parseArguments(pluralDirective, directive) as { value: string };
+    const { value } = parseArguments<{ value: string }>(pluralDirective, directive);
     return new PluralAnnotation({
         value,
     });

--- a/packages/graphql/src/schema-model/parser/annotations-parser/populated-by-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/populated-by-annotation.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { populatedByDirective } from "../../../graphql/directives";
 import { PopulatedByAnnotation } from "../../annotation/PopulatedByAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { populatedByDirective } from "../../../graphql/directives";
 
 export function parsePopulatedByAnnotation(directive: DirectiveNode): PopulatedByAnnotation {
-    const { callback, operations } = parseArguments(populatedByDirective, directive) as {
+    const { callback, operations } = parseArguments<{
         callback: string;
         operations: string[];
-    };
+    }>(populatedByDirective, directive);
 
     return new PopulatedByAnnotation({
         callback,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/query-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/query-annotation.ts
@@ -18,12 +18,12 @@
  */
 
 import type { DirectiveNode } from "graphql";
+import { queryDirective } from "../../../graphql/directives";
 import { QueryAnnotation } from "../../annotation/QueryAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { queryDirective } from "../../../graphql/directives";
 
 export function parseQueryAnnotation(directive: DirectiveNode): QueryAnnotation {
-    const { read, aggregate } = parseArguments(queryDirective, directive) as { read: boolean; aggregate: boolean };
+    const { read, aggregate } = parseArguments<{ read: boolean; aggregate: boolean }>(queryDirective, directive);
 
     return new QueryAnnotation({
         read,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/selectable-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/selectable-annotation.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { selectableDirective } from "../../../graphql/directives";
 import { SelectableAnnotation } from "../../annotation/SelectableAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { selectableDirective } from "../../../graphql/directives";
 
 export function parseSelectableAnnotation(directive: DirectiveNode): SelectableAnnotation {
-    const { onRead, onAggregate } = parseArguments(selectableDirective, directive) as {
+    const { onRead, onAggregate } = parseArguments<{
         onRead: boolean;
         onAggregate: boolean;
-    };
+    }>(selectableDirective, directive);
 
     return new SelectableAnnotation({
         onRead,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/settable-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/settable-annotation.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { settableDirective } from "../../../graphql/directives";
 import { SettableAnnotation } from "../../annotation/SettableAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { settableDirective } from "../../../graphql/directives";
 
 export function parseSettableAnnotation(directive: DirectiveNode): SettableAnnotation {
-    const { onCreate, onUpdate } = parseArguments(settableDirective, directive) as {
+    const { onCreate, onUpdate } = parseArguments<{
         onCreate: boolean;
         onUpdate: boolean;
-    };
+    }>(settableDirective, directive);
 
     return new SettableAnnotation({
         onCreate,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/subscription-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/subscription-annotation.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { subscriptionDirective } from "../../../graphql/directives";
 import { SubscriptionAnnotation } from "../../annotation/SubscriptionAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { subscriptionDirective } from "../../../graphql/directives";
 
 export function parseSubscriptionAnnotation(directive: DirectiveNode): SubscriptionAnnotation {
-    const { events } = parseArguments(subscriptionDirective, directive) as { events: string[] };
+    const { events } = parseArguments<{ events: string[] }>(subscriptionDirective, directive);
 
     return new SubscriptionAnnotation({
         events,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/timestamp-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/timestamp-annotation.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { timestampDirective } from "../../../graphql/directives";
 import { TimestampAnnotation } from "../../annotation/TimestampAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { timestampDirective } from "../../../graphql/directives";
 
 export function parseTimestampAnnotation(directive: DirectiveNode): TimestampAnnotation {
-    const { operations } = parseArguments(timestampDirective, directive) as { operations: string[] };
+    const { operations } = parseArguments<{ operations: string[] }>(timestampDirective, directive);
 
     return new TimestampAnnotation({
         operations,

--- a/packages/graphql/src/schema-model/parser/annotations-parser/unique-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/unique-annotation.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 import type { DirectiveNode } from "graphql";
+import { uniqueDirective } from "../../../graphql/directives";
 import { UniqueAnnotation } from "../../annotation/UniqueAnnotation";
 import { parseArguments } from "../parse-arguments";
-import { uniqueDirective } from "../../../graphql/directives";
 
 export function parseUniqueAnnotation(directive: DirectiveNode): UniqueAnnotation {
-    const { constraintName } = parseArguments(uniqueDirective, directive) as { constraintName: string };
+    const { constraintName } = parseArguments<{ constraintName: string }>(uniqueDirective, directive);
 
     return new UniqueAnnotation({
         constraintName,

--- a/packages/graphql/src/schema-model/parser/parse-arguments.ts
+++ b/packages/graphql/src/schema-model/parser/parse-arguments.ts
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) "Neo4j"
  * Neo4j Sweden AB [http://neo4j.com]
@@ -20,10 +19,10 @@
 
 import { inspect } from "@graphql-tools/utils";
 import type { Maybe } from "@graphql-tools/utils/typings/types";
-import { isNonNullType, Kind, valueFromAST, print } from "graphql";
+import type { DirectiveNode, FieldNode, GraphQLDirective, GraphQLField } from "graphql";
+import { Kind, isNonNullType, print, valueFromAST } from "graphql";
 import type { ObjMap } from "graphql/jsutils/ObjMap";
 import { parseValueNode } from "./parse-value-node";
-import type { DirectiveNode, FieldNode, GraphQLDirective, GraphQLField } from "graphql";
 
 export function parseArgumentsFromUnknownDirective(directive: DirectiveNode): Record<string, unknown> {
     return (directive.arguments || [])?.reduce((acc, argument) => {
@@ -42,11 +41,11 @@ export function parseArgumentsFromUnknownDirective(directive: DirectiveNode): Re
  * exposed to user code. Care should be taken to not pull values from the
  * Object prototype.
  */
-export function parseArguments(
+export function parseArguments<T extends Record<string, unknown>>(
     def: GraphQLField<unknown, unknown> | GraphQLDirective,
     node: FieldNode | DirectiveNode,
     variableValues?: Maybe<ObjMap<unknown>>
-): { [argument: string]: unknown } {
+): T {
     const coercedValues: { [argument: string]: unknown } = {};
     const argumentNodes = node.arguments ?? [];
     const argNodeMap = new Map(argumentNodes.map((arg) => [arg.name.value, arg]));
@@ -94,5 +93,5 @@ export function parseArguments(
         }
         coercedValues[name] = coercedValue;
     }
-    return coercedValues;
+    return coercedValues as T;
 }

--- a/packages/graphql/src/schema-model/parser/parse-attribute.ts
+++ b/packages/graphql/src/schema-model/parser/parse-attribute.ts
@@ -67,7 +67,7 @@ function getDatabaseName(
 ): string | undefined {
     const aliasUsage = findDirective(fieldDefinitionNode.directives, aliasDirective.name);
     if (aliasUsage) {
-        const { property } = parseArguments(aliasDirective, aliasUsage) as { property: string };
+        const { property } = parseArguments<{ property: string }>(aliasDirective, aliasUsage);
         return property;
     }
     const inheritedAliasUsage = inheritedFields?.reduce<DirectiveNode | undefined>((aliasUsage, field) => {
@@ -79,7 +79,7 @@ function getDatabaseName(
         return aliasUsage;
     }, undefined);
     if (inheritedAliasUsage) {
-        const { property } = parseArguments(aliasDirective, inheritedAliasUsage) as { property: string };
+        const { property } = parseArguments<{ property: string }>(aliasDirective, inheritedAliasUsage);
         return property;
     }
 }

--- a/packages/graphql/src/schema/parse-mutation-directive.ts
+++ b/packages/graphql/src/schema/parse-mutation-directive.ts
@@ -19,7 +19,7 @@
 
 import type { DirectiveNode } from "graphql";
 import { MutationDirective } from "../classes/MutationDirective";
-import type { MutationOperations} from "../graphql/directives/mutation";
+import type { MutationOperations } from "../graphql/directives/mutation";
 import { mutationDirective as mutationDirectiveDefinition } from "../graphql/directives/mutation";
 import { parseArguments } from "../schema-model/parser/parse-arguments";
 
@@ -27,9 +27,9 @@ function parseMutationDirective(directiveNode: DirectiveNode | undefined) {
     if (!directiveNode || directiveNode.name.value !== mutationDirectiveDefinition.name) {
         throw new Error("Undefined or incorrect directive passed into parseMutationDirective function");
     }
-    const arg = parseArguments(mutationDirectiveDefinition, directiveNode) as {
+    const arg = parseArguments<{
         operations: MutationOperations[];
-    };
+    }>(mutationDirectiveDefinition, directiveNode);
 
     return new MutationDirective(arg.operations);
 }

--- a/packages/graphql/src/schema/parse-query-directive.ts
+++ b/packages/graphql/src/schema/parse-query-directive.ts
@@ -18,17 +18,18 @@
  */
 
 import type { DirectiveNode } from "graphql";
-import { parseArguments } from "../schema-model/parser/parse-arguments";
 import { QueryDirective } from "../classes/QueryDirective";
 import { queryDirective as queryDirectiveDefinition } from "../graphql/directives/query";
+import { parseArguments } from "../schema-model/parser/parse-arguments";
 
 function parseQueryDirective(directiveNode: DirectiveNode | undefined) {
     if (!directiveNode || directiveNode.name.value !== queryDirectiveDefinition.name) {
         throw new Error("Undefined or incorrect directive passed into parseQueryDirective function");
     }
-    const arg = parseArguments(queryDirectiveDefinition, directiveNode) as ConstructorParameters<
-        typeof QueryDirective
-    >[0];
+    const arg = parseArguments<ConstructorParameters<typeof QueryDirective>[0]>(
+        queryDirectiveDefinition,
+        directiveNode
+    );
 
     return new QueryDirective(arg);
 }

--- a/packages/graphql/src/schema/parse-subscription-directive.ts
+++ b/packages/graphql/src/schema/parse-subscription-directive.ts
@@ -18,17 +18,18 @@
  */
 
 import type { DirectiveNode } from "graphql";
-import { parseArguments } from "../schema-model/parser/parse-arguments";
 import { SubscriptionDirective } from "../classes/SubscriptionDirective";
 import { subscriptionDirective as subscriptionDirectiveDefinition } from "../graphql/directives/subscription";
+import { parseArguments } from "../schema-model/parser/parse-arguments";
 
 function parseSubscriptionDirective(directiveNode: DirectiveNode | undefined) {
     if (!directiveNode || directiveNode.name.value !== subscriptionDirectiveDefinition.name) {
         throw new Error("Undefined or incorrect directive passed into parseSubscriptionDirective function");
     }
-    const arg = parseArguments(subscriptionDirectiveDefinition, directiveNode) as {
+
+    const arg = parseArguments<{
         events: ConstructorParameters<typeof SubscriptionDirective>[0];
-    };
+    }>(subscriptionDirectiveDefinition, directiveNode);
 
     return new SubscriptionDirective(arg.events);
 }


### PR DESCRIPTION
# Description

Adds a generic type parameter to the parseArguments function and uses it in place of many cases of type assertions.

## Complexity

Low