### PR TITLE
improve performance test coverage around sorting and cypher

### DIFF
--- a/packages/graphql/tests/performance/graphql/connections.graphql
+++ b/packages/graphql/tests/performance/graphql/connections.graphql
@@ -28,38 +28,3 @@ query NestedConnection {
         }
     }
 }
-
-query ConnectionWithSort {
-    moviesConnection(first: 5, sort: { title: ASC }) {
-        edges {
-            node {
-                title
-                actorsConnection {
-                    edges {
-                        node {
-                            name
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-query ConnectionWithSortAndCypher {
-    moviesConnection(first: 5, sort: [{ title: ASC }, { oneActorName: DESC }]) {
-        edges {
-            node {
-                title
-                oneActorName
-                actorsConnection {
-                    edges {
-                        node {
-                            name
-                        }
-                    }
-                }
-            }
-        }
-    }
-}

--- a/packages/graphql/tests/performance/graphql/sorting-and-cypher.graphql
+++ b/packages/graphql/tests/performance/graphql/sorting-and-cypher.graphql
@@ -1,0 +1,70 @@
+query TopLevelSortWithCypher {
+    movies(options: { limit: 5, sort: { oneActorName: DESC } }) {
+        title
+        oneActorName
+    }
+}
+
+query TopLevelConnectionSortWithCypher {
+    moviesConnection(first: 5, sort: { oneActorName: DESC }) {
+        edges {
+            node {
+                title
+                oneActorName
+            }
+        }
+    }
+}
+
+query TopLevelSortWithCypherWithNested {
+    movies(options: { limit: 5, sort: { oneActorName: DESC } }) {
+        title
+        oneActorName
+        actors {
+            name
+        }
+    }
+}
+
+query TopLevelConnectionSortWithCypherWithNested {
+    moviesConnection(first: 5, sort: { oneActorName: DESC }) {
+        edges {
+            node {
+                title
+                oneActorName
+                actorsConnection {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+# Expensive Cypher fields not present in sort
+query TopLevelSortWithExpensiveCypher {
+    movies(options: { limit: 5, sort: { oneActorName: DESC } }) {
+        title
+        oneActorName
+        otherMoviesWhereActorsActedIn {
+            title
+        }
+    }
+}
+
+query TopLevelConnectionSortWithExpensiveCypher {
+    moviesConnection(first: 5, sort: { oneActorName: DESC }) {
+        edges {
+            node {
+                title
+                oneActorName
+                otherMoviesWhereActorsActedIn {
+                     title
+                }
+            }
+        }
+    }
+}

--- a/packages/graphql/tests/performance/graphql/sorting.graphql
+++ b/packages/graphql/tests/performance/graphql/sorting.graphql
@@ -57,9 +57,19 @@ query SortDeeplyNestedFields {
     }
 }
 
-query SortWithTopLevelCypher {
-    movies(options: { limit: 5, sort: { title: ASC, oneActorName: DESC } }) {
-        title
-        oneActorName
+query ConnectionWithSort {
+    moviesConnection(first: 5, sort: { title: ASC }) {
+        edges {
+            node {
+                title
+                actorsConnection {
+                    edges {
+                        node {
+                            name
+                        }
+                    }
+                }
+            }
+        }
     }
 }

--- a/packages/graphql/tests/performance/typedefs.ts
+++ b/packages/graphql/tests/performance/typedefs.ts
@@ -47,6 +47,13 @@ export const typeDefs = `#graphql
         likedBy: [User!]! @relationship(type: "LIKES", direction: IN)
         oneActorName: String
             @cypher(statement: "MATCH (this)<-[:ACTED_IN]-(a:Person) RETURN a.name AS name", columnName: "name")
+        otherMoviesWhereActorsActedIn: [Movie!]! 
+            @cypher(statement: """
+                MATCH (this)<-[:ACTED_IN]-(a:Person)-[:ACTED_IN]->(m:Movie)
+                WITH m
+                ORDER BY m.title DESC
+                RETURN distinct (m) as otherMovies
+                """, columnName: "otherMovies")
         favouriteActor: Person @relationship(type: "FAV", direction: OUT)
     }
 


### PR DESCRIPTION
Moved sort tests to sort files. Added test coverage for cases when multiple cypher fields with pagination and sorting are applied. Added a more expensive `@cypher` field called `otherMoviesWhereActorsActedIn` which returns all the other movies where the actors have also acted.
