### PR TITLE
Migrate global node resolver to use new translation-layer

### DIFF
--- a/packages/graphql/src/schema/resolvers/query/global-node.ts
+++ b/packages/graphql/src/schema/resolvers/query/global-node.ts
@@ -71,7 +71,6 @@ export function globalNodeResolver({ nodes, entities }: { nodes: Node[]; entitie
         const { cypher, params } = translateRead({
             context: context as Neo4jGraphQLTranslationContext,
             node,
-            isGlobalNode: true,
             entityAdapter,
         });
         const executeResult = await execute({

--- a/packages/graphql/src/translate/translate-read.ts
+++ b/packages/graphql/src/translate/translate-read.ts
@@ -87,18 +87,17 @@ export function translateRead(
         node,
         context,
         isRootConnectionField,
-        isGlobalNode,
         entityAdapter,
     }: {
         context: Neo4jGraphQLTranslationContext;
         node?: Node;
         isRootConnectionField?: boolean;
-        isGlobalNode?: boolean;
         entityAdapter: EntityAdapter;
     },
     varName = "this"
 ): Cypher.CypherResult {
-    if (!context.resolveTree.args.fulltext && !context.resolveTree.args.phrase && !isGlobalNode) {
+    
+    if (!context.resolveTree.args.fulltext && !context.resolveTree.args.phrase) {
         return translateQuery({ context, entityAdapter });
     }
     if (isRootConnectionField) {


### PR DESCRIPTION
This PR migrate the global node resolver to use new translation-layer
