### PR TITLE
Collect interfaces for concrete entities when translating read

### DIFF
--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -301,7 +301,6 @@ export class OperationsFactory {
             return this.hydrateReadOperation({
                 relationship,
                 entity: concreteEntity,
-                interfaceEntity: entity,
                 resolveTree,
                 context,
                 operation: connectionPartial,
@@ -323,18 +322,18 @@ export class OperationsFactory {
         operation,
         resolveTree,
         context,
-        interfaceEntity,
     }: {
         entity: ConcreteEntityAdapter;
         relationship?: RelationshipAdapter;
         operation: T;
         resolveTree: ResolveTree;
         context: Neo4jGraphQLTranslationContext;
-        interfaceEntity?: InterfaceEntityAdapter | UnionEntityAdapter;
     }): T {
-        // TODO: get abstract types of concrete entity
         let projectionFields = { ...resolveTree.fieldsByTypeName[entity.name] };
-        if (interfaceEntity) {
+
+        // Get the abstract types of the interface
+        const entityInterfaces = entity.compositeEntities;
+        for (const interfaceEntity of entityInterfaces) {
             projectionFields = { ...resolveTree.fieldsByTypeName[interfaceEntity.name], ...projectionFields };
         }
 

--- a/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
@@ -84,12 +84,12 @@ describe("Interface Relationships", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
+                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
+                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
@@ -127,12 +127,12 @@ describe("Interface Relationships", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:CURRENTLY_ACTING_IN]->(this1:Movie)
-                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
+                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:CURRENTLY_ACTING_IN]->(this4:Series)
-                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
+                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
@@ -170,12 +170,12 @@ describe("Interface Relationships", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .runtime, .title } AS this1
+                    WITH this1 { .title, .runtime, __resolveType: \\"Movie\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .episodes, .title } AS this4
+                    WITH this4 { .title, .episodes, __resolveType: \\"Series\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2

--- a/packages/graphql/tests/tck/fragments.test.ts
+++ b/packages/graphql/tests/tck/fragments.test.ts
@@ -109,12 +109,12 @@ describe("Cypher Fragment", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:OWNS]->(this1:Tile)
-                    WITH this1 { __resolveType: \\"Tile\\", __id: id(this), .id } AS this1
+                    WITH this1 { .id, __resolveType: \\"Tile\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:OWNS]->(this4:Character)
-                    WITH this4 { __resolveType: \\"Character\\", __id: id(this), .id } AS this4
+                    WITH this4 { .id, __resolveType: \\"Character\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
@@ -144,7 +144,7 @@ describe("Cypher Fragment", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
-            RETURN this { .id, .username } AS this"
+            RETURN this { .username, .id } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);

--- a/packages/graphql/tests/tck/issues/583.test.ts
+++ b/packages/graphql/tests/tck/issues/583.test.ts
@@ -87,17 +87,17 @@ describe("https://github.com/neo4j/graphql/issues/583", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH this1 { __resolveType: \\"Movie\\", __id: id(this), .title, .awardsGiven } AS this1
+                    WITH this1 { .awardsGiven, .title, __resolveType: \\"Movie\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this3:ACTED_IN]->(this4:Series)
-                    WITH this4 { __resolveType: \\"Series\\", __id: id(this), .title, .awardsGiven } AS this4
+                    WITH this4 { .awardsGiven, .title, __resolveType: \\"Series\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                     UNION
                     WITH *
                     MATCH (this)-[this5:ACTED_IN]->(this6:ShortFilm)
-                    WITH this6 { __resolveType: \\"ShortFilm\\", __id: id(this), .title } AS this6
+                    WITH this6 { .title, __resolveType: \\"ShortFilm\\", __id: id(this) } AS this6
                     RETURN this6 AS var2
                 }
                 WITH var2


### PR DESCRIPTION
# Description

```
Test Suites: 30 failed, 210 passed, 240 total
Tests:       70 failed, 1212 passed, 1282 total
```

```
Tests improved in branch B:  [
  'Cypher Fragment > Fragment On Interface',
  'Cypher Fragment > Fragment On Union',
  'Interface Relationships > Simple Interface Relationship Query',
  'Interface Relationships > Simple Interface Relationship Query For Non-Array Field',
  'https://github.com/neo4j/graphql/issues/583 > Should resolve properties from common interface'
]
```