### PR TITLE
Custom resolvers

### DIFF
--- a/packages/graphql/src/schema-model/annotation/CustomResolverAnnotation.ts
+++ b/packages/graphql/src/schema-model/annotation/CustomResolverAnnotation.ts
@@ -24,23 +24,22 @@ import { getDefinitionNodes } from "../../schema/get-definition-nodes";
 import type { ResolveTree } from "graphql-parse-resolve-info";
 
 export class CustomResolverAnnotation {
-    public readonly requires: string;
+    public readonly requires: string | undefined;
+    public parsedRequires: Record<string, ResolveTree> | undefined;
 
-    public parsedRequires: Record<string, ResolveTree> = {};
-    // Record<string, ResolveTree>;
-    // getCustomResolverMeta
-
-    constructor({ requires }: { requires: string }) {
+    constructor({ requires }: { requires: string | undefined }) {
         this.requires = requires;
     }
 
-    public parseRequire(document: DocumentNode, objectFields?: ReadonlyArray<FieldDefinitionNode>) {
+    public parseRequire(document: DocumentNode, objectFields?: ReadonlyArray<FieldDefinitionNode>): void {
+        if (!this.requires) {
+            return;
+        }
         const definitionNodes = getDefinitionNodes(document);
 
         const { interfaceTypes, objectTypes, unionTypes } = definitionNodes;
 
         const selectionSetDocument = parse(`{ ${this.requires} }`);
-
         this.parsedRequires = selectionSetToResolveTree(
             objectFields || [],
             objectTypes,
@@ -50,7 +49,3 @@ export class CustomResolverAnnotation {
         );
     }
 }
-// objectFields: ReadonlyArray<FieldDefinitionNode>,
-// objects: ObjectTypeDefinitionNode[],
-// interfaces: InterfaceTypeDefinitionNode[],
-// unions: UnionTypeDefinitionNode[],

--- a/packages/graphql/src/schema-model/annotation/CustomResolverAnnotation.ts
+++ b/packages/graphql/src/schema-model/annotation/CustomResolverAnnotation.ts
@@ -17,10 +17,40 @@
  * limitations under the License.
  */
 
+import type { DocumentNode, FieldDefinitionNode } from "graphql";
+import { parse } from "graphql";
+import { selectionSetToResolveTree } from "../../schema/get-custom-resolver-meta";
+import { getDefinitionNodes } from "../../schema/get-definition-nodes";
+import type { ResolveTree } from "graphql-parse-resolve-info";
+
 export class CustomResolverAnnotation {
     public readonly requires: string;
+
+    public parsedRequires: Record<string, ResolveTree> = {};
+    // Record<string, ResolveTree>;
+    // getCustomResolverMeta
 
     constructor({ requires }: { requires: string }) {
         this.requires = requires;
     }
+
+    public parseRequire(document: DocumentNode, objectFields?: ReadonlyArray<FieldDefinitionNode>) {
+        const definitionNodes = getDefinitionNodes(document);
+
+        const { interfaceTypes, objectTypes, unionTypes } = definitionNodes;
+
+        const selectionSetDocument = parse(`{ ${this.requires} }`);
+
+        this.parsedRequires = selectionSetToResolveTree(
+            objectFields || [],
+            objectTypes,
+            interfaceTypes,
+            unionTypes,
+            selectionSetDocument
+        );
+    }
 }
+// objectFields: ReadonlyArray<FieldDefinitionNode>,
+// objects: ObjectTypeDefinitionNode[],
+// interfaces: InterfaceTypeDefinitionNode[],
+// unions: UnionTypeDefinitionNode[],

--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -308,7 +308,7 @@ function generateRelationshipField(
                 filteredInheritedFields,
                 definitionCollection,
                 propertyInterface.fields
-            ); // TODO: check relationships for customResolvers
+            );
         });
 
         attributes = filterTruthy(fields) as Attribute[];

--- a/packages/graphql/src/schema-model/generate-model.ts
+++ b/packages/graphql/src/schema-model/generate-model.ts
@@ -164,6 +164,7 @@ function generateInterfaceEntity(
             const interfaceName = interfaceNamedNode.name.value;
             return definitionCollection.interfaceTypes.get(interfaceName)?.fields || [];
         }) || [];
+
     const fields = (definition.fields || []).map((fieldDefinition) => {
         const inheritedField = inheritedFields?.filter(
             (inheritedField) => inheritedField.name.value === fieldDefinition.name.value
@@ -175,7 +176,7 @@ function generateInterfaceEntity(
         if (isRelationshipAttribute || isInheritedRelationshipAttribute) {
             return;
         }
-        return parseAttribute(fieldDefinition, inheritedField, definitionCollection);
+        return parseAttribute(fieldDefinition, inheritedField, definitionCollection, definition.fields);
     });
 
     const inheritedDirectives =
@@ -299,10 +300,15 @@ function generateRelationshipField(
                 return definitionCollection.interfaceTypes.get(interfaceName)?.fields || [];
             }) || [];
         const fields = (propertyInterface.fields || []).map((fieldDefinition) => {
-            const inheritedField = inheritedFields?.filter(
+            const filteredInheritedFields = inheritedFields?.filter(
                 (inheritedField) => inheritedField.name.value === fieldDefinition.name.value
             );
-            return parseAttribute(fieldDefinition, inheritedField, definitionCollection);
+            return parseAttribute(
+                fieldDefinition,
+                filteredInheritedFields,
+                definitionCollection,
+                propertyInterface.fields
+            ); // TODO: check relationships for customResolvers
         });
 
         attributes = filterTruthy(fields) as Attribute[];
@@ -342,7 +348,7 @@ function generateConcreteEntity(
         if (isRelationshipAttribute || isInheritedRelationshipAttribute) {
             return;
         }
-        return parseAttribute(fieldDefinition, inheritedField, definitionCollection);
+        return parseAttribute(fieldDefinition, inheritedField, definitionCollection, definition.fields);
     });
 
     const annotations = createEntityAnnotations(definition.directives || []);

--- a/packages/graphql/src/schema-model/parser/annotations-parser/custom-resolver-annotation.test.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/custom-resolver-annotation.test.ts
@@ -24,7 +24,21 @@ import { customResolverDirective } from "../../../graphql/directives";
 
 describe("parseCustomResolverAnnotation", () => {
     it("should parse correctly", () => {
-        const directive: DirectiveNode = makeDirectiveNode("customResolver", { requires: "firstName lastName" }, customResolverDirective);
+        const directive: DirectiveNode = makeDirectiveNode(
+            "customResolver",
+            { requires: "firstName lastName" },
+            customResolverDirective
+        );
+        const customResolverAnnotation = parseCustomResolverAnnotation(directive);
+        expect(customResolverAnnotation.requires).toBe("firstName lastName");
+    });
+
+    it("should parse fields with multiple spaces correctly", () => {
+        const directive: DirectiveNode = makeDirectiveNode(
+            "customResolver",
+            { requires: "firstName  lastName" },
+            customResolverDirective
+        );
         const customResolverAnnotation = parseCustomResolverAnnotation(directive);
         expect(customResolverAnnotation.requires).toBe("firstName lastName");
     });

--- a/packages/graphql/src/schema-model/parser/annotations-parser/custom-resolver-annotation.ts
+++ b/packages/graphql/src/schema-model/parser/annotations-parser/custom-resolver-annotation.ts
@@ -22,8 +22,7 @@ import { CustomResolverAnnotation } from "../../annotation/CustomResolverAnnotat
 import { parseArguments } from "../parse-arguments";
 
 export function parseCustomResolverAnnotation(directive: DirectiveNode): CustomResolverAnnotation {
-    const { requires } = parseArguments<{ requires: string }>(customResolverDirective, directive);
-
+    const { requires } = parseArguments<{ requires: string | undefined }>(customResolverDirective, directive);
     return new CustomResolverAnnotation({
         requires,
     });

--- a/packages/graphql/src/schema-model/parser/definition-collection.ts
+++ b/packages/graphql/src/schema-model/parser/definition-collection.ts
@@ -46,6 +46,7 @@ export type DefinitionCollection = {
     interfaceToImplementingTypeNamesMap: Map<string, string[]>; // TODO: change this logic, this was the logic contained in initInterfacesToTypeNamesMap but potentially can be simplified now.
     operations: ObjectTypeDefinitionNode[];
     schemaDirectives: DirectiveNode[];
+    document: DocumentNode; // Raw Document from which the collection is made. NOTE: This is added here so we can generate customResolve fields following the old code.
 };
 
 export function getDefinitionCollection(document: DocumentNode): DefinitionCollection {
@@ -68,9 +69,7 @@ export function getDefinitionCollection(document: DocumentNode): DefinitionColle
                     definitionCollection.enumTypes.set(definition.name.value, definition);
                     break;
                 case Kind.INTERFACE_TYPE_DEFINITION:
-                    if (
-                        findDirective(definition.directives, relationshipPropertiesDirective.name)
-                    ) {
+                    if (findDirective(definition.directives, relationshipPropertiesDirective.name)) {
                         definitionCollection.relationshipProperties.set(definition.name.value, definition);
                     } else {
                         definitionCollection.interfaceTypes.set(definition.name.value, definition);
@@ -86,7 +85,9 @@ export function getDefinitionCollection(document: DocumentNode): DefinitionColle
                 case Kind.SCHEMA_EXTENSION:
                     // This is based on the assumption that mergeTypeDefs is used and therefore there is only one schema extension (merged), this assumption is currently used as well for object extensions.
                     definitionCollection.schemaExtension = definition;
-                    definitionCollection.schemaDirectives = definition.directives ? Array.from(definition.directives) : [];
+                    definitionCollection.schemaDirectives = definition.directives
+                        ? Array.from(definition.directives)
+                        : [];
                     break;
             }
 
@@ -105,6 +106,7 @@ export function getDefinitionCollection(document: DocumentNode): DefinitionColle
             interfaceToImplementingTypeNamesMap: new Map(),
             operations: [],
             schemaDirectives: [],
+            document,
         }
     );
 }

--- a/packages/graphql/src/schema-model/parser/parse-attribute.ts
+++ b/packages/graphql/src/schema-model/parser/parse-attribute.ts
@@ -43,6 +43,7 @@ import { parseAnnotations } from "./parse-annotation";
 import { aliasDirective } from "../../graphql/directives";
 import { parseArguments } from "./parse-arguments";
 import { findDirective } from "./utils";
+import { CustomResolverAnnotation } from "../annotation/CustomResolverAnnotation";
 
 function parseAttributeArguments(
     fieldArgs: readonly InputValueDefinitionNode[],
@@ -61,13 +62,22 @@ function parseAttributeArguments(
 export function parseAttribute(
     field: FieldDefinitionNode,
     inheritedField: FieldDefinitionNode[] | undefined,
-    definitionCollection: DefinitionCollection
+    definitionCollection: DefinitionCollection,
+    definitionFields?: ReadonlyArray<FieldDefinitionNode>
 ): Attribute | Field {
     const name = field.name.value;
     const type = parseTypeNode(definitionCollection, field.type);
     const args = parseAttributeArguments(field.arguments || [], definitionCollection);
     const inheritedDirectives = inheritedField?.flatMap((f) => f.directives || []) || [];
+
     const annotations = parseAnnotations((field.directives || []).concat(inheritedDirectives));
+
+    for (const annotation of annotations) {
+        if (annotation instanceof CustomResolverAnnotation) {
+            annotation.parseRequire(definitionCollection.document, definitionFields);
+        }
+    }
+
     const databaseName = getDatabaseName(field, inheritedField);
     return new Attribute({
         name,

--- a/packages/graphql/src/schema/get-custom-resolver-meta.ts
+++ b/packages/graphql/src/schema/get-custom-resolver-meta.ts
@@ -98,7 +98,7 @@ export function getCustomResolverMeta({
     }
 }
 
-function selectionSetToResolveTree(
+export function selectionSetToResolveTree(
     objectFields: ReadonlyArray<FieldDefinitionNode>,
     objects: ObjectTypeDefinitionNode[],
     interfaces: InterfaceTypeDefinitionNode[],

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -93,7 +93,7 @@ export class FieldFactory {
             });
         });
 
-        return [...fields];
+        return fields;
     }
 
     private createRelationshipAggregationField(

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -35,7 +35,7 @@ import { RelationshipAdapter } from "../../../schema-model/relationship/model-ad
 import { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
 import { isConcreteEntity } from "../utils/is-concrete-entity";
-import { fromGlobalId } from "../../../utils/global-ids";
+import { mergeDeep } from "@graphql-tools/utils";
 
 export class FieldFactory {
     private queryASTFactory: QueryASTFactory;
@@ -48,7 +48,20 @@ export class FieldFactory {
         rawFields: Record<string, ResolveTree>,
         context: Neo4jGraphQLTranslationContext
     ): Field[] {
-        return Object.values(rawFields).map((field: ResolveTree) => {
+        const fieldsToMerge = filterTruthy(
+            Object.values(rawFields).map((field) => {
+                const { fieldName } = parseSelectionSetField(field.name);
+
+                return this.getRequiredResolveTree({
+                    entity,
+                    fieldName,
+                });
+            })
+        );
+
+        const mergedFields: Record<string, ResolveTree> = mergeDeep([rawFields, ...fieldsToMerge]);
+
+        const fields = Object.values(mergedFields).flatMap((field: ResolveTree): Field[] | Field => {
             const { fieldName, isConnection, isAggregation } = parseSelectionSetField(field.name);
             if (isConnection) {
                 if (entity instanceof RelationshipAdapter)
@@ -79,6 +92,8 @@ export class FieldFactory {
                 context,
             });
         });
+
+        return [...fields];
     }
 
     private createRelationshipAggregationField(
@@ -86,12 +101,6 @@ export class FieldFactory {
         fieldName: string,
         resolveTree: ResolveTree
     ): OperationField {
-        // const operation = this.queryASTFactory.operationsFactory.createReadOperationAST(relationship, field);
-        // console.log(fieldName, resolveTree, relationship.aggregationFieldTypename);
-
-        // const args = resolveTree.args;
-        // const fields = resolveTree.fieldsByTypeName[relationship.aggregationFieldTypename];
-
         const operation = this.queryASTFactory.operationsFactory.createAggregationOperation(relationship, resolveTree);
         return new OperationField({
             alias: resolveTree.alias,
@@ -120,6 +129,24 @@ export class FieldFactory {
                 }
             })
         );
+    }
+
+    private getRequiredResolveTree({
+        entity,
+        fieldName,
+    }: {
+        entity: ConcreteEntityAdapter | RelationshipAdapter;
+        fieldName: string;
+    }): Record<string, ResolveTree> | undefined {
+        const attribute = entity.findAttribute(fieldName);
+        if (!attribute) return undefined;
+
+        const customResolver = attribute.annotations.customResolver;
+        if (!customResolver) {
+            return undefined;
+        }
+
+        return customResolver.parsedRequires;
     }
 
     private createAttributeField({

--- a/packages/graphql/tests/tck/directives/customResolver.test.ts
+++ b/packages/graphql/tests/tck/directives/customResolver.test.ts
@@ -314,7 +314,7 @@ describe("@customResolver directive", () => {
                     WITH this1 { city: var4 } AS this1
                     RETURN head(collect(this1)) AS var5
                 }
-                RETURN this { .lastName, .fullName, address: var5, .firstName } AS this"
+                RETURN this { .lastName, .fullName, .firstName, address: var5 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -475,18 +475,18 @@ describe("@customResolver directive", () => {
                     CALL {
                         WITH *
                         MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title } AS this1
+                        WITH this1 { .title, __resolveType: \\"Book\\", __id: id(this) } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
                         MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject } AS this4
+                        WITH this4 { .subject, __resolveType: \\"Journal\\", __id: id(this) } AS this4
                         RETURN this4 AS var2
                     }
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .publicationsWithAuthor, publications: var2, .name } AS this"
+                RETURN this { .publicationsWithAuthor, .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -510,12 +510,12 @@ describe("@customResolver directive", () => {
                     CALL {
                         WITH *
                         MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title } AS this1
+                        WITH this1 { .title, __resolveType: \\"Book\\", __id: id(this) } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
                         MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject } AS this4
+                        WITH this4 { .subject, __resolveType: \\"Journal\\", __id: id(this) } AS this4
                         RETURN this4 AS var2
                     }
                     WITH var2
@@ -656,18 +656,18 @@ describe("@customResolver directive", () => {
                     CALL {
                         WITH *
                         MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title, .publicationYear } AS this1
+                        WITH this1 { .publicationYear, .title, __resolveType: \\"Book\\", __id: id(this) } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
                         MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject, .publicationYear } AS this4
+                        WITH this4 { .publicationYear, .subject, __resolveType: \\"Journal\\", __id: id(this) } AS this4
                         RETURN this4 AS var2
                     }
                     WITH var2
                     RETURN collect(var2) AS var2
                 }
-                RETURN this { .publicationsWithAuthor, publications: var2, .name } AS this"
+                RETURN this { .publicationsWithAuthor, .name, publications: var2 } AS this"
             `);
 
             expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
@@ -691,12 +691,12 @@ describe("@customResolver directive", () => {
                     CALL {
                         WITH *
                         MATCH (this)-[this0:WROTE]->(this1:Book)
-                        WITH this1 { __resolveType: \\"Book\\", __id: id(this), .title, .publicationYear } AS this1
+                        WITH this1 { .publicationYear, .title, __resolveType: \\"Book\\", __id: id(this) } AS this1
                         RETURN this1 AS var2
                         UNION
                         WITH *
                         MATCH (this)-[this3:WROTE]->(this4:Journal)
-                        WITH this4 { __resolveType: \\"Journal\\", __id: id(this), .subject, .publicationYear } AS this4
+                        WITH this4 { .publicationYear, .subject, __resolveType: \\"Journal\\", __id: id(this) } AS this4
                         RETURN this4 AS var2
                     }
                     WITH var2


### PR DESCRIPTION
# Description

```
Tests improved in branch B:  [
  '@customResolver directive > Require fields on nested interfaces > should not over fetch when no required fields are manually selected',
  '@customResolver directive > Require fields on nested interfaces > should not over fetch when some required fields are manually selected',
  '@customResolver directive > Require fields on nested types > should not over fetch when no required fields are manually selected',
  '@customResolver directive > Require fields on nested types > should not over fetch when some required fields are manually selected',
  '@customResolver directive > Require fields on nested unions > should not over fetch when no required fields are manually selected',
  '@customResolver directive > Require fields on nested unions > should not over fetch when some required fields are manually selected',
  '@customResolver directive > Require fields on same type > should not over fetch when no required fields are manually selected',
  '@customResolver directive > Require fields on same type > should not over fetch when some required fields are manually selected'
]
```

```
Test Suites: 9 failed, 232 passed, 241 total
Tests:       16 failed, 1267 passed, 1283 total
```