### PR TITLE
Bump Toolbox version to match current max

### DIFF
--- a/packages/graphql-toolbox/package.json
+++ b/packages/graphql-toolbox/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@neo4j/graphql-toolbox",
     "private": true,
-    "version": "2.0.7",
+    "version": "2.0.8",
     "description": "Developer UI For Neo4j GraphQL",
     "exports": "./dist/main.js",
     "main": "./dist/main.js",


### PR DESCRIPTION
# Description

At some point during the 4.0.0 release, Toolbox versions got a bit messy, meaning that the current proposal by changesets has actually already been released. This bumps the version so that changesets releases the next version along.

## Complexity

Complexity: Low
