### PR TITLE
Apply Renovate best practices by default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
-    "extends": ["config:base"],
+    "extends": ["config:best-practices"],
     "baseBranches": ["dev"],
     "rebaseWhen": "auto",
     "automerge": true,


### PR DESCRIPTION
# Description

Please see https://docs.renovatebot.com/presets-config/#configbest-practices and go down the docs tree for details.

But does things such as:

* Pin GitHub Actions to digests
* Pin Docker to digests
* Replace known package names (such as `apollo-server` is now `@apollo/server`)
* Group together certain known dependencies and monorepos