### PR TITLE
Relationship filters on 1-1 relationships

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/QueryASTNode.ts
+++ b/packages/graphql/src/translate/queryAST/ast/QueryASTNode.ts
@@ -31,4 +31,8 @@ export abstract class QueryASTNode {
     public getSubqueries(_context: QueryASTContext): Cypher.Clause[] {
         return [];
     }
+
+    public getSelection(_queryASTContext: QueryASTContext): Array<Cypher.Match | Cypher.With> {
+        return [];
+    }
 }

--- a/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthRelationshipFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthRelationshipFilter.ts
@@ -24,7 +24,8 @@ import { Memoize } from "typescript-memoize";
 import type { QueryASTNode } from "../../QueryASTNode";
 
 export class AuthRelationshipFilter extends RelationshipFilter {
-    public getSubqueries(context: QueryASTContext): Cypher.Clause[] {
+    // TODO: move to getSelection
+    public getSelection(context: QueryASTContext): Cypher.With[] {
         const relatedNode = this.relatedNode;
         const relVar = this.relationshipVar;
 

--- a/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthRelationshipFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthRelationshipFilter.ts
@@ -24,8 +24,6 @@ import { Memoize } from "typescript-memoize";
 import type { QueryASTNode } from "../../QueryASTNode";
 
 export class AuthRelationshipFilter extends RelationshipFilter {
-    private countVar = new Cypher.Variable();
-
     public getSubqueries(context: QueryASTContext): Cypher.Clause[] {
         const relatedNode = this.relatedNode;
         const relVar = this.relationshipVar;
@@ -40,7 +38,7 @@ export class AuthRelationshipFilter extends RelationshipFilter {
         if (!this.relationship.isList && this.relationship.isNullable) {
             return [];
         }
-        return [new Cypher.OptionalMatch(pattern).with("*", [Cypher.count(nestedContext.target), this.countVar])];
+        return [new Cypher.OptionalMatch(pattern).with("*", [Cypher.count(nestedContext.target), this.countVariable])];
     }
 
     public getPredicate(queryASTContext: QueryASTContext): Cypher.Predicate | undefined {
@@ -65,7 +63,7 @@ export class AuthRelationshipFilter extends RelationshipFilter {
             return Cypher.single(nestedContext.target, comprehension, Cypher.true);
         }
 
-        return Cypher.and(Cypher.neq(this.countVar, new Cypher.Literal(0)), innerPredicate);
+        return Cypher.and(Cypher.neq(this.countVariable, new Cypher.Literal(0)), innerPredicate);
     }
 
     public getChildren(): QueryASTNode[] {

--- a/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationFilters.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationFilters.ts
@@ -67,6 +67,10 @@ export class AuthorizationFilters extends Filter {
         return [...this.validationFilters, ...this.whereFilters].flatMap((c) => c.getSubqueries(context));
     }
 
+    public getSelection(context: QueryASTContext): Array<Cypher.Match | Cypher.With> {
+        return [...this.validationFilters, ...this.whereFilters].flatMap((c) => c.getSelection(context));
+    }
+
     public getChildren(): QueryASTNode[] {
         return [...this.validationFilters, ...this.whereFilters];
     }

--- a/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationRuleFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/authorization-filters/AuthorizationRuleFilter.ts
@@ -60,6 +60,10 @@ export class AuthorizationRuleFilter extends Filter {
         return this.children.flatMap((c) => c.getSubqueries(context));
     }
 
+    public getSelection(context: QueryASTContext): Array<Cypher.Match | Cypher.With> {
+        return this.children.flatMap((c) => c.getSelection(context));
+    }
+
     public getChildren(): QueryASTNode[] {
         return [...this.children];
     }

--- a/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
@@ -187,7 +187,16 @@ export class ReadOperation extends Operation {
 
         const projection = this.getProjectionMap(context);
 
-        const matchClause = new Cypher.Match(node);
+        let matchClause: Cypher.Match | Cypher.With = new Cypher.Match(node);
+
+        let extraMatches = this.filters.flatMap((f) => {
+            return f.getSelection(context);
+        });
+
+        if (extraMatches.length > 0) {
+            extraMatches = [matchClause, ...extraMatches];
+            matchClause = new Cypher.With("*");
+        }
 
         let filterSubqueryWith: Cypher.With | undefined;
         let filterSubqueriesClause: Cypher.Clause | undefined = undefined;
@@ -230,6 +239,7 @@ export class ReadOperation extends Operation {
         }
 
         const clause = Cypher.concat(
+            ...extraMatches,
             matchClause,
             filterSubqueriesClause,
             filterSubqueryWith,

--- a/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/interfaces/InterfaceReadPartial.ts
@@ -48,9 +48,8 @@ export class InterfaceReadPartial extends ReadOperation {
             .withDirection(relDirection)
             .to(targetNode);
 
-        const matchClause = new Cypher.Match(pattern);
-
         const nestedContext = context.push({ target: targetNode, relationship: relVar });
+        const { preSelection, selectionClause: matchClause } = this.getSelectionClauses(nestedContext, pattern);
         const filterPredicates = this.getPredicates(nestedContext);
         const authFilterSubqueries = this.authFilters ? this.authFilters.getSubqueries(nestedContext) : [];
         const authFiltersPredicate = this.authFilters ? this.authFilters.getPredicate(nestedContext) : undefined;
@@ -67,7 +66,14 @@ export class InterfaceReadPartial extends ReadOperation {
 
         const ret = this.getProjectionClause(nestedContext, returnVariable);
 
-        const clause = Cypher.concat(matchClause, ...authFilterSubqueries, subqueries, ...sortSubqueries, ret);
+        const clause = Cypher.concat(
+            ...preSelection,
+            matchClause,
+            ...authFilterSubqueries,
+            subqueries,
+            ...sortSubqueries,
+            ret
+        );
 
         return {
             clauses: [clause],

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
@@ -198,13 +198,13 @@ describe("Cypher Auth Allow", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var4
+                RETURN collect(this1) AS var3
             }
-            RETURN this { .id, posts: var4 } AS this"
+            RETURN this { .id, posts: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -101,7 +101,7 @@ describe("@auth allow on specific interface implementation", () => {
                 CALL {
                     WITH *
                     MATCH (this)-[this0:HAS_CONTENT]->(this1:Comment)
-                    WITH this1 { __resolveType: \\"Comment\\", __id: id(this), .id, .content } AS this1
+                    WITH this1 { .id, .content, __resolveType: \\"Comment\\", __id: id(this) } AS this1
                     RETURN this1 AS var2
                     UNION
                     WITH *
@@ -110,7 +110,7 @@ describe("@auth allow on specific interface implementation", () => {
                     WITH *, count(this5) AS creatorCount
                     WITH *
                     WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id, .content } AS this4
+                    WITH this4 { .id, .content, __resolveType: \\"Post\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2
@@ -178,7 +178,7 @@ describe("@auth allow on specific interface implementation", () => {
                         WITH this7 { .content } AS this7
                         RETURN collect(this7) AS var8
                     }
-                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), comments: var8 } AS this4
+                    WITH this4 { comments: var8, __resolveType: \\"Post\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -178,7 +178,6 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WITH *
                 WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param4 IN $jwt.roles) OR ($isAuthenticated = true AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
@@ -332,11 +331,11 @@ describe("Cypher Auth Where with Roles", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:User)
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles)) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND $param2 IN $jwt.roles) OR ($isAuthenticated = true AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
-                WHERE (this1.content = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles)) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+                WHERE (this1.content = $param4 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(this2 IN [(this1)<-[:HAS_POST]-(this2:User) WHERE ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub) | 1] WHERE true) AND $param5 IN $jwt.roles) OR ($isAuthenticated = true AND $param6 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
                 WITH this1 { .content } AS this1
                 RETURN collect(this1) AS var3
             }

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -196,7 +196,7 @@ describe("Cypher Auth Where", () => {
                     WITH *, count(this5) AS creatorCount
                     WITH *
                     WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)))
-                    WITH this4 { __resolveType: \\"Post\\", __id: id(this), .id } AS this4
+                    WITH this4 { .id, __resolveType: \\"Post\\", __id: id(this) } AS this4
                     RETURN this4 AS var2
                 }
                 WITH var2

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -254,17 +254,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                    WITH *, count(this4) AS var5
+                    WITH *, count(this4) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (var5 <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var6
+                RETURN { edges: edges, totalCount: totalCount } AS var5
             }
-            RETURN this { .id, contentConnection: var6 } AS this"
+            RETURN this { .id, contentConnection: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -317,17 +317,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this2:HAS_CONTENT]->(this3:Post)
                     OPTIONAL MATCH (this3)<-[:HAS_CONTENT]-(this4:User)
-                    WITH *, count(this4) AS var5
+                    WITH *, count(this4) AS creatorCount
                     WITH *
-                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (var5 <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub))))
+                    WHERE (this3.id = $param3 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this3), id: this3.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var6
+                RETURN { edges: edges, totalCount: totalCount } AS var5
             }
-            RETURN this { .id, contentConnection: var6 } AS this"
+            RETURN this { .id, contentConnection: var5 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -166,13 +166,13 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                 WITH this1 { .content } AS this1
-                RETURN collect(this1) AS var4
+                RETURN collect(this1) AS var3
             }
-            RETURN this { .id, posts: var4 } AS this"
+            RETURN this { .id, posts: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -217,15 +217,15 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
+                WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN { edges: edges, totalCount: totalCount } AS var3
             }
-            RETURN this { .id, postsConnection: var4 } AS this"
+            RETURN this { .id, postsConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -270,15 +270,15 @@ describe("Cypher Auth Where", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
+                WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN { edges: edges, totalCount: totalCount } AS var3
             }
-            RETURN this { .id, postsConnection: var4 } AS this"
+            RETURN this { .id, postsConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -430,17 +430,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:Post)
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WITH *, count(this2) AS var3
+                    WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
+                    WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN { edges: edges, totalCount: totalCount } AS var3
             }
-            RETURN this { .id, contentConnection: var4 } AS this"
+            RETURN this { .id, contentConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -489,17 +489,17 @@ describe("Cypher Auth Where", () => {
                     WITH this
                     MATCH (this)-[this0:HAS_POST]->(this1:Post)
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WITH *, count(this2) AS var3
+                    WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
+                    WHERE (this1.id = $param2 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))))
                     WITH { node: { __resolveType: \\"Post\\", __id: id(this1), id: this1.id } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN { edges: edges, totalCount: totalCount } AS var3
             }
-            RETURN this { .id, contentConnection: var4 } AS this"
+            RETURN this { .id, contentConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -375,7 +375,7 @@ describe("Cypher Auth Where", () => {
                     WITH *, count(this2) AS creatorCount
                     WITH *
                     WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub)))
-                    WITH this1 { __resolveType: \\"Post\\", __id: id(this), .id } AS this1
+                    WITH this1 { .id, __resolveType: \\"Post\\", __id: id(this) } AS this1
                     RETURN this1 AS var3
                 }
                 WITH var3

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection-union.test.ts
@@ -97,26 +97,26 @@ describe("Cypher Auth Projection On Connections On Unions", () => {
                     WITH this
                     MATCH (this)-[this0:PUBLISHED]->(this1:Post)
                     OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                    WITH *, count(this2) AS var3
+                    WITH *, count(this2) AS creatorCount
                     WITH *
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                     CALL {
                         WITH this1
-                        MATCH (this1)<-[this4:HAS_POST]-(this5:User)
-                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH { node: { name: this5.name } } AS edge
+                        MATCH (this1)<-[this3:HAS_POST]-(this4:User)
+                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        WITH { node: { name: this4.name } } AS edge
                         WITH collect(edge) AS edges
                         WITH edges, size(edges) AS totalCount
-                        RETURN { edges: edges, totalCount: totalCount } AS var6
+                        RETURN { edges: edges, totalCount: totalCount } AS var5
                     }
-                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var6 } } AS edge
+                    WITH { node: { __resolveType: \\"Post\\", __id: id(this1), content: this1.content, creatorConnection: var5 } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var7
+                RETURN { edges: edges, totalCount: totalCount } AS var6
             }
-            RETURN this { contentConnection: var7 } AS this"
+            RETURN this { contentConnection: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/projection-connection.test.ts
@@ -85,15 +85,15 @@ describe("Cypher Auth Projection On Connections", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN { edges: edges, totalCount: totalCount } AS var3
             }
-            RETURN this { .name, postsConnection: var4 } AS this"
+            RETURN this { .name, postsConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`
@@ -143,24 +143,24 @@ describe("Cypher Auth Projection On Connections", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Post)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:User)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 CALL {
                     WITH this1
-                    MATCH (this1)<-[this4:HAS_POST]-(this5:User)
-                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this5.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                    WITH { node: { name: this5.name } } AS edge
+                    MATCH (this1)<-[this3:HAS_POST]-(this4:User)
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this4.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH { node: { name: this4.name } } AS edge
                     WITH collect(edge) AS edges
                     WITH edges, size(edges) AS totalCount
-                    RETURN { edges: edges, totalCount: totalCount } AS var6
+                    RETURN { edges: edges, totalCount: totalCount } AS var5
                 }
-                WITH { node: { content: this1.content, creatorConnection: var6 } } AS edge
+                WITH { node: { content: this1.content, creatorConnection: var5 } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var7
+                RETURN { edges: edges, totalCount: totalCount } AS var6
             }
-            RETURN this { .name, postsConnection: var7 } AS this"
+            RETURN this { .name, postsConnection: var6 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
+++ b/packages/graphql/tests/tck/directives/node/node-with-auth-projection.test.ts
@@ -81,15 +81,15 @@ describe("Cypher Auth Projection On Connections", () => {
                 WITH this
                 MATCH (this)-[this0:HAS_POST]->(this1:Comment)
                 OPTIONAL MATCH (this1)<-[:HAS_POST]-(this2:Person)
-                WITH *, count(this2) AS var3
+                WITH *, count(this2) AS creatorCount
                 WITH *
-                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (var3 <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND this2.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
                 WITH { node: { content: this1.content } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
-                RETURN { edges: edges, totalCount: totalCount } AS var4
+                RETURN { edges: edges, totalCount: totalCount } AS var3
             }
-            RETURN this { .name, postsConnection: var4 } AS this"
+            RETURN this { .name, postsConnection: var3 } AS this"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`


### PR DESCRIPTION
# Description
Fix relationship filters on 1-1 relationships.

Note that some tck tests have been changed, going from `varx` to `xcount` in some variables. These were already updated before and now are reverted back to how they are in dev branch to reduce diff in the translation refactor

```
Test Suites: 20 failed, 220 passed, 240 total
Tests:       45 failed, 1237 passed, 1282 total
```


```
Tests improved in branch B:  [
  '@auth allow on specific interface implementation > Read Two Relationships',
  '@auth allow on specific interface implementation > read allow protected interface relationship',
  'Cypher Auth Allow > Read Two Relationships',
  'Cypher Auth Where > Read Node',
  'Cypher Auth Where > Read Node + User Defined Where',
  'Cypher Auth Where > Read Union',
  'Cypher Auth Where > Read Union Relationship + User Defined Where',
  'Cypher Auth Where > Read interface relationship field',
  'Cypher Auth Where with Roles > Read Union Relationship + User Defined Where',
  'https://github.com/neo4j/graphql/issues/2871 > should be able to filter by ALL nested within single relationship',
  'https://github.com/neo4j/graphql/issues/2871 > should be able to filter by SOME nested within single relationship',
  'https://github.com/neo4j/graphql/issues/2871 > should not match if SOME second level relationships meet nested predicates',
  'https://github.com/neo4j/graphql/issues/2925 > should query required relationship'
]
Regressions in branch B:  []
```
