### PR TITLE
Fix coalesce tests in new translation layer

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/filters/property-filters/PropertyFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/property-filters/PropertyFilter.ts
@@ -104,7 +104,18 @@ export class PropertyFilter extends Filter {
         property: Cypher.Expr;
         param: Cypher.Expr;
     }): Cypher.ComparisonOp {
-        return createComparisonOperation({ operator, property, param });
+        const coalesceProperty = this.coalesceValueIfNeeded(property);
+
+        return createComparisonOperation({ operator, property: coalesceProperty, param });
+    }
+
+    protected coalesceValueIfNeeded(expr: Cypher.Expr): Cypher.Expr {
+        if (this.attribute.annotations.coalesce) {
+            const value = this.attribute.annotations.coalesce.value;
+            const literal = new Cypher.Literal(value);
+            return Cypher.coalesce(expr, literal);
+        }
+        return expr;
     }
 
     private getNullPredicate(propertyRef: Cypher.Property): Cypher.Predicate {

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -39,7 +39,6 @@ import { RelationshipAdapter } from "../../../schema-model/relationship/model-ad
 import { isLogicalOperator } from "../../utils/logical-operators";
 import { AggregationDurationFilter } from "../ast/filters/aggregation/AggregationDurationPropertyFilter";
 import type { InterfaceEntityAdapter } from "../../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
-import type { UnionEntityAdapter } from "../../../schema-model/entity/model-adapters/UnionEntityAdapter";
 import { getConcreteEntities } from "../utils/get-concrete-entities";
 
 type AggregateWhereInput = {
@@ -210,21 +209,6 @@ export class FilterFactory {
         operator: RelationshipWhereOperator;
     }): RelationshipFilter {
         return new RelationshipFilter(options);
-    }
-
-    private getConcreteWhere(
-        entity: ConcreteEntityAdapter | InterfaceEntityAdapter | UnionEntityAdapter,
-        value: Record<string, unknown>
-    ): Record<string, unknown> {
-        const concreteEntities = getConcreteEntities(entity);
-
-        let concreteWhere: Record<string, unknown> = {};
-        for (const concreteEntity of concreteEntities) {
-            const concreteEntityWhere = (value as any)[concreteEntity.name];
-            concreteWhere = { ...concreteEntityWhere, ...concreteWhere };
-        }
-
-        return concreteWhere;
     }
 
     // TODO: rename and refactor this, createNodeFilters is misleading for non-connection operations

--- a/packages/graphql/tests/tck/directives/coalesce.test.ts
+++ b/packages/graphql/tests/tck/directives/coalesce.test.ts
@@ -98,7 +98,7 @@ describe("Cypher coalesce()", () => {
 
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
-            WHERE (coalesce(this.id, \\"00000000-00000000-00000000-00000000\\") = $param0 AND coalesce(this.name, \\"Jane Smith\\") =~ $param1 AND NOT (this.verified = $param2) AND this.numberOfFriends > $param3 AND coalesce(this.rating, 2.5) < $param4 AND coalesce(this.fromInterface, \\"From Interface\\") = $param5 AND coalesce(this.toBeOverridden, \\"Overridden\\") = $param6)
+            WHERE (coalesce(this.id, \\"00000000-00000000-00000000-00000000\\") = $param0 AND coalesce(this.name, \\"Jane Smith\\") =~ $param1 AND NOT (coalesce(this.verified, false) = $param2) AND coalesce(this.numberOfFriends, 0) > $param3 AND coalesce(this.rating, 2.5) < $param4 AND coalesce(this.fromInterface, \\"From Interface\\") = $param5 AND coalesce(this.toBeOverridden, \\"Overridden\\") = $param6)
             RETURN this { .name } AS this"
         `);
 


### PR DESCRIPTION
# Description
Fix `@coalesce`

```
Test Suites: 25 failed, 215 passed, 240 total
Tests:       58 failed, 1224 passed, 1282 total
```


```
Tests improved in branch B:  [
  'Cypher coalesce() > Coalesce with enum in match',
  'Cypher coalesce() > Coalesce with enum in projection',
  'Cypher coalesce() > Coalesce with enum list in projection',
  'Cypher coalesce() > Simple coalesce'
]
```

A weird behaviour seems to happen in the updated test. It looks like the current implementation has a bug

