### PR TITLE
OGM: throw errors caught in createInitializer

### DIFF
--- a/.changeset/warm-trainers-repeat.md
+++ b/.changeset/warm-trainers-repeat.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-ogm": patch
+---
+
+OGM.init() calls will throw errors instead of silently capturing them.

--- a/packages/ogm/src/classes/OGM.test.ts
+++ b/packages/ogm/src/classes/OGM.test.ts
@@ -39,7 +39,9 @@ describe("OGM", () => {
             test("should throw to await ogm.init()", async () => {
                 const ogm = new OGM({ typeDefs: "type User {id: ID}" });
 
-                await expect(ogm.assertIndexesAndConstraints()).rejects.toThrow(`You must await \`.init()\` before \`.assertIndexesAndConstraints()\``);
+                await expect(ogm.assertIndexesAndConstraints()).rejects.toThrow(
+                    `You must await \`.init()\` before \`.assertIndexesAndConstraints()\``
+                );
             });
             test("should throw neo4j-driver Driver missing", async () => {
                 const ogm = new OGM({ typeDefs: "type User {id: ID}" });
@@ -57,6 +59,19 @@ describe("OGM", () => {
                 const model = "not-real";
 
                 expect(() => ogm.model(model)).toThrow(`Could not find model ${model}`);
+            });
+        });
+
+        describe("createInitializer", () => {
+            test("should throw an error if schema initialization fails", async () => {
+                const incorrectTypeDefs = `
+                    type Query {
+                        randomNumber: Int @cypher(statement: "RETURN rand() as result", columnName: test)
+                    }
+                `;
+
+                const ogm = new OGM({ typeDefs: incorrectTypeDefs });
+                await expect(ogm.init()).rejects.toThrow(`Argument "columnName" has invalid value test.`);
             });
         });
     });

--- a/packages/ogm/src/classes/OGM.ts
+++ b/packages/ogm/src/classes/OGM.ts
@@ -20,9 +20,9 @@
 import type { Neo4jGraphQLConstructor } from "@neo4j/graphql";
 import { Neo4jGraphQL } from "@neo4j/graphql";
 import type { GraphQLSchema } from "graphql";
-import Model from "./Model";
-import { filterDocument } from "../utils/filter-document";
 import type { Driver, SessionConfig } from "neo4j-driver";
+import { filterDocument } from "../utils/filter-document";
+import Model from "./Model";
 
 export interface OGMConstructor extends Neo4jGraphQLConstructor {
     database?: string;
@@ -166,14 +166,19 @@ class OGM<ModelMap = unknown> {
     }
 
     private createInitializer(): Promise<void> {
-        return new Promise((resolve) => {
-            this.neoSchema.getSchema().then((schema) => {
-                this._schema = schema;
+        return new Promise((resolve, reject) => {
+            this.neoSchema
+                .getSchema()
+                .then((schema) => {
+                    this._schema = schema;
 
-                this.models.forEach((model) => this.initModel(model));
+                    this.models.forEach((model) => this.initModel(model));
 
-                resolve();
-            });
+                    resolve();
+                })
+                .catch((e) => {
+                    reject(e);
+                });
         });
     }
 }


### PR DESCRIPTION
# Description

This PR makes it so that the `OGM.init()` call will throw errors instead of silently capturing them.

## Complexity

Low

# Issue

Closes  #4123 
