### PR TITLE
Fix authorization before and after parameter name clash

### DIFF
--- a/.changeset/forty-shrimps-cover.md
+++ b/.changeset/forty-shrimps-cover.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix authorization before and after parameter name clash

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "eslint-plugin-eslint-comments": "3.2.0",
         "eslint-plugin-import": "2.29.0",
         "eslint-plugin-jest": "27.6.0",
-        "eslint-plugin-jsx-a11y": "6.7.1",
+        "eslint-plugin-jsx-a11y": "6.8.0",
         "eslint-plugin-react": "7.33.2",
         "eslint-plugin-simple-import-sort": "10.0.0",
         "graphql": "16.8.1",

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
@@ -66,7 +66,7 @@ export function createAuthorizationAfterAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix}after_`);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}after_`);
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-after-and-params.ts
@@ -66,7 +66,7 @@ export function createAuthorizationAfterAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, indexPrefix);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix}after_`);
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
@@ -66,7 +66,7 @@ export function createAuthorizationBeforeAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn, `${indexPrefix}before_`);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix || "_"}before_`);
     }
 
     return undefined;

--- a/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
+++ b/packages/graphql/src/translate/authorization/compatibility/create-authorization-before-and-params.ts
@@ -50,10 +50,12 @@ export function createAuthorizationBeforeAndParams({
     context,
     nodes,
     operations,
+    indexPrefix,
 }: {
     context: Neo4jGraphQLTranslationContext;
     nodes: StringNodeMap[];
     operations: AuthorizationOperation[];
+    indexPrefix?: string;
 }): AuthorizationBeforeAndParams | undefined {
     const nodeMap = stringNodeMapToNodeMap(nodes);
 
@@ -64,7 +66,7 @@ export function createAuthorizationBeforeAndParams({
     });
 
     if (predicateReturn) {
-        return compilePredicateReturn(predicateReturn);
+        return compilePredicateReturn(predicateReturn, `${indexPrefix}before_`);
     }
 
     return undefined;

--- a/packages/graphql/src/translate/create-connect-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-and-params.ts
@@ -51,6 +51,7 @@ function createConnectAndParams({
     includeRelationshipValidation,
     isFirstLevel = true,
     source,
+    indexPrefix,
 }: {
     withVars: string[];
     value: any;
@@ -65,6 +66,7 @@ function createConnectAndParams({
     includeRelationshipValidation?: boolean;
     isFirstLevel?: boolean;
     source: "CREATE" | "UPDATE" | "CONNECT";
+    indexPrefix?: string;
 }): [string, any] {
     checkAuthentication({ context, node: parentNode, targetOperations: ["CREATE_RELATIONSHIP"] });
 
@@ -181,6 +183,7 @@ function createConnectAndParams({
             context,
             nodes: authorizationNodes,
             operations: ["CREATE_RELATIONSHIP"],
+            indexPrefix,
         });
 
         if (authorizationBeforeAndParams) {
@@ -440,6 +443,7 @@ function createConnectAndParams({
                 { node: relatedNode, variable: nodeName },
             ],
             operations: ["CREATE_RELATIONSHIP"],
+            indexPrefix,
         });
 
         if (authorizationAfterAndParams) {

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -237,6 +237,7 @@ function createCreateAndParams({
                         labelOverride: unionTypeName,
                         parentNode: node,
                         source: "CREATE",
+                        indexPrefix: makeAuthorizationParamsPrefix({ refNodeIndex, idx }),
                     });
                     res.creates.push(connectAndParams[0]);
                     res.params = { ...res.params, ...connectAndParams[1] };
@@ -290,6 +291,7 @@ function createCreateAndParams({
                 },
             ],
             operations: ["CREATE"],
+            indexPrefix: makeAuthorizationParamsPrefix({ refNodeIndex, idx }),
         });
 
         if (authorizationAndParams) {
@@ -388,6 +390,10 @@ function createCreateAndParams({
     }
 
     return { create: creates.join("\n"), params, authorizationPredicates, authorizationSubqueries };
+}
+
+function makeAuthorizationParamsPrefix({ refNodeIndex, idx }: { refNodeIndex: number; idx: number }): string {
+    return `${refNodeIndex}_${idx}_`;
 }
 
 export default createCreateAndParams;

--- a/packages/graphql/tests/tck/array-methods.test.ts
+++ b/packages/graphql/tests/tck/array-methods.test.ts
@@ -213,10 +213,10 @@ describe("Arrays Methods", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:Movie)
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
             SET this.ratings = this.ratings + $this_update_ratings_PUSH
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .title, .ratings }) AS data"
         `);
 
@@ -226,7 +226,8 @@ describe("Arrays Methods", () => {
                 \\"jwt\\": {
                     \\"roles\\": []
                 },
-                \\"authorization_param2\\": \\"update\\",
+                \\"authorization__before_param2\\": \\"update\\",
+                \\"authorization__after_param2\\": \\"update\\",
                 \\"this_update_ratings_PUSH\\": [
                     1
                 ],
@@ -366,10 +367,10 @@ describe("Arrays Methods", () => {
         expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
             "MATCH (this:Movie)
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(this.ratings IS NULL, \\"Property %s cannot be NULL\\", ['ratings'])
             SET this.ratings = this.ratings[0..-$this_update_ratings_POP]
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .title, .ratings }) AS data"
         `);
 
@@ -379,7 +380,8 @@ describe("Arrays Methods", () => {
                 \\"jwt\\": {
                     \\"roles\\": []
                 },
-                \\"authorization_param2\\": \\"update\\",
+                \\"authorization__before_param2\\": \\"update\\",
+                \\"authorization__after_param2\\": \\"update\\",
                 \\"this_update_ratings_POP\\": {
                     \\"low\\": 1,
                     \\"high\\": 0

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/allow.test.ts
@@ -588,9 +588,9 @@ describe("Cypher Auth Allow", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_posts0.id = $this_deleteUsers_args_delete_posts0_where_this_posts0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this_posts0_relationship, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -655,9 +655,9 @@ describe("Cypher Auth Allow", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -732,11 +732,11 @@ describe("Cypher Auth Allow", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)<-[this_post0_disconnect0_rel:HAS_COMMENT]-(this_post0_disconnect0:Post)
-            OPTIONAL MATCH (this)<-[:HAS_COMMENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization_this1:User)
-            WITH *, count(authorization_this1) AS creatorCount
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this1.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            OPTIONAL MATCH (this)<-[:HAS_COMMENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization__before_this1:User)
+            WITH *, count(authorization__before_this1) AS creatorCount
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this1.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_post0_disconnect0, this_post0_disconnect0_rel, this
             	WITH collect(this_post0_disconnect0) as this_post0_disconnect0, this_post0_disconnect0_rel, this
@@ -746,9 +746,9 @@ describe("Cypher Auth Allow", () => {
             CALL {
             WITH this, this_post0_disconnect0
             OPTIONAL MATCH (this_post0_disconnect0)<-[this_post0_disconnect0_creator0_rel:HAS_POST]-(this_post0_disconnect0_creator0:User)
-            OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_post0_disconnect0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            OPTIONAL MATCH (this_post0_disconnect0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_post0_disconnect0_creator0.id = $updateComments_args_update_post_disconnect_disconnect_creator_where_User_this_post0_disconnect0_creator0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_post0_disconnect0_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
             	WITH collect(this_post0_disconnect0_creator0) as this_post0_disconnect0_creator0, this_post0_disconnect0_creator0_rel, this_post0_disconnect0
@@ -836,10 +836,10 @@ describe("Cypher Auth Allow", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes

--- a/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/allow/interface-relationships/implementation-allow.test.ts
@@ -259,9 +259,9 @@ describe("@auth allow on specific interface implementation", () => {
             CALL {
             	WITH this
             	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
-            	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            	WITH *, count(authorization__before_this0) AS creatorCount
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
@@ -348,9 +348,9 @@ describe("@auth allow on specific interface implementation", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_content_Post0.id = $this_deleteUsers_args_delete_content0_where_this_content_Post0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this_content_Post0_relationship, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -427,9 +427,9 @@ describe("@auth allow on specific interface implementation", () => {
             CALL {
             	WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -517,9 +517,9 @@ describe("@auth allow on specific interface implementation", () => {
             CALL {
             	WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -529,9 +529,9 @@ describe("@auth allow on specific interface implementation", () => {
             CALL {
             WITH this, this_disconnect_content0
             OPTIONAL MATCH (this_disconnect_content0)-[this_disconnect_content0_comments0_rel:HAS_COMMENT]->(this_disconnect_content0_comments0:Comment)
-            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_disconnect_content0_comments0.id = $updateUsers_args_disconnect_content0_disconnect__on_Post0_comments0_where_Comment_this_disconnect_content0_comments0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             CALL {
             	WITH this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
             	WITH collect(this_disconnect_content0_comments0) as this_disconnect_content0_comments0, this_disconnect_content0_comments0_rel, this_disconnect_content0
@@ -636,10 +636,10 @@ describe("@auth allow on specific interface implementation", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/bind.test.ts
@@ -417,10 +417,10 @@ describe("Cypher Auth Allow", () => {
             	}
             WITH this, this_connect_creator0_node
             WITH *
-            OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization__after_this0:User)
+            WITH *, count(authorization__after_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_connect_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_connect_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_creator_User0
             }
             WITH *
@@ -482,10 +482,10 @@ describe("Cypher Auth Allow", () => {
             	DELETE this_disconnect_creator0_rel
             }
             WITH *
-            OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this)<-[:HAS_POST]-(authorization__after_this0:User)
+            WITH *, count(authorization__after_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_disconnect_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this_disconnect_creator0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_creator_User
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -139,10 +139,10 @@ describe("Cypher Auth Allow", () => {
             	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
             }
             WITH *
-            OPTIONAL MATCH (this0_contentPost0_node)<-[:HAS_CONTENT]-(authorization_1_1_this0:User)
-            WITH *, count(authorization_1_1_this0) AS creatorCount
+            OPTIONAL MATCH (this0_contentPost0_node)<-[:HAS_CONTENT]-(authorization_1_1_after_this0:User)
+            WITH *, count(authorization_1_1_after_this0) AS creatorCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_1_1_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_1_1_after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -328,10 +328,10 @@ describe("Cypher Auth Allow", () => {
             		RETURN count(*) AS update_this_content0_creator0
             	}
             	WITH this, this_content0
-            	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            	WITH *, count(authorization_this0) AS creatorCount
+            	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization__after_this0:User)
+            	WITH *, count(authorization__after_this0) AS creatorCount
             	WITH *
-            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_content0
             	CALL {
             		WITH this_content0
@@ -447,10 +447,10 @@ describe("Cypher Auth Allow", () => {
             	}
             WITH this, this_connect_content1_node
             WITH *
-            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization__after_this0:User)
+            WITH *, count(authorization__after_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_content_Post1
             }
             WITH *
@@ -522,10 +522,10 @@ describe("Cypher Auth Allow", () => {
             	DELETE this_disconnect_content0_rel
             }
             WITH *
-            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization__after_this0:User)
+            WITH *, count(authorization__after_this0) AS creatorCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_content_Post
             }
             WITH *

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -560,7 +560,7 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.name = $this_update_name
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -576,8 +576,8 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
                 \\"this_update_name\\": \\"Bob\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -605,7 +605,7 @@ describe("Cypher Auth Where with Roles", () => {
             WHERE (this.name = $param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param4 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.name = $this_update_name
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -622,8 +622,8 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"param3\\": \\"user\\",
                 \\"param4\\": \\"admin\\",
                 \\"this_update_name\\": \\"Bob\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -656,10 +656,10 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	WITH this, this_posts0
             	CALL {
             		WITH this_posts0
@@ -671,7 +671,7 @@ describe("Cypher Auth Where with Roles", () => {
             	RETURN count(*) AS update_this_posts0
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
             CALL {
                 WITH this
@@ -696,9 +696,11 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"update_param3\\": \\"admin\\",
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
                 \\"this_update_posts0_id\\": \\"new-id\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -762,7 +764,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_posts0)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this_posts0_relationship, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -784,8 +786,8 @@ describe("Cypher Auth Where with Roles", () => {
                 },
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\"
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\"
             }"
         `);
     });
@@ -820,7 +822,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_0_0_before_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -833,11 +835,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_0_0_after_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -859,12 +861,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
-                \\"authorization_0_0_param2\\": \\"user\\",
-                \\"authorization_0_0_param3\\": \\"admin\\",
+                \\"authorization_0_0_before_param2\\": \\"user\\",
+                \\"authorization_0_0_before_param3\\": \\"admin\\",
+                \\"authorization_0_0_after_param2\\": \\"user\\",
+                \\"authorization_0_0_after_param3\\": \\"admin\\",
+                \\"authorization_0_0_after_param4\\": \\"user\\",
+                \\"authorization_0_0_after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -905,7 +907,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_0_0_before_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -918,11 +920,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_0_0_after_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -945,12 +947,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
-                \\"authorization_0_0_param2\\": \\"user\\",
-                \\"authorization_0_0_param3\\": \\"admin\\",
+                \\"authorization_0_0_before_param2\\": \\"user\\",
+                \\"authorization_0_0_before_param3\\": \\"admin\\",
+                \\"authorization_0_0_after_param2\\": \\"user\\",
+                \\"authorization_0_0_after_param3\\": \\"admin\\",
+                \\"authorization_0_0_after_param4\\": \\"user\\",
+                \\"authorization_0_0_after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -980,7 +982,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -993,11 +995,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_posts0_connect0_node
             WITH this, this_posts0_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_posts0_connect_Post0
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1012,10 +1014,14 @@ describe("Cypher Auth Where with Roles", () => {
                 },
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1045,7 +1051,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1058,11 +1064,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_posts0_connect0_node
             WITH this, this_posts0_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_posts0_connect0_node)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_posts0_connect_Post0
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1078,10 +1084,14 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
                 \\"this_posts0_connect0_node_param0\\": \\"new-id\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1111,7 +1121,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1124,7 +1134,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post0
             }
             WITH *
@@ -1142,10 +1152,14 @@ describe("Cypher Auth Where with Roles", () => {
                 },
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1175,7 +1189,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1188,7 +1202,7 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_connect_posts0_node)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post0
             }
             WITH *
@@ -1207,10 +1221,14 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
                 \\"this_connect_posts0_node_param0\\": \\"some-id\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1240,7 +1258,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1248,11 +1266,11 @@ describe("Cypher Auth Where with Roles", () => {
             	DELETE this_posts0_disconnect0_rel
             }
             WITH this, this_posts0_disconnect0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_posts0_disconnect_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1267,10 +1285,14 @@ describe("Cypher Auth Where with Roles", () => {
                 },
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -1300,7 +1322,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1308,11 +1330,11 @@ describe("Cypher Auth Where with Roles", () => {
             	DELETE this_posts0_disconnect0_rel
             }
             WITH this, this_posts0_disconnect0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_posts0_disconnect0)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_posts0_disconnect_Post
             }
             WITH this
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -1328,10 +1350,14 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
                 \\"updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0\\": \\"new-id\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"update\\": {
@@ -1380,7 +1406,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1388,7 +1414,7 @@ describe("Cypher Auth Where with Roles", () => {
             	DELETE this_disconnect_posts0_rel
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *
@@ -1406,10 +1432,14 @@ describe("Cypher Auth Where with Roles", () => {
                 },
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {
@@ -1450,7 +1480,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__before_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization__before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__before_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1458,7 +1488,7 @@ describe("Cypher Auth Where with Roles", () => {
             	DELETE this_disconnect_posts0_rel
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (($jwt.sub IS NOT NULL AND this.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND (single(authorization__after_this0 IN [(this_disconnect_posts0)<-[:HAS_POST]-(authorization__after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization__after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization__after_param4 IN $jwt.roles))) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *
@@ -1477,10 +1507,14 @@ describe("Cypher Auth Where with Roles", () => {
                 \\"param2\\": \\"user\\",
                 \\"param3\\": \\"admin\\",
                 \\"updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0\\": \\"some-id\\",
-                \\"authorization_param2\\": \\"user\\",
-                \\"authorization_param3\\": \\"admin\\",
-                \\"authorization_param4\\": \\"user\\",
-                \\"authorization_param5\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"user\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__before_param4\\": \\"user\\",
+                \\"authorization__before_param5\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"user\\",
+                \\"authorization__after_param3\\": \\"admin\\",
+                \\"authorization__after_param4\\": \\"user\\",
+                \\"authorization__after_param5\\": \\"admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles/roles.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles/roles.test.ts
@@ -346,7 +346,7 @@ describe("Cypher Auth Roles", () => {
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             SET this.id = $this_update_id
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -362,7 +362,7 @@ describe("Cypher Auth Roles", () => {
                 },
                 \\"param3\\": \\"admin\\",
                 \\"this_update_id\\": \\"id-1\\",
-                \\"authorization_param2\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -389,10 +389,10 @@ describe("Cypher Auth Roles", () => {
             WITH *
             WHERE (this.id = $param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.password = $this_update_password
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .id }) AS data"
         `);
 
@@ -408,7 +408,8 @@ describe("Cypher Auth Roles", () => {
                 },
                 \\"param3\\": \\"admin\\",
                 \\"this_update_password\\": \\"password\\",
-                \\"authorization_param2\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"super-admin\\",
+                \\"authorization__after_param2\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -438,7 +439,7 @@ describe("Cypher Auth Roles", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            	WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -451,7 +452,7 @@ describe("Cypher Auth Roles", () => {
             	}
             WITH this, this_connect_posts0_node
             WITH this, this_connect_posts0_node
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this_connect_posts_Post0
             }
             WITH *
@@ -468,8 +469,10 @@ describe("Cypher Auth Roles", () => {
                     \\"sub\\": \\"super_admin\\"
                 },
                 \\"param2\\": \\"admin\\",
-                \\"authorization_param2\\": \\"admin\\",
-                \\"authorization_param3\\": \\"super-admin\\",
+                \\"authorization__before_param2\\": \\"super-admin\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"admin\\",
+                \\"authorization__after_param3\\": \\"super-admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -505,7 +508,7 @@ describe("Cypher Auth Roles", () => {
             	CALL {
             		WITH this, this_post0
             		OPTIONAL MATCH (this_post0_creator0_connect0_node:User)
-            		WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            		WHERE this_post0_creator0_connect0_node.id = $this_post0_creator0_connect0_node_param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             		CALL {
             			WITH *
             			WITH this, collect(this_post0_creator0_connect0_node) as connectedNodes, collect(this_post0) as parentNodes
@@ -518,7 +521,7 @@ describe("Cypher Auth Roles", () => {
             		}
             	WITH this, this_post0, this_post0_creator0_connect0_node
             	WITH this, this_post0, this_post0_creator0_connect0_node
-            	WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             		RETURN count(*) AS connect_this_post0_creator0_connect_User0
             	}
             	WITH this, this_post0
@@ -552,8 +555,10 @@ describe("Cypher Auth Roles", () => {
                     ],
                     \\"sub\\": \\"super_admin\\"
                 },
-                \\"authorization_param2\\": \\"super-admin\\",
-                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"admin\\",
+                \\"authorization__before_param3\\": \\"super-admin\\",
+                \\"authorization__after_param2\\": \\"super-admin\\",
+                \\"authorization__after_param3\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -583,7 +588,7 @@ describe("Cypher Auth Roles", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -591,7 +596,7 @@ describe("Cypher Auth Roles", () => {
             	DELETE this_disconnect_posts0_rel
             }
             WITH this, this_disconnect_posts0
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             RETURN count(*) AS disconnect_this_disconnect_posts_Post
             }
             WITH *
@@ -608,8 +613,10 @@ describe("Cypher Auth Roles", () => {
                     \\"sub\\": \\"super_admin\\"
                 },
                 \\"param2\\": \\"admin\\",
-                \\"authorization_param2\\": \\"admin\\",
-                \\"authorization_param3\\": \\"super-admin\\",
+                \\"authorization__before_param2\\": \\"admin\\",
+                \\"authorization__before_param3\\": \\"super-admin\\",
+                \\"authorization__after_param2\\": \\"admin\\",
+                \\"authorization__after_param3\\": \\"super-admin\\",
                 \\"updateUsers\\": {
                     \\"args\\": {
                         \\"disconnect\\": {
@@ -654,7 +661,7 @@ describe("Cypher Auth Roles", () => {
             	CALL {
             	WITH this, this_post0
             	OPTIONAL MATCH (this_post0)-[this_post0_creator0_disconnect0_rel:HAS_POST]->(this_post0_creator0_disconnect0:User)
-            	WHERE this_post0_creator0_disconnect0.id = $updateComments_args_update_post_update_node_creator_disconnect_where_User_this_post0_creator0_disconnect0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this_post0_creator0_disconnect0.id = $updateComments_args_update_post_update_node_creator_disconnect_where_User_this_post0_creator0_disconnect0param0 AND (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel, this_post0
             		WITH collect(this_post0_creator0_disconnect0) as this_post0_creator0_disconnect0, this_post0_creator0_disconnect0_rel, this_post0
@@ -662,7 +669,7 @@ describe("Cypher Auth Roles", () => {
             		DELETE this_post0_creator0_disconnect0_rel
             	}
             	WITH this, this_post0, this_post0_creator0_disconnect0
-            	WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__after_param3 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS disconnect_this_post0_creator0_disconnect_User
             	}
             	WITH this, this_post0
@@ -696,8 +703,10 @@ describe("Cypher Auth Roles", () => {
                     ],
                     \\"sub\\": \\"super_admin\\"
                 },
-                \\"authorization_param2\\": \\"super-admin\\",
-                \\"authorization_param3\\": \\"admin\\",
+                \\"authorization__before_param2\\": \\"super-admin\\",
+                \\"authorization__before_param3\\": \\"admin\\",
+                \\"authorization__after_param2\\": \\"super-admin\\",
+                \\"authorization__after_param3\\": \\"admin\\",
                 \\"updateComments\\": {
                     \\"args\\": {
                         \\"update\\": {
@@ -781,7 +790,7 @@ describe("Cypher Auth Roles", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization__before_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this_posts0_relationship, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -802,7 +811,7 @@ describe("Cypher Auth Roles", () => {
                     \\"sub\\": \\"super_admin\\"
                 },
                 \\"param2\\": \\"admin\\",
-                \\"authorization_param2\\": \\"super-admin\\"
+                \\"authorization__before_param2\\": \\"super-admin\\"
             }"
         `);
     });

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/interface-relationships/implementation-where.test.ts
@@ -486,9 +486,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	MATCH (this)-[this_has_content0_relationship:HAS_CONTENT]->(this_content0:Post)
-            	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            	OPTIONAL MATCH (this_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            	WITH *, count(authorization__before_this0) AS creatorCount
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub)))
             	SET this_content0.id = $this_update_content0_id
             	WITH this, this_content0
             	CALL {
@@ -620,9 +620,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)-[this_content_Post0_relationship:HAS_CONTENT]->(this_content_Post0:Post)
-            OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            OPTIONAL MATCH (this_content_Post0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub)))
             WITH this_content_Post0_relationship, collect(DISTINCT this_content_Post0) AS this_content_Post0_to_delete
             CALL {
             	WITH this_content_Post0_to_delete
@@ -690,10 +690,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this0
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
-            OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -783,10 +783,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this0
             	OPTIONAL MATCH (this0_content_connect1_node:Post)
-            OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this0_content_connect1_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            	WHERE this0_content_connect1_node.id = $this0_content_connect1_node_param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_content_connect1_node) as connectedNodes, collect(this0) as parentNodes
@@ -875,10 +875,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -958,10 +958,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_content0_connect0_node:Post)
-            OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_content0_connect0_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE this_content0_connect0_node.id = $this_content0_connect0_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_content0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1034,10 +1034,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1108,10 +1108,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             		WITH this
             	OPTIONAL MATCH (this_connect_content1_node:Post)
-            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_content1_node)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE this_connect_content1_node.id = $this_connect_content1_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_content1_node) as connectedNodes, collect(this) as parentNodes
@@ -1187,9 +1187,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1259,9 +1259,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_content0_disconnect0_rel:HAS_CONTENT]->(this_content0_disconnect0:Post)
-            OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_content0_disconnect0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_content0_disconnect0.id = $updateUsers_args_update_content0_disconnect0_where_Post_this_content0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_content0_disconnect0, this_content0_disconnect0_rel, this
             	WITH collect(this_content0_disconnect0) as this_content0_disconnect0, this_content0_disconnect0_rel, this
@@ -1344,9 +1344,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this
@@ -1418,9 +1418,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             OPTIONAL MATCH (this)-[this_disconnect_content0_rel:HAS_CONTENT]->(this_disconnect_content0:Post)
-            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_disconnect_content0)<-[:HAS_CONTENT]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_disconnect_content0.id = $updateUsers_args_disconnect_content0_where_Post_this_disconnect_content0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_content0, this_disconnect_content0_rel, this
             	WITH collect(this_disconnect_content0) as this_disconnect_content0, this_disconnect_content0_rel, this

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -624,9 +624,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	MATCH (this)-[this_has_post0_relationship:HAS_POST]->(this_posts0:Post)
-            	OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:User)
-            	WITH *, count(authorization_this0) AS creatorCount
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            	OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization__before_this0:User)
+            	WITH *, count(authorization__before_this0) AS creatorCount
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub)))
             	SET this_posts0.id = $this_update_posts0_id
             	WITH this, this_posts0
             	CALL {
@@ -758,9 +758,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)-[this_posts0_relationship:HAS_POST]->(this_posts0:Post)
-            OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            OPTIONAL MATCH (this_posts0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub)))
             WITH this_posts0_relationship, collect(DISTINCT this_posts0) AS this_posts0_to_delete
             CALL {
             	WITH this_posts0_to_delete
@@ -814,10 +814,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_before_this0:User)
+            WITH *, count(authorization_0_0_before_this0) AS creatorCount
             WITH *
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_before_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -892,10 +892,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_before_this0:User)
+            WITH *, count(authorization_0_0_before_this0) AS creatorCount
             WITH *
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub)))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_before_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -960,10 +960,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1018,10 +1018,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_posts0_connect0_node:Post)
-            OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_posts0_connect0_node)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE this_posts0_connect0_node.id = $this_posts0_connect0_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_posts0_connect0_node) as connectedNodes, collect(this) as parentNodes
@@ -1077,10 +1077,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1136,10 +1136,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this
             	OPTIONAL MATCH (this_connect_posts0_node:Post)
-            OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
+            OPTIONAL MATCH (this_connect_posts0_node)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
             WITH *
-            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
+            	WHERE this_connect_posts0_node.id = $this_connect_posts0_node_param0 AND (($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))) AND ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this_connect_posts0_node) as connectedNodes, collect(this) as parentNodes
@@ -1196,9 +1196,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1248,9 +1248,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_posts0_disconnect0_rel:HAS_POST]->(this_posts0_disconnect0:Post)
-            OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_posts0_disconnect0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_posts0_disconnect0.id = $updateUsers_args_update_posts0_disconnect0_where_Post_this_posts0_disconnect0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_posts0_disconnect0, this_posts0_disconnect0_rel, this
             	WITH collect(this_posts0_disconnect0) as this_posts0_disconnect0, this_posts0_disconnect0_rel, this
@@ -1320,9 +1320,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this
@@ -1384,9 +1384,9 @@ describe("Cypher Auth Where", () => {
             CALL {
             WITH this
             OPTIONAL MATCH (this)-[this_disconnect_posts0_rel:HAS_POST]->(this_disconnect_posts0:Post)
-            OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_this0.id = $jwt.sub))))
+            OPTIONAL MATCH (this_disconnect_posts0)<-[:HAS_POST]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_disconnect_posts0.id = $updateUsers_args_disconnect_posts0_where_Post_this_disconnect_posts0param0 AND (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this.id = $jwt.sub)) AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization__before_this0.id = $jwt.sub))))
             CALL {
             	WITH this_disconnect_posts0, this_disconnect_posts0_rel, this
             	WITH collect(this_disconnect_posts0) as this_disconnect_posts0, this_disconnect_posts0_rel, this

--- a/packages/graphql/tests/tck/issues/2789.test.ts
+++ b/packages/graphql/tests/tck/issues/2789.test.ts
@@ -56,10 +56,10 @@ describe("https://github.com/neo4j/graphql/issues/2789", () => {
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($param1 IS NOT NULL AND this.id = $param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization_param1 IS NOT NULL AND this.id = $authorization_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization__before_param1 IS NOT NULL AND this.id = $authorization__before_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             SET this.password = $this_update_password
             WITH this
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization_param1 IS NOT NULL AND this.id = $authorization_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization_param1 IS NOT NULL AND this.id = $authorization_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization__after_param1 IS NOT NULL AND this.id = $authorization__after_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($authorization__after_param1 IS NOT NULL AND this.id = $authorization__after_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH *
             WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($update_param1 IS NOT NULL AND this.id = $update_param1)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN collect(DISTINCT this { .password }) AS data"
@@ -71,7 +71,8 @@ describe("https://github.com/neo4j/graphql/issues/2789", () => {
                 \\"update_param1\\": \\"Bar\\",
                 \\"param1\\": \\"Foo\\",
                 \\"this_update_password\\": \\"123\\",
-                \\"authorization_param1\\": \\"Foo\\",
+                \\"authorization__before_param1\\": \\"Bar\\",
+                \\"authorization__after_param1\\": \\"Foo\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/issues/3901.test.ts
+++ b/packages/graphql/tests/tck/issues/3901.test.ts
@@ -167,17 +167,17 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
             WITH *
             CALL {
                 WITH this0_seasons0_node
-                MATCH (this0_seasons0_node)-[:SEASON_OF]->(authorization_0_1_this1:Serie)
-                OPTIONAL MATCH (authorization_0_1_this1)<-[:PUBLISHER]-(authorization_0_1_this2:User)
-                WITH *, count(authorization_0_1_this2) AS publisherCount
+                MATCH (this0_seasons0_node)-[:SEASON_OF]->(authorization_0_1_after_this1:Serie)
+                OPTIONAL MATCH (authorization_0_1_after_this1)<-[:PUBLISHER]-(authorization_0_1_after_this2:User)
+                WITH *, count(authorization_0_1_after_this2) AS publisherCount
                 WITH *
-                WHERE (publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_1_this2.id = $jwt.sub))
-                RETURN count(authorization_0_1_this1) = 1 AS authorization_0_1_var0
+                WHERE (publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_1_after_this2.id = $jwt.sub))
+                RETURN count(authorization_0_1_after_this1) = 1 AS authorization_0_1_after_var0
             }
-            OPTIONAL MATCH (this0)<-[:PUBLISHER]-(authorization_0_0_this0:User)
-            WITH *, count(authorization_0_0_this0) AS publisherCount
+            OPTIONAL MATCH (this0)<-[:PUBLISHER]-(authorization_0_0_after_this0:User)
+            WITH *, count(authorization_0_0_after_this0) AS publisherCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (authorization_0_1_var0 = true AND ($jwt.roles IS NOT NULL AND $authorization_0_1_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_1_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_this0.id = $jwt.sub)) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (authorization_0_1_after_var0 = true AND ($jwt.roles IS NOT NULL AND $authorization_0_1_after_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_1_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_after_this0.id = $jwt.sub)) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -199,11 +199,11 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"michel\\"
                 },
-                \\"authorization_0_1_param2\\": \\"verified\\",
-                \\"authorization_0_1_param3\\": \\"creator\\",
+                \\"authorization_0_1_after_param2\\": \\"verified\\",
+                \\"authorization_0_1_after_param3\\": \\"creator\\",
                 \\"this0_publisher_connect0_node_param0\\": \\"ID\\",
-                \\"authorization_0_0_param2\\": \\"verified\\",
-                \\"authorization_0_0_param3\\": \\"creator\\",
+                \\"authorization_0_0_after_param2\\": \\"verified\\",
+                \\"authorization_0_0_after_param3\\": \\"creator\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/issues/3929.test.ts
+++ b/packages/graphql/tests/tck/issues/3929.test.ts
@@ -106,9 +106,9 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
             CALL {
             WITH *
             OPTIONAL MATCH (this)<-[this_delete_members0_relationship:MEMBER_OF]-(this_delete_members0:Person)
-            OPTIONAL MATCH (this_delete_members0)<-[:CREATOR_OF]-(authorization_this0:User)
-            WITH *, count(authorization_this0) AS creatorCount
-            WHERE this_delete_members0.id = $updateGroups_args_delete_members0_where_this_delete_members0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.uid IS NOT NULL AND authorization_this0.id = $jwt.uid))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            OPTIONAL MATCH (this_delete_members0)<-[:CREATOR_OF]-(authorization__before_this0:User)
+            WITH *, count(authorization__before_this0) AS creatorCount
+            WHERE this_delete_members0.id = $updateGroups_args_delete_members0_where_this_delete_members0param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.uid IS NOT NULL AND authorization__before_this0.id = $jwt.uid))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             WITH this_delete_members0_relationship, collect(DISTINCT this_delete_members0) AS this_delete_members0_to_delete
             CALL {
             	WITH this_delete_members0_to_delete

--- a/packages/graphql/tests/tck/issues/4118.test.ts
+++ b/packages/graphql/tests/tck/issues/4118.test.ts
@@ -131,7 +131,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_host_connect0_node:Tenant)
-            	WHERE this0_host_connect0_node.id = $this0_host_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_this0.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this0_host_connect0_node.id = $this0_host_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_0_0_before_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_before_this0.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_host_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -144,10 +144,10 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	}
             WITH this0, this0_host_connect0_node
             WITH *
-            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_this1:Tenant)
-            WITH *, count(authorization_this1) AS hostCount
+            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_after_this1:Tenant)
+            WITH *, count(authorization_0_0_after_this1) AS hostCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_this1)<-[:ADMIN_IN]-(authorization_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_this2:User) WHERE ($jwt.id IS NOT NULL AND authorization_this2.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_0_0_after_this2:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_after_this2.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_host_connect_Tenant0
             }
             WITH *
@@ -156,15 +156,15 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	OPTIONAL MATCH (this0_openingDays_connect0_node:OpeningDay)
             CALL {
                 WITH this0_openingDays_connect0_node
-                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_this1:Settings)
-                OPTIONAL MATCH (authorization_this1)<-[:HAS_SETTINGS]-(authorization_this2:Tenant)
-                WITH *, count(authorization_this2) AS tenantCount
+                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_0_0_before_this1:Settings)
+                OPTIONAL MATCH (authorization_0_0_before_this1)<-[:HAS_SETTINGS]-(authorization_0_0_before_this2:Tenant)
+                WITH *, count(authorization_0_0_before_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_this2)<-[:ADMIN_IN]-(authorization_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_this1) = 1 AS authorization_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_before_this2)<-[:ADMIN_IN]-(authorization_0_0_before_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_before_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_before_this1) = 1 AS authorization_0_0_before_var0
             }
             WITH *
-            	WHERE this0_openingDays_connect0_node.id = $this0_openingDays_connect0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this0_openingDays_connect0_node.id = $this0_openingDays_connect0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_before_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_openingDays_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -177,19 +177,19 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	}
             WITH this0, this0_openingDays_connect0_node
             WITH *
-            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_this1:Tenant)
-            WITH *, count(authorization_this1) AS hostCount
+            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_after_this1:Tenant)
+            WITH *, count(authorization_0_0_after_this1) AS hostCount
             CALL {
                 WITH this0_openingDays_connect0_node
-                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_this3:Settings)
-                OPTIONAL MATCH (authorization_this3)<-[:HAS_SETTINGS]-(authorization_this4:Tenant)
-                WITH *, count(authorization_this4) AS tenantCount
+                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_0_0_after_this3:Settings)
+                OPTIONAL MATCH (authorization_0_0_after_this3)<-[:HAS_SETTINGS]-(authorization_0_0_after_this4:Tenant)
+                WITH *, count(authorization_0_0_after_this4) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_this4)<-[:ADMIN_IN]-(authorization_this5:User) WHERE ($jwt.id IS NOT NULL AND authorization_this5.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_this3) = 1 AS authorization_var2
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_after_this4)<-[:ADMIN_IN]-(authorization_0_0_after_this5:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_after_this5.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_after_this3) = 1 AS authorization_0_0_after_var2
             }
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_this1)<-[:ADMIN_IN]-(authorization_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_var2 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_after_var2 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_openingDays_connect_OpeningDay0
             }
             WITH *
@@ -201,10 +201,10 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	RETURN c AS this0_host_Tenant_unique_ignored
             }
             WITH *
-            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_this1:Tenant)
-            WITH *, count(authorization_0_0_this1) AS hostCount
+            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_after_this1:Tenant)
+            WITH *, count(authorization_0_0_after_this1) AS hostCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_this1)<-[:ADMIN_IN]-(authorization_0_0_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -226,7 +226,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
                 \\"isAuthenticated\\": true,
                 \\"create_param2\\": \\"overlord\\",
                 \\"this0_host_connect0_node_param0\\": \\"userid\\",
-                \\"authorization_param2\\": \\"overlord\\",
+                \\"authorization_0_0_before_param2\\": \\"overlord\\",
+                \\"authorization_0_0_after_param2\\": \\"overlord\\",
                 \\"this0_openingDays_connect0_node_param0\\": \\"openingdayid\\",
                 \\"resolvedCallbacks\\": {}
             }"

--- a/packages/graphql/tests/tck/issues/4170.test.ts
+++ b/packages/graphql/tests/tck/issues/4170.test.ts
@@ -182,33 +182,33 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
             WITH *
             CALL {
                 WITH this0_settings0_node_openingDays0_node_open0_node
-                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_3_this1:OpeningDay)
+                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_3_after_this1:OpeningDay)
                 CALL {
-                    WITH authorization_0_3_this1
-                    MATCH (authorization_0_3_this1)<-[:VALID_GARAGES]-(authorization_0_3_this2:Settings)
-                    OPTIONAL MATCH (authorization_0_3_this2)<-[:HAS_SETTINGS]-(authorization_0_3_this3:Tenant)
-                    WITH *, count(authorization_0_3_this3) AS tenantCount
+                    WITH authorization_0_3_after_this1
+                    MATCH (authorization_0_3_after_this1)<-[:VALID_GARAGES]-(authorization_0_3_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_0_3_after_this2)<-[:HAS_SETTINGS]-(authorization_0_3_after_this3:Tenant)
+                    WITH *, count(authorization_0_3_after_this3) AS tenantCount
                     WITH *
-                    WHERE (tenantCount <> 0 AND size([(authorization_0_3_this3)<-[:ADMIN_IN]-(authorization_0_3_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_3_this4.userId = $jwt.id) | 1]) > 0)
-                    RETURN count(authorization_0_3_this2) = 1 AS authorization_0_3_var5
+                    WHERE (tenantCount <> 0 AND size([(authorization_0_3_after_this3)<-[:ADMIN_IN]-(authorization_0_3_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_3_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_0_3_after_this2) = 1 AS authorization_0_3_after_var5
                 }
                 WITH *
-                WHERE authorization_0_3_var5 = true
-                RETURN count(authorization_0_3_this1) = 1 AS authorization_0_3_var0
+                WHERE authorization_0_3_after_var5 = true
+                RETURN count(authorization_0_3_after_this1) = 1 AS authorization_0_3_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays0_node
-                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_0_2_this1:Settings)
-                OPTIONAL MATCH (authorization_0_2_this1)<-[:HAS_SETTINGS]-(authorization_0_2_this2:Tenant)
-                WITH *, count(authorization_0_2_this2) AS tenantCount
+                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_0_2_after_this1:Settings)
+                OPTIONAL MATCH (authorization_0_2_after_this1)<-[:HAS_SETTINGS]-(authorization_0_2_after_this2:Tenant)
+                WITH *, count(authorization_0_2_after_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_0_2_this2)<-[:ADMIN_IN]-(authorization_0_2_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_2_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_0_2_this1) = 1 AS authorization_0_2_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_2_after_this2)<-[:ADMIN_IN]-(authorization_0_2_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_2_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_2_after_this1) = 1 AS authorization_0_2_after_var0
             }
-            OPTIONAL MATCH (this0_settings0_node)<-[:HAS_SETTINGS]-(authorization_0_1_this1:Tenant)
-            WITH *, count(authorization_0_1_this1) AS tenantCount
+            OPTIONAL MATCH (this0_settings0_node)<-[:HAS_SETTINGS]-(authorization_0_1_after_this1:Tenant)
+            WITH *, count(authorization_0_1_after_this1) AS tenantCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_3_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_2_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_0_1_this1)<-[:ADMIN_IN]-(authorization_0_1_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_1_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_0_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_3_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_2_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_0_1_after_this1)<-[:ADMIN_IN]-(authorization_0_1_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_1_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {

--- a/packages/graphql/tests/tck/issues/4214.test.ts
+++ b/packages/graphql/tests/tck/issues/4214.test.ts
@@ -168,12 +168,12 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_transaction_connect0_node:Transaction)
-            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_this0:Store)
-            WITH *, count(authorization_this0) AS storeCount
-            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_this1:Store)
-            WITH *, count(authorization_this1) AS storeCount
+            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_0_before_this0:Store)
+            WITH *, count(authorization_0_0_before_this0) AS storeCount
+            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_0_before_this1:Store)
+            WITH *, count(authorization_0_0_before_this1) AS storeCount
             WITH *
-            	WHERE this0_transaction_connect0_node.id = $this0_transaction_connect0_node_param0 AND ((($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_this0.id = $jwt.store))))) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_param6 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_this1.id = $jwt.store)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this0_transaction_connect0_node.id = $this0_transaction_connect0_node_param0 AND ((($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_0_0_before_param3 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param4 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_before_this0.id = $jwt.store))))) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_0_0_before_param5 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_before_param6 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_before_this1.id = $jwt.store)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this0_transaction_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -188,17 +188,17 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             WITH *
             CALL {
                 WITH this0
-                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_this2:Transaction)
-                OPTIONAL MATCH (authorization_this2)-[:TRANSACTION]->(authorization_this3:Store)
-                WITH *, count(authorization_this3) AS storeCount
+                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_0_after_this2:Transaction)
+                OPTIONAL MATCH (authorization_0_0_after_this2)-[:TRANSACTION]->(authorization_0_0_after_this3:Store)
+                WITH *, count(authorization_0_0_after_this3) AS storeCount
                 WITH *
-                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_this3.id = $jwt.store))
-                RETURN count(authorization_this2) = 1 AS authorization_var0
+                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_after_this3.id = $jwt.store))
+                RETURN count(authorization_0_0_after_this2) = 1 AS authorization_0_0_after_var0
             }
-            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_this1:Store)
-            WITH *, count(authorization_this1) AS storeCount
+            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_0_after_this1:Store)
+            WITH *, count(authorization_0_0_after_this1) AS storeCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_param3 IN $jwt.roles)) AND authorization_var0 = true)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_param4 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_param5 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_this1.id = $jwt.store)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles)) AND authorization_0_0_after_var0 = true)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_0_0_after_param4 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param5 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_after_this1.id = $jwt.store)))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_transaction_connect_Transaction0
             }
             WITH *
@@ -212,15 +212,15 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             WITH *
             CALL {
                 WITH this0
-                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_0_this1:Transaction)
-                OPTIONAL MATCH (authorization_0_0_this1)-[:TRANSACTION]->(authorization_0_0_this2:Store)
-                WITH *, count(authorization_0_0_this2) AS storeCount
+                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_0_after_this1:Transaction)
+                OPTIONAL MATCH (authorization_0_0_after_this1)-[:TRANSACTION]->(authorization_0_0_after_this2:Store)
+                WITH *, count(authorization_0_0_after_this2) AS storeCount
                 WITH *
-                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_this2.id = $jwt.store))
-                RETURN count(authorization_0_0_this1) = 1 AS authorization_0_0_var0
+                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_after_this2.id = $jwt.store))
+                RETURN count(authorization_0_0_after_this1) = 1 AS authorization_0_0_after_var0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_param3 IN $jwt.roles)) AND authorization_0_0_var0 = true)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param3 IN $jwt.roles)) AND authorization_0_0_after_var0 = true)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -265,13 +265,15 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
                     \\"high\\": 0
                 },
                 \\"this0_transaction_connect0_node_param0\\": \\"transactionid\\",
-                \\"authorization_param2\\": \\"store-owner\\",
-                \\"authorization_param3\\": \\"employee\\",
-                \\"authorization_param4\\": \\"store-owner\\",
-                \\"authorization_param5\\": \\"employee\\",
-                \\"authorization_param6\\": \\"employee\\",
-                \\"authorization_0_0_param2\\": \\"store-owner\\",
-                \\"authorization_0_0_param3\\": \\"employee\\",
+                \\"authorization_0_0_before_param2\\": \\"admin\\",
+                \\"authorization_0_0_before_param3\\": \\"store-owner\\",
+                \\"authorization_0_0_before_param4\\": \\"employee\\",
+                \\"authorization_0_0_before_param5\\": \\"store-owner\\",
+                \\"authorization_0_0_before_param6\\": \\"employee\\",
+                \\"authorization_0_0_after_param2\\": \\"store-owner\\",
+                \\"authorization_0_0_after_param3\\": \\"employee\\",
+                \\"authorization_0_0_after_param4\\": \\"store-owner\\",
+                \\"authorization_0_0_after_param5\\": \\"employee\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
@@ -310,7 +310,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this0_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -339,7 +339,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this1_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this1
             }
             CALL {
@@ -358,7 +358,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this2_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this2
             }
             CALL {
@@ -391,7 +391,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this3_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this3
             }
             CALL {
@@ -415,7 +415,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this4_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this4
             }
             CALL {
@@ -519,7 +519,7 @@ describe("Batch Create, Auth", () => {
                     \\"low\\": 2022,
                     \\"high\\": 0
                 },
-                \\"authorization_0_0_param2\\": \\"admin\\",
+                \\"authorization_0_0_after_param2\\": \\"admin\\",
                 \\"this1_id\\": \\"2\\",
                 \\"this1_actors0_node_name\\": \\"actor 2\\",
                 \\"this1_actors0_relationship_year\\": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1209,12 +1209,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.20.7, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
+"@babel/runtime@npm:^7.0.0, @babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.13.10, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.20.1, @babel/runtime@npm:^7.20.13, @babel/runtime@npm:^7.21.0, @babel/runtime@npm:^7.3.1, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.23.1
   resolution: "@babel/runtime@npm:7.23.1"
   dependencies:
     regenerator-runtime: ^0.14.0
   checksum: 0cd0d43e6e7dc7f9152fda8c8312b08321cda2f56ef53d6c22ebdd773abdc6f5d0a69008de90aa41908d00e2c1facb24715ff121274e689305c858355ff02c70
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.23.2":
+  version: 7.23.2
+  resolution: "@babel/runtime@npm:7.23.2"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 6c4df4839ec75ca10175f636d6362f91df8a3137f86b38f6cd3a4c90668a0fe8e9281d320958f4fbd43b394988958585a17c3aab2a4ea6bf7316b22916a371fb
   languageName: node
   linkType: hard
 
@@ -8913,7 +8922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.1.3":
+"aria-query@npm:^5.3.0":
   version: 5.3.0
   resolution: "aria-query@npm:5.3.0"
   dependencies:
@@ -9121,10 +9130,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ast-types-flow@npm:^0.0.7":
-  version: 0.0.7
-  resolution: "ast-types-flow@npm:0.0.7"
-  checksum: a26dcc2182ffee111cad7c471759b0bda22d3b7ebacf27c348b22c55f16896b18ab0a4d03b85b4020dce7f3e634b8f00b593888f622915096ea1927fa51866c4
+"ast-types-flow@npm:^0.0.8":
+  version: 0.0.8
+  resolution: "ast-types-flow@npm:0.0.8"
+  checksum: 0a64706609a179233aac23817837abab614f3548c252a2d3d79ea1e10c74aa28a0846e11f466cf72771b6ed8713abc094dcf8c40c3ec4207da163efa525a94a8
   languageName: node
   linkType: hard
 
@@ -9306,10 +9315,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axe-core@npm:^4.6.2":
-  version: 4.8.2
-  resolution: "axe-core@npm:4.8.2"
-  checksum: 8c19f507dabfcb8514e4280c7fc66e85143be303ddb57ec9f119338021228dc9b80560993938003837bda415fde7c07bba3a96560008ffa5f4145a248ed8f5fe
+"axe-core@npm:=4.7.0":
+  version: 4.7.0
+  resolution: "axe-core@npm:4.7.0"
+  checksum: f086bcab42be1761ba2b0b127dec350087f4c3a853bba8dd58f69d898cefaac31a1561da23146f6f3c07954c76171d1f2ce460e555e052d2b02cd79af628fa4a
   languageName: node
   linkType: hard
 
@@ -9340,7 +9349,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axobject-query@npm:^3.1.1":
+"axobject-query@npm:^3.2.1":
   version: 3.2.1
   resolution: "axobject-query@npm:3.2.1"
   dependencies:
@@ -12907,7 +12916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"es-iterator-helpers@npm:^1.0.12":
+"es-iterator-helpers@npm:^1.0.12, es-iterator-helpers@npm:^1.0.15":
   version: 1.0.15
   resolution: "es-iterator-helpers@npm:1.0.15"
   dependencies:
@@ -13236,29 +13245,29 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-plugin-jsx-a11y@npm:6.7.1":
-  version: 6.7.1
-  resolution: "eslint-plugin-jsx-a11y@npm:6.7.1"
+"eslint-plugin-jsx-a11y@npm:6.8.0":
+  version: 6.8.0
+  resolution: "eslint-plugin-jsx-a11y@npm:6.8.0"
   dependencies:
-    "@babel/runtime": ^7.20.7
-    aria-query: ^5.1.3
-    array-includes: ^3.1.6
-    array.prototype.flatmap: ^1.3.1
-    ast-types-flow: ^0.0.7
-    axe-core: ^4.6.2
-    axobject-query: ^3.1.1
+    "@babel/runtime": ^7.23.2
+    aria-query: ^5.3.0
+    array-includes: ^3.1.7
+    array.prototype.flatmap: ^1.3.2
+    ast-types-flow: ^0.0.8
+    axe-core: =4.7.0
+    axobject-query: ^3.2.1
     damerau-levenshtein: ^1.0.8
     emoji-regex: ^9.2.2
-    has: ^1.0.3
-    jsx-ast-utils: ^3.3.3
-    language-tags: =1.0.5
+    es-iterator-helpers: ^1.0.15
+    hasown: ^2.0.0
+    jsx-ast-utils: ^3.3.5
+    language-tags: ^1.0.9
     minimatch: ^3.1.2
-    object.entries: ^1.1.6
-    object.fromentries: ^2.0.6
-    semver: ^6.3.0
+    object.entries: ^1.1.7
+    object.fromentries: ^2.0.7
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8
-  checksum: f166dd5fe7257c7b891c6692e6a3ede6f237a14043ae3d97581daf318fc5833ddc6b4871aa34ab7656187430170500f6d806895747ea17ecdf8231a666c3c2fd
+  checksum: 3dec00e2a3089c4c61ac062e4196a70985fb7eda1fd67fe035363d92578debde92fdb8ed2e472321fc0d71e75f4a1e8888c6a3218c14dd93c8e8d19eb6f51554
   languageName: node
   linkType: hard
 
@@ -17645,7 +17654,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.3":
+"jsx-ast-utils@npm:^2.4.1 || ^3.0.0, jsx-ast-utils@npm:^3.3.5":
   version: 3.3.5
   resolution: "jsx-ast-utils@npm:3.3.5"
   dependencies:
@@ -17829,19 +17838,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"language-subtag-registry@npm:~0.3.2":
+"language-subtag-registry@npm:^0.3.20":
   version: 0.3.22
   resolution: "language-subtag-registry@npm:0.3.22"
   checksum: 8ab70a7e0e055fe977ac16ea4c261faec7205ac43db5e806f72e5b59606939a3b972c4bd1e10e323b35d6ffa97c3e1c4c99f6553069dad2dfdd22020fa3eb56a
   languageName: node
   linkType: hard
 
-"language-tags@npm:=1.0.5":
-  version: 1.0.5
-  resolution: "language-tags@npm:1.0.5"
+"language-tags@npm:^1.0.9":
+  version: 1.0.9
+  resolution: "language-tags@npm:1.0.9"
   dependencies:
-    language-subtag-registry: ~0.3.2
-  checksum: c81b5d8b9f5f9cfd06ee71ada6ddfe1cf83044dd5eeefcd1e420ad491944da8957688db4a0a9bc562df4afdc2783425cbbdfd152c01d93179cf86888903123cf
+    language-subtag-registry: ^0.3.20
+  checksum: 57c530796dc7179914dee71bc94f3747fd694612480241d0453a063777265dfe3a951037f7acb48f456bf167d6eb419d4c00263745326b3ba1cdcf4657070e78
   languageName: node
   linkType: hard
 
@@ -19797,7 +19806,7 @@ __metadata:
     eslint-plugin-eslint-comments: 3.2.0
     eslint-plugin-import: 2.29.0
     eslint-plugin-jest: 27.6.0
-    eslint-plugin-jsx-a11y: 6.7.1
+    eslint-plugin-jsx-a11y: 6.8.0
     eslint-plugin-react: 7.33.2
     eslint-plugin-simple-import-sort: 10.0.0
     graphql: 16.8.1
@@ -20361,7 +20370,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.entries@npm:^1.1.6":
+"object.entries@npm:^1.1.6, object.entries@npm:^1.1.7":
   version: 1.1.7
   resolution: "object.entries@npm:1.1.7"
   dependencies:


### PR DESCRIPTION
# Description

This PR modifies the prefix with which authorization subqueries are being built for creates by appending "before" or "after" depending on which function is being built. It also takes into account the create index for further collision protection. Once again, we should move creates to the new Translation Layer to fix these sort of problems once and for all.

## Complexity

Complexity: Low

# Issue

Closes #4214 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
