### PR TITLE
Rename Interface operations to Composite operations.

### DIFF
--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
@@ -24,7 +24,7 @@ import type { OperationTranspileOptions, OperationTranspileResult } from "../ope
 import type { Sort } from "../../sort/Sort";
 import type { Pagination } from "../../pagination/Pagination";
 
-export class InterfaceConnectionPartial extends ConnectionReadOperation {
+export class CompositeConnectionPartial extends ConnectionReadOperation {
     public transpile({ returnVariable, context }: OperationTranspileOptions): OperationTranspileResult {
         if (!context.target) throw new Error();
         const node = createNodeFromEntity(this.target, context.neo4jGraphQLContext);
@@ -127,12 +127,12 @@ export class InterfaceConnectionPartial extends ConnectionReadOperation {
         };
     }
 
-    // Sort is handled by InterfaceConnectionReadOperation
+    // Sort is handled by CompositeConnectionReadOperation
     public addSort(sortElement: { node: Sort[]; edge: Sort[] }): void {
         this.sortFields.push(sortElement);
     }
 
-    // Pagination is handled by InterfaceConnectionReadOperation
+    // Pagination is handled by CompositeConnectionReadOperation
     public addPagination(_pagination: Pagination): void {
         return undefined;
     }

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -22,18 +22,18 @@ import type { OperationTranspileOptions, OperationTranspileResult } from "../ope
 import { Operation } from "../operations";
 
 import type { QueryASTNode } from "../../QueryASTNode";
-import type { InterfaceConnectionPartial } from "./InterfaceConnectionPartial";
+import type { CompositeConnectionPartial } from "./CompositeConnectionPartial";
 import type { Sort, SortField } from "../../sort/Sort";
 import type { Pagination } from "../../pagination/Pagination";
 import { QueryASTContext } from "../../QueryASTContext";
 import { filterTruthy } from "../../../../../utils/utils";
 
-export class InterfaceConnectionReadOperation extends Operation {
-    private children: InterfaceConnectionPartial[];
+export class CompositeConnectionReadOperation extends Operation {
+    private children: CompositeConnectionPartial[];
     protected sortFields: Array<{ node: Sort[]; edge: Sort[] }> = [];
     private pagination: Pagination | undefined;
 
-    constructor(children: InterfaceConnectionPartial[]) {
+    constructor(children: CompositeConnectionPartial[]) {
         super();
 
         this.children = children;

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadOperation.ts
@@ -21,7 +21,7 @@ import Cypher from "@neo4j/cypher-builder";
 import type { QueryASTNode } from "../../QueryASTNode";
 import type { OperationTranspileOptions, OperationTranspileResult } from "../operations";
 import { Operation } from "../operations";
-import type { InterfaceReadPartial } from "./InterfaceReadPartial";
+import type { CompositeReadPartial } from "./CompositeReadPartial";
 import type { UnionEntityAdapter } from "../../../../../schema-model/entity/model-adapters/UnionEntityAdapter";
 import type { InterfaceEntityAdapter } from "../../../../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
 import type { RelationshipAdapter } from "../../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
@@ -29,24 +29,24 @@ import type { Pagination } from "../../pagination/Pagination";
 import type { Sort, SortField } from "../../sort/Sort";
 import type { QueryASTContext } from "../../QueryASTContext";
 
-export class InterfaceReadOperation extends Operation {
-    private children: InterfaceReadPartial[];
+export class CompositeReadOperation extends Operation {
+    private children: CompositeReadPartial[];
     private entity: InterfaceEntityAdapter | UnionEntityAdapter;
     private relationship: RelationshipAdapter | undefined;
     protected pagination: Pagination | undefined;
     protected sortFields: Sort[] = [];
 
     constructor({
-        interfaceEntity,
+        compositeEntity,
         children,
         relationship,
     }: {
-        interfaceEntity: InterfaceEntityAdapter | UnionEntityAdapter;
-        children: InterfaceReadPartial[];
+        compositeEntity: InterfaceEntityAdapter | UnionEntityAdapter;
+        children: CompositeReadPartial[];
         relationship: RelationshipAdapter | undefined;
     }) {
         super();
-        this.entity = interfaceEntity;
+        this.entity = compositeEntity;
         this.children = children;
         this.relationship = relationship;
     }

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadPartial.ts
@@ -24,16 +24,16 @@ import { ReadOperation } from "../ReadOperation";
 import type { OperationTranspileOptions, OperationTranspileResult } from "../operations";
 import type { RelationshipAdapter } from "../../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
 
-export class InterfaceReadPartial extends ReadOperation {
+export class CompositeReadPartial extends ReadOperation {
     public transpile({ returnVariable, context }: OperationTranspileOptions): OperationTranspileResult {
         if (this.relationship) {
-            return this.transpileNestedInterfaceRelationship(this.relationship, { returnVariable, context });
+            return this.transpileNestedCompositeRelationship(this.relationship, { returnVariable, context });
         } else {
             throw new Error("Top level interfaces are not supported");
         }
     }
 
-    private transpileNestedInterfaceRelationship(
+    private transpileNestedCompositeRelationship(
         entity: RelationshipAdapter,
         { returnVariable, context }: OperationTranspileOptions
     ): OperationTranspileResult {


### PR DESCRIPTION
As title, rename  `Interface{Read/ConnectionRead}`  to `Composite{Read/ConnectionRead}`, in fact the operations under the name `Interface{Read/ConnectionRead}` are used to implement both union and interface types.