### PR TITLE
Fix 1566

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherUnionAttributePartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherUnionAttributePartial.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ConcreteEntityAdapter } from "../../../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
+import type { QueryASTContext } from "../../QueryASTContext";
+import { QueryASTNode } from "../../QueryASTNode";
+import type { Field } from "../Field";
+import Cypher from "@neo4j/cypher-builder";
+
+export class CypherUnionAttributePartial extends QueryASTNode {
+    protected fields: Field[];
+    protected target: ConcreteEntityAdapter;
+
+    constructor({ fields, target }: { fields: Field[]; target: ConcreteEntityAdapter }) {
+        super();
+        this.fields = fields;
+        this.target = target;
+    }
+
+    public getChildren(): QueryASTNode[] {
+        return this.fields;
+    }
+
+    public getSubqueries(context: QueryASTContext): Cypher.Clause[] {
+        return this.fields.flatMap((f) => f.getSubqueries(context));
+    }
+
+    public getProjectionExpression(variable: Cypher.Variable): Cypher.Expr {
+        const projection = new Cypher.MapProjection(variable);
+        this.setSubqueriesProjection(projection, this.fields, variable);
+        projection.set({
+            __resolveType: new Cypher.Literal(this.target.name),
+        });
+        return projection;
+    }
+
+    public getFilterPredicate(variable: Cypher.Variable): Cypher.Predicate {
+        return (variable as Cypher.Node).hasLabels(...this.target.getLabels());
+    }
+
+    private setSubqueriesProjection(projection: Cypher.MapProjection, fields: Field[], fromVariable: Cypher.Variable) {
+        const subqueriesProjection = fields?.map((f) => f.getProjectionField(fromVariable));
+        for (const subqueryProjection of subqueriesProjection) {
+            projection.set(subqueryProjection);
+        }
+    }
+}

--- a/packages/graphql/tests/tck/issues/1566.test.ts
+++ b/packages/graphql/tests/tck/issues/1566.test.ts
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
         });
     });
 
-    test("expectMultipleValues should be set to true in apoc.cypher.runFirstColumn", async () => {
+    test("collect unions returned by cypher directive", async () => {
         const query = gql`
             query {
                 communities(where: { id: 4656564 }) {
@@ -95,8 +95,8 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
                 WITH *
                 WHERE (this0:Content OR this0:Project)
                 RETURN collect(CASE
-                    WHEN this0:Content THEN this0 { __resolveType: \\"Content\\",  .name }
-                    WHEN this0:Project THEN this0 { __resolveType: \\"Project\\",  .name }
+                    WHEN this0:Content THEN this0 { .name, __resolveType: \\"Content\\" }
+                    WHEN this0:Project THEN this0 { .name, __resolveType: \\"Project\\" }
                 END) AS this0
             }
             RETURN this { .id, hasFeedItems: this0 } AS this"


### PR DESCRIPTION
# Description
Solves cypher returning unions by creating a new CypherUnionAttributeField class and a "Partial" class to handle this edge case.

```
Tests improved in branch B:  [
  'Cypher directive > Union directive - querying only __typename',
  'https://github.com/neo4j/graphql/issues/1566 > expectMultipleValues should be set to true in apoc.cypher.runFirstColumn'
]
```
