### PR TITLE
Fix Toolbox linting error on Enum default directive arguments

### DIFF
--- a/.changeset/sixty-pets-wave.md
+++ b/.changeset/sixty-pets-wave.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add enum case to parseLiteral in ScalarOrEnumType

--- a/packages/graphql/src/graphql/directives/arguments/scalars/ScalarOrEnum.ts
+++ b/packages/graphql/src/graphql/directives/arguments/scalars/ScalarOrEnum.ts
@@ -46,6 +46,8 @@ export const ScalarOrEnumType = new GraphQLScalarType({
                 return ast.value;
             case Kind.BOOLEAN:
                 return ast.value;
+            case Kind.ENUM:
+                return ast.value;
             default:
                 throw new Error(
                     "Value must be one of types: Int | Float | String | Boolean | ID | DateTime | Date | Enum"


### PR DESCRIPTION
# Description

Toolbox shows a linting error for valid `@default` argument when using an enum. This PR adds a `Kind.ENUM` case to `parseLiteral` in `ScalarOrEnum`

## Complexity

Low

# Issue

Closes  #4023