### PR TITLE
Only run performance tests when tck tests have had changes

### DIFF
--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -6,7 +6,7 @@ on:
       - dev
       - master
     paths:
-      - "packages/graphql/**"
+      - "packages/graphql/tests/tck/**"
 
 jobs:
   performance-tests:


### PR DESCRIPTION
# Description

We should only need to run performance tests when tck tests have changed, so this PR narrows down the path

## Complexity

Low
