### PR TITLE
Sort limit translation layer

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
@@ -240,12 +240,8 @@ export class ReadOperation extends Operation {
         };
     }
 
-    private hasCypherSort() {
-        return (
-            this.sortFields.filter((s) => {
-                return s instanceof CypherPropertySort;
-            }).length > 0
-        );
+    private hasCypherSort(): boolean {
+        return this.sortFields.some((s) => s instanceof CypherPropertySort);
     }
 
     public getChildren(): QueryASTNode[] {
@@ -253,13 +249,11 @@ export class ReadOperation extends Operation {
     }
 
     protected getFieldsSubqueries(context: QueryASTContext): Cypher.Clause[] {
-        const nonCypherFields = this.fields.filter((f) => {
-            const isCypher = f instanceof CypherAttributeField;
-            return !isCypher;
-        });
-
         return filterTruthy(
-            nonCypherFields.flatMap((f) => {
+            this.fields.flatMap((f) => {
+                if (f instanceof CypherAttributeField) {
+                    return;
+                }
                 return f.getSubqueries(context);
             })
         ).map((sq) => {

--- a/packages/graphql/src/translate/queryAST/ast/pagination/Pagination.ts
+++ b/packages/graphql/src/translate/queryAST/ast/pagination/Pagination.ts
@@ -18,7 +18,7 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Integer } from "neo4j-driver";
+import { int, type Integer } from "neo4j-driver";
 import { QueryASTNode } from "../QueryASTNode";
 
 export type PaginationField = {
@@ -27,13 +27,13 @@ export type PaginationField = {
 };
 
 export class Pagination extends QueryASTNode {
-    private skip: Integer | number | undefined;
-    private limit: Integer | number | undefined;
+    private skip: Integer | undefined;
+    private limit: Integer | undefined;
 
     constructor({ skip, limit }: { skip?: number | Integer; limit?: number | Integer }) {
         super();
-        this.skip = skip;
-        this.limit = limit;
+        this.skip = this.toNeo4jInt(skip);
+        this.limit = this.toNeo4jInt(limit);
     }
 
     public getPagination(): PaginationField | undefined {
@@ -45,5 +45,12 @@ export class Pagination extends QueryASTNode {
 
     public getChildren(): QueryASTNode[] {
         return [];
+    }
+
+    private toNeo4jInt(n: Integer | number | undefined): Integer | undefined {
+        if (typeof n === "number") {
+            return int(n);
+        }
+        return n;
     }
 }

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -25,7 +25,7 @@ import { ConnectionReadOperation } from "../ast/operations/ConnectionReadOperati
 import { ReadOperation } from "../ast/operations/ReadOperation";
 import type { ConnectionSortArg, GraphQLOptionsArg } from "../../../types";
 import { SortAndPaginationFactory } from "./SortAndPaginationFactory";
-import type { Integer } from "neo4j-driver";
+import { Integer } from "neo4j-driver";
 import type { Filter } from "../ast/filters/Filter";
 import { AggregationOperation } from "../ast/operations/AggregationOperation";
 import { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
@@ -368,8 +368,10 @@ export class OperationsFactory {
     private getOptions(entity: ConcreteEntityAdapter, options: Record<string, any>): GraphQLOptionsArg | undefined {
         const limitDirective = entity.annotations.limit;
 
-        let limit: number | undefined = options?.limit ?? limitDirective?.default;
-
+        let limit: Integer | number | undefined = options?.limit ?? limitDirective?.default ?? limitDirective?.max;
+        if (limit instanceof Integer) {
+            limit = limit.toNumber();
+        }
         const maxLimit = limitDirective?.max;
         if (limit !== undefined && maxLimit !== undefined) {
             limit = Math.min(limit, maxLimit);

--- a/packages/graphql/tests/tck/alias.test.ts
+++ b/packages/graphql/tests/tck/alias.test.ts
@@ -70,14 +70,9 @@ describe("Cypher Alias", () => {
 
         const result = await translateQuery(neoSchema, query);
 
+        // NOTE: Order of these subqueries have been reversed after refactor
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:Movie)
-            CALL {
-                WITH this
-                MATCH (this)<-[this0:ACTED_IN]-(this1:Actor)
-                WITH this1 { aliasActorsName: this1.name } AS this1
-                RETURN collect(this1) AS var2
-            }
             CALL {
                 WITH this
                 CALL {
@@ -86,10 +81,16 @@ describe("Cypher Alias", () => {
                     MATCH (m:Movie)
                     RETURN m
                 }
-                WITH m AS this3
-                RETURN collect(this3 { aliasCustomId: this3.id }) AS this3
+                WITH m AS this0
+                RETURN collect(this0 { aliasCustomId: this0.id }) AS this0
             }
-            RETURN this { movieId: this.id, actors: var2, custom: this3 } AS this"
+            CALL {
+                WITH this
+                MATCH (this)<-[this1:ACTED_IN]-(this2:Actor)
+                WITH this2 { aliasActorsName: this2.name } AS this2
+                RETURN collect(this2) AS var3
+            }
+            RETURN this { movieId: this.id, actors: var3, custom: this0 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/issues/2267.test.ts
+++ b/packages/graphql/tests/tck/issues/2267.test.ts
@@ -77,12 +77,12 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
                 CALL {
                     WITH *
                     MATCH (this)<-[this0:ACTIVITY]-(this1:Post)
-                    WITH this1 { __resolveType: \\"Post\\", __id: id(this), .name } AS this1
+                    WITH this1 { .name, __resolveType: \\"Post\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)<-[this3:ACTIVITY]-(this4:Story)
-                    WITH this4 { __resolveType: \\"Story\\", __id: id(this), .name } AS this4
+                    WITH this4 { .name, __resolveType: \\"Story\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2


### PR DESCRIPTION
# Description

A few extra tests fixed related to sort:

```
Test Suites: 32 failed, 208 passed, 240 total
Tests:       75 failed, 1207 passed, 1282 total
```

```
Tests improved in branch B:  [
  'Cypher directive > LIMIT happens before custom Cypher if not sorting on the custom Cypher field',
  'https://github.com/neo4j/graphql/issues/2267 > sort should be correct when querying interface relationship field',
  'tck/rfcs/query-limits > Field Level Query Limits > should extend the limit to the connection field if `first` provided',
  'tck/rfcs/query-limits > Field Level Query Limits > should extend the limit to the connection field if `first` provided, honouring the `max` argument',
  'tck/rfcs/query-limits > Field Level Query Limits > should limit the connection field level query',
  'tck/rfcs/query-limits > Field Level Query Limits > should limit the normal field level query',
  'tck/rfcs/query-limits > Field Level Query Limits > should limit the relationship field level query',
  'tck/rfcs/query-limits > Top Level Query Limits > should limit the top level query with default value',
  'tck/rfcs/query-limits > Top Level Query Limits > should limit the top level query with max value if not default is available',
  'tck/rfcs/query-limits > Top Level Query Limits > should limit the top level query with max value the option given is higher'
]
Regressions in branch B:  []

```
