### PR TITLE
Interfaces translation layer

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/QueryAST.ts
+++ b/packages/graphql/src/translate/queryAST/ast/QueryAST.ts
@@ -40,7 +40,7 @@ export class QueryAST {
             neo4jGraphQLContext,
         });
         const result = this.operation.transpile({ context, returnVariable: new Cypher.NamedVariable("this") });
-        return result.clauses[0] as Cypher.Clause;
+        return Cypher.concat(...result.clauses);
     }
 
     public print(): string {

--- a/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
@@ -21,7 +21,7 @@ import { filterTruthy } from "../../../../utils/utils";
 import { createNodeFromEntity, createRelationshipFromEntity } from "../../utils/create-node-from-entity";
 import type { Field } from "../fields/Field";
 import type { Filter } from "../filters/Filter";
-import Cypher, { relationships } from "@neo4j/cypher-builder";
+import Cypher from "@neo4j/cypher-builder";
 import type { OperationTranspileOptions, OperationTranspileResult } from "./operations";
 import { Operation } from "./operations";
 import type { Pagination } from "../pagination/Pagination";
@@ -33,7 +33,6 @@ import type { QueryASTNode } from "../QueryASTNode";
 import type { Sort } from "../sort/Sort";
 
 export class ReadOperation extends Operation {
-    // public readonly entity: ConcreteEntityAdapter | RelationshipAdapter; // TODO: normal entities
     public readonly target: ConcreteEntityAdapter;
     public readonly relationship: RelationshipAdapter | undefined;
 

--- a/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
@@ -21,19 +21,22 @@ import { filterTruthy } from "../../../../utils/utils";
 import { createNodeFromEntity, createRelationshipFromEntity } from "../../utils/create-node-from-entity";
 import type { Field } from "../fields/Field";
 import type { Filter } from "../filters/Filter";
-import Cypher from "@neo4j/cypher-builder";
+import Cypher, { relationships } from "@neo4j/cypher-builder";
 import type { OperationTranspileOptions, OperationTranspileResult } from "./operations";
 import { Operation } from "./operations";
 import type { Pagination } from "../pagination/Pagination";
 import { QueryASTContext } from "../QueryASTContext";
 import type { ConcreteEntityAdapter } from "../../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
-import { RelationshipAdapter } from "../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
+import type { RelationshipAdapter } from "../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import type { AuthorizationFilters } from "../filters/authorization-filters/AuthorizationFilters";
 import type { QueryASTNode } from "../QueryASTNode";
 import type { Sort } from "../sort/Sort";
 
 export class ReadOperation extends Operation {
-    public readonly entity: ConcreteEntityAdapter | RelationshipAdapter; // TODO: normal entities
+    // public readonly entity: ConcreteEntityAdapter | RelationshipAdapter; // TODO: normal entities
+    public readonly target: ConcreteEntityAdapter;
+    public readonly relationship: RelationshipAdapter | undefined;
+
     protected directed: boolean;
 
     public fields: Field[] = [];
@@ -45,10 +48,19 @@ export class ReadOperation extends Operation {
 
     public nodeAlias: string | undefined; // This is just to maintain naming with the old way (this), remove after refactor
 
-    constructor(entity: ConcreteEntityAdapter | RelationshipAdapter, directed = true) {
+    constructor({
+        target,
+        relationship,
+        directed,
+    }: {
+        target: ConcreteEntityAdapter;
+        relationship?: RelationshipAdapter;
+        directed?: boolean;
+    }) {
         super();
-        this.entity = entity;
-        this.directed = directed;
+        this.target = target;
+        this.directed = directed ?? true;
+        this.relationship = relationship;
     }
 
     public setFields(fields: Field[]) {
@@ -120,7 +132,7 @@ export class ReadOperation extends Operation {
         };
     }
 
-    private getProjectionClause(
+    protected getProjectionClause(
         context: QueryASTContext,
         returnVariable: Cypher.Variable,
         isArray: boolean
@@ -140,15 +152,15 @@ export class ReadOperation extends Operation {
         return withClause.return([aggregationExpr, returnVariable]);
     }
 
-    private getPredicates(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
+    protected getPredicates(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
         return Cypher.and(...[...this.filters].map((f) => f.getPredicate(queryASTContext)));
     }
 
     public transpile({ returnVariable, parentNode }: OperationTranspileOptions): OperationTranspileResult {
-        if (this.entity instanceof RelationshipAdapter) {
-            return this.transpileNestedRelationship(this.entity, { returnVariable, parentNode });
+        if (this.relationship) {
+            return this.transpileNestedRelationship(this.relationship, { returnVariable, parentNode });
         }
-        const node = createNodeFromEntity(this.entity, this.nodeAlias);
+        const node = createNodeFromEntity(this.target, this.nodeAlias);
         const context = new QueryASTContext({ target: node });
         const filterSubqueries = this.filters
             .flatMap((f) => f.getSubqueries(context))
@@ -227,7 +239,7 @@ export class ReadOperation extends Operation {
         });
     }
 
-    private getProjectionMap(context: QueryASTContext): Cypher.MapProjection {
+    protected getProjectionMap(context: QueryASTContext): Cypher.MapProjection {
         const projectionFields = this.fields.map((f) => f.getProjectionField(context.target));
         const sortProjectionFields = this.sortFields.map((f) => f.getProjectionField(context));
 
@@ -246,7 +258,7 @@ export class ReadOperation extends Operation {
         return new Cypher.MapProjection(context.target, stringFields, otherFields);
     }
 
-    private addSortToClause(context: QueryASTContext, node: Cypher.Node, clause: Cypher.With | Cypher.Return): void {
+    protected addSortToClause(context: QueryASTContext, node: Cypher.Node, clause: Cypher.With | Cypher.Return): void {
         const isNested = Boolean(context.source); // This is to keep Cypher compatibility
         const orderByFields = this.sortFields.flatMap((f) => f.getSortFields(context, node, !isNested));
         const pagination = this.pagination ? this.pagination.getPagination() : undefined;

--- a/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadOperation.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "@neo4j/cypher-builder";
+import type { QueryASTNode } from "../../QueryASTNode";
+import type { OperationTranspileOptions, OperationTranspileResult } from "../operations";
+import { Operation } from "../operations";
+import type { InterfaceReadPartial } from "./InterfaceReadPartial";
+
+export class InterfaceReadOperation extends Operation {
+    private children: InterfaceReadPartial[];
+    // protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
+
+    constructor(children: InterfaceReadPartial[]) {
+        super();
+
+        this.children = children;
+    }
+
+    public getChildren(): QueryASTNode[] {
+        return this.children;
+    }
+
+    public transpile(options: OperationTranspileOptions): OperationTranspileResult {
+        const nestedSubqueries = this.children.flatMap((c) => {
+            const result = c.transpile({
+                parentNode: options.parentNode,
+                returnVariable: options.returnVariable,
+            });
+            // const callSubqueries = result.clauses.map((sq) => new Cypher.Call(sq));
+            const parentNode = options.parentNode;
+
+            let clauses = result.clauses;
+            if (parentNode) {
+                clauses = clauses.map((sq) => Cypher.concat(new Cypher.With("*"), sq));
+            }
+            return clauses;
+        });
+
+        const nestedSubquery = new Cypher.Call(new Cypher.Union(...nestedSubqueries))
+            .with(options.returnVariable)
+            .return([Cypher.collect(options.returnVariable), options.returnVariable]);
+
+        return {
+            projectionExpr: options.returnVariable,
+            clauses: [nestedSubquery],
+        };
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
@@ -19,7 +19,7 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import { createNodeFromEntity, createRelationshipFromEntity } from "../../../utils/create-node-from-entity";
-import { QueryASTContext } from "../../QueryASTContext";
+import type { QueryASTContext } from "../../QueryASTContext";
 import { ReadOperation } from "../ReadOperation";
 import type { OperationTranspileOptions, OperationTranspileResult } from "../operations";
 import type { RelationshipAdapter } from "../../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
@@ -51,7 +51,6 @@ export class InterfaceReadPartial extends ReadOperation {
         const matchClause = new Cypher.Match(pattern);
 
         const nestedContext = context.push({ target: targetNode, relationship: relVar });
-        // const nestedContext = new QueryASTContext({ target: targetNode, relationship: relVar, source: parentNode });
         const filterPredicates = this.getPredicates(nestedContext);
         const authFilterSubqueries = this.authFilters ? this.authFilters.getSubqueries(nestedContext) : [];
         const authFiltersPredicate = this.authFilters ? this.authFilters.getPredicate(nestedContext) : undefined;

--- a/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Cypher from "@neo4j/cypher-builder";
+import { createNodeFromEntity, createRelationshipFromEntity } from "../../../utils/create-node-from-entity";
+import { QueryASTContext } from "../../QueryASTContext";
+import { ReadOperation } from "../ReadOperation";
+import type { OperationTranspileOptions, OperationTranspileResult } from "../operations";
+import type { RelationshipAdapter } from "../../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
+
+export class InterfaceReadPartial extends ReadOperation {
+    public transpile({ returnVariable, parentNode }: OperationTranspileOptions): OperationTranspileResult {
+        if (this.relationship) {
+            return this.transpileNestedInterfaceRelationship(this.relationship, { returnVariable, parentNode });
+        } else {
+            throw new Error("Top level interfaces are not supported");
+        }
+    }
+
+    private transpileNestedInterfaceRelationship(
+        entity: RelationshipAdapter,
+        { returnVariable, parentNode }: OperationTranspileOptions
+    ): OperationTranspileResult {
+        //TODO: dupe from transpile
+        if (!parentNode) throw new Error("No parent node found!");
+        const relVar = createRelationshipFromEntity(entity);
+        const targetNode = createNodeFromEntity(this.target);
+        const relDirection = entity.getCypherDirection(this.directed);
+
+        const pattern = new Cypher.Pattern(parentNode)
+            .withoutLabels()
+            .related(relVar)
+            .withDirection(relDirection)
+            .to(targetNode);
+
+        const matchClause = new Cypher.Match(pattern);
+        const nestedContext = new QueryASTContext({ target: targetNode, relationship: relVar, source: parentNode });
+        const filterPredicates = this.getPredicates(nestedContext);
+        const authFilterSubqueries = this.authFilters ? this.authFilters.getSubqueries(nestedContext) : [];
+        const authFiltersPredicate = this.authFilters ? this.authFilters.getPredicate(nestedContext) : undefined;
+
+        const wherePredicate = Cypher.and(filterPredicates, authFiltersPredicate);
+        let withWhere: Cypher.Clause | undefined;
+        if (wherePredicate) {
+            withWhere = new Cypher.With("*").where(wherePredicate);
+        }
+        const subqueries = Cypher.concat(...this.getFieldsSubqueries(nestedContext));
+        const sortSubqueries = this.sortFields
+            .flatMap((sq) => sq.getSubqueries(nestedContext))
+            .map((sq) => new Cypher.Call(sq).innerWith(targetNode));
+
+        const ret = this.getProjectionClause(nestedContext, returnVariable, entity.isList);
+
+        const clause = Cypher.concat(
+            matchClause,
+            ...authFilterSubqueries,
+            withWhere,
+            subqueries,
+            ...sortSubqueries,
+            ret
+        );
+
+        return {
+            clauses: [clause],
+            projectionExpr: returnVariable,
+        };
+    }
+
+    protected getProjectionClause(
+        context: QueryASTContext,
+        returnVariable: Cypher.Variable,
+        isArray: boolean
+    ): Cypher.Return {
+        const projection = this.getProjectionMap(context);
+
+        const targetNodeName = this.target.name;
+        projection.set({
+            __resolveType: new Cypher.Literal(targetNodeName),
+            __id: Cypher.id(context.source!), // NOTE: I think this is a bug and should be target
+        });
+        // let aggregationExpr: Cypher.Expr = Cypher.collect(context.target);
+        // if (!isArray) {
+        //     aggregationExpr = Cypher.head(aggregationExpr);
+        // }
+
+        const withClause = new Cypher.With([projection, context.target]);
+        // if (this.sortFields.length > 0 || this.pagination) {
+        //     this.addSortToClause(context, context.target, withClause);
+        // }
+
+        return withClause.return([context.target, returnVariable]);
+    }
+}

--- a/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
@@ -65,16 +65,9 @@ export class InterfaceReadPartial extends ReadOperation {
             .flatMap((sq) => sq.getSubqueries(nestedContext))
             .map((sq) => new Cypher.Call(sq).innerWith(targetNode));
 
-        const ret = this.getProjectionClause(nestedContext, returnVariable, entity.isList);
+        const ret = this.getProjectionClause(nestedContext, returnVariable);
 
-        const clause = Cypher.concat(
-            matchClause,
-            ...authFilterSubqueries,
-            // withWhere,
-            subqueries,
-            ...sortSubqueries,
-            ret
-        );
+        const clause = Cypher.concat(matchClause, ...authFilterSubqueries, subqueries, ...sortSubqueries, ret);
 
         return {
             clauses: [clause],
@@ -82,11 +75,7 @@ export class InterfaceReadPartial extends ReadOperation {
         };
     }
 
-    protected getProjectionClause(
-        context: QueryASTContext,
-        returnVariable: Cypher.Variable,
-        isArray: boolean
-    ): Cypher.Return {
+    protected getProjectionClause(context: QueryASTContext, returnVariable: Cypher.Variable): Cypher.Return {
         const projection = this.getProjectionMap(context);
 
         const targetNodeName = this.target.name;
@@ -94,15 +83,8 @@ export class InterfaceReadPartial extends ReadOperation {
             __resolveType: new Cypher.Literal(targetNodeName),
             __id: Cypher.id(context.source!), // NOTE: I think this is a bug and should be target
         });
-        // let aggregationExpr: Cypher.Expr = Cypher.collect(context.target);
-        // if (!isArray) {
-        //     aggregationExpr = Cypher.head(aggregationExpr);
-        // }
 
         const withClause = new Cypher.With([projection, context.target]);
-        // if (this.sortFields.length > 0 || this.pagination) {
-        //     this.addSortToClause(context, context.target, withClause);
-        // }
 
         return withClause.return([context.target, returnVariable]);
     }

--- a/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
@@ -56,9 +56,9 @@ export class InterfaceReadPartial extends ReadOperation {
         const authFiltersPredicate = this.authFilters ? this.authFilters.getPredicate(nestedContext) : undefined;
 
         const wherePredicate = Cypher.and(filterPredicates, authFiltersPredicate);
-        let withWhere: Cypher.Clause | undefined;
         if (wherePredicate) {
-            withWhere = new Cypher.With("*").where(wherePredicate);
+            // NOTE: This is slightly different to ReadOperation for cypher compatibility, this could use `WITH *`
+            matchClause.where(wherePredicate);
         }
         const subqueries = Cypher.concat(...this.getFieldsSubqueries(nestedContext));
         const sortSubqueries = this.sortFields
@@ -70,7 +70,7 @@ export class InterfaceReadPartial extends ReadOperation {
         const clause = Cypher.concat(
             matchClause,
             ...authFilterSubqueries,
-            withWhere,
+            // withWhere,
             subqueries,
             ...sortSubqueries,
             ret

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -64,17 +64,9 @@ export class OperationsFactory {
         context: Neo4jGraphQLTranslationContext
     ): ReadOperation | InterfaceReadOperation {
         const entity = entityOrRel instanceof RelationshipAdapter ? entityOrRel.target : entityOrRel;
-
         const relationship = entityOrRel instanceof RelationshipAdapter ? entityOrRel : undefined;
 
-        if (!(entity instanceof ConcreteEntityAdapter)) {
-            return this.createInterfaceReadOperationAST({
-                entity: entity as InterfaceEntityAdapter,
-                relationship,
-                resolveTree,
-                context,
-            });
-        } else {
+        if (entity instanceof ConcreteEntityAdapter) {
             const operation = new ReadOperation({
                 target: entity,
                 relationship,
@@ -84,6 +76,13 @@ export class OperationsFactory {
             return this.hydrateReadOperation({
                 operation,
                 entity,
+                relationship,
+                resolveTree,
+                context,
+            });
+        } else {
+            return this.createInterfaceReadOperationAST({
+                entity: entity as InterfaceEntityAdapter,
                 relationship,
                 resolveTree,
                 context,
@@ -307,33 +306,6 @@ export class OperationsFactory {
             children: concreteOperations,
             interfaceEntity: entity,
         });
-
-        // const fields = this.fieldFactory.createFields(entity, projectionFields, context);
-
-        // const authFilters = this.authorizationFactory.createEntityAuthFilters(entity, ["READ"], context);
-
-        // let filters: Filter[];
-        // if (relationship) {
-        //     filters = this.filterFactory.createRelationshipFilters(relationship, whereArgs);
-        // } else {
-        //     filters = this.filterFactory.createNodeFilters(entity, whereArgs);
-        // }
-        // operation.setFields(fields);
-        // operation.setFilters(filters);
-        // if (authFilters) {
-        //     operation.setAuthFilters(authFilters);
-        // }
-
-        // const options = resolveTree.args.options as GraphQLOptionsArg | undefined;
-        // if (options) {
-        //     const sort = this.sortAndPaginationFactory.createSortFields(options, entity);
-        //     operation.addSort(...sort);
-
-        //     const pagination = this.sortAndPaginationFactory.createPagination(options);
-        //     if (pagination) {
-        //         operation.addPagination(pagination);
-        //     }
-        // }
 
         return operation;
     }

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -285,15 +285,6 @@ export class OperationsFactory {
         context: Neo4jGraphQLTranslationContext;
     }): InterfaceReadOperation {
         const directed = Boolean(resolveTree.args?.directed ?? true);
-        // const projectionFields = { ...resolveTree.fieldsByTypeName[entity.name] };
-        // const whereArgs = (resolveTree.args.where || {}) as Record<string, unknown>;
-
-        // const operation = new InterfaceReadOperation({
-        //     target: entity,
-        //     relationship,
-        //     directed,
-        // });
-
         const concreteOperations = entity.concreteEntities.map((concreteEntity: ConcreteEntityAdapter) => {
             const connectionPartial = new InterfaceReadPartial({
                 relationship,
@@ -311,7 +302,11 @@ export class OperationsFactory {
             });
         });
 
-        const operation = new InterfaceReadOperation(concreteOperations);
+        const operation = new InterfaceReadOperation({
+            relationship,
+            children: concreteOperations,
+            interfaceEntity: entity,
+        });
 
         // const fields = this.fieldFactory.createFields(entity, projectionFields, context);
 

--- a/packages/graphql/src/translate/queryAST/factory/QueryASTFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/QueryASTFactory.ts
@@ -24,6 +24,7 @@ import { QueryAST } from "../ast/QueryAST";
 import { OperationsFactory } from "./OperationFactory";
 import type { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
+import type { ReadOperation } from "../ast/operations/ReadOperation";
 
 const TOP_LEVEL_NODE_NAME = "this";
 
@@ -38,7 +39,11 @@ export class QueryASTFactory {
 
     public createQueryAST(resolveTree: ResolveTree, entity: ConcreteEntity, context: Neo4jGraphQLTranslationContext) {
         const entityAdapter = this.schemaModel.getConcreteEntityAdapter(entity.name) as ConcreteEntityAdapter;
-        const operation = this.operationsFactory.createReadOperationAST(entityAdapter, resolveTree, context);
+        const operation = this.operationsFactory.createReadOperationAST(
+            entityAdapter,
+            resolveTree,
+            context
+        ) as ReadOperation; // TOP level with interfaces is not yet supported
         operation.nodeAlias = TOP_LEVEL_NODE_NAME;
         return new QueryAST(operation);
     }

--- a/packages/graphql/src/translate/queryAST/utils/get-concrete-entities.ts
+++ b/packages/graphql/src/translate/queryAST/utils/get-concrete-entities.ts
@@ -25,6 +25,5 @@ export function getConcreteEntities(
     entity: ConcreteEntityAdapter | InterfaceEntityAdapter | UnionEntityAdapter
 ): ConcreteEntityAdapter[] {
     if (entity instanceof ConcreteEntityAdapter) return [entity];
-
-    return Array.from(new Set(entity.concreteEntities.flatMap((e) => getConcreteEntities(e))));
+    return entity.concreteEntities;
 }

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -383,14 +383,14 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
                     WITH *
                     MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
+                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH this1 { .id, __resolveType: \\"Post\\", __id: id(this) } AS this1
                     RETURN this1 AS var3
                 }
                 WITH var3
@@ -442,13 +442,13 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles)) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
@@ -502,13 +502,13 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 CALL {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                    WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                    WHERE (this1.id = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -254,17 +254,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                    WITH *, count(this4) AS creatorCount
+                    WITH *, count(this4) AS var5
                     WITH *
-                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)))
+                    WHERE ($isAuthenticated = true AND (var5 <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var5
+                RETURN { edges: edges, totalCount: totalCount } AS var6
             }
-            RETURN this { .id, contentConnection: var5 } AS this"
+            RETURN this { .id, contentConnection: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -317,17 +317,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                    WITH *, count(this4) AS creatorCount
+                    WITH *, count(this4) AS var5
                     WITH *
-                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub))))
+                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (var5 <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var5
+                RETURN { edges: edges, totalCount: totalCount } AS var6
             }
-            RETURN this { .id, contentConnection: var5 } AS this"
+            RETURN this { .id, contentConnection: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -489,17 +489,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:Post)
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WITH *, count(this2) AS creatorCount
+                    WITH *, count(this2) AS var3
                     WITH *
-                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
+                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var3
+                RETURN { edges: edges, totalCount: totalCount } AS var4
             }
-            RETURN this { .id, contentConnection: var3 } AS this"
+            RETURN this { .id, contentConnection: var4 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -97,26 +97,26 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                     WITH this
                     MATCH (this)-[this0:PUBLISHED]->(this1:Post)
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WITH *, count(this2) AS creatorCount
+                    WITH *, count(this2) AS var3
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     CALL {
                         WITH this1
-                        MATCH (this1:Post)<-[this3:HAS_POST]-(this4:User)
-                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH { node: { name: this4.name } } AS edge
+                        MATCH (this1)<-[this4:HAS_POST]-(this5:User)
+                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        WITH { node: { name: this5.name } } AS edge
                         WITH collect(edge) AS edges
                         WITH edges, size(edges) AS totalCount
-                        RETURN { edges: edges, totalCount: totalCount } AS var5
+                        RETURN { edges: edges, totalCount: totalCount } AS var6
                     }
-                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var5 } } AS edge
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var6 } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var6
+                RETURN { edges: edges, totalCount: totalCount } AS var7
             }
-            RETURN this { contentConnection: var6 } AS this"
+            RETURN this { contentConnection: var7 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-interface-relationships.test.ts
@@ -95,13 +95,13 @@ describe("Auth projections for interface relationship fields", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
+                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:ACTED_IN]->(this4:Series)
                     WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.episodes = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
+                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2

--- a/packages/graphql/tests/tck/directives/customResolver.test.ts
+++ b/packages/graphql/tests/tck/directives/customResolver.test.ts
@@ -416,12 +416,12 @@ describe("@customResolver directive", () => {
                     CALL {
                         WITH *
                         MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title } AS this1
+                        WITH this1 { .title, __resolveType: \\"Book\\", __id: id(this) } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
                         MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject } AS this4
+                        WITH this4 { .subject, __resolveType: \\"Journal\\", __id: id(this) } AS this4
                         RETURN this4 AS var2
                     }
                     WITH var2
@@ -597,12 +597,12 @@ describe("@customResolver directive", () => {
                     CALL {
                         WITH *
                         MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title, .publicationYear } AS this1
+                        WITH this1 { .publicationYear, .title, __resolveType: \\"Book\\", __id: id(this) } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
                         MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject, .publicationYear } AS this4
+                        WITH this4 { .publicationYear, .subject, __resolveType: \\"Journal\\", __id: id(this) } AS this4
                         RETURN this4 AS var2
                     }
                     WITH var2

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -117,13 +117,13 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                     WITH this1
                     CALL {
                         WITH this1
-                        MATCH (this1:DriveComposition)-[this2:HAS]->(this3:Battery)
+                        MATCH (this1)-[this2:HAS]->(this3:Battery)
                         WHERE (this2.current = $param2 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND $param4 IN $jwt.roles), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                         WITH { current: this2.current, node: { __resolveType: \\"Battery\\", __id: id(this3), id: this3.id } } AS edge
                         RETURN edge
                         UNION
                         WITH this1
-                        MATCH (this1:DriveComposition)-[this4:HAS]->(this5:CombustionEngine)
+                        MATCH (this1)-[this4:HAS]->(this5:CombustionEngine)
                         WHERE this4.current = $param6
                         WITH { current: this4.current, node: { __resolveType: \\"CombustionEngine\\", __id: id(this5), id: this5.id } } AS edge
                         RETURN edge

--- a/packages/graphql/tests/tck/issues/1348.test.ts
+++ b/packages/graphql/tests/tck/issues/1348.test.ts
@@ -87,17 +87,17 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:RELATES_TO]-(this1:Series)
-                    WITH this1 { __resolveType: \\"Series\\", __id: id(this), .productTitle } AS this1
+                    WITH this1 { .productTitle, __resolveType: \\"Series\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:RELATES_TO]-(this4:Season)
-                    WITH this4 { __resolveType: \\"Season\\", __id: id(this), .productTitle } AS this4
+                    WITH this4 { .productTitle, __resolveType: \\"Season\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this5:RELATES_TO]-(this6:ProgrammeItem)
-                    WITH this6 { __resolveType: \\"ProgrammeItem\\", __id: id(this), .productTitle } AS this6
+                    WITH this6 { .productTitle, __resolveType: \\"ProgrammeItem\\", __id: id(this) } AS this6
                     RETURN this6 AS var2
                 }
                 WITH var2

--- a/packages/graphql/tests/tck/issues/1535.test.ts
+++ b/packages/graphql/tests/tck/issues/1535.test.ts
@@ -86,12 +86,12 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
                 CALL {
                     WITH *
                     MATCH (this)<-[this0:HOSTED_BY]-(this1:Screening)
-                    WITH this1 { __resolveType: \\"Screening\\", __id: id(this), .id } AS this1
+                    WITH this1 { .id, __resolveType: \\"Screening\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)<-[this3:HOSTED_BY]-(this4:Booking)
-                    WITH this4 { __resolveType: \\"Booking\\", __id: id(this), .id } AS this4
+                    WITH this4 { .id, __resolveType: \\"Booking\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2

--- a/packages/graphql/tests/tck/issues/1536.test.ts
+++ b/packages/graphql/tests/tck/issues/1536.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/1536", () => {
                     CALL {
                         WITH *
                         MATCH (this1)-[this2:HAS_INTERFACE_NODES]->(this3:MyImplementation)
-                        WITH this3 { __resolveType: \\"MyImplementation\\", __id: id(this1), .id } AS this3
+                        WITH this3 { .id, __resolveType: \\"MyImplementation\\", __id: id(this1) } AS this3
                         RETURN this3 AS var4
                     }
                     WITH var4

--- a/packages/graphql/tests/tck/issues/583.test.ts
+++ b/packages/graphql/tests/tck/issues/583.test.ts
@@ -22,7 +22,7 @@ import type { DocumentNode } from "graphql";
 import { Neo4jGraphQL } from "../../../src";
 import { formatCypher, translateQuery, formatParams } from "../utils/tck-test-utils";
 
-describe("#583", () => {
+describe("https://github.com/neo4j/graphql/issues/583", () => {
     let typeDefs: DocumentNode;
     let neoSchema: Neo4jGraphQL;
 
@@ -62,7 +62,7 @@ describe("#583", () => {
         });
     });
 
-    test("Should replicate issue and return correct cypher", async () => {
+    test("Should resolve properties from common interface", async () => {
         const query = gql`
             query shows {
                 actors {

--- a/packages/graphql/tests/tck/issues/847.test.ts
+++ b/packages/graphql/tests/tck/issues/847.test.ts
@@ -73,12 +73,12 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
                 CALL {
                     WITH *
                     MATCH (this)<-[this0:ACTED_IN]-(this1:Person)
-                    WITH this1 { __resolveType: \\"Person\\", __id: id(this), .id } AS this1
+                    WITH this1 { .id, __resolveType: \\"Person\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)<-[this3:ACTED_IN]-(this4:Place)
-                    WITH this4 { __resolveType: \\"Place\\", __id: id(this), .id } AS this4
+                    WITH this4 { .id, __resolveType: \\"Place\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
@@ -89,12 +89,12 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this5:ACTED_IN]->(this6:Person)
-                    WITH this6 { __resolveType: \\"Person\\", __id: id(this), .id } AS this6
+                    WITH this6 { .id, __resolveType: \\"Person\\", __id: id(this) } AS this6
                     RETURN this6 AS var7
                     UNION
                     WITH *
                     MATCH (this)-[this8:ACTED_IN]->(this9:Place)
-                    WITH this9 { __resolveType: \\"Place\\", __id: id(this), .id } AS this9
+                    WITH this9 { .id, __resolveType: \\"Place\\", __id: id(this) } AS this9
                     RETURN this9 AS var7
                 }
                 WITH var7

--- a/packages/graphql/tests/tck/undirected-relationships/undirected-relationships.test.ts
+++ b/packages/graphql/tests/tck/undirected-relationships/undirected-relationships.test.ts
@@ -119,12 +119,12 @@ describe("Undirected relationships", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:HAS_CONTENT]-(this1:Blog)
-                    WITH this1 { __resolveType: \\"Blog\\", __id: id(this), .title } AS this1
+                    WITH this1 { .title, __resolveType: \\"Blog\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:HAS_CONTENT]-(this4:Post)
-                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), .content } AS this4
+                    WITH this4 { .content, __resolveType: \\"Post\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
@@ -187,12 +187,12 @@ describe("Undirected relationships", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:ACTED_IN]-(this1:Movie)
-                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .title } AS this1
+                    WITH this1 { .title, __resolveType: \\"Movie\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:ACTED_IN]-(this4:Series)
-                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .title } AS this4
+                    WITH this4 { .title, __resolveType: \\"Series\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2


### PR DESCRIPTION
# Description
This PR implements interfaces for read operations and updates several tck tests:

```
Tests improved in branch B:  [
  '#583 > Should replicate issue and return correct cypher',
  '@customResolver directive > Require fields on nested interfaces > should not over fetch when all required fields are manually selected',
  '@customResolver directive > Require fields on nested unions > should not over fetch when all required fields are manually selected',
  'Auth projections for interface relationship fields > Simple Interface Relationship Query for protected type',
  'Cypher Auth Projection On Connections On Unions > Two connection',
  'Cypher Auth Where > Read Union Using Connection + User Defined Where',
  'Cypher Auth Where > Read interface relationship Using Connection',
  'Cypher Auth Where > Read interface relationship Using Connection + User Defined Where',
  'Cypher Auth Where with Roles > Read Union',
  'Cypher Auth Where with Roles > Read Union Using Connection',
  'Cypher Auth Where with Roles > Read Union Using Connection + User Defined Where',
  'Undirected relationships > undirected with interfaces',
  'Undirected relationships > undirected with unions',
  'https://github.com/neo4j/graphql/issues/1150 > union types with auth and connection-where',
  'https://github.com/neo4j/graphql/issues/1535 > should use alias in result projection for a field using an interface',
  'https://github.com/neo4j/graphql/issues/1536 > query nested interfaces',
  'https://github.com/neo4j/graphql/issues/847 > should be able to query multiple interface relations'
]
Regressions in branch B:  [
  'https://github.com/neo4j/graphql/issues/583 > Should resolve properties from common interface'
]
```

Note that test `#583` and regression `https://github.com/neo4j/graphql/issues/583` are reported due to the test being renamed, it is not a real regression