### PR TITLE
Non scalar cypher fields

### DIFF
--- a/packages/graphql/src/schema-model/relationship/model-adapters/RelationshipAdapter.test.ts
+++ b/packages/graphql/src/schema-model/relationship/model-adapters/RelationshipAdapter.test.ts
@@ -83,6 +83,7 @@ describe("RelationshipAdapter", () => {
             queryDirection: "DEFAULT_DIRECTED",
             nestedOperations: ["CREATE", "UPDATE", "DELETE", "CONNECT", "DISCONNECT", "CONNECT_OR_CREATE"],
             aggregate: false,
+            isNullable: false,
         });
         userEntity.addRelationship(relationship);
 

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
@@ -66,5 +66,4 @@ export class CypherAttributeField extends AttributeField {
 
         return [subquery];
     }
-    
 }

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
@@ -55,7 +55,7 @@ export class CypherAttributeField extends AttributeField {
         if (scope.has(this.attribute.name)) {
             throw new Error("Compile error, should execute attribute field before CypherPropertySort");
         }
-    
+
         scope.set(this.attribute.name, this.customCypherVar);
         const subquery = createCypherAnnotationSubquery({
             context,
@@ -66,5 +66,5 @@ export class CypherAttributeField extends AttributeField {
 
         return [subquery];
     }
+    
 }
-

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
@@ -33,7 +33,7 @@ export class CypherAttributeField extends AttributeField {
     }: {
         alias: string;
         attribute: AttributeAdapter;
-        projection: Record<string, string> | undefined;
+        projection?: Record<string, string>;
     }) {
         super({ alias, attribute });
         this.projection = projection;

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
@@ -20,23 +20,28 @@
 import Cypher from "@neo4j/cypher-builder";
 import { AttributeField } from "./AttributeField";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import type { Field } from "../Field";
 
 // Should Cypher be an operation?
 export class CypherAttributeField extends AttributeField {
     private customCypherVar = new Cypher.Node(); // Using node only to keep consistency with tck
     private projection: Record<string, string> | undefined;
+    private nestedFields: Field[] | undefined;
 
     constructor({
         alias,
         attribute,
         projection,
+        nestedFields,
     }: {
         alias: string;
         attribute: AttributeAdapter;
         projection?: Record<string, string>;
+        nestedFields?: Field[];
     }) {
         super({ alias, attribute });
         this.projection = projection;
+        this.nestedFields = nestedFields;
     }
 
     public getProjectionField(_variable: Cypher.Variable): string | Record<string, Cypher.Expr> {
@@ -54,7 +59,7 @@ export class CypherAttributeField extends AttributeField {
         const returnVar = new Cypher.NamedNode(columnName);
 
         let projection: Cypher.Expr = this.customCypherVar;
-        if (this.projection) {
+        if (this.projection && !this.nestedFields) {
             projection = new Cypher.MapProjection(this.customCypherVar);
             for (const [alias, name] of Object.entries(this.projection)) {
                 if (alias === name) projection.set(alias);
@@ -63,6 +68,13 @@ export class CypherAttributeField extends AttributeField {
                         [alias]: this.customCypherVar.property(name),
                     });
                 }
+            }
+        }
+        if (this.nestedFields && (this.attribute.isObject() || this.attribute.isAbstract())) {
+            projection = new Cypher.MapProjection(this.customCypherVar);
+            const subqueriesProjection = this.nestedFields?.map((f) => f.getProjectionField(this.customCypherVar));
+            for (const subqueryProjection of subqueriesProjection) {
+                projection.set(subqueryProjection);
             }
         }
 
@@ -78,7 +90,18 @@ export class CypherAttributeField extends AttributeField {
         } else {
             callClause.with([returnVar, this.customCypherVar]);
         }
+        const nestedFieldClause = this.getFieldsSubquery();
+        return [
+            Cypher.concat(callClause, nestedFieldClause, new Cypher.Return([returnProjection, this.customCypherVar])),
+        ];
+    }
 
-        return [Cypher.concat(callClause, new Cypher.Return([returnProjection, this.customCypherVar]))];
+    private getFieldsSubquery(): Cypher.Clause | undefined {
+        if (this.nestedFields) {
+            const nodeProjectionSubqueries = this.nestedFields
+            ?.flatMap((f) => f.getSubqueries(this.customCypherVar))
+            .map((sq) => new Cypher.Call(sq).innerWith(this.customCypherVar));
+            return Cypher.concat(...nodeProjectionSubqueries);
+        }
     }
 }

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
@@ -61,19 +61,10 @@ export class CypherAttributeField extends AttributeField {
             context,
             attribute: this.attribute,
             projectionFields: this.projection,
+            nestedFields: this.nestedFields,
         });
 
         return [subquery];
     }
 }
 
-
-/* 
-   if (this.nestedFields && (this.attribute.isObject() || this.attribute.isAbstract())) {
-            projection = new Cypher.MapProjection(this.customCypherVar);
-            const subqueriesProjection = this.nestedFields?.map((f) => f.getProjectionField(this.customCypherVar));
-            for (const subqueryProjection of subqueriesProjection) {
-                projection.set(subqueryProjection);
-            }
-        }
-*/

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -185,22 +185,21 @@ export class FieldFactory {
         let nestedFields: Field[] | undefined;
 
         if (rawFields) {
+            cypherProjection = Object.values(rawFields).reduce((acc, f) => {
+                acc[f.alias] = f.name;
+                return acc;
+            }, {});
             // if the attribute is an object or an abstract type we may have nested fields
             if (attribute.isAbstract() || attribute.isObject()) {
                 // TODO: this code block could be handled directly in the schema model or in some schema model helper
                 const targetEntity = this.queryASTFactory.schemaModel.getEntity(typeName);
                 // Raise an error as we expect that any complex attributes type are always entities
-                if (!targetEntity) throw new Error(`Entity ${typeName} not found`); 
+                if (!targetEntity) throw new Error(`Entity ${typeName} not found`);
                 if (this.queryASTFactory.schemaModel.isConcreteEntity(targetEntity)) {
                     const concreteEntityAdapter = new ConcreteEntityAdapter(targetEntity);
                     nestedFields = this.createFields(concreteEntityAdapter, rawFields, context);
                 }
                 // TODO: implement composite entities
-            } else {
-                cypherProjection = Object.values(rawFields).reduce((acc, f) => {
-                    acc[f.alias] = f.name;
-                    return acc;
-                }, {});
             }
         }
 

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -34,8 +34,6 @@ import type { AttributeAdapter } from "../../../schema-model/attribute/model-ada
 import { RelationshipAdapter } from "../../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
-import { Entity } from "../../../schema-model/entity/Entity";
-import type { ConcreteEntity } from "../../../schema-model/entity/ConcreteEntity";
 
 export class FieldFactory {
     private queryASTFactory: QueryASTFactory;

--- a/packages/graphql/src/translate/queryAST/utils/create-cypher-subquery.ts
+++ b/packages/graphql/src/translate/queryAST/utils/create-cypher-subquery.ts
@@ -76,7 +76,6 @@ function getNestedFieldsSubqueries(
     return Cypher.concat(...nodeProjectionSubqueries);
 }
 
-
 function getStatementSubquery(context: QueryASTContext, cypherAnnotation: CypherAnnotation): Cypher.Call {
     const innerAlias = new Cypher.With([context.target, "this"]);
     const statementSubquery = new Cypher.RawCypher(cypherAnnotation.statement);

--- a/packages/graphql/tests/tck/issues/630.test.ts
+++ b/packages/graphql/tests/tck/issues/630.test.ts
@@ -60,9 +60,6 @@ describe("Cypher directive", () => {
                         actorsConnection {
                             totalCount
                         }
-                        actors {
-                            name
-                        }
                     }
                 }
             }

--- a/packages/graphql/tests/tck/issues/630.test.ts
+++ b/packages/graphql/tests/tck/issues/630.test.ts
@@ -60,6 +60,9 @@ describe("Cypher directive", () => {
                         actorsConnection {
                             totalCount
                         }
+                        actors {
+                            name
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Support Cypher Fields that returns Entity.
Fix tests:
 - 'https://github.com/neo4j/graphql/issues/2581 query nested custom cypher with columnName',
 - 'https://github.com/neo4j/graphql/issues/2581 query nested custom cypher without columnName'

Tests like "Cypher directive › Nested directive" `packages/graphql/tests/tck/directives/cypher.test.ts:278:45` will be fixed when Arguments will be supported