### PR TITLE
Implement properties field 

### DIFF
--- a/.changeset/little-toys-look.md
+++ b/.changeset/little-toys-look.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": minor
+---
+
+Introduce new properties field in edge for relationship properties

--- a/.changeset/little-toys-look.md
+++ b/.changeset/little-toys-look.md
@@ -1,5 +1,5 @@
 ---
-"@neo4j/graphql": minor
+"@neo4j/graphql": major
 ---
 
-Introduce new properties field in edge for relationship properties
+Introduce new properties field in connection edges field for relationship properties.

--- a/.changeset/little-toys-look.md
+++ b/.changeset/little-toys-look.md
@@ -1,5 +1,7 @@
 ---
+"@neo4j/introspector": major
 "@neo4j/graphql": major
+"@neo4j/graphql-ogm": major
 ---
 
 Introduce new properties field in connection edges field for relationship properties.

--- a/packages/graphql/src/schema/create-connection-fields.ts
+++ b/packages/graphql/src/schema/create-connection-fields.ts
@@ -158,9 +158,10 @@ export function createConnectionFields({
         });
 
         if (relationship.propertiesTypeName) {
-            const propertiesInterface = schemaComposer.getIFTC(relationship.propertiesTypeName);
-            relationshipObjectType.addInterface(propertiesInterface);
-            relationshipObjectType.addFields(propertiesInterface.getFields());
+            const propertiesObjectType = schemaComposer.getOTC(relationship.propertiesTypeName);
+            relationshipObjectType.addFields({
+                properties: propertiesObjectType.NonNull,
+            });
         }
 
         const fields = augmentWhereInputTypeWithConnectionFields(relationship, deprecatedDirectives);

--- a/packages/graphql/src/schema/generation/interface-type.ts
+++ b/packages/graphql/src/schema/generation/interface-type.ts
@@ -18,8 +18,7 @@
  */
 import type { DirectiveNode } from "graphql";
 import type { InterfaceTypeComposer, SchemaComposer } from "graphql-compose";
-import { InterfaceEntityAdapter } from "../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
-import type { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
+import type { InterfaceEntityAdapter } from "../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
 import {
     attributeAdapterToComposeFields,
     graphqlDirectivesToCompose,
@@ -27,7 +26,7 @@ import {
 } from "../to-compose";
 
 export function withInterfaceType({
-    entityAdapter,
+    interfaceEntityAdapter,
     userDefinedFieldDirectives,
     userDefinedInterfaceDirectives,
     composer,
@@ -35,7 +34,7 @@ export function withInterfaceType({
         includeRelationships: false,
     },
 }: {
-    entityAdapter: InterfaceEntityAdapter | RelationshipAdapter;
+    interfaceEntityAdapter: InterfaceEntityAdapter;
     userDefinedFieldDirectives: Map<string, DirectiveNode[]>;
     userDefinedInterfaceDirectives: DirectiveNode[];
     composer: SchemaComposer;
@@ -46,23 +45,20 @@ export function withInterfaceType({
     // TODO: maybe create interfaceEntity.interfaceFields() method abstraction even if it retrieves all attributes?
     // can also take includeRelationships as argument
     const objectComposeFields = attributeAdapterToComposeFields(
-        Array.from(entityAdapter.attributes.values()),
+        Array.from(interfaceEntityAdapter.attributes.values()),
         userDefinedFieldDirectives
     );
     let fields = objectComposeFields;
-    if (config.includeRelationships && entityAdapter instanceof InterfaceEntityAdapter) {
+    if (config.includeRelationships) {
         fields = {
             ...fields,
             ...relationshipAdapterToComposeFields(
-                Array.from(entityAdapter.relationships.values()),
+                Array.from(interfaceEntityAdapter.relationships.values()),
                 userDefinedFieldDirectives
             ),
         };
     }
-    const interfaceTypeName =
-        entityAdapter instanceof InterfaceEntityAdapter
-            ? entityAdapter.name
-            : (entityAdapter.propertiesTypeName as string); // this is checked one layer above in execution
+    const interfaceTypeName = interfaceEntityAdapter.name;
     const composeInterface = composer.createInterfaceTC({
         name: interfaceTypeName,
         fields: fields,

--- a/packages/graphql/src/schema/generation/object-type.ts
+++ b/packages/graphql/src/schema/generation/object-type.ts
@@ -21,38 +21,51 @@ import { GraphQLID, GraphQLNonNull } from "graphql";
 import type { ObjectTypeComposer, SchemaComposer } from "graphql-compose";
 import { InterfaceEntity } from "../../schema-model/entity/InterfaceEntity";
 import type { ConcreteEntityAdapter } from "../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
+import { RelationshipAdapter } from "../../schema-model/relationship/model-adapters/RelationshipAdapter";
 import { attributeAdapterToComposeFields, graphqlDirectivesToCompose } from "../to-compose";
 
 export function withObjectType({
-    concreteEntityAdapter,
+    entityAdapter,
     userDefinedFieldDirectives,
     userDefinedObjectDirectives,
     composer,
 }: {
-    concreteEntityAdapter: ConcreteEntityAdapter;
+    entityAdapter: ConcreteEntityAdapter | RelationshipAdapter;
     userDefinedFieldDirectives: Map<string, DirectiveNode[]>;
     userDefinedObjectDirectives: DirectiveNode[];
     composer: SchemaComposer;
 }): ObjectTypeComposer {
-    const nodeFields = attributeAdapterToComposeFields(concreteEntityAdapter.objectFields, userDefinedFieldDirectives);
+    if (entityAdapter instanceof RelationshipAdapter) {
+        // @relationshipProperties
+        const objectComposeFields = attributeAdapterToComposeFields(
+            Array.from(entityAdapter.attributes.values()),
+            userDefinedFieldDirectives
+        );
+        const composeObject = composer.createObjectTC({
+            name: entityAdapter.propertiesTypeName as string, // this is checked one layer above in execution
+            fields: objectComposeFields,
+            directives: graphqlDirectivesToCompose(userDefinedObjectDirectives),
+        });
+        return composeObject;
+    }
+
+    const nodeFields = attributeAdapterToComposeFields(entityAdapter.objectFields, userDefinedFieldDirectives);
     const composeNode = composer.createObjectTC({
-        name: concreteEntityAdapter.name,
+        name: entityAdapter.name,
         fields: nodeFields,
-        description: concreteEntityAdapter.description,
+        description: entityAdapter.description,
         directives: graphqlDirectivesToCompose(userDefinedObjectDirectives),
-        interfaces: concreteEntityAdapter.compositeEntities
-            .filter((e) => e instanceof InterfaceEntity)
-            .map((e) => e.name),
+        interfaces: entityAdapter.compositeEntities.filter((e) => e instanceof InterfaceEntity).map((e) => e.name),
     });
 
     // TODO: maybe split this global node logic?
-    if (concreteEntityAdapter.isGlobalNode()) {
+    if (entityAdapter.isGlobalNode()) {
         composeNode.setField("id", {
             type: new GraphQLNonNull(GraphQLID),
             resolve: (src) => {
-                const field = concreteEntityAdapter.globalIdField.name;
+                const field = entityAdapter.globalIdField.name;
                 const value = src[field] as string | number;
-                return concreteEntityAdapter.toGlobalId(value.toString());
+                return entityAdapter.toGlobalId(value.toString());
             },
         });
 

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -305,7 +305,7 @@ function makeAugmentedSchema({
         withUpdateInputType({ entityAdapter: concreteEntityAdapter, userDefinedFieldDirectives, composer });
         withMutationResponseTypes({ concreteEntityAdapter, propagatedDirectives, composer });
         const composeNode = withObjectType({
-            concreteEntityAdapter,
+            entityAdapter: concreteEntityAdapter,
             userDefinedFieldDirectives,
             userDefinedObjectDirectives,
             composer,
@@ -444,7 +444,7 @@ function makeAugmentedSchema({
             const propagatedDirectives = propagatedDirectivesForNode.get(entity.name) || [];
             const interfaceEntityAdapter = new InterfaceEntityAdapter(entity);
             withInterfaceType({
-                entityAdapter: interfaceEntityAdapter,
+                interfaceEntityAdapter,
                 userDefinedFieldDirectives,
                 userDefinedInterfaceDirectives,
                 composer,
@@ -674,11 +674,12 @@ function doForRelationshipPropertiesInterface({
     const userDefinedFieldDirectives = userDefinedFieldDirectivesForNode.get(
         relationshipAdapter.propertiesTypeName
     ) as Map<string, DirectiveNode[]>;
+    // TODO: update once this has been changed to a type
     const userDefinedInterfaceDirectives = userDefinedDirectivesForInterface.get(relationshipAdapter.name) || [];
-    withInterfaceType({
+    withObjectType({
         entityAdapter: relationshipAdapter,
         userDefinedFieldDirectives,
-        userDefinedInterfaceDirectives,
+        userDefinedObjectDirectives: userDefinedInterfaceDirectives,
         composer,
     });
     withSortInputType({ relationshipAdapter, userDefinedFieldDirectives, composer });
@@ -732,7 +733,7 @@ function doForInterfacesThatAreTargetOfARelationship({
     withUpdateInputType({ entityAdapter: interfaceEntityAdapter, userDefinedFieldDirectives, composer });
 
     const composeInterface = withInterfaceType({
-        entityAdapter: interfaceEntityAdapter,
+        interfaceEntityAdapter,
         userDefinedFieldDirectives,
         userDefinedInterfaceDirectives: [],
         composer,

--- a/packages/graphql/src/schema/make-augmented-schema.ts
+++ b/packages/graphql/src/schema/make-augmented-schema.ts
@@ -214,7 +214,7 @@ function makeAugmentedSchema({
 
     // this is the new "functional" way for the above forEach
     // helper to only create relationshipProperties Interface types once, even if multiple relationships reference it
-    const seenRelationshipPropertiesInterfaces = new Set<string>();
+    const seenRelationshipPropertiesTypes = new Set<string>();
     schemaModel.concreteEntities.forEach((concreteEntity) => {
         const concreteEntityAdapter = new ConcreteEntityAdapter(concreteEntity);
 
@@ -222,19 +222,19 @@ function makeAugmentedSchema({
             {
                 if (
                     !relationshipAdapter.propertiesTypeName ||
-                    seenRelationshipPropertiesInterfaces.has(relationshipAdapter.propertiesTypeName)
+                    seenRelationshipPropertiesTypes.has(relationshipAdapter.propertiesTypeName)
                 ) {
                     continue;
                 }
-                doForRelationshipPropertiesInterface({
+                doForRelationshipPropertiesType({
                     composer,
                     relationshipAdapter,
-                    userDefinedDirectivesForInterface,
+                    userDefinedDirectivesForNode,
                     userDefinedFieldDirectivesForNode,
                     features,
                     experimental,
                 });
-                seenRelationshipPropertiesInterfaces.add(relationshipAdapter.propertiesTypeName);
+                seenRelationshipPropertiesTypes.add(relationshipAdapter.propertiesTypeName);
             }
         }
     });
@@ -656,17 +656,17 @@ function makeAugmentedSchema({
 
 export default makeAugmentedSchema;
 
-function doForRelationshipPropertiesInterface({
+function doForRelationshipPropertiesType({
     composer,
     relationshipAdapter,
-    userDefinedDirectivesForInterface,
+    userDefinedDirectivesForNode,
     userDefinedFieldDirectivesForNode,
     features,
     experimental,
 }: {
     composer: SchemaComposer;
     relationshipAdapter: RelationshipAdapter;
-    userDefinedDirectivesForInterface: Map<string, DirectiveNode[]>;
+    userDefinedDirectivesForNode: Map<string, DirectiveNode[]>;
     userDefinedFieldDirectivesForNode: Map<string, Map<string, DirectiveNode[]>>;
     features?: Neo4jFeaturesSettings;
     experimental: boolean;
@@ -677,8 +677,7 @@ function doForRelationshipPropertiesInterface({
     const userDefinedFieldDirectives = userDefinedFieldDirectivesForNode.get(
         relationshipAdapter.propertiesTypeName
     ) as Map<string, DirectiveNode[]>;
-    // TODO: update once this has been changed to a type
-    const userDefinedInterfaceDirectives = userDefinedDirectivesForInterface.get(relationshipAdapter.name) || [];
+    const userDefinedInterfaceDirectives = userDefinedDirectivesForNode.get(relationshipAdapter.name) || [];
     withObjectType({
         entityAdapter: relationshipAdapter,
         userDefinedFieldDirectives,

--- a/packages/graphql/src/translate/connection-clause/create-sort-and-limit.ts
+++ b/packages/graphql/src/translate/connection-clause/create-sort-and-limit.ts
@@ -71,7 +71,7 @@ export function createSortAndLimitProjection({
         const [nodeOrEdge, sortKeyAndValue] = sortFieldEntries[0];
         addSortAndLimitOptionsToClause({
             optionsInput: { sort: [sortKeyAndValue], limit: firstArg, offset },
-            target: nodeOrEdge === "node" ? nodeRef : relationshipRef,
+            target: nodeOrEdge === "node" ? nodeRef : relationshipRef.property("properties"),
             projectionClause: withStatement,
         });
     });

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -233,10 +233,13 @@ export class ConnectionReadOperation extends Operation {
             });
         }
 
-        let edgeProjectionMap = new Cypher.Map();
+        const edgeProjectionMap = new Cypher.Map();
 
         if (context.relationship) {
-            edgeProjectionMap = this.generateProjectionMapForFields(this.edgeFields, context.relationship);
+            const propertiesProjectionMap = this.generateProjectionMapForFields(this.edgeFields, context.relationship);
+            if (propertiesProjectionMap.size) {
+                edgeProjectionMap.set("properties", propertiesProjectionMap);
+            }
         }
 
         edgeProjectionMap.set("node", nodeProjectionMap);

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionPartial.ts
@@ -87,14 +87,18 @@ export class CompositeConnectionPartial extends ConnectionReadOperation {
 
         const uniqueEdgeProjectionFields = Array.from(new Set([...edgeProjectionFields, ...edgeSortProjectionFields]));
 
+        const propertiesProjectionMap = new Cypher.Map();
         uniqueEdgeProjectionFields.forEach((p) => {
             if (typeof p === "string") {
-                edgeProjectionMap.set(p, relationship.property(p));
+                propertiesProjectionMap.set(p, relationship.property(p));
             } else {
-                edgeProjectionMap.set(p);
+                propertiesProjectionMap.set(p);
             }
         });
 
+        if (propertiesProjectionMap.size) {
+            edgeProjectionMap.set("properties", propertiesProjectionMap);
+        }
         edgeProjectionMap.set("node", nodeProjectionMap);
 
         let withWhere: Cypher.Clause | undefined;

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -69,7 +69,11 @@ export class CompositeConnectionReadOperation extends Operation {
                 neo4jGraphQLContext: context.neo4jGraphQLContext,
             });
 
-            const sortFields = this.getSortFields(nestedContext, edgeVar.property("node"), edgeVar);
+            const sortFields = this.getSortFields(
+                nestedContext,
+                edgeVar.property("node"),
+                edgeVar.property("properties")
+            );
             extraWithOrder = new Cypher.Unwind([edgesVar, edgeVar]).with(edgeVar, totalCount).orderBy(...sortFields);
 
             if (paginationField && paginationField.skip) {

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -774,12 +774,10 @@ export class OperationsFactory {
         };
 
         const edgeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeConnectionFields, "edges");
-        // console.log("edgeFieldsRaw", edgeFieldsRaw, entityOrRel.operations.relationshipFieldTypename);
         const resolveTreeEdgeFields = getFieldsByTypeName(
             edgeFieldsRaw,
             entityOrRel.operations.relationshipFieldTypename
         );
-        // console.log("resolveTreeEdgeFields", JSON.stringify(resolveTreeEdgeFields, null, 2));
 
         const nodeFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeEdgeFields, "node");
         const propertiesFieldsRaw = findFieldsByNameInFieldsByTypeNameField(resolveTreeEdgeFields, "properties");

--- a/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
@@ -344,7 +344,9 @@ describe("array-pop-errors", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                               properties {
+                                 pay
+                                }
                             }
                         }
                     }

--- a/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
@@ -770,7 +770,9 @@ describe("array-pop", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                               properties { 
+                                    pay
+                               }
                             }
                         }
                     }
@@ -854,10 +856,12 @@ describe("array-pop", () => {
                         }
                         actedInConnection {
                             edges {
-                                locations {
-                                    latitude
-                                    longitude
-                                    height
+                                properties {
+                                    locations {
+                                        latitude
+                                        longitude
+                                        height
+                                    }
                                 }
                             }
                         }
@@ -890,7 +894,7 @@ describe("array-pop", () => {
                 {
                     name: "Keanu",
                     actedIn: [{ title: "The Matrix" }],
-                    actedInConnection: { edges: [{ locations: [] }] },
+                    actedInConnection: { edges: [{ properties: { locations: [] } }] },
                 },
             ])
         );

--- a/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
@@ -296,7 +296,9 @@ describe("array-push", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                                properties {
+                                    pay
+                                }
                             }
                         }
                     }

--- a/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
@@ -270,11 +270,11 @@ describe("array-push", () => {
 
             await session.run(cypher, { movieTitle });
 
-        const gqlResult = await graphql({
-            schema: await neoSchema.getSchema(),
-            source: update,
-            contextValue: neo4j.getContextValues(),
-        });
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: update,
+                contextValue: neo4j.getContextValues(),
+            });
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -352,12 +352,12 @@ describe("array-push", () => {
 
             await session.run(cypher, { movieTitle });
 
-        const gqlResult = await graphql({
-            schema: await neoSchema.getSchema(),
-            source: update,
-            contextValue: neo4j.getContextValues(),
-            variableValues: { inputValue },
-        });
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: update,
+                contextValue: neo4j.getContextValues(),
+                variableValues: { inputValue },
+            });
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -433,12 +433,12 @@ describe("array-push", () => {
 
             await session.run(cypher, { movieTitle });
 
-        const gqlResult = await graphql({
-            schema: await neoSchema.getSchema(),
-            source: update,
-            contextValue: neo4j.getContextValues(),
-            variableValues: { inputValue },
-        });
+            const gqlResult = await graphql({
+                schema: await neoSchema.getSchema(),
+                source: update,
+                contextValue: neo4j.getContextValues(),
+                variableValues: { inputValue },
+            });
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -623,7 +623,9 @@ describe("array-push", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                                properties {
+                                    pay
+                                }
                             }
                         }
                     }
@@ -707,10 +709,12 @@ describe("array-push", () => {
                         }
                         actedInConnection {
                             edges {
-                                locations {
-                                    latitude
-                                    longitude
-                                    height
+                               properties {
+                                    locations {
+                                        latitude
+                                        longitude
+                                        height
+                                    }
                                 }
                             }
                         }
@@ -742,7 +746,7 @@ describe("array-push", () => {
                 {
                     name: "Keanu",
                     actedIn: [{ title: "The Matrix" }],
-                    actedInConnection: { edges: [{ locations: [point] }] },
+                    actedInConnection: { edges: [{ properties: { locations: [point] } }] },
                 },
             ])
         );

--- a/packages/graphql/tests/integration/connection-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/connection-resolvers-int.test.ts
@@ -70,7 +70,7 @@ describe("Connection Resolvers", () => {
             charset: "alphabetic",
         });
 
-        const create = `
+        const create = /* GraphQL */ `
             mutation {
                 createMovies(input:[{
                     id: "${movieId}",
@@ -98,7 +98,9 @@ describe("Connection Resolvers", () => {
                                 startCursor
                             }
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     id
                                     name
@@ -131,7 +133,7 @@ describe("Connection Resolvers", () => {
                     },
                     edges: [
                         {
-                            screenTime: 100,
+                            properties: { screenTime: 100 },
                             node: {
                                 id: actorId,
                                 name: "Keanu Reeves",
@@ -171,7 +173,7 @@ describe("Connection Resolvers", () => {
             driver,
         });
 
-        const create = `
+        const create = /* GraphQL */ `
             mutation CreateMovie($input: [MovieCreateInput!]!) {
                 createMovies(input: $input) {
                     movies {
@@ -187,7 +189,9 @@ describe("Connection Resolvers", () => {
                             }
                             edges {
                                 cursor
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     id
                                     name
@@ -242,7 +246,7 @@ describe("Connection Resolvers", () => {
                         totalCount: 20,
                         edges: actors.slice(0, 5).map(({ node, edge }) => ({
                             node,
-                            screenTime: edge.screenTime,
+                            properties: { screenTime: edge.screenTime },
                             cursor: expect.any(String),
                         })),
                         pageInfo: {
@@ -255,7 +259,7 @@ describe("Connection Resolvers", () => {
                 },
             ]);
 
-            const secondQuery = `
+            const secondQuery = /* GraphQL */ `
                 query Movies($movieId: ID!, $endCursor: String) {
                     movies(where: { id: $movieId }) {
                         id
@@ -264,7 +268,9 @@ describe("Connection Resolvers", () => {
                             totalCount
                             edges {
                                 cursor
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     id
                                     name
@@ -300,7 +306,7 @@ describe("Connection Resolvers", () => {
                     edges: actors.slice(5, 10).map(({ node, edge }) => ({
                         node,
                         cursor: expect.any(String),
-                        screenTime: edge.screenTime,
+                        properties: { screenTime: edge.screenTime },
                     })),
                     pageInfo: {
                         hasPreviousPage: true,
@@ -331,7 +337,7 @@ describe("Connection Resolvers", () => {
                     edges: actors.slice(10, 15).map(({ node, edge }) => ({
                         node,
                         cursor: expect.any(String),
-                        screenTime: edge.screenTime,
+                        properties: { screenTime: edge.screenTime },
                     })),
                     pageInfo: {
                         hasPreviousPage: true,

--- a/packages/graphql/tests/integration/connections/alias.int.test.ts
+++ b/packages/graphql/tests/integration/connections/alias.int.test.ts
@@ -739,7 +739,9 @@ describe("Connections Alias", () => {
                 ${typeMovie.plural}(where: { title: "${movieTitle}" }) {
                     actorsConnection(first: 1) {
                         edges {
-                            r:roles
+                           r:properties {
+                             r:roles
+                           }
                         }
                     }
                 }
@@ -767,7 +769,7 @@ describe("Connections Alias", () => {
 
             expect(result.errors).toBeUndefined();
 
-            expect((result.data as any)[typeMovie.plural][0].actorsConnection.edges[0].r).toBeDefined();
+            expect((result.data as any)[typeMovie.plural][0].actorsConnection.edges[0].r.r).toBeDefined();
         } finally {
             await session.close();
         }
@@ -815,7 +817,9 @@ describe("Connections Alias", () => {
                             n:node {
                                 n:name
                             }
-                            r:roles
+                           p:properties {
+                             r:roles
+                           }
                         }
                         page:pageInfo {
                             hNP:hasNextPage
@@ -852,7 +856,7 @@ describe("Connections Alias", () => {
                         title: movieTitle,
                         connection: {
                             tC: 1,
-                            edges: [{ n: { n: actorName }, r: roles }],
+                            edges: [{ n: { n: actorName }, p: { r: roles } }],
                             page: {
                                 hNP: false,
                             },
@@ -972,7 +976,9 @@ describe("Connections Alias", () => {
                     title
                     actorsConnection(where: { node: { name: "${actorName}" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 b: moviesConnection(where: { node: { title: "${movieTitle}"}}) {

--- a/packages/graphql/tests/integration/connections/enums.int.test.ts
+++ b/packages/graphql/tests/integration/connections/enums.int.test.ts
@@ -78,28 +78,20 @@ describe("Enum Relationship Properties", () => {
             charset: "alphabetic",
         });
 
-        const create = `
+        const create = /* GraphQL */ `
             mutation CreateMovies($title: String!, $name: String!) {
                 createMovies(
                     input: [
-                        {
-                            title: $title
-                            actors: {
-                                create: [
-                                    {
-                                        edge: { roleType: LEADING }
-                                        node: { name: $name }
-                                    }
-                                ]
-                            }
-                        }
+                        { title: $title, actors: { create: [{ edge: { roleType: LEADING }, node: { name: $name } }] } }
                     ]
                 ) {
                     movies {
                         title
                         actorsConnection {
                             edges {
-                                roleType
+                                properties {
+                                    roleType
+                                }
                                 node {
                                     name
                                 }
@@ -122,7 +114,12 @@ describe("Enum Relationship Properties", () => {
 
             expect(gqlResult.data).toEqual({
                 createMovies: {
-                    movies: [{ title, actorsConnection: { edges: [{ roleType: "LEADING", node: { name } }] } }],
+                    movies: [
+                        {
+                            title,
+                            actorsConnection: { edges: [{ properties: { roleType: "LEADING" }, node: { name } }] },
+                        },
+                    ],
                 },
             });
 

--- a/packages/graphql/tests/integration/connections/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/connections/interfaces.int.test.ts
@@ -139,7 +139,9 @@ describe("Connections -> Interfaces", () => {
                     name
                     actedInConnection {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on ${typeMovie.name} {
@@ -175,21 +177,21 @@ describe("Connections -> Interfaces", () => {
                     actedInConnection: {
                         edges: expect.toIncludeSameMembers([
                             {
-                                screenTime: movie1ScreenTime,
+                                properties: { screenTime: movie1ScreenTime },
                                 node: {
                                     title: movie1Title,
                                     runtime: movie1Runtime,
                                 },
                             },
                             {
-                                screenTime: movie2ScreenTime,
+                                properties: { screenTime: movie2ScreenTime },
                                 node: {
                                     title: movie2Title,
                                     runtime: movie2Runtime,
                                 },
                             },
                             {
-                                screenTime: seriesScreenTime,
+                                properties: { screenTime: seriesScreenTime },
                                 node: {
                                     title: seriesTitle,
                                     episodes: seriesEpisodes,
@@ -215,7 +217,9 @@ describe("Connections -> Interfaces", () => {
                     name
                     actedInConnection(where: { node: { title: "Game of Thrones" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on ${typeMovie.name} {
@@ -251,7 +255,7 @@ describe("Connections -> Interfaces", () => {
                     actedInConnection: {
                         edges: [
                             {
-                                screenTime: seriesScreenTime,
+                                properties: { screenTime: seriesScreenTime },
                                 node: {
                                     title: seriesTitle,
                                     episodes: seriesEpisodes,
@@ -277,7 +281,9 @@ describe("Connections -> Interfaces", () => {
                     name
                     actedInConnection(where: { node: { title: "Game of Thrones", _on: { ${typeMovie.name}: { title: "Dune" } } } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on ${typeMovie.name} {
@@ -313,14 +319,14 @@ describe("Connections -> Interfaces", () => {
                     actedInConnection: {
                         edges: [
                             {
-                                screenTime: movie1ScreenTime,
+                                properties: { screenTime: movie1ScreenTime },
                                 node: {
                                     title: movie1Title,
                                     runtime: movie1Runtime,
                                 },
                             },
                             {
-                                screenTime: seriesScreenTime,
+                                properties: { screenTime: seriesScreenTime },
                                 node: {
                                     title: seriesTitle,
                                     episodes: seriesEpisodes,
@@ -346,7 +352,9 @@ describe("Connections -> Interfaces", () => {
                     name
                     actedInConnection(sort: [{ edge: { screenTime: DESC } }]) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on ${typeMovie.name} {
@@ -382,21 +390,21 @@ describe("Connections -> Interfaces", () => {
                     actedInConnection: {
                         edges: [
                             {
-                                screenTime: seriesScreenTime,
+                                properties: { screenTime: seriesScreenTime },
                                 node: {
                                     title: seriesTitle,
                                     episodes: seriesEpisodes,
                                 },
                             },
                             {
-                                screenTime: movie2ScreenTime,
+                                properties: { screenTime: movie2ScreenTime },
                                 node: {
                                     title: movie2Title,
                                     runtime: movie2Runtime,
                                 },
                             },
                             {
-                                screenTime: movie1ScreenTime,
+                                properties: { screenTime: movie1ScreenTime },
                                 node: {
                                     title: movie1Title,
                                     runtime: movie1Runtime,
@@ -427,7 +435,9 @@ describe("Connections -> Interfaces", () => {
                             endCursor
                         }
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on ${typeMovie.name} {
@@ -468,14 +478,14 @@ describe("Connections -> Interfaces", () => {
                         },
                         edges: [
                             {
-                                screenTime: seriesScreenTime,
+                                properties: { screenTime: seriesScreenTime },
                                 node: {
                                     title: seriesTitle,
                                     episodes: seriesEpisodes,
                                 },
                             },
                             {
-                                screenTime: movie2ScreenTime,
+                                properties: { screenTime: movie2ScreenTime },
                                 node: {
                                     title: movie2Title,
                                     runtime: movie2Runtime,
@@ -509,7 +519,7 @@ describe("Connections -> Interfaces", () => {
                         },
                         edges: [
                             {
-                                screenTime: movie1ScreenTime,
+                                properties: { screenTime: movie1ScreenTime },
                                 node: {
                                     title: movie1Title,
                                     runtime: movie1Runtime,
@@ -535,7 +545,9 @@ describe("Connections -> Interfaces", () => {
                 name
                 actedInConnection(where: { node: { title: $title } }) {
                     edges {
-                        screenTime
+                        properties {
+                            screenTime
+                        }
                         node {
                             title
                             ... on ${typeMovie.name} {
@@ -572,7 +584,7 @@ describe("Connections -> Interfaces", () => {
                     actedInConnection: {
                         edges: [
                             {
-                                screenTime: movie1ScreenTime,
+                                properties: { screenTime: movie1ScreenTime },
                                 node: {
                                     title: movie1Title,
                                     runtime: movie1Runtime,

--- a/packages/graphql/tests/integration/connections/nested.int.test.ts
+++ b/packages/graphql/tests/integration/connections/nested.int.test.ts
@@ -83,7 +83,9 @@ describe("Connections Alias", () => {
                     title
                     actorsConnection(where: { node: { name: "${actorName}" } }) {
                         edges {
-                            screenTime
+                            properties { 
+                                screenTime
+                            }
                             node {
                                 name
                                 moviesConnection {
@@ -147,7 +149,9 @@ describe("Connections Alias", () => {
                     title
                     actorsConnection(where: { node: { name: "${actorName}" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 moviesConnection(where: { node: { title: "${movieTitle}" } }) {

--- a/packages/graphql/tests/integration/connections/sort.int.test.ts
+++ b/packages/graphql/tests/integration/connections/sort.int.test.ts
@@ -512,7 +512,9 @@ describe("connections sort", () => {
                                 id
                                 actedInConnection(sort: [{ edge: { screenTime: $direction } }]) {
                                     edges {
-                                        screenTime
+                                        properties {
+                                            screenTime
+                                        }
                                         node {
                                             id
                                             title
@@ -562,7 +564,9 @@ describe("connections sort", () => {
                                 id
                                 actedInConnection(sort: [{ edge: { screenTime: $direction } }]) {
                                     edges {
-                                        aliased: screenTime
+                                        properties {
+                                            aliased: screenTime
+                                        }
                                         node {
                                             id
                                             title

--- a/packages/graphql/tests/integration/connections/unions.int.test.ts
+++ b/packages/graphql/tests/integration/connections/unions.int.test.ts
@@ -126,7 +126,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -161,19 +163,19 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: expect.toIncludeSameMembers([
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },
                             },
                             {
-                                words: book2WordCount,
+                                properties: { words: book2WordCount },
                                 node: {
                                     title: book2Title,
                                 },
                             },
                             {
-                                words: journalWordCount,
+                                properties: { words: journalWordCount },
                                 node: {
                                     subject: journalSubject,
                                 },
@@ -198,7 +200,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection(sort: [{ edge: { words: ASC } }]) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -233,19 +237,19 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: [
                             {
-                                words: journalWordCount,
+                                properties: { words: journalWordCount },
                                 node: {
                                     subject: journalSubject,
                                 },
                             },
                             {
-                                words: book2WordCount,
+                                properties: { words: book2WordCount },
                                 node: {
                                     title: book2Title,
                                 },
                             },
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },
@@ -275,7 +279,9 @@ describe("Connections -> Unions", () => {
                             endCursor
                         }
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -315,13 +321,13 @@ describe("Connections -> Unions", () => {
                         },
                         edges: [
                             {
-                                words: journalWordCount,
+                                properties: { words: journalWordCount },
                                 node: {
                                     subject: journalSubject,
                                 },
                             },
                             {
-                                words: book2WordCount,
+                                properties: { words: book2WordCount },
                                 node: {
                                     title: book2Title,
                                 },
@@ -354,7 +360,7 @@ describe("Connections -> Unions", () => {
                         },
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },
@@ -379,7 +385,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -411,19 +419,19 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: expect.toIncludeSameMembers([
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },
                             },
                             {
-                                words: book2WordCount,
+                                properties: { words: book2WordCount },
                                 node: {
                                     title: book2Title,
                                 },
                             },
                             {
-                                words: journalWordCount,
+                                properties: { words: journalWordCount },
                                 node: {},
                             },
                         ]),
@@ -446,7 +454,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection(where: { Book: { node: { title: $bookTitle } } }) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -479,7 +489,7 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },
@@ -504,7 +514,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection(where: { Book: { node: { title_NOT: $bookTitle } } }) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -540,7 +552,7 @@ describe("Connections -> Unions", () => {
                                 node: {
                                     title: "A Christmas Carol",
                                 },
-                                words: 30953,
+                                properties: { words: 30953 },
                             },
                         ],
                     },
@@ -568,7 +580,9 @@ describe("Connections -> Unions", () => {
                     ) {
                         totalCount
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 __typename
                                 ... on Book {
@@ -607,14 +621,14 @@ describe("Connections -> Unions", () => {
                         totalCount: 2,
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     __typename: "Book",
                                     title: book1Title,
                                 },
                             },
                             {
-                                words: journalWordCount,
+                                properties: { words: journalWordCount },
                                 node: {
                                     __typename: "Journal",
                                     subject: journalSubject,
@@ -646,7 +660,9 @@ describe("Connections -> Unions", () => {
                     ) {
                         totalCount
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 __typename
                                 ... on Book {
@@ -685,7 +701,7 @@ describe("Connections -> Unions", () => {
                         totalCount: 1,
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     __typename: "Book",
                                     title: book1Title,
@@ -711,7 +727,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection(where: { Book: { edge: { words: $bookWordCount } } }) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -744,7 +762,7 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },
@@ -769,7 +787,9 @@ describe("Connections -> Unions", () => {
                     name
                     publicationsConnection(where: { Book: { edge: { words_NOT: $bookWordCount } } }) {
                         edges {
-                            words
+                           properties {
+                             words
+                           }
                             node {
                                 ... on Book {
                                     title
@@ -802,7 +822,7 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: [
                             {
-                                words: book2WordCount,
+                                properties: { words: book2WordCount },
                                 node: {
                                     title: book2Title,
                                 },
@@ -833,7 +853,9 @@ describe("Connections -> Unions", () => {
                     ) {
                         totalCount
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 __typename
                                 ... on Book {
@@ -872,14 +894,14 @@ describe("Connections -> Unions", () => {
                         totalCount: 2,
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     __typename: "Book",
                                     title: book1Title,
                                 },
                             },
                             {
-                                words: journalWordCount,
+                                properties: { words: journalWordCount },
                                 node: {
                                     __typename: "Journal",
                                     subject: journalSubject,
@@ -911,7 +933,9 @@ describe("Connections -> Unions", () => {
                     ) {
                         totalCount
                         edges {
-                            words
+                           properties {
+                             words
+                           }
                             node {
                                 __typename
                                 ... on Book {
@@ -950,7 +974,7 @@ describe("Connections -> Unions", () => {
                         totalCount: 1,
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     __typename: "Book",
                                     title: book1Title,
@@ -983,7 +1007,9 @@ describe("Connections -> Unions", () => {
                         }
                     ) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -1017,7 +1043,7 @@ describe("Connections -> Unions", () => {
                     publicationsConnection: {
                         edges: [
                             {
-                                words: book1WordCount,
+                                properties: { words: book1WordCount },
                                 node: {
                                     title: book1Title,
                                 },

--- a/packages/graphql/tests/integration/directives/alias.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias.int.test.ts
@@ -171,13 +171,15 @@ describe("@alias directive", () => {
         expect((gqlResult.data as any)[ProtectedUser.plural][0]).toEqual({ name: dbName });
     });
     test("Aliased fields on nodes through connections (incl. rel props)", async () => {
-        const usersQuery = `
+        const usersQuery = /* GraphQL */ `
             query UsersLikesMovies {
                 ${AliasDirectiveTestUser.plural} {
                     name
                     likesConnection {
                         edges {
-                            comment
+                            properties {
+                                comment
+                            }
                             node {
                                 title
                                 year
@@ -201,7 +203,7 @@ describe("@alias directive", () => {
             likesConnection: {
                 edges: [
                     {
-                        comment: dbComment,
+                        properties: { comment: dbComment },
                         node: {
                             title: dbTitle,
                             year: year.toNumber(),
@@ -213,13 +215,15 @@ describe("@alias directive", () => {
     });
 
     test("Using GraphQL query alias with @alias (using CONTAINS filter)", async () => {
-        const usersQuery = `
+        const usersQuery = /* GraphQL */ `
             query UsersLikesMovies {
                 ${AliasDirectiveTestUser.plural}(where: {name_CONTAINS: "${dbName.substring(0, 6)}"}) {
                     myName: name
                     likesConnection {
                         edges {
-                            myComment: comment
+                           properties {
+                             myComment: comment 
+                            }
                         }
                     }
                 }
@@ -236,7 +240,7 @@ describe("@alias directive", () => {
 
         expect((gqlResult.data as any)[AliasDirectiveTestUser.plural][0]).toEqual({
             myName: dbName,
-            likesConnection: { edges: [{ myComment: dbComment }] },
+            likesConnection: { edges: [{ properties: { myComment: dbComment } }] },
         });
     });
 
@@ -259,8 +263,10 @@ describe("@alias directive", () => {
                     }
                     likesConnection {
                         edges {
-                            relationshipCreatedAt
-                            comment
+                            properties {
+                                relationshipCreatedAt
+                                comment
+                            }
                             node {
                                 title
                                 year
@@ -295,8 +301,10 @@ describe("@alias directive", () => {
             likesConnection: {
                 edges: [
                     {
-                        relationshipCreatedAt: expect.any(String),
-                        comment,
+                        properties: {
+                            relationshipCreatedAt: expect.any(String),
+                            comment,
+                        },
                         node: {
                             title,
                             year: year.toNumber(),
@@ -327,7 +335,9 @@ describe("@alias directive", () => {
                     }
                     likesConnection {
                         edges {
-                            comment
+                            properties {
+                                comment
+                            }
                             node {
                                 title
                                 year
@@ -360,7 +370,7 @@ describe("@alias directive", () => {
             likesConnection: {
                 edges: [
                     {
-                        comment,
+                        properties: { comment },
                         node: {
                             title,
                             year: year.toNumber(),
@@ -416,7 +426,9 @@ describe("@alias directive", () => {
                     }
                     likesConnection {
                         edges {
-                            comment
+                            properties {
+                                comment
+                            }
                             node {
                                 title
                                 year
@@ -449,7 +461,7 @@ describe("@alias directive", () => {
             likesConnection: {
                 edges: [
                     {
-                        comment: newComment,
+                        properties: { comment: newComment },
                         node: {
                             title: newTitle,
                             year: newYear.toNumber(),

--- a/packages/graphql/tests/integration/directives/id.int.test.ts
+++ b/packages/graphql/tests/integration/directives/id.int.test.ts
@@ -213,8 +213,8 @@ describe("@id directive", () => {
             charset: "alphabetic",
         });
 
-        const create = `
-            mutation($title: String!, $name: String!) {
+        const create = /* GraphQL */ `
+            mutation ($title: String!, $name: String!) {
                 createMovies(
                     input: [
                         { title: $title, actors: { create: [{ node: { name: $name }, edge: { screenTime: 60 } }] } }
@@ -223,7 +223,9 @@ describe("@id directive", () => {
                     movies {
                         actorsConnection {
                             edges {
-                                id
+                                properties {
+                                    id
+                                }
                             }
                         }
                     }
@@ -243,7 +245,9 @@ describe("@id directive", () => {
 
             const { actorsConnection } = (result.data as any).createMovies.movies[0];
 
-            expect(["v1", "v2", "v3", "v4", "v5"].some((t) => isUUID[t](actorsConnection.edges[0].id))).toBe(true);
+            expect(["v1", "v2", "v3", "v4", "v5"].some((t) => isUUID[t](actorsConnection.edges[0].properties.id))).toBe(
+                true
+            );
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/directives/populatedBy.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy.int.test.ts
@@ -905,7 +905,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                       properties { callback
+                                       }
                                         node {
                                             id
                                         }
@@ -931,7 +932,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: string1,
+                                            properties: { callback: string1 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1013,7 +1014,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                       properties { callback
+                                       }
                                         node {
                                             id
                                         }
@@ -1049,7 +1051,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: string1,
+                                            properties: { callback: string1 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1147,7 +1149,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                      properties {  callback
+                                      }
                                         node {
                                             id
                                         }
@@ -1172,7 +1175,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                       properties { callback
+                                       }
                                         node {
                                             id
                                         }
@@ -1198,7 +1202,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: string1,
+                                            properties: { callback: string1 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1215,7 +1219,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: string2,
+                                            properties: { callback: string2 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1306,7 +1310,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                       properties { callback
+                                       }
                                         node {
                                             id
                                         }
@@ -1332,7 +1337,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: int1,
+                                            properties: { callback: int1 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1417,7 +1422,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                      properties { callback
+                                      }
                                         node {
                                             id
                                         }
@@ -1453,7 +1459,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: int1,
+                                            properties: { callback: int1 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1557,7 +1563,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                       properties { callback
+                                       }
                                         node {
                                             id
                                         }
@@ -1582,7 +1589,8 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        callback
+                                       properties { callback
+                                       }
                                         node {
                                             id
                                         }
@@ -1608,7 +1616,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: int1,
+                                            properties: { callback: int1 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1625,7 +1633,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            callback: int2,
+                                            properties: { callback: int2 },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1714,8 +1722,10 @@ describe("@populatedBy directive", () => {
                                 id
                                 genresConnection {
                                     edges {
-                                        title
-                                        slug
+                                      properties { 
+                                         title
+                                         slug
+                                      }
                                         node {
                                             id
                                         }
@@ -1741,8 +1751,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            title: movieTitle,
-                                            slug: `${movieTitle}-slug`,
+                                            properties: { title: movieTitle, slug: `${movieTitle}-slug` },
                                             node: {
                                                 id: genreId,
                                             },
@@ -1824,8 +1833,10 @@ describe("@populatedBy directive", () => {
                             id
                             genresConnection {
                                 edges {
-                                    title
-                                    slug
+                                  properties { 
+                                     title
+                                     slug
+                                  }
                                     node {
                                         id
                                     }
@@ -1861,8 +1872,7 @@ describe("@populatedBy directive", () => {
                                 genresConnection: {
                                     edges: [
                                         {
-                                            title: movieTitle,
-                                            slug: `${movieTitle}-slug`,
+                                            properties: { title: movieTitle, slug: `${movieTitle}-slug` },
                                             node: {
                                                 id: genreId,
                                             },

--- a/packages/graphql/tests/integration/directives/timestamp/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/directives/timestamp/datetime.int.test.ts
@@ -129,7 +129,9 @@ describe("timestamp/datetime", () => {
                         movies {
                             actorsConnection {
                                 edges {
-                                    createdAt
+                                    properties {
+                                        createdAt
+                                    }
                                 }
                             }
                         }
@@ -149,7 +151,7 @@ describe("timestamp/datetime", () => {
 
                 const { actorsConnection } = (result.data as any).createMovies.movies[0];
 
-                expect(new Date(actorsConnection.edges[0].createdAt as string)).toBeInstanceOf(Date);
+                expect(new Date(actorsConnection.edges[0].properties.createdAt as string)).toBeInstanceOf(Date);
             } finally {
                 await session.close();
             }
@@ -252,7 +254,9 @@ describe("timestamp/datetime", () => {
                         movies {
                             actorsConnection {
                                 edges {
-                                    updatedAt
+                                    properties {
+                                        updatedAt
+                                    }
                                 }
                             }
                         }
@@ -279,7 +283,7 @@ describe("timestamp/datetime", () => {
 
                 const { actorsConnection } = (result.data as any).updateMovies.movies[0];
 
-                expect(new Date(actorsConnection.edges[0].updatedAt as string)).toBeInstanceOf(Date);
+                expect(new Date(actorsConnection.edges[0].properties.updatedAt as string)).toBeInstanceOf(Date);
             } finally {
                 await session.close();
             }
@@ -379,7 +383,9 @@ describe("timestamp/datetime", () => {
                         movies {
                             actorsConnection {
                                 edges {
-                                    createdAt
+                                    properties {
+                                        createdAt
+                                    }
                                 }
                             }
                         }
@@ -399,7 +405,7 @@ describe("timestamp/datetime", () => {
 
                 const { actorsConnection } = (result.data as any).createMovies.movies[0];
 
-                expect(new Date(actorsConnection.edges[0].createdAt as string)).toBeInstanceOf(Date);
+                expect(new Date(actorsConnection.edges[0].properties.createdAt as string)).toBeInstanceOf(Date);
             } finally {
                 await session.close();
             }
@@ -442,7 +448,9 @@ describe("timestamp/datetime", () => {
                         movies {
                             actorsConnection {
                                 edges {
-                                    updatedAt
+                                    properties {
+                                        updatedAt
+                                    }
                                 }
                             }
                         }
@@ -469,7 +477,7 @@ describe("timestamp/datetime", () => {
 
                 const { actorsConnection } = (result.data as any).updateMovies.movies[0];
 
-                expect(new Date(actorsConnection.edges[0].updatedAt as string)).toBeInstanceOf(Date);
+                expect(new Date(actorsConnection.edges[0].properties.updatedAt as string)).toBeInstanceOf(Date);
             } finally {
                 await session.close();
             }
@@ -627,7 +635,9 @@ describe("timestamp/datetime", () => {
                         movies {
                             actorsConnection {
                                 edges {
-                                    createdAt
+                                    properties {
+                                        createdAt
+                                    }
                                 }
                             }
                         }
@@ -647,7 +657,7 @@ describe("timestamp/datetime", () => {
 
                 const { actorsConnection } = (result.data as any).createMovies.movies[0];
 
-                expect(new Date(actorsConnection.edges[0].createdAt as string)).toBeInstanceOf(Date);
+                expect(new Date(actorsConnection.edges[0].properties.createdAt as string)).toBeInstanceOf(Date);
             } finally {
                 await session.close();
             }
@@ -690,7 +700,9 @@ describe("timestamp/datetime", () => {
                         movies {
                             actorsConnection {
                                 edges {
-                                    updatedAt
+                                    properties {
+                                        updatedAt
+                                    }
                                 }
                             }
                         }
@@ -717,7 +729,7 @@ describe("timestamp/datetime", () => {
 
                 const { actorsConnection } = (result.data as any).updateMovies.movies[0];
 
-                expect(new Date(actorsConnection.edges[0].updatedAt as string)).toBeInstanceOf(Date);
+                expect(new Date(actorsConnection.edges[0].properties.updatedAt as string)).toBeInstanceOf(Date);
             } finally {
                 await session.close();
             }

--- a/packages/graphql/tests/integration/directives/timestamp/time.int.test.ts
+++ b/packages/graphql/tests/integration/directives/timestamp/time.int.test.ts
@@ -131,7 +131,9 @@ describe("timestamp/time", () => {
                             movies {
                                 actorsConnection {
                                     edges {
-                                        createdAt
+                                        properties {
+                                            createdAt
+                                        }
                                     }
                                 }
                             }
@@ -263,7 +265,9 @@ describe("timestamp/time", () => {
                             movies {
                                 actorsConnection {
                                     edges {
-                                        updatedAt
+                                        properties {
+                                            updatedAt
+                                        }
                                     }
                                 }
                             }
@@ -398,7 +402,9 @@ describe("timestamp/time", () => {
                             movies {
                                 actorsConnection {
                                     edges {
-                                        createdAt
+                                        properties {
+                                            createdAt
+                                        }
                                     }
                                 }
                             }
@@ -473,7 +479,9 @@ describe("timestamp/time", () => {
                             movies {
                                 actorsConnection {
                                     edges {
-                                        updatedAt
+                                        properties {
+                                            updatedAt
+                                        }
                                     }
                                 }
                             }
@@ -662,7 +670,9 @@ describe("timestamp/time", () => {
                             movies {
                                 actorsConnection {
                                     edges {
-                                        createdAt
+                                        properties {
+                                            createdAt
+                                        }
                                     }
                                 }
                             }
@@ -737,7 +747,9 @@ describe("timestamp/time", () => {
                             movies {
                                 actorsConnection {
                                     edges {
-                                        updatedAt
+                                        properties {
+                                            updatedAt
+                                        }
                                     }
                                 }
                             }

--- a/packages/graphql/tests/integration/issues/1150.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1150.int.test.ts
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
     });
 
     test("should handle union types with auth and connection-where", async () => {
-        const query = `
+        const query = /* GraphQL */ `
             query getDrivesWithFilteredUnionType {
                 drives(where: { current: true }) {
                     current
@@ -104,7 +104,9 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                                     }
                                 ) {
                                     edges {
-                                        current
+                                        properties {
+                                            current
+                                        }
                                         node {
                                             ... on Battery {
                                                 id

--- a/packages/graphql/tests/integration/issues/1249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1249.int.test.ts
@@ -72,7 +72,7 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
         });
         schema = await neoGraphql.getSchema();
 
-        const query = `
+        const query = /* GraphQL */ `
             query {
                 bulks {
                     supplierMaterialNumber
@@ -80,7 +80,9 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
                         id
                         suppliersConnection {
                             edges {
-                                supplierMaterialNumber
+                                properties {
+                                    supplierMaterialNumber
+                                }
                                 node {
                                     supplierId
                                 }

--- a/packages/graphql/tests/integration/issues/2068.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2068.int.test.ts
@@ -898,7 +898,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                             title
                             actorsConnection(where: { node: { name: "${actorName}" } }) {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         name
                                     }
@@ -954,7 +956,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         name
                                     }

--- a/packages/graphql/tests/integration/issues/3165.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3165.int.test.ts
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
     });
 
     test("create and query by edge property over an union", async () => {
-        const mutation = `
+        const mutation = /* GraphQL */ `
             mutation CreateA {
                 createAs(
                     input: {
@@ -99,7 +99,9 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
                         name
                         relatedConnection {
                             edges {
-                                prop
+                                properties {
+                                    prop
+                                }
                                 node {
                                     name
                                 }
@@ -110,7 +112,7 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
             }
         `;
 
-        const query = `
+        const query = /* GraphQL */ `
             query Relateds {
                 relateds(
                     where: {

--- a/packages/graphql/tests/integration/issues/369.int.test.ts
+++ b/packages/graphql/tests/integration/issues/369.int.test.ts
@@ -76,13 +76,13 @@ describe("369", () => {
 
         const neoSchema = new Neo4jGraphQL({ typeDefs });
 
-        const query = `
+        const query = /* GraphQL */ `
             {
                 getDato(uuid: "${datoUUID}" ){
                   uuid
                   dependeToConnection {
                     edges {
-                      uuid
+                     properties { uuid }
                       node {
                           uuid
                       }
@@ -114,7 +114,7 @@ describe("369", () => {
             expect(result.data as any).toEqual({
                 getDato: {
                     uuid: datoUUID,
-                    dependeToConnection: { edges: [{ uuid: relUUID, node: { uuid: datoToUUID } }] },
+                    dependeToConnection: { edges: [{ properties: { uuid: relUUID }, node: { uuid: datoToUUID } }] },
                 },
             });
         } finally {
@@ -161,13 +161,13 @@ describe("369", () => {
 
         const neoSchema = new Neo4jGraphQL({ typeDefs });
 
-        const query = `
+        const query = /* GraphQL */ `
             {
                 getDato(uuid: "${datoUUID}" ){
                   uuid
                   dependeToConnection(where: { node: { uuid: "${datoToUUID}" } }) {
                     edges {
-                      uuid
+                     properties{ uuid}
                       node {
                           uuid
                       }
@@ -201,7 +201,7 @@ describe("369", () => {
             expect(result.data as any).toEqual({
                 getDato: {
                     uuid: datoUUID,
-                    dependeToConnection: { edges: [{ uuid: relUUID, node: { uuid: datoToUUID } }] },
+                    dependeToConnection: { edges: [{ properties: { uuid: relUUID }, node: { uuid: datoToUUID } }] },
                 },
             });
         } finally {

--- a/packages/graphql/tests/integration/issues/4292.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4292.int.test.ts
@@ -217,9 +217,11 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
                         name
                         partnersConnection {
                             edges {
-                                active
-                                firstDay
-                                lastDay
+                               properties {
+                                    active
+                                    firstDay
+                                    lastDay
+                               }
                             }
                         }
                     }
@@ -257,9 +259,11 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
                         name
                         partnersConnection {
                             edges {
-                                active
-                                firstDay
-                                lastDay
+                               properties {
+                                    active
+                                    firstDay
+                                    lastDay
+                               }
                             }
                         }
                     }

--- a/packages/graphql/tests/integration/issues/579.int.test.ts
+++ b/packages/graphql/tests/integration/issues/579.int.test.ts
@@ -65,7 +65,7 @@ describe("579", () => {
             charset: "alphabetic",
         });
 
-        const query = `
+        const query = /* GraphQL */ `
             mutation {
                 updateProducts(
                   where: { id: "${productId}" }
@@ -83,7 +83,9 @@ describe("579", () => {
                         id
                         colorConnection {
                             edges {
-                                test
+                                properties { 
+                                    test
+                                }
                             }
                         }
                     }
@@ -118,7 +120,7 @@ describe("579", () => {
                 colorConnection: {
                     edges: [
                         {
-                            test: true,
+                            properties: { test: true },
                         },
                     ],
                 },

--- a/packages/graphql/tests/integration/issues/988.int.test.ts
+++ b/packages/graphql/tests/integration/issues/988.int.test.ts
@@ -85,14 +85,16 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
     });
 
     test("should query nested connection", async () => {
-        const query = `
+        const query = /* GraphQL */ `
             query getSeriesWithRelationFilters($where: ${seriesType.name}Where = { current: true }) {
                 ${seriesType.plural}(where: $where) {
                     name
                     current
                     manufacturerConnection {
                         edges {
-                            current
+                            properties {
+                                current
+                            }
                             node {
                                 name
                             }
@@ -100,7 +102,9 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     }
                     brandConnection {
                         edges {
-                            current
+                            properties {
+                                current
+                            }
                             node {
                                 name
                             }
@@ -171,7 +175,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     manufacturerConnection: {
                         edges: [
                             {
-                                current: true,
+                                properties: { current: true },
                                 node: {
                                     name: "C",
                                 },
@@ -181,7 +185,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     brandConnection: {
                         edges: [
                             {
-                                current: true,
+                                properties: { current: true },
                                 node: {
                                     name: "smart",
                                 },
@@ -195,7 +199,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     manufacturerConnection: {
                         edges: [
                             {
-                                current: false,
+                                properties: { current: false },
                                 node: {
                                     name: "AM",
                                 },
@@ -205,7 +209,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     brandConnection: {
                         edges: [
                             {
-                                current: true,
+                                properties: { current: true },
                                 node: {
                                     name: "smart",
                                 },

--- a/packages/graphql/tests/integration/math.int.test.ts
+++ b/packages/graphql/tests/integration/math.int.test.ts
@@ -686,7 +686,9 @@ describe("Mathematical operations tests", () => {
                 }
                 actedInConnection {
                   edges {
-                    pay
+                    properties {
+                        pay
+                    }
                   }
                 }
               }
@@ -774,7 +776,9 @@ describe("Mathematical operations tests", () => {
                 }
                 actedInConnection {
                   edges {
-                    pay
+                    properties { 
+                        pay
+                    }
                   }
                 }
               }

--- a/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
@@ -143,7 +143,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         name
                                     }
@@ -151,7 +153,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             }
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         name
                                     }
@@ -234,7 +238,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         name
                                     }
@@ -242,7 +248,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             }
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         name
                                     }
@@ -365,7 +373,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         name
                                     }
@@ -393,7 +403,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
             expect((gqlResultUpdate.data as any)?.[typeMovie.operations.update][typeMovie.plural]).toEqual([
                 {
                     title: movieTitle,
-                    actorsConnection: { edges: [{ screenTime: screenTimeUpdate, node: { name: actorName } }] },
+                    actorsConnection: {
+                        edges: [{ properties: { screenTime: screenTimeUpdate }, node: { name: actorName } }],
+                    },
                 },
             ]);
 
@@ -425,7 +437,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -483,7 +497,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -540,7 +556,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -568,7 +586,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
             expect((gqlResultUpdate.data as any)?.[typeMovie.operations.update][typeMovie.plural]).toEqual([
                 {
                     title: movieTitle,
-                    actorsConnection: { edges: [{ screenTime: screenTimeUpdate, node: { name: actorName } }] },
+                    actorsConnection: {
+                        edges: [{ properties: { screenTime: screenTimeUpdate }, node: { name: actorName } }],
+                    },
                 },
             ]);
 
@@ -602,7 +622,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             name
                             moviesConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         title
                                     }
@@ -660,7 +682,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             name
                             moviesConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         title
                                     }
@@ -746,7 +770,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                         id
@@ -806,7 +832,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             name
                             moviesConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         title
                                     }
@@ -871,7 +899,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -936,7 +966,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -1004,7 +1036,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -1073,7 +1107,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                               properties {
+                                 screenTime
+                               }
                                 node {
                                     name
                                 }
@@ -1135,7 +1171,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -1202,7 +1240,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             actorsConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         name
                                     }
@@ -1283,7 +1323,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             name
                             moviesConnection {
                                 edges {
-                                    screenTime
+                                   properties {
+                                     screenTime
+                                   }
                                     node {
                                         title
                                     }
@@ -1405,7 +1447,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         name
                                     }
@@ -1472,7 +1516,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         name
                                     }
@@ -1535,7 +1581,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             name
                             directedConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         title
                                     }
@@ -1598,7 +1646,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             name
                             directedConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         title
                                     }
@@ -1673,7 +1723,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                                 name
                                 directedConnection {
                                     edges {
-                                        year
+                                       properties {
+                                         year
+                                       }
                                         node {
                                             title
                                         }
@@ -1746,7 +1798,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                                 name
                                 directedConnection {
                                     edges {
-                                        year
+                                       properties {
+                                         year
+                                       }
                                         node {
                                             title
                                         }
@@ -1824,7 +1878,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                   properties {
+                                     year
+                                   }
                                     node {
                                         name
                                     }
@@ -1903,7 +1959,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                                 title
                                 directorsConnection {
                                     edges {
-                                        year
+                                       properties {
+                                         year
+                                       }
                                         node {
                                             name
                                         }
@@ -1973,7 +2031,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                   properties {
+                                     year
+                                   }
                                     node {
                                         name
                                     }
@@ -2045,7 +2105,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         name
                                     }
@@ -2116,7 +2178,9 @@ describe("Relationship properties - connect with and without `overwrite` argumen
                             title
                             directorsConnection {
                                 edges {
-                                    year
+                                    properties {
+                                        year
+                                    }
                                     node {
                                         name
                                     }

--- a/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
@@ -63,17 +63,14 @@ describe("Relationship properties - connect", () => {
         const actorName = generate({ charset: "alphabetic" });
         const screenTime = Math.floor((Math.random() * 1e3) / Math.random());
 
-        const source = `
-            mutation($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
+        const source = /* GraphQL */ `
+            mutation ($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
                 createMovies(
                     input: [
                         {
                             title: $movieTitle
                             actors: {
-                                connect: [{
-                                    where: { node: { name: $actorName } },
-                                    edge: { screenTime: $screenTime },
-                                }]
+                                connect: [{ where: { node: { name: $actorName } }, edge: { screenTime: $screenTime } }]
                             }
                         }
                     ]
@@ -82,7 +79,9 @@ describe("Relationship properties - connect", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -111,7 +110,7 @@ describe("Relationship properties - connect", () => {
             expect((gqlResult.data as any)?.createMovies.movies).toEqual([
                 {
                     title: movieTitle,
-                    actorsConnection: { edges: [{ screenTime, node: { name: actorName } }] },
+                    actorsConnection: { edges: [{ properties: { screenTime }, node: { name: actorName } }] },
                 },
             ]);
 
@@ -246,22 +245,19 @@ describe("Relationship properties - connect", () => {
         const actorName = generate({ charset: "alphabetic" });
         const screenTime = Math.floor((Math.random() * 1e3) / Math.random());
 
-        const source = `
-            mutation($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
+        const source = /* GraphQL */ `
+            mutation ($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
                 updateMovies(
-                  where: { title: $movieTitle }
-                  connect: {
-                    actors: {
-                      where: { node: { name: $actorName } }
-                      edge: { screenTime: $screenTime }
-                    }
-                  }
+                    where: { title: $movieTitle }
+                    connect: { actors: { where: { node: { name: $actorName } }, edge: { screenTime: $screenTime } } }
                 ) {
                     movies {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -291,7 +287,7 @@ describe("Relationship properties - connect", () => {
             expect((gqlResult.data as any)?.updateMovies.movies).toEqual([
                 {
                     title: movieTitle,
-                    actorsConnection: { edges: [{ screenTime, node: { name: actorName } }] },
+                    actorsConnection: { edges: [{ properties: { screenTime }, node: { name: actorName } }] },
                 },
             ]);
 

--- a/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
@@ -63,18 +63,13 @@ describe("Relationship properties - create", () => {
         const actorName = generate({ charset: "alphabetic" });
         const screenTime = Math.floor((Math.random() * 1e3) / Math.random());
 
-        const source = `
-            mutation($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
+        const source = /* GraphQL */ `
+            mutation ($movieTitle: String!, $screenTime: Int!, $actorName: String!) {
                 createMovies(
                     input: [
                         {
                             title: $movieTitle
-                            actors: {
-                                create: [{
-                                    edge: { screenTime: $screenTime },
-                                    node: { name: $actorName }
-                                }]
-                            }
+                            actors: { create: [{ edge: { screenTime: $screenTime }, node: { name: $actorName } }] }
                         }
                     ]
                 ) {
@@ -82,7 +77,9 @@ describe("Relationship properties - create", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -103,7 +100,7 @@ describe("Relationship properties - create", () => {
         expect((result.data as any)?.createMovies.movies).toEqual([
             {
                 title: movieTitle,
-                actorsConnection: { edges: [{ screenTime, node: { name: actorName } }] },
+                actorsConnection: { edges: [{ properties: { screenTime }, node: { name: actorName } }] },
             },
         ]);
 

--- a/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
@@ -100,7 +100,9 @@ describe("Relationship properties - read", () => {
                     actorsConnection {
                         totalCount
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -133,19 +135,19 @@ describe("Relationship properties - read", () => {
 
             expect((result?.data as any)?.[typeMovie.plural][0].actorsConnection.edges).toHaveLength(3);
             expect((result?.data as any)?.[typeMovie.plural][0].actorsConnection.edges).toContainEqual({
-                screenTime: 5,
+                properties: { screenTime: 5 },
                 node: {
                     name: actorC,
                 },
             });
             expect((result?.data as any)?.[typeMovie.plural][0].actorsConnection.edges).toContainEqual({
-                screenTime: 105,
+                properties: { screenTime: 105 },
                 node: {
                     name: actorB,
                 },
             });
             expect((result?.data as any)?.[typeMovie.plural][0].actorsConnection.edges).toContainEqual({
-                screenTime: 105,
+                properties: { screenTime: 105 },
                 node: {
                     name: actorA,
                 },
@@ -170,7 +172,9 @@ describe("Relationship properties - read", () => {
                         totalCount
                         edges {
                             cursor
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -202,7 +206,7 @@ describe("Relationship properties - read", () => {
                         edges: [
                             {
                                 cursor: offsetToCursor(0),
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
@@ -234,7 +238,9 @@ describe("Relationship properties - read", () => {
                         totalCount
                         edges {
                             cursor
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -264,21 +270,21 @@ describe("Relationship properties - read", () => {
                         edges: [
                             {
                                 cursor: offsetToCursor(0),
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
                             },
                             {
                                 cursor: offsetToCursor(1),
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorB,
                                 },
                             },
                             {
                                 cursor: offsetToCursor(2),
-                                screenTime: 5,
+                                properties: { screenTime: 5 },
                                 node: {
                                     name: actorC,
                                 },
@@ -305,21 +311,21 @@ describe("Relationship properties - read", () => {
                         edges: [
                             {
                                 cursor: offsetToCursor(0),
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorB,
                                 },
                             },
                             {
                                 cursor: offsetToCursor(1),
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
                             },
                             {
                                 cursor: offsetToCursor(2),
-                                screenTime: 5,
+                                properties: { screenTime: 5 },
                                 node: {
                                     name: actorC,
                                 },
@@ -345,7 +351,9 @@ describe("Relationship properties - read", () => {
                         sort: [{ edge: { screenTime: DESC } }, { node: { name: ASC } }]
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -362,7 +370,9 @@ describe("Relationship properties - read", () => {
                         sort: [{ node: { name: ASC } }, { edge: { screenTime: DESC } }]
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -395,25 +405,25 @@ describe("Relationship properties - read", () => {
                     actorsConnection: {
                         edges: [
                             {
-                                screenTime: 106,
+                                properties: { screenTime: 106 },
                                 node: {
                                     name: actorD,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorB,
                                 },
                             },
                             {
-                                screenTime: 5,
+                                properties: { screenTime: 5 },
                                 node: {
                                     name: actorC,
                                 },
@@ -436,25 +446,25 @@ describe("Relationship properties - read", () => {
                     actorsConnection: {
                         edges: [
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorB,
                                 },
                             },
                             {
-                                screenTime: 5,
+                                properties: { screenTime: 5 },
                                 node: {
                                     name: actorC,
                                 },
                             },
                             {
-                                screenTime: 106,
+                                properties: { screenTime: 106 },
                                 node: {
                                     name: actorD,
                                 },
@@ -483,7 +493,9 @@ describe("Relationship properties - read", () => {
                     ) {
                         totalCount
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -515,13 +527,13 @@ describe("Relationship properties - read", () => {
                         totalCount: 2,
                         edges: [
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorB,
                                 },
@@ -550,13 +562,13 @@ describe("Relationship properties - read", () => {
                         totalCount: 2,
                         edges: [
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorB,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actorA,
                                 },
@@ -586,7 +598,9 @@ describe("Relationship properties - read", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                               properties {
+                                 screenTime
+                               }
                                 node {
                                     name
                                 }
@@ -615,19 +629,19 @@ describe("Relationship properties - read", () => {
 
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toHaveLength(3);
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toContainEqual({
-                screenTime: 5,
+                properties: { screenTime: 5 },
                 node: {
                     name: actorC,
                 },
             });
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toContainEqual({
-                screenTime: 105,
+                properties: { screenTime: 105 },
                 node: {
                     name: actorB,
                 },
             });
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toContainEqual({
-                screenTime: 105,
+                properties: { screenTime: 105 },
                 node: {
                     name: actorA,
                 },
@@ -650,7 +664,9 @@ describe("Relationship properties - read", () => {
                         title
                         actorsConnection(where: { node: { name_NOT: "${actorA}" } }) {
                             edges {
-                                screenTime
+                               properties {
+                                 screenTime
+                               }
                                 node {
                                     name
                                 }
@@ -679,13 +695,13 @@ describe("Relationship properties - read", () => {
 
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toHaveLength(2);
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toContainEqual({
-                screenTime: 5,
+                properties: { screenTime: 5 },
                 node: {
                     name: actorC,
                 },
             });
             expect((result?.data as any)?.[typeActor.plural][0].movies[0].actorsConnection.edges).toContainEqual({
-                screenTime: 105,
+                properties: { screenTime: 105 },
                 node: {
                     name: actorB,
                 },

--- a/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
@@ -99,7 +99,9 @@ describe("Relationship properties - update", () => {
                         title
                         actorsConnection(sort: { edge: { screenTime: DESC }}) {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -127,13 +129,13 @@ describe("Relationship properties - update", () => {
                     actorsConnection: {
                         edges: [
                             {
-                                screenTime: 100,
+                                properties: { screenTime: 100 },
                                 node: {
                                     name: actor2,
                                 },
                             },
                             {
-                                screenTime: 60,
+                                properties: { screenTime: 60 },
                                 node: {
                                     name: actor1,
                                 },
@@ -172,7 +174,9 @@ describe("Relationship properties - update", () => {
                         title
                         actorsConnection(sort: { edge: { screenTime: ASC }}) {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -200,13 +204,13 @@ describe("Relationship properties - update", () => {
                     actorsConnection: {
                         edges: [
                             {
-                                screenTime: 60,
+                                properties: { screenTime: 60 },
                                 node: {
                                     name: actor3,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actor1,
                                 },
@@ -244,7 +248,9 @@ describe("Relationship properties - update", () => {
                         title
                         actorsConnection(sort: { edge: { screenTime: ASC }}) {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -272,19 +278,19 @@ describe("Relationship properties - update", () => {
                     actorsConnection: {
                         edges: [
                             {
-                                screenTime: 60,
+                                properties: { screenTime: 60 },
                                 node: {
                                     name: actor3,
                                 },
                             },
                             {
-                                screenTime: 100,
+                                properties: { screenTime: 100 },
                                 node: {
                                     name: actor2,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actor1,
                                 },
@@ -320,7 +326,9 @@ describe("Relationship properties - update", () => {
                         title
                         actorsConnection(sort: { edge: { screenTime: ASC }}) {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -348,19 +356,19 @@ describe("Relationship properties - update", () => {
                     actorsConnection: {
                         edges: [
                             {
-                                screenTime: 60,
+                                properties: { screenTime: 60 },
                                 node: {
                                     name: actor3,
                                 },
                             },
                             {
-                                screenTime: 100,
+                                properties: { screenTime: 100 },
                                 node: {
                                     name: actor2,
                                 },
                             },
                             {
-                                screenTime: 105,
+                                properties: { screenTime: 105 },
                                 node: {
                                     name: actor1,
                                 },

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -519,7 +519,7 @@ describe("Aggregations", () => {
               sum: Int
             }
 
-            interface Likes {
+            type Likes {
               someBigInt: BigInt
               someDateTime: DateTime
               someDuration: Duration
@@ -1193,19 +1193,10 @@ describe("Aggregations", () => {
               someTime_MIN_LTE: Time
             }
 
-            type PostLikesRelationship implements Likes {
+            type PostLikesRelationship {
               cursor: String!
               node: User!
-              someBigInt: BigInt
-              someDateTime: DateTime
-              someDuration: Duration
-              someFloat: Float
-              someId: ID
-              someInt: Int
-              someLocalDateTime: LocalDateTime
-              someLocalTime: LocalTime
-              someString: String
-              someTime: Time
+              properties: Likes!
             }
 
             input PostLikesUpdateConnectionInput {

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -50,7 +50,7 @@ describe("Arrays Methods", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               pay: [Float]
             }
 
@@ -180,10 +180,10 @@ describe("Arrays Methods", () => {
               id_EQUAL: ID @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Movie!
-              pay: [Float]
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -479,10 +479,10 @@ describe("Arrays Methods", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              pay: [Float]
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -735,7 +735,7 @@ describe("Comments", () => {
                   mutation: Mutation
                 }
 
-                interface ActedIn {
+                type ActedIn {
                   screenTime: Int!
                 }
 
@@ -818,10 +818,10 @@ describe("Comments", () => {
                   create: [ActorActedInCreateFieldInput!]
                 }
 
-                type ActorActedInRelationship implements ActedIn {
+                type ActorActedInRelationship {
                   cursor: String!
                   node: Production!
-                  screenTime: Int!
+                  properties: ActedIn!
                 }
 
                 input ActorActedInUpdateConnectionInput {

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -55,7 +55,7 @@ describe("Connect Or Create", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -197,10 +197,10 @@ describe("Connect Or Create", () => {
               where: ActorActedInMovieConnectionWhere
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInSeriesConnectFieldInput {

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -536,7 +536,7 @@ describe("Connect Or Create", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               characterName: String
               screentime: Int!
             }
@@ -850,11 +850,10 @@ describe("Connect Or Create", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
-              characterName: String
+            type ActorMoviesRelationship {
               cursor: String!
               node: Movie!
-              screentime: Int!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -53,7 +53,7 @@ describe("Enums", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               roleType: RoleType!
             }
 
@@ -230,10 +230,10 @@ describe("Enums", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
+            type ActorMoviesRelationship {
               cursor: String!
               node: Movie!
-              roleType: RoleType!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -474,10 +474,10 @@ describe("Enums", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              roleType: RoleType!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -241,10 +241,10 @@ describe("Unions", () => {
               where: AuthorPublicationsJournalConnectionWhere
             }
 
-            type AuthorPublicationsRelationship implements Wrote {
+            type AuthorPublicationsRelationship {
               cursor: String!
               node: Publication!
-              words: Int!
+              properties: Wrote!
             }
 
             input AuthorPublicationsUpdateInput {
@@ -470,10 +470,10 @@ describe("Unions", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type BookAuthorRelationship implements Wrote {
+            type BookAuthorRelationship {
               cursor: String!
               node: Author!
-              words: Int!
+              properties: Wrote!
             }
 
             input BookAuthorUpdateConnectionInput {
@@ -794,10 +794,10 @@ describe("Unions", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type JournalAuthorRelationship implements Wrote {
+            type JournalAuthorRelationship {
               cursor: String!
               node: Author!
-              words: Int!
+              properties: Wrote!
             }
 
             input JournalAuthorUpdateConnectionInput {
@@ -1000,7 +1000,7 @@ describe("Unions", () => {
               journals: [Journal!]!
             }
 
-            interface Wrote {
+            type Wrote {
               words: Int!
             }
 

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -909,7 +909,7 @@ describe("Directive-preserve", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               role: String!
             }
 
@@ -994,10 +994,10 @@ describe("Directive-preserve", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              role: String!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -1460,10 +1460,10 @@ describe("Directive-preserve", () => {
               create: [ProductionActorsCreateFieldInput!]
             }
 
-            type ProductionActorsRelationship implements ActedIn {
+            type ProductionActorsRelationship {
               cursor: String!
               node: Actor!
-              role: String!
+              properties: ActedIn!
             }
 
             input ProductionActorsUpdateConnectionInput {
@@ -1885,7 +1885,7 @@ describe("Directive-preserve", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               role: String!
             }
 
@@ -1970,10 +1970,10 @@ describe("Directive-preserve", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              role: String!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -2436,10 +2436,10 @@ describe("Directive-preserve", () => {
               create: [ProductionActorsCreateFieldInput!]
             }
 
-            type ProductionActorsRelationship implements ActedIn {
+            type ProductionActorsRelationship {
               cursor: String!
               node: Actor!
-              role: String!
+              properties: ActedIn!
             }
 
             input ProductionActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -251,7 +251,7 @@ describe("Alias", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            interface ActorActedInProps {
+            type ActorActedInProps {
               character: String!
               screenTime: Int
             }
@@ -297,11 +297,10 @@ describe("Alias", () => {
               screenTime_NOT_IN: [Int] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type ActorActedInRelationship implements ActorActedInProps {
-              character: String!
+            type ActorActedInRelationship {
               cursor: String!
               node: Movie!
-              screenTime: Int
+              properties: ActorActedInProps!
             }
 
             input ActorActedInUpdateConnectionInput {

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -1061,13 +1061,10 @@ describe("@populatedBy tests", () => {
                   id_EQUAL: ID @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
                 }
 
-                type MovieGenresRelationship implements RelProperties {
-                  callback1: String!
-                  callback2: String!
-                  callback3: String!
+                type MovieGenresRelationship {
                   cursor: String!
-                  id: ID!
                   node: Genre!
+                  properties: RelProperties!
                 }
 
                 input MovieGenresUpdateConnectionInput {
@@ -1186,7 +1183,7 @@ describe("@populatedBy tests", () => {
                   moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
                 }
 
-                interface RelProperties {
+                type RelProperties {
                   callback1: String!
                   callback2: String!
                   callback3: String!
@@ -1644,13 +1641,10 @@ describe("@populatedBy tests", () => {
                   id_EQUAL: ID @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
                 }
 
-                type MovieGenresRelationship implements RelProperties {
-                  callback1: Int!
-                  callback2: Int!
-                  callback3: Int!
+                type MovieGenresRelationship {
                   cursor: String!
-                  id: ID!
                   node: Genre!
+                  properties: RelProperties!
                 }
 
                 input MovieGenresUpdateConnectionInput {
@@ -1769,7 +1763,7 @@ describe("@populatedBy tests", () => {
                   moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
                 }
 
-                interface RelProperties {
+                type RelProperties {
                   callback1: Int!
                   callback2: Int!
                   callback3: Int!

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -50,7 +50,7 @@ describe("Relationship-properties", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               leadRole: Boolean!
               screenTime: Int!
               startDate: Date!
@@ -288,12 +288,10 @@ describe("Relationship-properties", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
+            type ActorMoviesRelationship {
               cursor: String!
-              leadRole: Boolean!
               node: Movie!
-              screenTime: Int!
-              startDate: Date!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -581,12 +579,10 @@ describe("Relationship-properties", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
-              leadRole: Boolean!
               node: Actor!
-              screenTime: Int!
-              startDate: Date!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
@@ -799,7 +795,7 @@ describe("Relationship-properties", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               id: ID!
               screenTime: Int!
               timestamp: DateTime!
@@ -1059,12 +1055,10 @@ describe("Relationship-properties", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
+            type ActorMoviesRelationship {
               cursor: String!
-              id: ID!
               node: Movie!
-              screenTime: Int!
-              timestamp: DateTime!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -1380,12 +1374,10 @@ describe("Relationship-properties", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
-              id: ID!
               node: Actor!
-              screenTime: Int!
-              timestamp: DateTime!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
@@ -1597,7 +1589,7 @@ describe("Relationship-properties", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               id: ID!
               timestamp: DateTime!
             }
@@ -1809,11 +1801,10 @@ describe("Relationship-properties", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
+            type ActorMoviesRelationship {
               cursor: String!
-              id: ID!
               node: Movie!
-              timestamp: DateTime!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -2093,11 +2084,10 @@ describe("Relationship-properties", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
-              id: ID!
               node: Actor!
-              timestamp: DateTime!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/comments.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/comments.test.ts
@@ -735,7 +735,7 @@ describe("Comments", () => {
                   mutation: Mutation
                 }
 
-                interface ActedIn {
+                type ActedIn {
                   screenTime: Int!
                 }
 
@@ -819,10 +819,10 @@ describe("Comments", () => {
                   create: [ActorActedInCreateFieldInput!]
                 }
 
-                type ActorActedInRelationship implements ActedIn {
+                type ActorActedInRelationship {
                   cursor: String!
                   node: Production!
-                  screenTime: Int!
+                  properties: ActedIn!
                 }
 
                 input ActorActedInUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directive-preserve.test.ts
@@ -909,7 +909,7 @@ describe("Directive-preserve", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               role: String!
             }
 
@@ -995,10 +995,10 @@ describe("Directive-preserve", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              role: String!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -1475,10 +1475,10 @@ describe("Directive-preserve", () => {
               create: [ProductionActorsCreateFieldInput!]
             }
 
-            type ProductionActorsRelationship implements ActedIn {
+            type ProductionActorsRelationship {
               cursor: String!
               node: Actor!
-              role: String!
+              properties: ActedIn!
             }
 
             input ProductionActorsUpdateConnectionInput {
@@ -1904,7 +1904,7 @@ describe("Directive-preserve", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               role: String!
             }
 
@@ -1990,10 +1990,10 @@ describe("Directive-preserve", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              role: String!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -2470,10 +2470,10 @@ describe("Directive-preserve", () => {
               create: [ProductionActorsCreateFieldInput!]
             }
 
-            type ProductionActorsRelationship implements ActedIn {
+            type ProductionActorsRelationship {
               cursor: String!
               node: Actor!
-              role: String!
+              properties: ActedIn!
             }
 
             input ProductionActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/inheritance.test.ts
@@ -231,7 +231,7 @@ describe("inheritance", () => {
               relationshipsDeleted: Int!
             }
 
-            interface FriendsWith {
+            type FriendsWith {
               since: Int
             }
 
@@ -365,10 +365,10 @@ describe("inheritance", () => {
               create: [PersonFriendsCreateFieldInput!]
             }
 
-            type PersonFriendsRelationship implements FriendsWith {
+            type PersonFriendsRelationship {
               cursor: String!
               node: Person!
-              since: Int
+              properties: FriendsWith!
             }
 
             input PersonFriendsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
@@ -57,7 +57,7 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -140,10 +140,10 @@ describe("Interface Relationships", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -634,7 +634,7 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -720,10 +720,10 @@ describe("Interface Relationships", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -1526,10 +1526,10 @@ describe("Interface Relationships", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ProductionActorsRelationship implements ActedIn {
+            type ProductionActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ProductionActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/interfaces/aggregations.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interfaces/aggregations.test.ts
@@ -316,7 +316,7 @@ describe("Interface Top Level Aggregations", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -399,10 +399,10 @@ describe("Interface Top Level Aggregations", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/2993.test.ts
@@ -81,7 +81,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               relationshipsDeleted: Int!
             }
 
-            interface FOLLOWS {
+            type FOLLOWS {
               since: DateTime!
             }
 
@@ -336,10 +336,10 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               create: [UserFollowingCreateFieldInput!]
             }
 
-            type UserFollowingRelationship implements FOLLOWS {
+            type UserFollowingRelationship {
               cursor: String!
               node: Profile!
-              since: DateTime!
+              properties: FOLLOWS!
             }
 
             input UserFollowingUpdateConnectionInput {
@@ -505,7 +505,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               relationshipsDeleted: Int!
             }
 
-            interface FOLLOWS {
+            type FOLLOWS {
               since: DateTime!
             }
 
@@ -759,10 +759,10 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               create: [UserFollowingCreateFieldInput!]
             }
 
-            type UserFollowingRelationship implements FOLLOWS {
+            type UserFollowingRelationship {
               cursor: String!
               node: Profile!
-              since: DateTime!
+              properties: FOLLOWS!
             }
 
             input UserFollowingUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/math.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/math.test.ts
@@ -1790,7 +1790,7 @@ describe("Algebraic", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               pay: Float
               roles: [String!]
             }
@@ -2012,11 +2012,10 @@ describe("Algebraic", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Person!
-              pay: Float
-              roles: [String!]
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
@@ -2320,11 +2319,10 @@ describe("Algebraic", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type PersonActedInMoviesRelationship implements ActedIn {
+            type PersonActedInMoviesRelationship {
               cursor: String!
               node: Movie!
-              pay: Float
-              roles: [String!]
+              properties: ActedIn!
             }
 
             input PersonActedInMoviesUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/nested-aggregation-on-interface.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/nested-aggregation-on-interface.test.ts
@@ -41,7 +41,7 @@ describe("nested aggregation on interface", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -124,10 +124,10 @@ describe("nested aggregation on interface", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -671,7 +671,7 @@ describe("nested aggregation on interface", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -753,10 +753,10 @@ describe("nested aggregation on interface", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {

--- a/packages/graphql/tests/schema/experimental-schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/subscriptions.test.ts
@@ -2609,7 +2609,7 @@ describe("Subscriptions", () => {
               subscription: Subscription
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -3123,10 +3123,10 @@ describe("Subscriptions", () => {
               create: [MovieActorsCreateFieldInput!]
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input MovieActorsRelationshipSubscriptionWhere {

--- a/packages/graphql/tests/schema/experimental-schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/union-interface-relationship.test.ts
@@ -80,7 +80,7 @@ describe("Union Interface Relationships", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -348,10 +348,10 @@ describe("Union Interface Relationships", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
+            type ActorMoviesRelationship {
               cursor: String!
               node: Movie!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -504,7 +504,7 @@ describe("Union Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            interface Directed {
+            type Directed {
               year: Int!
             }
 
@@ -847,10 +847,10 @@ describe("Union Interface Relationships", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
@@ -1076,10 +1076,10 @@ describe("Union Interface Relationships", () => {
               where: MovieDirectorsPersonConnectionWhere
             }
 
-            type MovieDirectorsRelationship implements Directed {
+            type MovieDirectorsRelationship {
               cursor: String!
               node: Director!
-              year: Int!
+              properties: Directed!
             }
 
             input MovieDirectorsUpdateInput {
@@ -1180,10 +1180,10 @@ describe("Union Interface Relationships", () => {
               create: [MovieReviewersCreateFieldInput!]
             }
 
-            type MovieReviewersRelationship implements Review {
+            type MovieReviewersRelationship {
               cursor: String!
               node: Reviewer!
-              score: Int!
+              properties: Review!
             }
 
             input MovieReviewersUpdateConnectionInput {
@@ -1588,10 +1588,10 @@ describe("Union Interface Relationships", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type PersonMoviesRelationship implements Review {
+            type PersonMoviesRelationship {
               cursor: String!
               node: Movie!
-              score: Int!
+              properties: Review!
             }
 
             input PersonMoviesUpdateConnectionInput {
@@ -1751,7 +1751,7 @@ describe("Union Interface Relationships", () => {
               offset: Int
             }
 
-            interface Review {
+            type Review {
               score: Int!
             }
 

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -216,7 +216,7 @@ describe("inheritance", () => {
               relationshipsDeleted: Int!
             }
 
-            interface FriendsWith {
+            type FriendsWith {
               since: Int
             }
 
@@ -338,10 +338,10 @@ describe("inheritance", () => {
               create: [PersonFriendsCreateFieldInput!]
             }
 
-            type PersonFriendsRelationship implements FriendsWith {
+            type PersonFriendsRelationship {
               cursor: String!
               node: Person!
-              since: Int
+              properties: FriendsWith!
             }
 
             input PersonFriendsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -57,7 +57,7 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -139,10 +139,10 @@ describe("Interface Relationships", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -615,7 +615,7 @@ describe("Interface Relationships", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -700,10 +700,10 @@ describe("Interface Relationships", () => {
               create: [ActorActedInCreateFieldInput!]
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Production!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -1492,10 +1492,10 @@ describe("Interface Relationships", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ProductionActorsRelationship implements ActedIn {
+            type ProductionActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ProductionActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -213,10 +213,10 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type CrewMemberMoviesRelationship implements CrewPosition {
+            type CrewMemberMoviesRelationship {
               cursor: String!
               node: Movie!
-              position: CrewPositionType
+              properties: CrewPosition!
             }
 
             input CrewMemberMoviesUpdateConnectionInput {
@@ -263,7 +263,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               totalCount: Int!
             }
 
-            interface CrewPosition {
+            type CrewPosition {
               position: CrewPositionType
             }
 

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               relationshipsDeleted: Int!
             }
 
-            interface FOLLOWS {
+            type FOLLOWS {
               since: DateTime!
             }
 
@@ -323,10 +323,10 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               create: [UserFollowingCreateFieldInput!]
             }
 
-            type UserFollowingRelationship implements FOLLOWS {
+            type UserFollowingRelationship {
               cursor: String!
               node: Profile!
-              since: DateTime!
+              properties: FOLLOWS!
             }
 
             input UserFollowingUpdateConnectionInput {

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -1775,7 +1775,7 @@ describe("Algebraic", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               pay: Float
               roles: [String!]
             }
@@ -1997,11 +1997,10 @@ describe("Algebraic", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Person!
-              pay: Float
-              roles: [String!]
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
@@ -2305,11 +2304,10 @@ describe("Algebraic", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type PersonActedInMoviesRelationship implements ActedIn {
+            type PersonActedInMoviesRelationship {
               cursor: String!
               node: Movie!
-              pay: Float
-              roles: [String!]
+              properties: ActedIn!
             }
 
             input PersonActedInMoviesUpdateConnectionInput {

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -30,7 +30,7 @@ describe("nested aggregation on interface", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -252,10 +252,10 @@ describe("nested aggregation on interface", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Movie!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -539,7 +539,7 @@ describe("String Comparators", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: String
             }
 
@@ -728,10 +728,10 @@ describe("String Comparators", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorActedInRelationship implements ActedIn {
+            type ActorActedInRelationship {
               cursor: String!
               node: Movie!
-              screenTime: String
+              properties: ActedIn!
             }
 
             input ActorActedInUpdateConnectionInput {
@@ -1068,10 +1068,10 @@ describe("String Comparators", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: String
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -2604,7 +2604,7 @@ describe("Subscriptions", () => {
               subscription: Subscription
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -3118,10 +3118,10 @@ describe("Subscriptions", () => {
               create: [MovieActorsCreateFieldInput!]
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input MovieActorsRelationshipSubscriptionWhere {

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -80,7 +80,7 @@ describe("Union Interface Relationships", () => {
               mutation: Mutation
             }
 
-            interface ActedIn {
+            type ActedIn {
               screenTime: Int!
             }
 
@@ -348,10 +348,10 @@ describe("Union Interface Relationships", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type ActorMoviesRelationship implements ActedIn {
+            type ActorMoviesRelationship {
               cursor: String!
               node: Movie!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input ActorMoviesUpdateConnectionInput {
@@ -504,7 +504,7 @@ describe("Union Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            interface Directed {
+            type Directed {
               year: Int!
             }
 
@@ -846,10 +846,10 @@ describe("Union Interface Relationships", () => {
               name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type MovieActorsRelationship implements ActedIn {
+            type MovieActorsRelationship {
               cursor: String!
               node: Actor!
-              screenTime: Int!
+              properties: ActedIn!
             }
 
             input MovieActorsUpdateConnectionInput {
@@ -1075,10 +1075,10 @@ describe("Union Interface Relationships", () => {
               where: MovieDirectorsPersonConnectionWhere
             }
 
-            type MovieDirectorsRelationship implements Directed {
+            type MovieDirectorsRelationship {
               cursor: String!
               node: Director!
-              year: Int!
+              properties: Directed!
             }
 
             input MovieDirectorsUpdateInput {
@@ -1164,10 +1164,10 @@ describe("Union Interface Relationships", () => {
               create: [MovieReviewersCreateFieldInput!]
             }
 
-            type MovieReviewersRelationship implements Review {
+            type MovieReviewersRelationship {
               cursor: String!
               node: Reviewer!
-              score: Int!
+              properties: Review!
             }
 
             input MovieReviewersUpdateConnectionInput {
@@ -1572,10 +1572,10 @@ describe("Union Interface Relationships", () => {
               title_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
             }
 
-            type PersonMoviesRelationship implements Review {
+            type PersonMoviesRelationship {
               cursor: String!
               node: Movie!
-              score: Int!
+              properties: Review!
             }
 
             input PersonMoviesUpdateConnectionInput {
@@ -1732,7 +1732,7 @@ describe("Union Interface Relationships", () => {
               offset: Int
             }
 
-            interface Review {
+            type Review {
               score: Int!
             }
 

--- a/packages/graphql/tests/tck/array-methods.test.ts
+++ b/packages/graphql/tests/tck/array-methods.test.ts
@@ -473,7 +473,9 @@ describe("Arrays Methods", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                                properties {
+                                    pay
+                                }
                             }
                         }
                     }
@@ -503,7 +505,7 @@ describe("Arrays Methods", () => {
             CALL {
                 WITH this
                 MATCH (this)-[update_this3:ACTED_IN]->(update_this4:Movie)
-                WITH { pay: update_this3.pay } AS edge
+                WITH { properties: { pay: update_this3.pay } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS update_var5
@@ -568,7 +570,9 @@ describe("Arrays Methods", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                                properties {
+                                    pay
+                                }
                             }
                         }
                     }
@@ -598,7 +602,7 @@ describe("Arrays Methods", () => {
             CALL {
                 WITH this
                 MATCH (this)-[update_this3:ACTED_IN]->(update_this4:Movie)
-                WITH { pay: update_this3.pay } AS edge
+                WITH { properties: { pay: update_this3.pay } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS update_var5

--- a/packages/graphql/tests/tck/connections/alias.test.ts
+++ b/packages/graphql/tests/tck/connections/alias.test.ts
@@ -89,7 +89,9 @@ describe("Connections Alias", () => {
                     title
                     hanks: actorsConnection(where: { node: { name: "Tom Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -97,7 +99,9 @@ describe("Connections Alias", () => {
                     }
                     jenny: actorsConnection(where: { node: { name: "Robin Wright" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -122,7 +126,7 @@ describe("Connections Alias", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -136,7 +140,7 @@ describe("Connections Alias", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this5, edge.relationship AS this4
-                    RETURN collect({ screenTime: this4.screenTime, node: { name: this5.name } }) AS var6
+                    RETURN collect({ properties: { screenTime: this4.screenTime }, node: { name: this5.name } }) AS var6
                 }
                 RETURN { edges: var6, totalCount: totalCount } AS var7
             }

--- a/packages/graphql/tests/tck/connections/filtering/composite.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/composite.test.ts
@@ -61,7 +61,9 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -87,7 +89,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -123,7 +125,9 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -149,7 +153,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -187,7 +191,9 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -213,7 +219,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -253,7 +259,9 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -279,7 +287,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -324,7 +332,9 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -350,7 +360,7 @@ describe("Cypher -> Connections -> Filtering -> Composite", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/and.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
                     title
                     actorsConnection(where: { node: { AND: [{ firstName: "Tom" }, { lastName: "Hanks" }] } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -81,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -103,7 +105,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
                     title
                     actorsConnection(where: { node: { NOT: { firstName: "Tom" } } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -128,7 +132,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> AND", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/arrays.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     title
                     actorsConnection(where: { node: { name_IN: ["Tom Hanks", "Robin Wright"] } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -80,7 +82,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -104,7 +106,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     title
                     actorsConnection(where: { node: { name_NOT_IN: ["Tom Hanks", "Robin Wright"] } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -128,7 +132,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -152,7 +156,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     title
                     actorsConnection(where: { node: { favouriteColours_INCLUDES: "Blue" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 favouriteColours
@@ -177,7 +183,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, favouriteColours: this1.favouriteColours } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, favouriteColours: this1.favouriteColours } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -198,7 +204,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     title
                     actorsConnection(where: { node: { favouriteColours_NOT_INCLUDES: "Blue" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 favouriteColours
@@ -223,7 +231,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, favouriteColours: this1.favouriteColours } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, favouriteColours: this1.favouriteColours } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/equality.test.ts
@@ -55,7 +55,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
                     title
                     actorsConnection(where: { node: { name: "Tom Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -79,7 +81,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -100,7 +102,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
                     title
                     actorsConnection(where: { node: { name_NOT: "Tom Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -124,7 +128,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Equality", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/numerical.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     title
                     actorsConnection(where: { node: { age_LT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 age
@@ -81,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, age: this1.age } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -105,7 +107,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     title
                     actorsConnection(where: { node: { age_LTE: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 age
@@ -130,7 +134,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, age: this1.age } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -154,7 +158,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     title
                     actorsConnection(where: { node: { age_GT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 age
@@ -179,7 +185,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, age: this1.age } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -203,7 +209,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     title
                     actorsConnection(where: { node: { age_GTE: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 age
@@ -228,7 +236,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Numerical", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, age: this1.age } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, age: this1.age } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/or.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
                     title
                     actorsConnection(where: { node: { OR: [{ firstName: "Tom" }, { lastName: "Hanks" }] } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 firstName
                                 lastName
@@ -81,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> OR", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { firstName: this1.firstName, lastName: this1.lastName } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/points.test.ts
@@ -69,7 +69,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 currentLocation {
@@ -97,7 +99,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> Points", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, currentLocation: CASE
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, currentLocation: CASE
                         WHEN this1.currentLocation IS NOT NULL THEN { point: this1.currentLocation }
                         ELSE NULL
                     END } }) AS var2

--- a/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/node/string.test.ts
@@ -73,7 +73,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_CONTAINS: "Tom" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -97,7 +99,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -118,7 +120,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_NOT_CONTAINS: "Tom" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -142,7 +146,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -163,7 +167,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_STARTS_WITH: "Tom" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -187,7 +193,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -208,7 +214,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_NOT_STARTS_WITH: "Tom" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -232,7 +240,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -253,7 +261,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_ENDS_WITH: "Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -277,7 +287,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -298,7 +308,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_NOT_ENDS_WITH: "Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -322,7 +334,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -343,7 +355,9 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     title
                     actorsConnection(where: { node: { name_MATCHES: "Tom.+" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -367,7 +381,7 @@ describe("Cypher -> Connections -> Filtering -> Node -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/and.test.ts
@@ -56,8 +56,10 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
                     title
                     actorsConnection(where: { edge: { AND: [{ role_ENDS_WITH: "Gump" }, { screenTime_LT: 60 }] } }) {
                         edges {
-                            role
-                            screenTime
+                            properties {
+                                role
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -81,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -106,8 +108,10 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
                     title
                     actorsConnection(where: { edge: { NOT: { role_ENDS_WITH: "Gump" } } }) {
                         edges {
-                            role
-                            screenTime
+                            properties {
+                                role
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -131,7 +135,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> AND", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/arrays.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     title
                     actorsConnection(where: { edge: { screenTime_IN: [60, 70] } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -80,7 +82,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -110,7 +112,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     title
                     actorsConnection(where: { edge: { screenTime_NOT_IN: [60, 70] } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -134,7 +138,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -164,7 +168,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     title
                     actorsConnection(where: { edge: { quotes_INCLUDES: "Life is like a box of chocolates" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -188,7 +194,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -209,7 +215,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     title
                     actorsConnection(where: { edge: { quotes_NOT_INCLUDES: "Life is like a box of chocolates" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -233,7 +241,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Arrays", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/equality.test.ts
@@ -55,7 +55,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
                     title
                     actorsConnection(where: { edge: { screenTime: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -79,7 +81,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -103,7 +105,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
                     title
                     actorsConnection(where: { edge: { screenTime_NOT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -127,7 +131,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Equality", () =>
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/numerical.test.ts
@@ -55,7 +55,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     title
                     actorsConnection(where: { edge: { screenTime_LT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -79,7 +81,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -103,7 +105,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     title
                     actorsConnection(where: { edge: { screenTime_LTE: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -127,7 +131,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -151,7 +155,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     title
                     actorsConnection(where: { edge: { screenTime_GT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -175,7 +181,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -199,7 +205,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     title
                     actorsConnection(where: { edge: { screenTime_GTE: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -223,7 +231,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Numerical", () =
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/or.test.ts
@@ -56,8 +56,10 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
                     title
                     actorsConnection(where: { edge: { OR: [{ role_ENDS_WITH: "Gump" }, { screenTime_LT: 60 }] } }) {
                         edges {
-                            role
-                            screenTime
+                            properties {
+                                role
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -81,7 +83,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> OR", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role, screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/points.test.ts
@@ -67,10 +67,12 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
                         }
                     ) {
                         edges {
-                            screenTime
-                            location {
-                                latitude
-                                longitude
+                            properties {
+                                screenTime
+                                location {
+                                    latitude
+                                    longitude
+                                }
                             }
                             node {
                                 name
@@ -95,10 +97,10 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Points", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, location: CASE
+                    RETURN collect({ properties: { screenTime: this0.screenTime, location: CASE
                         WHEN this0.location IS NOT NULL THEN { point: this0.location }
                         ELSE NULL
-                    END, node: { name: this1.name } }) AS var2
+                    END }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/string.test.ts
@@ -73,7 +73,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_CONTAINS: "Forrest" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -97,7 +99,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -118,7 +120,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_NOT_CONTAINS: "Forrest" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -142,7 +146,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -163,7 +167,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_STARTS_WITH: "Forrest" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -187,7 +193,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -208,7 +214,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_NOT_STARTS_WITH: "Forrest" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -232,7 +240,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -253,7 +261,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_ENDS_WITH: "Gump" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -277,7 +287,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -298,7 +308,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_NOT_ENDS_WITH: "Gump" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -322,7 +334,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -343,7 +355,9 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     title
                     actorsConnection(where: { edge: { role_MATCHES: "Forrest.+" } }) {
                         edges {
-                            role
+                            properties {
+                                role
+                            }
                             node {
                                 name
                             }
@@ -367,7 +381,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> String", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ role: this0.role, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { role: this0.role }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
+++ b/packages/graphql/tests/tck/connections/filtering/relationship/temporal.test.ts
@@ -58,8 +58,10 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
                         where: { edge: { startDate_GT: "2000-01-01", endDateTime_LT: "2010-01-01T00:00:00.000Z" } }
                     ) {
                         edges {
-                            startDate
-                            endDateTime
+                            properties {
+                                startDate
+                                endDateTime
+                            }
                             node {
                                 name
                             }
@@ -83,7 +85,7 @@ describe("Cypher -> Connections -> Filtering -> Relationship -> Temporal", () =>
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ startDate: this0.startDate, endDateTime: apoc.date.convertFormat(toString(this0.endDateTime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { startDate: this0.startDate, endDateTime: apoc.date.convertFormat(toString(this0.endDateTime), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }

--- a/packages/graphql/tests/tck/connections/interfaces.test.ts
+++ b/packages/graphql/tests/tck/connections/interfaces.test.ts
@@ -64,7 +64,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     name
                     actedInConnection {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -89,12 +91,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                 CALL {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -114,7 +116,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     name
                     actedInConnection(where: { node: { title_STARTS_WITH: "The " } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -140,13 +144,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE this1.title STARTS WITH $param0
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
                     WHERE this3.title STARTS WITH $param1
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -173,7 +177,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         where: { node: { _on: { Movie: { runtime_GT: 90 }, Series: { episodes_GT: 50 } } } }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -199,13 +205,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE this1.runtime > $param0
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
                     WHERE this3.episodes > $param1
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -236,7 +242,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     name
                     actedInConnection(where: { edge: { screenTime_GT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -262,13 +270,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE this0.screenTime > $param0
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
                     WHERE this2.screenTime > $param1
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -301,7 +309,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                             name
                             actedInConnection(sort: [{ edge: { screenTime: ASC } }]) {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         title
                                         ... on Movie {
@@ -326,19 +336,19 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         CALL {
                             WITH this
                             MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                            WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                            WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
                             MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                            WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                            WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
                         WITH collect(edge) AS edges
                         WITH edges, size(edges) AS totalCount
                         UNWIND edges AS edge
                         WITH edge, totalCount
-                        ORDER BY edge.screenTime ASC
+                        ORDER BY edge.properties.screenTime ASC
                         WITH collect(edge) AS edges, totalCount
                         RETURN { edges: edges, totalCount: totalCount } AS var4
                     }
@@ -355,7 +365,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                             name
                             actedInConnection(sort: [{ node: { title: ASC } }]) {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         title
                                         ... on Movie {
@@ -380,12 +392,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         CALL {
                             WITH this
                             MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                            WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                            WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
                             MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                            WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                            WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
                         WITH collect(edge) AS edges
@@ -435,19 +447,19 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         CALL {
                             WITH this
                             MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                            WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                            WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
                             MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                            WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                            WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
                         WITH collect(edge) AS edges
                         WITH edges, size(edges) AS totalCount
                         UNWIND edges AS edge
                         WITH edge, totalCount
-                        ORDER BY edge.screenTime ASC
+                        ORDER BY edge.properties.screenTime ASC
                         WITH collect(edge) AS edges, totalCount
                         RETURN { edges: edges, totalCount: totalCount } AS var4
                     }
@@ -464,7 +476,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                             name
                             actedInConnection(sort: [{ node: { title: ASC } }]) {
                                 edges {
-                                    screenTime
+                                    properties {
+                                        screenTime
+                                    }
                                     node {
                                         ... on Movie {
                                             runtime
@@ -488,12 +502,12 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         CALL {
                             WITH this
                             MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                            WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                            WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                             RETURN edge
                             UNION
                             WITH this
                             MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                            WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                            WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                             RETURN edge
                         }
                         WITH collect(edge) AS edges
@@ -521,7 +535,9 @@ describe("Cypher -> Connections -> Interfaces", () => {
                         where: { node: { title: "Game of Thrones", _on: { Movie: { title: "Dune" } } } }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -547,13 +563,13 @@ describe("Cypher -> Connections -> Interfaces", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE this1.title = $param0
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
                     WHERE this3.title = $param1
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
+++ b/packages/graphql/tests/tck/connections/mixed-nesting.test.ts
@@ -55,7 +55,9 @@ describe("Mixed nesting", () => {
                     title
                     actorsConnection(where: { node: { name: "Tom Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 movies(where: { title_NOT: "Forrest Gump" }) {
@@ -90,7 +92,7 @@ describe("Mixed nesting", () => {
                         WITH this3 { .title } AS this3
                         RETURN collect(this3) AS var4
                     }
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, movies: var4 } }) AS var5
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, movies: var4 } }) AS var5
                 }
                 RETURN { edges: var5, totalCount: totalCount } AS var6
             }
@@ -113,7 +115,9 @@ describe("Mixed nesting", () => {
                     title
                     actorsConnection(where: { node: { name: "Tom Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 moviesConnection(where: { node: { title_NOT: "Forrest Gump" } }) {
@@ -169,7 +173,7 @@ describe("Mixed nesting", () => {
                         }
                         RETURN { edges: var7, totalCount: totalCount } AS var8
                     }
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, moviesConnection: var8 } }) AS var9
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, moviesConnection: var8 } }) AS var9
                 }
                 RETURN { edges: var9, totalCount: totalCount } AS var10
             }
@@ -195,7 +199,9 @@ describe("Mixed nesting", () => {
                         name
                         moviesConnection(where: { node: { title_NOT: "Forrest Gump" } }) {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     title
                                 }
@@ -225,7 +231,7 @@ describe("Mixed nesting", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS this3, edge.relationship AS this2
-                        RETURN collect({ screenTime: this2.screenTime, node: { title: this3.title } }) AS var4
+                        RETURN collect({ properties: { screenTime: this2.screenTime }, node: { title: this3.title } }) AS var4
                     }
                     RETURN { edges: var4, totalCount: totalCount } AS var5
                 }

--- a/packages/graphql/tests/tck/connections/projections/create.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/create.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -87,7 +89,7 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS create_this3, edge.relationship AS create_this2
-                    RETURN collect({ screenTime: create_this2.screenTime, node: { name: create_this3.name } }) AS create_var4
+                    RETURN collect({ properties: { screenTime: create_this2.screenTime }, node: { name: create_this3.name } }) AS create_var4
                 }
                 RETURN { edges: create_var4, totalCount: totalCount } AS create_var5
             }
@@ -114,7 +116,9 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -145,7 +149,7 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS create_this3, edge.relationship AS create_this2
-                    RETURN collect({ screenTime: create_this2.screenTime, node: { name: create_this3.name } }) AS create_var4
+                    RETURN collect({ properties: { screenTime: create_this2.screenTime }, node: { name: create_this3.name } }) AS create_var4
                 }
                 RETURN { edges: create_var4, totalCount: totalCount } AS create_var5
             }
@@ -175,7 +179,9 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                         title
                         actorsConnection(where: { node: { name: "Tom Hanks" } }) {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -207,7 +213,7 @@ describe("Cypher -> Connections -> Projections -> Create", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS create_this3, edge.relationship AS create_this2
-                    RETURN collect({ screenTime: create_this2.screenTime, node: { name: create_this3.name } }) AS create_var4
+                    RETURN collect({ properties: { screenTime: create_this2.screenTime }, node: { name: create_this3.name } }) AS create_var4
                 }
                 RETURN { edges: create_var4, totalCount: totalCount } AS create_var5
             }

--- a/packages/graphql/tests/tck/connections/projections/update.test.ts
+++ b/packages/graphql/tests/tck/connections/projections/update.test.ts
@@ -56,7 +56,9 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -76,7 +78,7 @@ describe("Cypher -> Connections -> Projections -> Update", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:Actor)
-                WITH { screenTime: update_this0.screenTime, node: { name: update_this1.name } } AS edge
+                WITH { properties: { screenTime: update_this0.screenTime }, node: { name: update_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS update_var2

--- a/packages/graphql/tests/tck/connections/relationship-properties.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship-properties.test.ts
@@ -56,7 +56,9 @@ describe("Relationship Properties Cypher", () => {
                     title
                     actorsConnection {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -80,7 +82,7 @@ describe("Relationship Properties Cypher", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -101,7 +103,9 @@ describe("Relationship Properties Cypher", () => {
                     title
                     actorsConnection(where: { node: { name: "Tom Hanks" } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -126,7 +130,7 @@ describe("Relationship Properties Cypher", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -148,7 +152,9 @@ describe("Relationship Properties Cypher", () => {
                     title
                     actorsConnection(sort: { edge: { screenTime: DESC } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                             }
@@ -174,7 +180,7 @@ describe("Relationship Properties Cypher", () => {
                     WITH edge.node AS this1, edge.relationship AS this0
                     WITH *
                     ORDER BY this0.screenTime DESC
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -194,7 +200,9 @@ describe("Relationship Properties Cypher", () => {
                 movies {
                     actorsConnection(sort: [{ edge: { year: DESC } }, { node: { name: ASC } }]) {
                         edges {
-                            year
+                            properties {
+                                year
+                            }
                             node {
                                 name
                             }
@@ -219,7 +227,7 @@ describe("Relationship Properties Cypher", () => {
                     WITH edge.node AS this1, edge.relationship AS this0
                     WITH *
                     ORDER BY this0.year DESC, this1.name ASC
-                    RETURN collect({ year: this0.year, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { year: this0.year }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -234,7 +242,9 @@ describe("Relationship Properties Cypher", () => {
                 movies {
                     actorsConnection(sort: [{ node: { name: ASC } }, { edge: { year: DESC } }]) {
                         edges {
-                            year
+                            properties {
+                                year
+                            }
                             node {
                                 name
                             }
@@ -259,7 +269,7 @@ describe("Relationship Properties Cypher", () => {
                     WITH edge.node AS this1, edge.relationship AS this0
                     WITH *
                     ORDER BY this1.name ASC, this0.year DESC
-                    RETURN collect({ year: this0.year, node: { name: this1.name } }) AS var2
+                    RETURN collect({ properties: { year: this0.year }, node: { name: this1.name } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -276,12 +286,16 @@ describe("Relationship Properties Cypher", () => {
                     title
                     actorsConnection {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 moviesConnection {
                                     edges {
-                                        screenTime
+                                        properties {
+                                            screenTime
+                                        }
                                         node {
                                             title
                                         }
@@ -317,11 +331,11 @@ describe("Relationship Properties Cypher", () => {
                             WITH edges
                             UNWIND edges AS edge
                             WITH edge.node AS this3, edge.relationship AS this2
-                            RETURN collect({ screenTime: this2.screenTime, node: { title: this3.title } }) AS var4
+                            RETURN collect({ properties: { screenTime: this2.screenTime }, node: { title: this3.title } }) AS var4
                         }
                         RETURN { edges: var4, totalCount: totalCount } AS var5
                     }
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, moviesConnection: var5 } }) AS var6
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, moviesConnection: var5 } }) AS var6
                 }
                 RETURN { edges: var6, totalCount: totalCount } AS var7
             }
@@ -342,17 +356,23 @@ describe("Relationship Properties Cypher", () => {
                     title
                     actorsConnection {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 name
                                 moviesConnection {
                                     edges {
-                                        screenTime
+                                        properties {
+                                            screenTime
+                                        }
                                         node {
                                             title
                                             actorsConnection {
                                                 edges {
-                                                    screenTime
+                                                    properties {
+                                                        screenTime
+                                                    }
                                                     node {
                                                         name
                                                     }
@@ -400,15 +420,15 @@ describe("Relationship Properties Cypher", () => {
                                     WITH edges
                                     UNWIND edges AS edge
                                     WITH edge.node AS this5, edge.relationship AS this4
-                                    RETURN collect({ screenTime: this4.screenTime, node: { name: this5.name } }) AS var6
+                                    RETURN collect({ properties: { screenTime: this4.screenTime }, node: { name: this5.name } }) AS var6
                                 }
                                 RETURN { edges: var6, totalCount: totalCount } AS var7
                             }
-                            RETURN collect({ screenTime: this2.screenTime, node: { title: this3.title, actorsConnection: var7 } }) AS var8
+                            RETURN collect({ properties: { screenTime: this2.screenTime }, node: { title: this3.title, actorsConnection: var7 } }) AS var8
                         }
                         RETURN { edges: var8, totalCount: totalCount } AS var9
                     }
-                    RETURN collect({ screenTime: this0.screenTime, node: { name: this1.name, moviesConnection: var9 } }) AS var10
+                    RETURN collect({ properties: { screenTime: this0.screenTime }, node: { name: this1.name, moviesConnection: var9 } }) AS var10
                 }
                 RETURN { edges: var10, totalCount: totalCount } AS var11
             }

--- a/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/connect.test.ts
@@ -56,7 +56,9 @@ describe("Relationship Properties Connect Cypher", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -104,7 +106,7 @@ describe("Relationship Properties Connect Cypher", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS create_this1, edge.relationship AS create_this0
-                        RETURN collect({ screenTime: create_this0.screenTime, node: { name: create_this1.name } }) AS create_var2
+                        RETURN collect({ properties: { screenTime: create_this0.screenTime }, node: { name: create_this1.name } }) AS create_var2
                     }
                     RETURN { edges: create_var2, totalCount: totalCount } AS create_var3
                 }
@@ -140,7 +142,9 @@ describe("Relationship Properties Connect Cypher", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -189,7 +193,7 @@ describe("Relationship Properties Connect Cypher", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS create_this1, edge.relationship AS create_this0
-                        RETURN collect({ screenTime: create_this0.screenTime, node: { name: create_this1.name } }) AS create_var2
+                        RETURN collect({ properties: { screenTime: create_this0.screenTime }, node: { name: create_this1.name } }) AS create_var2
                     }
                     RETURN { edges: create_var2, totalCount: totalCount } AS create_var3
                 }
@@ -219,7 +223,9 @@ describe("Relationship Properties Connect Cypher", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -257,7 +263,7 @@ describe("Relationship Properties Connect Cypher", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:Actor)
-                WITH { screenTime: update_this0.screenTime, node: { name: update_this1.name } } AS edge
+                WITH { properties: { screenTime: update_this0.screenTime }, node: { name: update_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS update_var2
@@ -288,7 +294,9 @@ describe("Relationship Properties Connect Cypher", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -327,7 +335,7 @@ describe("Relationship Properties Connect Cypher", () => {
             CALL {
                 WITH this
                 MATCH (this)<-[update_this0:ACTED_IN]-(update_this1:Actor)
-                WITH { screenTime: update_this0.screenTime, node: { name: update_this1.name } } AS edge
+                WITH { properties: { screenTime: update_this0.screenTime }, node: { name: update_this1.name } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS update_var2

--- a/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
+++ b/packages/graphql/tests/tck/connections/relationship_properties/create.test.ts
@@ -63,7 +63,9 @@ describe("Relationship Properties Create Cypher", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -107,7 +109,7 @@ describe("Relationship Properties Create Cypher", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS create_this9, edge.relationship AS create_this8
-                    RETURN collect({ screenTime: create_this8.screenTime, node: { name: create_this9.name } }) AS create_var10
+                    RETURN collect({ properties: { screenTime: create_this8.screenTime }, node: { name: create_this9.name } }) AS create_var10
                 }
                 RETURN { edges: create_var10, totalCount: totalCount } AS create_var11
             }

--- a/packages/graphql/tests/tck/connections/unions.test.ts
+++ b/packages/graphql/tests/tck/connections/unions.test.ts
@@ -62,7 +62,9 @@ describe("Cypher -> Connections -> Unions", () => {
                     name
                     publicationsConnection {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -86,12 +88,12 @@ describe("Cypher -> Connections -> Unions", () => {
                 CALL {
                     WITH this
                     MATCH (this)-[this0:WROTE]->(this1:Book)
-                    WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
+                    WITH { properties: { words: this0.words }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:WROTE]->(this3:Journal)
-                    WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
+                    WITH { properties: { words: this2.words }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -116,7 +118,9 @@ describe("Cypher -> Connections -> Unions", () => {
                         }
                     ) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -141,13 +145,13 @@ describe("Cypher -> Connections -> Unions", () => {
                     WITH this
                     MATCH (this)-[this0:WROTE]->(this1:Book)
                     WHERE this1.title = $param0
-                    WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
+                    WITH { properties: { words: this0.words }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:WROTE]->(this3:Journal)
                     WHERE this3.subject = $param1
-                    WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
+                    WITH { properties: { words: this2.words }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -174,7 +178,9 @@ describe("Cypher -> Connections -> Unions", () => {
                         where: { Book: { edge: { words: 1000 } }, Journal: { edge: { words: 2000 } } }
                     ) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -199,13 +205,13 @@ describe("Cypher -> Connections -> Unions", () => {
                     WITH this
                     MATCH (this)-[this0:WROTE]->(this1:Book)
                     WHERE this0.words = $param0
-                    WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
+                    WITH { properties: { words: this0.words }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:WROTE]->(this3:Journal)
                     WHERE this2.words = $param1
-                    WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
+                    WITH { properties: { words: this2.words }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -241,7 +247,9 @@ describe("Cypher -> Connections -> Unions", () => {
                         }
                     ) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -266,13 +274,13 @@ describe("Cypher -> Connections -> Unions", () => {
                     WITH this
                     MATCH (this)-[this0:WROTE]->(this1:Book)
                     WHERE (this1.title = $param0 AND this0.words = $param1)
-                    WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
+                    WITH { properties: { words: this0.words }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:WROTE]->(this3:Journal)
                     WHERE (this3.subject = $param2 AND this2.words = $param3)
-                    WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
+                    WITH { properties: { words: this2.words }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -305,7 +313,9 @@ describe("Cypher -> Connections -> Unions", () => {
                     name
                     publicationsConnection(sort: [{ edge: { words: ASC } }]) {
                         edges {
-                            words
+                            properties {
+                                words
+                            }
                             node {
                                 ... on Book {
                                     title
@@ -329,19 +339,19 @@ describe("Cypher -> Connections -> Unions", () => {
                 CALL {
                     WITH this
                     MATCH (this)-[this0:WROTE]->(this1:Book)
-                    WITH { words: this0.words, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
+                    WITH { properties: { words: this0.words }, node: { __resolveType: \\"Book\\", __id: id(this1), title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:WROTE]->(this3:Journal)
-                    WITH { words: this2.words, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
+                    WITH { properties: { words: this2.words }, node: { __resolveType: \\"Journal\\", __id: id(this3), subject: this3.subject } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 UNWIND edges AS edge
                 WITH edge, totalCount
-                ORDER BY edge.words ASC
+                ORDER BY edge.properties.words ASC
                 WITH collect(edge) AS edges, totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS var4
             }

--- a/packages/graphql/tests/tck/directives/alias.test.ts
+++ b/packages/graphql/tests/tck/directives/alias.test.ts
@@ -88,8 +88,10 @@ describe("Cypher alias directive", () => {
                     city
                     actedInConnection {
                         edges {
-                            character
-                            screenTime
+                            properties {
+                                character
+                                screenTime
+                            }
                             node {
                                 title
                                 rating
@@ -113,7 +115,7 @@ describe("Cypher alias directive", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this1, edge.relationship AS this0
-                    RETURN collect({ character: this0.characterPropInDb, screenTime: this0.screenTime, node: { title: this1.title, rating: this1.ratingPropInDb } }) AS var2
+                    RETURN collect({ properties: { character: this0.characterPropInDb, screenTime: this0.screenTime }, node: { title: this1.title, rating: this1.ratingPropInDb } }) AS var2
                 }
                 RETURN { edges: var2, totalCount: totalCount } AS var3
             }
@@ -149,8 +151,10 @@ describe("Cypher alias directive", () => {
                         }
                         actedInConnection {
                             edges {
-                                character
-                                screenTime
+                                properties {
+                                    character
+                                    screenTime
+                                }
                                 node {
                                     title
                                     rating
@@ -204,7 +208,7 @@ describe("Cypher alias directive", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS create_this12, edge.relationship AS create_this11
-                    RETURN collect({ character: create_this11.characterPropInDb, screenTime: create_this11.screenTime, node: { title: create_this12.title, rating: create_this12.ratingPropInDb } }) AS create_var13
+                    RETURN collect({ properties: { character: create_this11.characterPropInDb, screenTime: create_this11.screenTime }, node: { title: create_this12.title, rating: create_this12.ratingPropInDb } }) AS create_var13
                 }
                 RETURN { edges: create_var13, totalCount: totalCount } AS create_var14
             }

--- a/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
+++ b/packages/graphql/tests/tck/directives/interface-relationships/read.test.ts
@@ -297,7 +297,9 @@ describe("Interface Relationships", () => {
                 actors {
                     actedInConnection {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -322,12 +324,12 @@ describe("Interface Relationships", () => {
                 CALL {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -346,7 +348,9 @@ describe("Interface Relationships", () => {
                 actors {
                     actedInConnection(where: { node: { title_STARTS_WITH: "The " }, edge: { screenTime_GT: 60 } }) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -372,13 +376,13 @@ describe("Interface Relationships", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE (this1.title STARTS WITH $param0 AND this0.screenTime > $param1)
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
                     WHERE (this3.title STARTS WITH $param2 AND this2.screenTime > $param3)
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -412,7 +416,9 @@ describe("Interface Relationships", () => {
                         where: { node: { _on: { Movie: { title_STARTS_WITH: "The " } } }, edge: { screenTime_GT: 60 } }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -435,7 +441,7 @@ describe("Interface Relationships", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE (this1.title STARTS WITH $param0 AND this0.screenTime > $param1)
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges
@@ -467,7 +473,9 @@ describe("Interface Relationships", () => {
                         }
                     ) {
                         edges {
-                            screenTime
+                            properties {
+                                screenTime
+                            }
                             node {
                                 title
                                 ... on Movie {
@@ -493,13 +501,13 @@ describe("Interface Relationships", () => {
                     WITH this
                     MATCH (this)-[this0:ACTED_IN]->(this1:Movie)
                     WHERE (this1.title STARTS WITH $param0 AND this0.screenTime > $param1)
-                    WITH { screenTime: this0.screenTime, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
+                    WITH { properties: { screenTime: this0.screenTime }, node: { __resolveType: \\"Movie\\", __id: id(this1), runtime: this1.runtime, title: this1.title } } AS edge
                     RETURN edge
                     UNION
                     WITH this
                     MATCH (this)-[this2:ACTED_IN]->(this3:Series)
                     WHERE (this3.title STARTS WITH $param2 AND this2.screenTime > $param3)
-                    WITH { screenTime: this2.screenTime, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
+                    WITH { properties: { screenTime: this2.screenTime }, node: { __resolveType: \\"Series\\", __id: id(this3), episodes: this3.episodes, title: this3.title } } AS edge
                     RETURN edge
                 }
                 WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/1150.test.ts
+++ b/packages/graphql/tests/tck/issues/1150.test.ts
@@ -83,7 +83,9 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                                     }
                                 ) {
                                     edges {
-                                        current
+                                        properties {
+                                            current
+                                        }
                                         node {
                                             ... on Battery {
                                                 id
@@ -125,13 +127,13 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
                             WITH this1
                             MATCH (this1)-[this2:HAS]->(this3:Battery)
                             WHERE (this2.current = $param2 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $param5 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
-                            WITH { current: this2.current, node: { __resolveType: \\"Battery\\", __id: id(this3), id: this3.id } } AS edge
+                            WITH { properties: { current: this2.current }, node: { __resolveType: \\"Battery\\", __id: id(this3), id: this3.id } } AS edge
                             RETURN edge
                             UNION
                             WITH this1
                             MATCH (this1)-[this4:HAS]->(this5:CombustionEngine)
                             WHERE this4.current = $param6
-                            WITH { current: this4.current, node: { __resolveType: \\"CombustionEngine\\", __id: id(this5), id: this5.id } } AS edge
+                            WITH { properties: { current: this4.current }, node: { __resolveType: \\"CombustionEngine\\", __id: id(this5), id: this5.id } } AS edge
                             RETURN edge
                         }
                         WITH collect(edge) AS edges

--- a/packages/graphql/tests/tck/issues/1249.test.ts
+++ b/packages/graphql/tests/tck/issues/1249.test.ts
@@ -67,7 +67,9 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
                         id
                         suppliersConnection {
                             edges {
-                                supplierMaterialNumber
+                                properties {
+                                    supplierMaterialNumber
+                                }
                                 node {
                                     supplierId
                                 }
@@ -94,7 +96,7 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS this3, edge.relationship AS this2
-                        RETURN collect({ supplierMaterialNumber: this2.supplierMaterialNumber, node: { supplierId: this3.supplierId } }) AS var4
+                        RETURN collect({ properties: { supplierMaterialNumber: this2.supplierMaterialNumber }, node: { supplierId: this3.supplierId } }) AS var4
                     }
                     RETURN { edges: var4, totalCount: totalCount } AS var5
                 }

--- a/packages/graphql/tests/tck/issues/4292.test.ts
+++ b/packages/graphql/tests/tck/issues/4292.test.ts
@@ -188,9 +188,11 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
                         name
                         partnersConnection {
                             edges {
-                                active
-                                firstDay
-                                lastDay
+                                properties {
+                                    active
+                                    firstDay
+                                    lastDay
+                                }
                             }
                         }
                     }
@@ -254,7 +256,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS this13, edge.relationship AS this12
-                        RETURN collect({ active: this12.active, firstDay: this12.firstDay, lastDay: this12.lastDay, node: { __resolveType: \\"Person\\", __id: id(this13) } }) AS var25
+                        RETURN collect({ properties: { active: this12.active, firstDay: this12.firstDay, lastDay: this12.lastDay }, node: { __resolveType: \\"Person\\", __id: id(this13) } }) AS var25
                     }
                     RETURN { edges: var25, totalCount: totalCount } AS var26
                 }

--- a/packages/graphql/tests/tck/issues/601.test.ts
+++ b/packages/graphql/tests/tck/issues/601.test.ts
@@ -79,8 +79,10 @@ describe("#601", () => {
                     documents {
                         customerContactConnection {
                             edges {
-                                fileId
-                                uploadedAt
+                                properties {
+                                    fileId
+                                    uploadedAt
+                                }
                             }
                         }
                     }
@@ -111,7 +113,7 @@ describe("#601", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS this3, edge.relationship AS this2
-                        RETURN collect({ fileId: this2.fileId, uploadedAt: apoc.date.convertFormat(toString(this2.uploadedAt), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\"), node: { __resolveType: \\"CustomerContact\\", __id: id(this3) } }) AS var4
+                        RETURN collect({ properties: { fileId: this2.fileId, uploadedAt: apoc.date.convertFormat(toString(this2.uploadedAt), \\"iso_zoned_date_time\\", \\"iso_offset_date_time\\") }, node: { __resolveType: \\"CustomerContact\\", __id: id(this3) } }) AS var4
                     }
                     RETURN { edges: var4, totalCount: totalCount } AS var5
                 }

--- a/packages/graphql/tests/tck/issues/988.test.ts
+++ b/packages/graphql/tests/tck/issues/988.test.ts
@@ -64,7 +64,9 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     current
                     manufacturerConnection {
                         edges {
-                            current
+                            properties {
+                                current
+                            }
                             node {
                                 name
                             }
@@ -72,7 +74,9 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     }
                     brandConnection {
                         edges {
-                            current
+                            properties {
+                                current
+                            }
                             node {
                                 name
                             }
@@ -151,7 +155,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this7, edge.relationship AS this6
-                    RETURN collect({ current: this6.current, node: { name: this7.name } }) AS var8
+                    RETURN collect({ properties: { current: this6.current }, node: { name: this7.name } }) AS var8
                 }
                 RETURN { edges: var8, totalCount: totalCount } AS var9
             }
@@ -164,7 +168,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
                     WITH edges
                     UNWIND edges AS edge
                     WITH edge.node AS this11, edge.relationship AS this10
-                    RETURN collect({ current: this10.current, node: { name: this11.name } }) AS var12
+                    RETURN collect({ properties: { current: this10.current }, node: { name: this11.name } }) AS var12
                 }
                 RETURN { edges: var12, totalCount: totalCount } AS var13
             }

--- a/packages/graphql/tests/tck/math.test.ts
+++ b/packages/graphql/tests/tck/math.test.ts
@@ -196,7 +196,9 @@ describe("Math operators", () => {
                         }
                         actedInConnection {
                             edges {
-                                pay
+                                properties {
+                                    pay
+                                }
                             }
                         }
                     }
@@ -231,7 +233,7 @@ describe("Math operators", () => {
             CALL {
                 WITH this
                 MATCH (this)-[update_this3:ACTED_IN]->(update_this4:Movie)
-                WITH { pay: update_this3.pay } AS edge
+                WITH { properties: { pay: update_this3.pay } } AS edge
                 WITH collect(edge) AS edges
                 WITH edges, size(edges) AS totalCount
                 RETURN { edges: edges, totalCount: totalCount } AS update_var5

--- a/packages/graphql/tests/tck/subscriptions/create.test.ts
+++ b/packages/graphql/tests/tck/subscriptions/create.test.ts
@@ -81,7 +81,9 @@ describe("Subscriptions metadata on create", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -128,7 +130,7 @@ describe("Subscriptions metadata on create", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS create_this1, edge.relationship AS create_this0
-                        RETURN collect({ screenTime: create_this0.screenTime, node: { name: create_this1.name } }) AS create_var2
+                        RETURN collect({ properties: { screenTime: create_this0.screenTime }, node: { name: create_this1.name } }) AS create_var2
                     }
                     RETURN { edges: create_var2, totalCount: totalCount } AS create_var3
                 }
@@ -276,7 +278,9 @@ describe("Subscriptions metadata on create", () => {
                         title
                         actorsConnection {
                             edges {
-                                screenTime
+                                properties {
+                                    screenTime
+                                }
                                 node {
                                     name
                                 }
@@ -329,7 +333,7 @@ describe("Subscriptions metadata on create", () => {
                         WITH edges
                         UNWIND edges AS edge
                         WITH edge.node AS create_this1, edge.relationship AS create_this0
-                        RETURN collect({ screenTime: create_this0.screenTime, node: { name: create_this1.name } }) AS create_var2
+                        RETURN collect({ properties: { screenTime: create_this0.screenTime }, node: { name: create_this1.name } }) AS create_var2
                     }
                     RETURN { edges: create_var2, totalCount: totalCount } AS create_var3
                 }

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -1086,6 +1086,7 @@ describe("generate", () => {
             }
 
             export type ActedIn = {
+              __typename?: \\"ActedIn\\";
               screenTime: Scalars[\\"Int\\"][\\"output\\"];
             };
 
@@ -1161,11 +1162,11 @@ describe("generate", () => {
               pageInfo: PageInfo;
             };
 
-            export type MovieActorsRelationship = ActedIn & {
+            export type MovieActorsRelationship = {
               __typename?: \\"MovieActorsRelationship\\";
               cursor: Scalars[\\"String\\"][\\"output\\"];
               node: Person;
-              screenTime: Scalars[\\"Int\\"][\\"output\\"];
+              properties: ActedIn;
             };
 
             export type MovieAggregateSelection = {
@@ -1889,10 +1890,6 @@ describe("generate", () => {
               Desc = \\"DESC\\",
             }
 
-            export type FaqEntryInFaq = {
-              position?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
-            };
-
             export type CreateFaqEntriesMutationResponse = {
               __typename?: \\"CreateFaqEntriesMutationResponse\\";
               info: CreateInfo;
@@ -1979,11 +1976,11 @@ describe("generate", () => {
               pageInfo: PageInfo;
             };
 
-            export type FaqEntriesRelationship = FaqEntryInFaq & {
+            export type FaqEntriesRelationship = {
               __typename?: \\"FAQEntriesRelationship\\";
               cursor: Scalars[\\"String\\"][\\"output\\"];
               node: FaqEntry;
-              position?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
+              properties: FaqEntryInFaq;
             };
 
             export type FaqEntry = {
@@ -2047,6 +2044,11 @@ describe("generate", () => {
               name: StringAggregateSelectionNonNullable;
             };
 
+            export type FaqEntryInFaq = {
+              __typename?: \\"FaqEntryInFaq\\";
+              position?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
+            };
+
             export type FaqEntryInFaQsConnection = {
               __typename?: \\"FAQEntryInFAQsConnection\\";
               edges: Array<FaqEntryInFaQsRelationship>;
@@ -2054,11 +2056,11 @@ describe("generate", () => {
               pageInfo: PageInfo;
             };
 
-            export type FaqEntryInFaQsRelationship = FaqEntryInFaq & {
+            export type FaqEntryInFaQsRelationship = {
               __typename?: \\"FAQEntryInFAQsRelationship\\";
               cursor: Scalars[\\"String\\"][\\"output\\"];
               node: Faq;
-              position?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
+              properties: FaqEntryInFaq;
             };
 
             export type FaqfaqEntryEntriesAggregationSelection = {


### PR DESCRIPTION
and change relationshipProperties generated type to object

# Description

This PR contains separating out the relationship properties from the `edge` object into its own `properties` object which now lives at the same level with `node`. 
Translation has been adjusted.
Schema generation has been adjusted to create an object type for the relationshipProperties annotated type instead of an interface.

Example:

```graphql
# before
type ActorActedInRelationship {
  node: Movie!
  runtime: Int!
  roles: [String!]!
}

# now
type ActedIn { # object type instead of interface
  runtime: Int!
  roles: [String!]!
}

type ActorActedInRelationship {
  node: Movie!
  properties: ActedIn! # new properties field
}
```

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
