### PR TITLE
Fix pipeline (DBNAME collision)

### DIFF
--- a/packages/introspector/tests/integration/graphql/label-injection.test.ts
+++ b/packages/introspector/tests/integration/graphql/label-injection.test.ts
@@ -23,7 +23,7 @@ import { toGraphQLTypeDefs } from "../../../src/index";
 import createDriver from "../neo4j";
 
 describe("GraphQL - Infer Schema on graphs", () => {
-    const dbName = "introspectToNeo4jGrahqlTypeDefsGraphITDb";
+    const dbName = "introspectToNeo4jGrahqlTypeDefsGraphITDbLabelInjection";
     let driver: neo4j.Driver;
     let MULTIDB_SUPPORT = true;
 


### PR DESCRIPTION
Two tests are using the same database name and this cause problem with the latest neo4j images. 
