### PR TITLE
Fix toolbox failing tests

### DIFF
--- a/packages/graphql-toolbox/package.json
+++ b/packages/graphql-toolbox/package.json
@@ -43,9 +43,9 @@
     "author": "Neo4j",
     "dependencies": {
         "@codemirror/autocomplete": "6.11.1",
-        "@codemirror/commands": "6.3.3",
+        "@codemirror/commands": "6.3.2",
         "@codemirror/lang-javascript": "6.2.1",
-        "@codemirror/language": "6.10.0",
+        "@codemirror/language": "6.9.3",
         "@dnd-kit/core": "6.1.0",
         "@dnd-kit/modifiers": "7.0.0",
         "@dnd-kit/sortable": "8.0.0",

--- a/packages/graphql-toolbox/playwright.config.ts
+++ b/packages/graphql-toolbox/playwright.config.ts
@@ -17,9 +17,9 @@
  * limitations under the License.
  */
 
-import { PlaywrightTestConfig, devices } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 
-const config: PlaywrightTestConfig = {
+export default defineConfig({
     webServer: {
         command: "yarn start",
         url: "http://localhost:4242",
@@ -35,6 +35,7 @@ const config: PlaywrightTestConfig = {
     forbidOnly: !!process.env.CI,
     retries: process.env.CI ? 2 : 0,
     workers: process.env.CI ? 6 : undefined,
+    maxFailures: process.env.CI ? 10 : undefined,
     projects: [
         {
             name: "chromium",
@@ -53,5 +54,4 @@ const config: PlaywrightTestConfig = {
         },
     ],
     outputDir: "tests/artifacts/",
-};
-export default config;
+});

--- a/packages/graphql-toolbox/src/modules/AppSettings/AppSettings.tsx
+++ b/packages/graphql-toolbox/src/modules/AppSettings/AppSettings.tsx
@@ -118,7 +118,7 @@ export const AppSettings = ({ onClickClose }: Props) => {
                 <div className="flex flex-col">
                     <span>Made by Neo4j, Inc</span>
                     {/* explicitly hard coded values for copyright */}
-                    <span data-test-copyright-information>Copyright &copy; 2002-2023</span>
+                    <span data-test-copyright-information>Copyright &copy; 2002-2024</span>
                     <div className="flex">
                         <span>App version:</span>&nbsp;
                         <pre>{process.env.VERSION}</pre>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1736,15 +1736,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/commands@npm:6.3.3":
-  version: 6.3.3
-  resolution: "@codemirror/commands@npm:6.3.3"
+"@codemirror/commands@npm:6.3.2":
+  version: 6.3.2
+  resolution: "@codemirror/commands@npm:6.3.2"
   dependencies:
     "@codemirror/language": ^6.0.0
-    "@codemirror/state": ^6.4.0
+    "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.0.0
     "@lezer/common": ^1.1.0
-  checksum: 7d23aecc973823969434b839aefa9a98bb47212d2ce0e6869ae903adbb5233aad22a760788fb7bb6eb45b00b01a4932fb93ad43bacdcbc0215e7500cf54b17bb
+  checksum: 683c444d8e6ad889ab5efd0d742b0fa28b78c8cad63276ec60d298b13d4939c8bd7e1d6fd3535645b8d255147de0d3aef46d89a29c19d0af58a7f2914bdcb3ab
   languageName: node
   linkType: hard
 
@@ -1775,17 +1775,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/language@npm:6.10.0":
-  version: 6.10.0
-  resolution: "@codemirror/language@npm:6.10.0"
+"@codemirror/language@npm:6.9.3":
+  version: 6.9.3
+  resolution: "@codemirror/language@npm:6.9.3"
   dependencies:
     "@codemirror/state": ^6.0.0
-    "@codemirror/view": ^6.23.0
+    "@codemirror/view": ^6.0.0
     "@lezer/common": ^1.1.0
     "@lezer/highlight": ^1.0.0
     "@lezer/lr": ^1.0.0
     style-mod: ^4.0.0
-  checksum: 3bfd9968f5a34ce22434489a5b226db5f3bc454a1ae7c4381587ff4270ac6af61b10f93df560cb73e9a77cc13d4843722a7a7b94dbed02a3ab1971dd329b9e81
+  checksum: 774a40bc91c748d418a9a774161a5b083061124e4439bb753072bc657ec4c4784f595161c10c7c3935154b22291bf6dc74c9abe827033db32e217ac3963478f3
   languageName: node
   linkType: hard
 
@@ -1832,13 +1832,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@codemirror/state@npm:^6.4.0":
-  version: 6.4.0
-  resolution: "@codemirror/state@npm:6.4.0"
-  checksum: c5236fe5786f1b85d17273a5c17fa8aeb063658c1404ab18caeb6e7591663ec96b65d453ab8162f75839c3801b04cd55ba4bc48f44cb61ebfeeee383f89553c7
-  languageName: node
-  linkType: hard
-
 "@codemirror/view@npm:^6.0.0, @codemirror/view@npm:^6.17.0, @codemirror/view@npm:^6.9.0":
   version: 6.20.2
   resolution: "@codemirror/view@npm:6.20.2"
@@ -1847,17 +1840,6 @@ __metadata:
     style-mod: ^4.1.0
     w3c-keyname: ^2.2.4
   checksum: eaf47726bb94b40f12c6f1d3494b558addaa7cd98a4ff05bfea7439c03cca3967d73380346ea8b06021478c21ec336a74665c9acb44e2b0280d5e0da4714387b
-  languageName: node
-  linkType: hard
-
-"@codemirror/view@npm:^6.23.0":
-  version: 6.23.0
-  resolution: "@codemirror/view@npm:6.23.0"
-  dependencies:
-    "@codemirror/state": ^6.4.0
-    style-mod: ^4.1.0
-    w3c-keyname: ^2.2.4
-  checksum: 6e5f2314a3da2c724dc6a525654d949d3f2fcf7009f4d85f980d52ddc885c8969717e903ca1d9132afbe7c524af5d19bff8285fd394106282a965ae83aa47db4
   languageName: node
   linkType: hard
 
@@ -3656,9 +3638,9 @@ __metadata:
   resolution: "@neo4j/graphql-toolbox@workspace:packages/graphql-toolbox"
   dependencies:
     "@codemirror/autocomplete": 6.11.1
-    "@codemirror/commands": 6.3.3
+    "@codemirror/commands": 6.3.2
     "@codemirror/lang-javascript": 6.2.1
-    "@codemirror/language": 6.10.0
+    "@codemirror/language": 6.9.3
     "@dnd-kit/core": 6.1.0
     "@dnd-kit/modifiers": 7.0.0
     "@dnd-kit/sortable": 8.0.0


### PR DESCRIPTION
In this PR:
- We update the year to 2024 in the Toolbox settings
- Downgrade codemirror packages to conform to the fixed-version peer dependencies in `cm6-graphql`
- Add a CI only `maxFailures` to playwright config
- Use `defineConfig` is playwright config