### PR TITLE
Fix spatial types

### DIFF
--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -219,7 +219,7 @@ export class FieldFactory {
             });
         }
 
-        if (attribute.isPoint()) {
+        if (attribute.isPoint() || attribute.isCartesianPoint()) {
             const typeName = attribute.isList() ? attribute.type.ofType.name : attribute.type.name;
             const { crs } = field.fieldsByTypeName[typeName] as any;
             return new PointAttributeField({

--- a/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FilterFactory.ts
@@ -166,7 +166,7 @@ export class FilterFactory {
                 attachedTo,
             });
         }
-        if (attribute.isPoint()) {
+        if (attribute.isPoint() || attribute.isCartesianPoint()) {
             return new PointFilter({
                 attribute,
                 comparisonValue,

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -593,6 +593,7 @@ describe("Subscriptions to spatial types", () => {
             ])
         );
     });
+
     test("query type with CartesianPoint field and filters", async () => {
         const x = faker.number.float();
         const y = faker.number.float();


### PR DESCRIPTION
# Description

Fix Carterian Point queries

```
  'CartesianPoint > enables query of a node with a cartesian point',
  'CartesianPoint > enables query of a node with a cartesian-3d point',
  'Subscriptions to spatial types > query type with CartesianPoint field and filters',
  '[CartesianPoint] > enables query of a node with multiple cartesian points',
  '[CartesianPoint] > enables query of a node with multiple cartesian-3d points'
```