### PR TITLE
Do not default description to empty string

### DIFF
--- a/packages/graphql/src/schema-model/attribute/Attribute.ts
+++ b/packages/graphql/src/schema-model/attribute/Attribute.ts
@@ -49,7 +49,7 @@ export class Attribute {
         this.type = type;
         this.args = args;
         this.databaseName = databaseName ?? name;
-        this.description = description || "";
+        this.description = description;
 
         for (const annotation of annotations) {
             this.addAnnotation(annotation);

--- a/packages/graphql/src/schema-model/entity/ConcreteEntity.ts
+++ b/packages/graphql/src/schema-model/entity/ConcreteEntity.ts
@@ -53,7 +53,7 @@ export class ConcreteEntity implements Entity {
         compositeEntities?: CompositeEntity[];
     }) {
         this.name = name;
-        this.description = description || "";
+        this.description = description;
         this.labels = new Set(labels);
         for (const attribute of attributes) {
             this.addAttribute(attribute);

--- a/packages/graphql/src/schema-model/parser/parse-attribute.ts
+++ b/packages/graphql/src/schema-model/parser/parse-attribute.ts
@@ -53,7 +53,7 @@ export function parseAttributeArguments(
             name: fieldArg.name.value,
             type: parseTypeNode(definitionCollection, fieldArg.type),
             defaultValue: fieldArg.defaultValue,
-            description: fieldArg.description?.value || "",
+            description: fieldArg.description?.value,
         });
     });
 }
@@ -75,7 +75,7 @@ export function parseAttribute(
         type,
         args,
         databaseName,
-        description: field.description?.value || "",
+        description: field.description?.value,
     });
 }
 


### PR DESCRIPTION
# Description

There were still some missing cases where in the schema we defaulted the description to an empty string instead of letting it be undefined.

## Complexity

Low