### PR TITLE
Fix global nodes

### DIFF
--- a/packages/graphql/src/schema-model/entity/model-adapters/ConcreteEntityAdapter.ts
+++ b/packages/graphql/src/schema-model/entity/model-adapters/ConcreteEntityAdapter.ts
@@ -38,7 +38,7 @@ export class ConcreteEntityAdapter {
     public readonly relationships: Map<string, RelationshipAdapter> = new Map();
     public readonly annotations: Partial<Annotations>;
     public readonly compositeEntities: CompositeEntity[] = [];
-    
+
     // These keys allow to store the keys of the map in memory and avoid keep iterating over the map.
     private mutableFieldsKeys: string[] = [];
     private uniqueFieldsKeys: string[] = [];
@@ -102,6 +102,16 @@ export class ConcreteEntityAdapter {
             this._relatedEntities = [...this.relationships.values()].map((relationship) => relationship.target);
         }
         return this._relatedEntities;
+    }
+
+    public getRelayId(): AttributeAdapter | undefined {
+        // TODO: make this O(1)
+        for (const attr of this.attributes.values()) {
+            if (attr.annotations.relayId) {
+                return attr;
+            }
+        }
+        return undefined;
     }
 
     // TODO: identify usage of old Node.[getLabels | getLabelsString] and migrate them if needed

--- a/packages/graphql/src/schema-model/entity/model-adapters/InterfaceEntityAdapter.ts
+++ b/packages/graphql/src/schema-model/entity/model-adapters/InterfaceEntityAdapter.ts
@@ -46,6 +46,10 @@ export class InterfaceEntityAdapter {
         return this.attributes.get(name);
     }
 
+    public getRelayId(): AttributeAdapter | undefined {
+        return undefined;
+    }
+
     private initConcreteEntities(entities: ConcreteEntity[]) {
         for (const entity of entities) {
             const entityAdapter = new ConcreteEntityAdapter(entity);

--- a/packages/graphql/src/schema/resolvers/query/global-node.ts
+++ b/packages/graphql/src/schema/resolvers/query/global-node.ts
@@ -66,7 +66,11 @@ export function globalNodeResolver({ nodes }: { nodes: Node[] }) {
 
         (context as Neo4jGraphQLTranslationContext).resolveTree = getNeo4jResolveTree(info, { resolveTree });
 
-        const { cypher, params } = translateRead({ context: context as Neo4jGraphQLTranslationContext, node });
+        const { cypher, params } = translateRead({
+            context: context as Neo4jGraphQLTranslationContext,
+            node,
+            isGlobalNode: true,
+        });
         const executeResult = await execute({
             cypher,
             params,

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -50,15 +50,17 @@ export function translateRead(
         node,
         context,
         isRootConnectionField,
+        isGlobalNode,
     }: {
         context: Neo4jGraphQLTranslationContext;
         node: Node;
         isRootConnectionField?: boolean;
+        isGlobalNode?: boolean;
     },
     varName = "this"
 ): Cypher.CypherResult {
     const { resolveTree } = context;
-    if (!isRootConnectionField && !resolveTree.args.fulltext && !resolveTree.args.phrase) {
+    if (!isRootConnectionField && !resolveTree.args.fulltext && !resolveTree.args.phrase && !isGlobalNode) {
         return testQueryAST({ context, node });
     }
 


### PR DESCRIPTION
# Description
```
Tests improved in branch B:  [
  'Global nodes > it should fetch the correct node and fields',
  'Global nodes > it should project the correct node and fields when id is the idField',
  'Global nodes > it should project the correct selectionSet when id is used as a where argument',
  'Global nodes > it should project the param as an integer when the underlying field is a number (fixes 1560)'
]
Regressions in branch B:  []
```
