### PR TITLE
Fix a validation error which was wrongly being thrown if two enum types contained the same value

### DIFF
--- a/.changeset/olive-deers-cry.md
+++ b/.changeset/olive-deers-cry.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix a validation error which was wrongly being thrown if two enum types contained the same value.

--- a/packages/graphql/src/classes/Neo4jGraphQL.test.ts
+++ b/packages/graphql/src/classes/Neo4jGraphQL.test.ts
@@ -20,6 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { getErrorAsync, NoErrorThrownError } from "../../tests/utils/get-error";
 import Neo4jGraphQL from "./Neo4jGraphQL";
+import gql from "graphql-tag";
 
 describe("Neo4jGraphQL", () => {
     test("should construct", () => {

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -17,6 +17,9 @@
  * limitations under the License.
  */
 
+import type { GraphQLNamedType, GraphQLType } from "graphql";
+import { isWrappingType } from "graphql";
+
 const DEBUG_PREFIX = "@neo4j/graphql";
 
 export const AUTH_FORBIDDEN_ERROR = "@neo4j/graphql/FORBIDDEN";
@@ -56,6 +59,14 @@ export const GRAPHQL_BUILTIN_SCALAR_TYPES = ["Boolean", "ID", "String", "Int", "
 export const TEMPORAL_SCALAR_TYPES = ["DateTime", "LocalDateTime", "Time", "LocalTime", "Date"];
 export const SCALAR_TYPES = [...GRAPHQL_BUILTIN_SCALAR_TYPES, ...TEMPORAL_SCALAR_TYPES, "BigInt", "Duration"];
 export const SPATIAL_TYPES = ["Point", "CartesianPoint"];
+
+export function isTemporalType(type: GraphQLType) {
+    if (isWrappingType(type)) {
+        return isTemporalType(type.ofType);
+    }
+
+    return TEMPORAL_SCALAR_TYPES.includes(type.name);
+}
 
 export function isTemporal(typeName: string) {
     return TEMPORAL_SCALAR_TYPES.includes(typeName);

--- a/packages/graphql/src/schema/validation/custom-rules/coalesce-default-value-of-correct-type.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/coalesce-default-value-of-correct-type.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    Kind,
+    coerceInputValue,
+    GraphQLObjectType,
+    GraphQLInterfaceType,
+    valueFromASTUntyped,
+    print,
+    isInputType,
+} from "graphql";
+import type {
+    ASTNode,
+    ASTVisitor,
+    DirectiveNode,
+    GraphQLSchema,
+    InterfaceTypeDefinitionNode,
+    InterfaceTypeExtensionNode,
+    ObjectTypeDefinitionNode,
+    ObjectTypeExtensionNode,
+} from "graphql";
+import type { ASTValidationContext } from "graphql/validation/ValidationContext";
+import { createGraphQLError } from "./utils/document-validation-error";
+import { getPathToNode } from "./utils/path-parser";
+import { isTemporal, isTemporalType } from "../../../constants";
+
+export function coalesceDefaultValueOfCorrectTypeRule(schema: GraphQLSchema) {
+    return function (context: ASTValidationContext): ASTVisitor {
+        return {
+            Directive(
+                directiveNode: DirectiveNode,
+                _key,
+                _parent,
+                path,
+                ancestors: ReadonlyArray<ASTNode | ReadonlyArray<ASTNode>>
+            ) {
+                const directiveName = directiveNode.name.value;
+
+                if (!["coalesce", "default"].includes(directiveName)) {
+                    return;
+                }
+
+                const value = directiveNode.arguments?.find((argument) => argument.name.value === "value");
+
+                if (!value) {
+                    return;
+                }
+
+                const typeNode = ancestors.slice(-3, -2)[0];
+                const fieldNode = ancestors.slice(-1)[0];
+
+                if (!isAncestorAstNode(fieldNode) || fieldNode.kind !== Kind.FIELD_DEFINITION) {
+                    return;
+                }
+
+                if (
+                    !isAncestorAstNode(typeNode) ||
+                    ![
+                        Kind.INTERFACE_TYPE_DEFINITION,
+                        Kind.OBJECT_TYPE_DEFINITION,
+                        Kind.INTERFACE_TYPE_EXTENSION,
+                        Kind.OBJECT_TYPE_EXTENSION,
+                    ].includes(typeNode.kind)
+                ) {
+                    return;
+                }
+
+                const type = schema.getType(
+                    (
+                        typeNode as
+                            | InterfaceTypeDefinitionNode
+                            | ObjectTypeDefinitionNode
+                            | InterfaceTypeExtensionNode
+                            | ObjectTypeExtensionNode
+                    ).name.value
+                );
+
+                if (!(type instanceof GraphQLObjectType || type instanceof GraphQLInterfaceType)) {
+                    return;
+                }
+
+                const field = Object.values(type.getFields()).find((f) => f.name === fieldNode.name.value);
+
+                if (!field) {
+                    return;
+                }
+
+                const [pathToNode, traversedDef] = getPathToNode(path, ancestors);
+                const pathToHere = [...pathToNode, `@${directiveName}`];
+
+                if (!traversedDef) {
+                    console.error("No last definition traversed");
+                    return;
+                }
+
+                const inputType = field.type;
+
+                if (!isInputType(inputType) || (directiveName === "coalesce" && isTemporalType(inputType))) {
+                    context.reportError(
+                        createGraphQLError({
+                            nodes: [directiveNode, traversedDef],
+                            path: pathToHere,
+                            errorMsg: `Directive "@${directiveName}" is not supported on fields of type "${inputType.toString()}".`,
+                        })
+                    );
+                    return;
+                }
+
+                const inputValue = valueFromASTUntyped(value.value);
+
+                // try to coerce the argument value given the definition type, and report the error if this fails
+                coerceInputValue(inputValue, inputType, () => {
+                    context.reportError(
+                        createGraphQLError({
+                            nodes: [directiveNode, traversedDef],
+                            path: [...pathToHere, "value"],
+                            errorMsg: `Expected argument "value" on directive "@${directiveName}" to have type "${inputType.toString()}", found ${print(
+                                value.value
+                            )}.`,
+                        })
+                    );
+                });
+            },
+        };
+    };
+}
+
+function isAncestorAstNode(ancestor: ASTNode | readonly ASTNode[] | undefined): ancestor is ASTNode {
+    if (!ancestor || Array.isArray(ancestor)) {
+        return false;
+    }
+
+    return true;
+}

--- a/packages/graphql/src/schema/validation/custom-rules/directives/valid-directive.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/directives/valid-directive.ts
@@ -54,10 +54,6 @@ function getValidationFunction(
     callbacks?: Neo4jGraphQLCallbacks
 ): ValidationFunction | undefined {
     switch (directiveName) {
-        case "coalesce":
-            return verifyCoalesce(extra.enums);
-        case "default":
-            return verifyDefault(extra.enums);
         case "fulltext":
             return verifyFulltext;
         case "populatedBy":

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -792,7 +792,10 @@ describe("validation 2.0", () => {
 
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value is not a valid DateTime");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "DateTime", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@default", "value"]);
             });
 
@@ -817,7 +820,10 @@ describe("validation 2.0", () => {
 
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value is not a valid DateTime");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "DateTime", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@default", "value"]);
             });
 
@@ -865,7 +871,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on Status fields must be of type Status");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "Status", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "status", "@default", "value"]);
             });
 
@@ -902,7 +911,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on Status fields must be of type Status");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "Status", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["Person", "status", "@default", "value"]);
             });
 
@@ -943,7 +955,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on Status fields must be of type Status");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "Status", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["Person", "status", "@default", "value"]);
             });
 
@@ -1003,7 +1018,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on Status list fields must be a list of Status values"
+                    'Expected argument "value" on directive "@default" to have type "[Status]", found "dummy".'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "statuses", "@default", "value"]);
             });
@@ -1037,7 +1052,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on Status list fields must be a list of Status values"
+                    'Expected argument "value" on directive "@default" to have type "[Status]", found ["dummy"].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "statuses", "@default", "value"]);
             });
@@ -1085,7 +1100,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on Int fields must be of type Int");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "Int", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "age", "@default", "value"]);
             });
 
@@ -1125,7 +1143,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on Int list fields must be a list of Int values"
+                    'Expected argument "value" on directive "@default" to have type "[Int]", found ["dummy"].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "ages", "@default", "value"]);
             });
@@ -1150,7 +1168,7 @@ describe("validation 2.0", () => {
             test("@default on float must be float", () => {
                 const doc = gql`
                     type User {
-                        avg: Float @default(value: 2)
+                        avg: Float @default(value: "not a float")
                     }
                 `;
 
@@ -1164,7 +1182,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on Float fields must be of type Float");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "Float", found "not a float".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "avg", "@default", "value"]);
             });
 
@@ -1188,7 +1209,7 @@ describe("validation 2.0", () => {
             test("@default on float list must be list of float values", () => {
                 const doc = gql`
                     type User {
-                        avgs: [Float] @default(value: [1])
+                        avgs: [Float] @default(value: ["not a float"])
                     }
                 `;
 
@@ -1204,7 +1225,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on Float list fields must be a list of Float values"
+                    'Expected argument "value" on directive "@default" to have type "[Float]", found ["not a float"].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "avgs", "@default", "value"]);
             });
@@ -1243,7 +1264,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on Boolean fields must be of type Boolean");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "Boolean", found 2.'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "registered", "@default", "value"]);
             });
 
@@ -1283,7 +1307,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on Boolean list fields must be a list of Boolean values"
+                    'Expected argument "value" on directive "@default" to have type "[Boolean]", found [2].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "statuses", "@default", "value"]);
             });
@@ -1322,7 +1346,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on String fields must be of type String");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "String", found 2.'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "name", "@default", "value"]);
             });
 
@@ -1362,7 +1389,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on String list fields must be a list of String values"
+                    'Expected argument "value" on directive "@default" to have type "[String]", found [2].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "names", "@default", "value"]);
             });
@@ -1387,28 +1414,7 @@ describe("validation 2.0", () => {
             test("@default on ID must be ID", () => {
                 const doc = gql`
                     type User {
-                        uid: ID @default(value: 2)
-                    }
-                `;
-
-                const executeValidate = () =>
-                    validateDocument({
-                        document: doc,
-                        additionalDefinitions,
-                        features: {},
-                    });
-
-                const errors = getError(executeValidate);
-                expect(errors).toHaveLength(1);
-                expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default.value on ID fields must be of type ID");
-                expect(errors[0]).toHaveProperty("path", ["User", "uid", "@default", "value"]);
-            });
-
-            test("@default on ID list must be list of ID values", () => {
-                const doc = gql`
-                    type User {
-                        ids: [ID] @default(value: [2])
+                        uid: ID @default(value: true)
                     }
                 `;
 
@@ -1424,7 +1430,31 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default.value on ID list fields must be a list of ID values"
+                    'Expected argument "value" on directive "@default" to have type "ID", found true.'
+                );
+                expect(errors[0]).toHaveProperty("path", ["User", "uid", "@default", "value"]);
+            });
+
+            test("@default on ID list must be list of ID values", () => {
+                const doc = gql`
+                    type User {
+                        ids: [ID] @default(value: [true])
+                    }
+                `;
+
+                const executeValidate = () =>
+                    validateDocument({
+                        document: doc,
+                        additionalDefinitions,
+                        features: {},
+                    });
+
+                const errors = getError(executeValidate);
+                expect(errors).toHaveLength(1);
+                expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@default" to have type "[ID]", found [true].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "ids", "@default", "value"]);
             });
@@ -1480,8 +1510,11 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@default is not supported by Spatial types.");
-                expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@default", "value"]);
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Directive "@default" is not supported on fields of type "Point".'
+                );
+                expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@default"]);
             });
 
             test("@default only supported on scalar types", () => {
@@ -1506,7 +1539,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@default directive can only be used on Temporal types and types: Int | Float | String | Boolean | ID | Enum"
+                    'Directive "@default" is not supported on fields of type "Post".'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "post", "@default"]);
             });
@@ -1540,7 +1573,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce.value on Status fields must be of type Status");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@coalesce" to have type "Status", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "status", "@coalesce", "value"]);
             });
 
@@ -1574,7 +1610,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce.value on Status fields must be of type Status");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@coalesce" to have type "Status", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "status", "@coalesce", "value"]);
             });
 
@@ -1634,7 +1673,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Status list fields must be a list of Status values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Status]", found "dummy".'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "statuses", "@coalesce", "value"]);
             });
@@ -1674,7 +1713,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Status list fields must be a list of Status values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Status]", found "dummy".'
                 );
                 expect(errors[0]).toHaveProperty("path", ["Person", "statuses", "@coalesce", "value"]);
             });
@@ -1718,7 +1757,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Status list fields must be a list of Status values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Status]", found "dummy".'
                 );
                 expect(errors[0]).toHaveProperty("path", ["Person", "statuses", "@coalesce", "value"]);
             });
@@ -1752,7 +1791,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Status list fields must be a list of Status values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Status]", found ["dummy"].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "statuses", "@coalesce", "value"]);
             });
@@ -1801,7 +1840,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce.value on Int fields must be of type Int");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@coalesce" to have type "Int", found "dummy".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "age", "@coalesce", "value"]);
             });
 
@@ -1841,7 +1883,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Int list fields must be a list of Int values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Int]", found ["dummy"].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "ages", "@coalesce", "value"]);
             });
@@ -1866,7 +1908,7 @@ describe("validation 2.0", () => {
             test("@coalesce on float must be float", () => {
                 const doc = gql`
                     type User {
-                        avg: Float @coalesce(value: 2)
+                        avg: Float @coalesce(value: "not a float")
                     }
                 `;
 
@@ -1880,7 +1922,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce.value on Float fields must be of type Float");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@coalesce" to have type "Float", found "not a float".'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "avg", "@coalesce", "value"]);
             });
 
@@ -1904,7 +1949,7 @@ describe("validation 2.0", () => {
             test("@coalesce on float list must be list of float values", () => {
                 const doc = gql`
                     type User {
-                        avgs: [Float] @coalesce(value: [1])
+                        avgs: [Float] @coalesce(value: ["not a float"])
                     }
                 `;
 
@@ -1920,7 +1965,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Float list fields must be a list of Float values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Float]", found ["not a float"].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "avgs", "@coalesce", "value"]);
             });
@@ -1961,7 +2006,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Boolean fields must be of type Boolean"
+                    'Expected argument "value" on directive "@coalesce" to have type "Boolean", found 2.'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "registered", "@coalesce", "value"]);
             });
@@ -2002,7 +2047,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on Boolean list fields must be a list of Boolean values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[Boolean]", found [2].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "statuses", "@coalesce", "value"]);
             });
@@ -2041,7 +2086,10 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce.value on String fields must be of type String");
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@coalesce" to have type "String", found 2.'
+                );
                 expect(errors[0]).toHaveProperty("path", ["User", "name", "@coalesce", "value"]);
             });
 
@@ -2081,7 +2129,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on String list fields must be a list of String values"
+                    'Expected argument "value" on directive "@coalesce" to have type "[String]", found [2].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "names", "@coalesce", "value"]);
             });
@@ -2106,28 +2154,7 @@ describe("validation 2.0", () => {
             test("@coalesce on ID must be ID", () => {
                 const doc = gql`
                     type User {
-                        uid: ID @coalesce(value: 2)
-                    }
-                `;
-
-                const executeValidate = () =>
-                    validateDocument({
-                        document: doc,
-                        additionalDefinitions,
-                        features: {},
-                    });
-
-                const errors = getError(executeValidate);
-                expect(errors).toHaveLength(1);
-                expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce.value on ID fields must be of type ID");
-                expect(errors[0]).toHaveProperty("path", ["User", "uid", "@coalesce", "value"]);
-            });
-
-            test("@coalesce on ID list must be list of ID values", () => {
-                const doc = gql`
-                    type User {
-                        ids: [ID] @coalesce(value: [2])
+                        uid: ID @coalesce(value: true)
                     }
                 `;
 
@@ -2143,7 +2170,31 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce.value on ID list fields must be a list of ID values"
+                    'Expected argument "value" on directive "@coalesce" to have type "ID", found true.'
+                );
+                expect(errors[0]).toHaveProperty("path", ["User", "uid", "@coalesce", "value"]);
+            });
+
+            test("@coalesce on ID list must be list of ID values", () => {
+                const doc = gql`
+                    type User {
+                        ids: [ID] @coalesce(value: [true])
+                    }
+                `;
+
+                const executeValidate = () =>
+                    validateDocument({
+                        document: doc,
+                        additionalDefinitions,
+                        features: {},
+                    });
+
+                const errors = getError(executeValidate);
+                expect(errors).toHaveLength(1);
+                expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Expected argument "value" on directive "@coalesce" to have type "[ID]", found [true].'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "ids", "@coalesce", "value"]);
             });
@@ -2199,8 +2250,11 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce is not supported by Spatial types.");
-                expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@coalesce", "value"]);
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Directive "@coalesce" is not supported on fields of type "Point".'
+                );
+                expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@coalesce"]);
             });
 
             test("@coalesce not supported on Temporal types", () => {
@@ -2220,8 +2274,11 @@ describe("validation 2.0", () => {
                 const errors = getError(executeValidate);
                 expect(errors).toHaveLength(1);
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
-                expect(errors[0]).toHaveProperty("message", "@coalesce is not supported by Temporal types.");
-                expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@coalesce", "value"]);
+                expect(errors[0]).toHaveProperty(
+                    "message",
+                    'Directive "@coalesce" is not supported on fields of type "DateTime".'
+                );
+                expect(errors[0]).toHaveProperty("path", ["User", "updatedAt", "@coalesce"]);
             });
 
             test("@coalesce only supported on scalar types", () => {
@@ -2246,7 +2303,7 @@ describe("validation 2.0", () => {
                 expect(errors[0]).not.toBeInstanceOf(NoErrorThrownError);
                 expect(errors[0]).toHaveProperty(
                     "message",
-                    "@coalesce directive can only be used on types: Int | Float | String | Boolean | ID | Enum"
+                    'Directive "@coalesce" is not supported on fields of type "Post".'
                 );
                 expect(errors[0]).toHaveProperty("path", ["User", "post", "@coalesce"]);
             });
@@ -5849,7 +5906,7 @@ describe("validation 2.0", () => {
             `;
 
             expect(() => validateDocument({ document: doc, features: undefined, additionalDefinitions })).toThrow(
-                'Unknown type "Unknown".'
+                'Unknown type: "Unknown".'
             );
         });
 

--- a/packages/graphql/tests/integration/directives/coalesce.int.test.ts
+++ b/packages/graphql/tests/integration/directives/coalesce.int.test.ts
@@ -50,7 +50,7 @@ describe("@coalesce directive", () => {
         });
 
         await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-            new GraphQLError("@coalesce is not supported by Spatial types."),
+            new GraphQLError('Directive "@coalesce" is not supported on fields of type "Point!".'),
         ]);
     });
 
@@ -67,7 +67,7 @@ describe("@coalesce directive", () => {
         });
 
         await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-            new GraphQLError("@coalesce is not supported by Temporal types."),
+            new GraphQLError('Directive "@coalesce" is not supported on fields of type "DateTime!".'),
         ]);
     });
 
@@ -83,7 +83,7 @@ describe("@coalesce directive", () => {
         });
 
         await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-            new GraphQLError("@coalesce.value on String fields must be of type String"),
+            new GraphQLError('Expected argument "value" on directive "@coalesce" to have type "String!", found 2.'),
         ]);
     });
 

--- a/packages/graphql/tests/integration/directives/default.int.test.ts
+++ b/packages/graphql/tests/integration/directives/default.int.test.ts
@@ -49,7 +49,7 @@ describe("@default directive", () => {
             });
 
             await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-                new GraphQLError("@default is not supported by Spatial types."),
+                new GraphQLError('Directive "@default" is not supported on fields of type "Point!".'),
             ]);
         });
 
@@ -65,7 +65,7 @@ describe("@default directive", () => {
             });
 
             await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-                new GraphQLError("@default.value on String fields must be of type String"),
+                new GraphQLError('Expected argument "value" on directive "@default" to have type "String!", found 2.'),
             ]);
         });
 
@@ -81,7 +81,9 @@ describe("@default directive", () => {
             });
 
             await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-                new GraphQLError("@default.value is not a valid DateTime"),
+                new GraphQLError(
+                    'Expected argument "value" on directive "@default" to have type "DateTime!", found "Not a date".'
+                ),
             ]);
         });
 
@@ -121,7 +123,9 @@ describe("@default directive", () => {
             });
 
             await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-                new GraphQLError("@default.value on Location fields must be of type Location"),
+                new GraphQLError(
+                    'Expected argument "value" on directive "@default" to have type "Location!", found DIFFERENT.'
+                ),
             ]);
         });
 
@@ -144,7 +148,7 @@ describe("@default directive", () => {
             });
 
             await expect(neoSchema.getSchema()).rejects.toIncludeSameMembers([
-                new GraphQLError("@default.value on Location fields must be of type Location"),
+                new GraphQLError('Expected argument "value" on directive "@default" to have type "Location!", found 2.'),
             ]);
         });
 

--- a/packages/graphql/tests/integration/issues/3932.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3932.int.test.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver, Session } from "neo4j-driver";
+import { graphql } from "graphql";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { UniqueType } from "../../utils/graphql-types";
+
+describe("https://github.com/neo4j/graphql/issues/3932", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let session: Session;
+
+    let neoSchema: Neo4jGraphQL;
+
+    const Image = new UniqueType("Image");
+    const Invite = new UniqueType("Invite");
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+
+        const typeDefs = /* GraphQL */ `
+            enum ImageStatus {
+                PENDING
+                UPLOADED
+            }
+
+            type ${Image} {
+                status: ImageStatus! @default(value: PENDING)
+            }
+
+            enum InviteStatus {
+                PENDING
+                ACCEPTED
+            }
+
+            type ${Invite} {
+                status: InviteStatus! @default(value: PENDING)
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    beforeEach(async () => {
+        session = await neo4j.getSession();
+    });
+
+    afterEach(async () => {
+        await session.close();
+    });
+    afterAll(async () => {
+        await driver.close();
+    });
+
+    test("Server starts up and defaults work", async () => {
+        const query = `#graphql
+            mutation {
+                ${Image.operations.create}(input: [{}]) {
+                    ${Image.plural} {
+                        status
+                    }
+                }
+            }
+        `;
+
+        const gqlResult = await graphql({
+            schema: await neoSchema.getSchema(),
+            source: query,
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(gqlResult.errors).toBeFalsy();
+        expect(gqlResult.data).toEqual({
+            [Image.operations.create]: {
+                [Image.plural]: [
+                    {
+                        status: "PENDING",
+                    },
+                ],
+            },
+        });
+    });
+});


### PR DESCRIPTION
# Description

Fix a validation error which was wrongly being thrown if two enum types contained the same value

## Complexity

Complexity: Medium

# Issue

Closes #3932
