### PR TITLE
Fix incorrect directive combination for inherited fields

### DIFF
--- a/.changeset/flat-badgers-itch.md
+++ b/.changeset/flat-badgers-itch.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix directive combination logic for inherited field in the directive combination validation rule

--- a/packages/graphql/src/schema/validation/validate-document.test.ts
+++ b/packages/graphql/src/schema/validation/validate-document.test.ts
@@ -6530,6 +6530,92 @@ describe("validation 2.0", () => {
             });
         });
 
+        describe("https://github.com/neo4j/graphql/issues/4232", () => {
+            test("interface at the end", () => {
+                const doc = gql`
+                    type Person {
+                        name: String!
+                    }
+
+                    type Episode implements IProduct {
+                        editorsInCharge: [Person!]!
+                            @relationship(
+                                type: "EDITORS_IN_CHARGE"
+                                direction: OUT
+                                nestedOperations: [CONNECT, DISCONNECT]
+                            )
+                    }
+
+                    type Series implements IProduct {
+                        editorsInCharge: [Person!]!
+                            @cypher(
+                                statement: """
+                                MATCH (this)-[:HAS_PART]->()-[:EDITORS_IN_CHARGE]->(n)
+                                RETURN distinct(n) as editorsInCharge
+                                """
+                                columnName: "editorsInCharge"
+                            )
+                    }
+
+                    interface IProduct {
+                        editorsInCharge: [Person!]!
+                    }
+                `;
+
+                const executeValidate = () =>
+                    validateDocument({
+                        document: doc,
+                        additionalDefinitions,
+                        features: {},
+                        experimental: false,
+                    });
+
+                expect(executeValidate).not.toThrow();
+            });
+
+            test("interface at the beginning", () => {
+                const doc = gql`
+                    type Person {
+                        name: String!
+                    }
+
+                    interface IProduct {
+                        editorsInCharge: [Person!]!
+                    }
+
+                    type Episode implements IProduct {
+                        editorsInCharge: [Person!]!
+                            @relationship(
+                                type: "EDITORS_IN_CHARGE"
+                                direction: OUT
+                                nestedOperations: [CONNECT, DISCONNECT]
+                            )
+                    }
+
+                    type Series implements IProduct {
+                        editorsInCharge: [Person!]!
+                            @cypher(
+                                statement: """
+                                MATCH (this)-[:HAS_PART]->()-[:EDITORS_IN_CHARGE]->(n)
+                                RETURN distinct(n) as editorsInCharge
+                                """
+                                columnName: "editorsInCharge"
+                            )
+                    }
+                `;
+
+                const executeValidate = () =>
+                    validateDocument({
+                        document: doc,
+                        additionalDefinitions,
+                        features: {},
+                        experimental: false,
+                    });
+
+                expect(executeValidate).not.toThrow();
+            });
+        });
+
         describe("https://github.com/neo4j/graphql/issues/442", () => {
             test("should not throw error on validation of schema if MutationResponse used", () => {
                 const doc = gql`


### PR DESCRIPTION
# Description

This PR fixes the validation for directive combination, more specifically the directive combination logic for inherited fields. It was before collecting all the directives on the inherited field, from all the implementing types. It is now returning multiple directive combinations between the Interface field and A Concrete Type field, as many combinations as many implementing types there are.

## Complexity

Complexity: Low

# Issue

Closes #4232 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
