### PR TITLE
Support argument on cypher fields

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherAttributeField.ts
@@ -29,21 +29,25 @@ export class CypherAttributeField extends AttributeField {
     private customCypherVar = new Cypher.Node(); // TODO: should be from context scope
     private projection: Record<string, string> | undefined;
     private nestedFields: Field[] | undefined;
+    private rawArguments: Record<string, any>;
 
     constructor({
         alias,
         attribute,
         projection,
         nestedFields,
+        rawArguments = {},
     }: {
         alias: string;
         attribute: AttributeAdapter;
         projection?: Record<string, string>;
         nestedFields?: Field[];
+        rawArguments: Record<string, any>;
     }) {
         super({ alias, attribute });
         this.projection = projection;
         this.nestedFields = nestedFields;
+        this.rawArguments = rawArguments;
     }
 
     public getProjectionField(_variable: Cypher.Variable): string | Record<string, Cypher.Expr> {
@@ -62,6 +66,7 @@ export class CypherAttributeField extends AttributeField {
             attribute: this.attribute,
             projectionFields: this.projection,
             nestedFields: this.nestedFields,
+            rawArguments: this.rawArguments,
         });
 
         return [subquery];

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -206,6 +206,7 @@ export class FieldFactory {
             alias: field.alias,
             projection: cypherProjection,
             nestedFields,
+            rawArguments: field.args,
         });
     }
 


### PR DESCRIPTION
Support arguments used in `@cypher` fields.
Fix the following tests:
-  'Cypher directive Nested Connection',
- 'Cypher directive Nested directive',
-  'Cypher directive Nested directive with params',
- 'Cypher directive Super Nested directive',
- 'Cypher directive Top level cypher should query field custom query and return relationship data with given columnName',
- 'https://github.com/neo4j/graphql/issues/2100 query nested relations under a root connection field'


