### PR TITLE
Fix authorization variable naming for create operations

### DIFF
--- a/.changeset/two-phones-look.md
+++ b/.changeset/two-phones-look.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix authorization variable naming in create operations

--- a/packages/graphql/src/translate/create-create-and-params.ts
+++ b/packages/graphql/src/translate/create-create-and-params.ts
@@ -63,12 +63,7 @@ function createCreateAndParams({
     withVars,
     includeRelationshipValidation,
     topLevelNodeVariable,
-    authorizationPrefix = {
-        inputIndex: 0,
-        reducerIndex: 0,
-        createIndex: 0,
-        refNodeIndex: 0,
-    },
+    authorizationPrefix = [0],
 }: {
     input: any;
     varName: string;
@@ -79,12 +74,7 @@ function createCreateAndParams({
     includeRelationshipValidation?: boolean;
     topLevelNodeVariable?: string;
     //used to build authorization variable in auth subqueries
-    authorizationPrefix?: {
-        inputIndex: number; // index of the input
-        reducerIndex: number; // index of the reducer in the context of the input
-        createIndex: number; // index of the create in the context of a run of the reducer
-        refNodeIndex: number; // when a relationship is to an abstract type, this is the index of the refNode in the context of a run of the reducer
-    };
+    authorizationPrefix?: number[];
 }): CreateAndParams {
     const conflictingProperties = findConflictingProperties({ node, input });
     if (conflictingProperties.length > 0) {
@@ -169,12 +159,7 @@ function createCreateAndParams({
                             withVars: [...withVars, nodeName],
                             includeRelationshipValidation: false,
                             topLevelNodeVariable,
-                            authorizationPrefix: {
-                                inputIndex: authorizationPrefix.inputIndex + 1,
-                                reducerIndex,
-                                createIndex,
-                                refNodeIndex,
-                            },
+                            authorizationPrefix: [...authorizationPrefix, reducerIndex, createIndex, refNodeIndex],
                         });
                         res.creates.push(nestedCreate);
                         res.params = { ...res.params, ...params };
@@ -408,13 +393,8 @@ function createCreateAndParams({
     return { create: creates.join("\n"), params, authorizationPredicates, authorizationSubqueries };
 }
 
-function makeAuthorizationParamsPrefix(authorizationPrefix: {
-    inputIndex: number;
-    reducerIndex: number;
-    createIndex: number;
-    refNodeIndex: number;
-}): string {
-    return `${authorizationPrefix.inputIndex}_${authorizationPrefix.reducerIndex}_${authorizationPrefix.refNodeIndex}_${authorizationPrefix.createIndex}_`;
+function makeAuthorizationParamsPrefix(authorizationPrefix: number[]): string {
+    return `${authorizationPrefix.join("_")}_`;
 }
 
 export default createCreateAndParams;

--- a/packages/graphql/tests/integration/issues/4429.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4429.int.test.ts
@@ -1,0 +1,247 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver } from "neo4j-driver";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { graphql } from "graphql";
+import { UniqueType } from "../../utils/graphql-types";
+import gql from "graphql-tag";
+
+describe("https://github.com/neo4j/graphql/issues/4429", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+
+    const User = new UniqueType("User");
+    const Tenant = new UniqueType("Tenant");
+    const Settings = new UniqueType("Settings");
+    const OpeningDay = new UniqueType("OpeningDay");
+    const OpeningHoursInterval = new UniqueType("OpeningHoursInterval");
+    const MyWorkspace = new UniqueType("MyWorkspace");
+
+    const typeDefs = gql`
+        type JWT @jwt {
+            id: String
+            roles: [String]
+        }
+        type ${User.name} @authorization(validate: [{ where: { node: { userId: "$jwt.id" } }, operations: [READ] }]) {
+            userId: String! @unique
+            adminAccess: [${Tenant.name}!]! @relationship(type: "ADMIN_IN", direction: OUT)
+        }
+
+        type ${Tenant.name} @authorization(validate: [{ where: { node: { admins: { userId: "$jwt.id" } } } }]) {
+            id: ID! @id
+            settings: ${Settings.name}! @relationship(type: "VEHICLECARD_OWNER", direction: IN)
+            admins: [${User.name}!]! @relationship(type: "ADMIN_IN", direction: IN)
+        }
+
+        type ${Settings.name} @authorization(validate: [{ where: { node: { tenant: { admins: { userId: "$jwt.id" } } } } }]) {
+            id: ID! @id
+            openingDays: [${OpeningDay.name}!]!  @relationship(type: "VALID_GARAGES", direction: OUT)
+            myWorkspace: ${MyWorkspace.name}! @relationship(type: "HAS_WORKSPACE_SETTINGS", direction: OUT)
+            tenant: ${Tenant.name}! @relationship(type: "VEHICLECARD_OWNER", direction: OUT)
+        }
+
+        type ${OpeningDay.name}
+            @authorization(
+                validate: [{ where: { node: { settings: { tenant: { admins: { userId: "$jwt.id" } } } } } }]
+            ) {
+            id: ID! @id
+            settings: ${Settings.name} @relationship(type: "VALID_GARAGES", direction: IN)
+            open: [${OpeningHoursInterval.name}!]! @relationship(type: "HAS_OPEN_INTERVALS", direction: OUT)
+        }
+
+        type ${OpeningHoursInterval.name}
+            @authorization(
+                validate: [
+                    { where: { node: { openingDay: { settings: { tenant: { admins: { userId: "$jwt.id" } } } } } } }
+                ]
+            ) {
+            name: String
+            openingDay: ${OpeningDay.name}! @relationship(type: "HAS_OPEN_INTERVALS", direction: IN)
+            createdAt: DateTime! @timestamp(operations: [CREATE])
+            updatedAt: DateTime! @timestamp(operations: [CREATE, UPDATE])
+            updatedBy: String
+                @populatedBy(
+                    callback: "getUserIDFromContext"
+                    operations: [CREATE, UPDATE]
+                )
+        }
+        
+        type ${MyWorkspace.name}
+            @authorization(
+                validate: [
+                    {
+                        where: {
+                            node: {
+                                settings: { tenant: { admins: { userId: "$jwt.id" } } }
+                            }
+                        }
+                    }
+                ]
+            ) {
+            settings: ${Settings.name}!
+                @relationship(type: "HAS_WORKSPACE_SETTINGS", direction: IN)
+            workspace: String
+            updatedBy: String
+                @populatedBy(
+                    callback: "getUserIDFromContext"
+                    operations: [CREATE, UPDATE]
+                )
+        }
+    `;
+
+    const ADD_TENANT = `
+        mutation addTenant($input: [${Tenant.name}CreateInput!]!) {
+            ${Tenant.operations.create}(input: $input) {
+                ${Tenant.plural} {
+                    id
+                    admins {
+                        userId
+                    }
+                    settings {
+                        openingDays {
+                            open {
+                                name
+                            }
+                        }
+                        myWorkspace {
+                            workspace
+                        }
+                    }
+                }
+            }
+        }
+    `;
+
+    let tenantVariables: Record<string, any>;
+    let myUserId: string;
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+    });
+
+    beforeEach(() => {
+        myUserId = Math.random().toString(36).slice(2, 7);
+        tenantVariables = {
+            input: {
+                settings: {
+                    create: {
+                        node: {
+                            openingDays: {
+                                create: [
+                                    {
+                                        node: {
+                                            open: {
+                                                create: [
+                                                    {
+                                                        node: {
+                                                            name: "hi",
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    },
+                                    {
+                                        node: {
+                                            open: {
+                                                create: [
+                                                    {
+                                                        node: {
+                                                            name: "hi",
+                                                        },
+                                                    },
+                                                    {
+                                                        node: {
+                                                            name: "hi",
+                                                        },
+                                                    },
+                                                ],
+                                            },
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+    });
+
+    afterEach(async () => {
+        const session = driver.session();
+        await session.run(` match (n) detach delete n`);
+        await session.close();
+    });
+
+    afterAll(async () => {
+        await driver.close();
+    });
+    test("create tenant with nested openingDays and openHoursInterval - subscriptions disabled", async () => {
+        const neo4jGraphql = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        getUserIDFromContext: () => "hi",
+                    },
+                },
+            },
+        });
+        const schema = await neo4jGraphql.getSchema();
+
+        const addTenantResponse = await graphql({
+            schema,
+            source: ADD_TENANT,
+            variableValues: tenantVariables,
+            contextValue: neo4j.getContextValues({ jwt: { id: myUserId } }),
+        });
+
+        expect(addTenantResponse.errors).toBeUndefined();
+    });
+
+    test("create tenant with nested openingDays and openHoursInterval - subscriptions enabled", async () => {
+        const neo4jGraphql = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            features: {
+                subscriptions: true,
+                populatedBy: {
+                    callbacks: {
+                        getUserIDFromContext: () => "hi",
+                    },
+                },
+            },
+        });
+        const schema = await neo4jGraphql.getSchema();
+
+        const addTenantResponse = await graphql({
+            schema,
+            source: ADD_TENANT,
+            variableValues: tenantVariables,
+            contextValue: neo4j.getContextValues({ jwt: { id: myUserId } }),
+        });
+
+        expect(addTenantResponse.errors).toBeUndefined();
+    });
+});

--- a/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/bind/interface-relationships/implementation-bind.test.ts
@@ -139,10 +139,10 @@ describe("Cypher Auth Allow", () => {
             	RETURN c AS this0_contentPost0_node_creator_User_unique_ignored
             }
             WITH *
-            OPTIONAL MATCH (this0_contentPost0_node)<-[:HAS_CONTENT]-(authorization_1_2_1_0_after_this0:User)
-            WITH *, count(authorization_1_2_1_0_after_this0) AS creatorCount
+            OPTIONAL MATCH (this0_contentPost0_node)<-[:HAS_CONTENT]-(authorization_0_2_0_1_after_this0:User)
+            WITH *, count(authorization_0_2_0_1_after_this0) AS creatorCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_1_2_1_0_after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0_contentPost0_node_creator0_node.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_2_0_1_after_this0.id = $jwt.sub))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {

--- a/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/roles-where.test.ts
@@ -832,7 +832,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_0_0_0_before_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_0_0_before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_before_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -845,11 +845,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_0_0_0_after_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_after_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -871,12 +871,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"authorization_0_0_0_0_before_param2\\": \\"user\\",
-                \\"authorization_0_0_0_0_before_param3\\": \\"admin\\",
-                \\"authorization_0_0_0_0_after_param2\\": \\"user\\",
-                \\"authorization_0_0_0_0_after_param3\\": \\"admin\\",
-                \\"authorization_0_0_0_0_after_param4\\": \\"user\\",
-                \\"authorization_0_0_0_0_after_param5\\": \\"admin\\",
+                \\"authorization_0_before_param2\\": \\"user\\",
+                \\"authorization_0_before_param3\\": \\"admin\\",
+                \\"authorization_0_after_param2\\": \\"user\\",
+                \\"authorization_0_after_param3\\": \\"admin\\",
+                \\"authorization_0_after_param4\\": \\"user\\",
+                \\"authorization_0_after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);
@@ -917,7 +917,7 @@ describe("Cypher Auth Where with Roles", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_0_0_0_before_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_0_0_before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_before_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_before_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_before_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_before_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -930,11 +930,11 @@ describe("Cypher Auth Where with Roles", () => {
             	}
             WITH this0, this0_posts_connect0_node
             WITH this0, this0_posts_connect0_node
-            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_0_0_0_after_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND single(authorization_0_after_this0 IN [(this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_after_this0:User) WHERE ($jwt.sub IS NOT NULL AND authorization_0_after_this0.id = $jwt.sub) | 1] WHERE true) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param4 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param5 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_posts_connect_Post0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT (($isAuthenticated = true AND ($jwt.sub IS NOT NULL AND this0.id = $jwt.sub) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -957,12 +957,12 @@ describe("Cypher Auth Where with Roles", () => {
                     ],
                     \\"sub\\": \\"id-01\\"
                 },
-                \\"authorization_0_0_0_0_before_param2\\": \\"user\\",
-                \\"authorization_0_0_0_0_before_param3\\": \\"admin\\",
-                \\"authorization_0_0_0_0_after_param2\\": \\"user\\",
-                \\"authorization_0_0_0_0_after_param3\\": \\"admin\\",
-                \\"authorization_0_0_0_0_after_param4\\": \\"user\\",
-                \\"authorization_0_0_0_0_after_param5\\": \\"admin\\",
+                \\"authorization_0_before_param2\\": \\"user\\",
+                \\"authorization_0_before_param3\\": \\"admin\\",
+                \\"authorization_0_after_param2\\": \\"user\\",
+                \\"authorization_0_after_param3\\": \\"admin\\",
+                \\"authorization_0_after_param4\\": \\"user\\",
+                \\"authorization_0_after_param5\\": \\"admin\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
+++ b/packages/graphql/tests/tck/directives/authorization/arguments/where/where.test.ts
@@ -824,10 +824,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_0_0_before_this0:User)
-            WITH *, count(authorization_0_0_0_0_before_this0) AS creatorCount
+            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_before_this0:User)
+            WITH *, count(authorization_0_before_this0) AS creatorCount
             WITH *
-            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_before_this0.id = $jwt.sub)))
+            	WHERE ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_before_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -902,10 +902,10 @@ describe("Cypher Auth Where", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_posts_connect0_node:Post)
-            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_0_0_0_before_this0:User)
-            WITH *, count(authorization_0_0_0_0_before_this0) AS creatorCount
+            OPTIONAL MATCH (this0_posts_connect0_node)<-[:HAS_POST]-(authorization_0_before_this0:User)
+            WITH *, count(authorization_0_before_this0) AS creatorCount
             WITH *
-            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_before_this0.id = $jwt.sub)))
+            	WHERE this0_posts_connect0_node.id = $this0_posts_connect0_node_param0 AND ($isAuthenticated = true AND (creatorCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_before_this0.id = $jwt.sub)))
             	CALL {
             		WITH *
             		WITH collect(this0_posts_connect0_node) as connectedNodes, collect(this0) as parentNodes

--- a/packages/graphql/tests/tck/issues/3901.test.ts
+++ b/packages/graphql/tests/tck/issues/3901.test.ts
@@ -167,17 +167,17 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
             WITH *
             CALL {
                 WITH this0_seasons0_node
-                MATCH (this0_seasons0_node)-[:SEASON_OF]->(authorization_1_1_0_0_after_this1:Serie)
-                OPTIONAL MATCH (authorization_1_1_0_0_after_this1)<-[:PUBLISHER]-(authorization_1_1_0_0_after_this2:User)
-                WITH *, count(authorization_1_1_0_0_after_this2) AS publisherCount
+                MATCH (this0_seasons0_node)-[:SEASON_OF]->(authorization_0_1_0_0_after_this1:Serie)
+                OPTIONAL MATCH (authorization_0_1_0_0_after_this1)<-[:PUBLISHER]-(authorization_0_1_0_0_after_this2:User)
+                WITH *, count(authorization_0_1_0_0_after_this2) AS publisherCount
                 WITH *
-                WHERE (publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_1_1_0_0_after_this2.id = $jwt.sub))
-                RETURN count(authorization_1_1_0_0_after_this1) = 1 AS authorization_1_1_0_0_after_var0
+                WHERE (publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_1_0_0_after_this2.id = $jwt.sub))
+                RETURN count(authorization_0_1_0_0_after_this1) = 1 AS authorization_0_1_0_0_after_var0
             }
-            OPTIONAL MATCH (this0)<-[:PUBLISHER]-(authorization_0_0_0_0_after_this0:User)
-            WITH *, count(authorization_0_0_0_0_after_this0) AS publisherCount
+            OPTIONAL MATCH (this0)<-[:PUBLISHER]-(authorization_0_after_this0:User)
+            WITH *, count(authorization_0_after_this0) AS publisherCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (authorization_1_1_0_0_after_var0 = true AND ($jwt.roles IS NOT NULL AND $authorization_1_1_0_0_after_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_1_1_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_0_0_0_after_this0.id = $jwt.sub)) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (authorization_0_1_0_0_after_var0 = true AND ($jwt.roles IS NOT NULL AND $authorization_0_1_0_0_after_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_1_0_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ((publisherCount <> 0 AND ($jwt.sub IS NOT NULL AND authorization_0_after_this0.id = $jwt.sub)) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles) AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -199,11 +199,11 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
                     \\"roles\\": [],
                     \\"sub\\": \\"michel\\"
                 },
-                \\"authorization_1_1_0_0_after_param2\\": \\"verified\\",
-                \\"authorization_1_1_0_0_after_param3\\": \\"creator\\",
+                \\"authorization_0_1_0_0_after_param2\\": \\"verified\\",
+                \\"authorization_0_1_0_0_after_param3\\": \\"creator\\",
                 \\"this0_publisher_connect0_node_param0\\": \\"ID\\",
-                \\"authorization_0_0_0_0_after_param2\\": \\"verified\\",
-                \\"authorization_0_0_0_0_after_param3\\": \\"creator\\",
+                \\"authorization_0_after_param2\\": \\"verified\\",
+                \\"authorization_0_after_param3\\": \\"creator\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/issues/4118.test.ts
+++ b/packages/graphql/tests/tck/issues/4118.test.ts
@@ -131,7 +131,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_host_connect0_node:Tenant)
-            	WHERE this0_host_connect0_node.id = $this0_host_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_0_0_0_0_before_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_before_this0.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this0_host_connect0_node.id = $this0_host_connect0_node_param0 AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_0_before_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_before_this0.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_before_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_host_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -144,10 +144,10 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	}
             WITH this0, this0_host_connect0_node
             WITH *
-            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_0_0_after_this1:Tenant)
-            WITH *, count(authorization_0_0_0_0_after_this1) AS hostCount
+            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_after_this1:Tenant)
+            WITH *, count(authorization_0_after_this1) AS hostCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this2:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this2.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_after_this1)<-[:ADMIN_IN]-(authorization_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT (($isAuthenticated = true AND size([(this0_host_connect0_node)<-[:ADMIN_IN]-(authorization_0_after_this2:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this2.userId = $jwt.id) | 1]) > 0) OR ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_host_connect_Tenant0
             }
             WITH *
@@ -156,15 +156,15 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	OPTIONAL MATCH (this0_openingDays_connect0_node:OpeningDay)
             CALL {
                 WITH this0_openingDays_connect0_node
-                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_0_0_0_0_before_this1:Settings)
-                OPTIONAL MATCH (authorization_0_0_0_0_before_this1)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_before_this2:Tenant)
-                WITH *, count(authorization_0_0_0_0_before_this2) AS tenantCount
+                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_0_before_this1:Settings)
+                OPTIONAL MATCH (authorization_0_before_this1)<-[:HAS_SETTINGS]-(authorization_0_before_this2:Tenant)
+                WITH *, count(authorization_0_before_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_before_this2)<-[:ADMIN_IN]-(authorization_0_0_0_0_before_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_before_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_0_0_0_0_before_this1) = 1 AS authorization_0_0_0_0_before_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_before_this2)<-[:ADMIN_IN]-(authorization_0_before_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_before_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_before_this1) = 1 AS authorization_0_before_var0
             }
             WITH *
-            	WHERE this0_openingDays_connect0_node.id = $this0_openingDays_connect0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_before_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            	WHERE this0_openingDays_connect0_node.id = $this0_openingDays_connect0_node_param0 AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_before_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             	CALL {
             		WITH *
             		WITH collect(this0_openingDays_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -177,19 +177,19 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	}
             WITH this0, this0_openingDays_connect0_node
             WITH *
-            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_0_0_after_this1:Tenant)
-            WITH *, count(authorization_0_0_0_0_after_this1) AS hostCount
+            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_after_this1:Tenant)
+            WITH *, count(authorization_0_after_this1) AS hostCount
             CALL {
                 WITH this0_openingDays_connect0_node
-                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_0_0_0_0_after_this3:Settings)
-                OPTIONAL MATCH (authorization_0_0_0_0_after_this3)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_after_this4:Tenant)
-                WITH *, count(authorization_0_0_0_0_after_this4) AS tenantCount
+                MATCH (this0_openingDays_connect0_node)<-[:VALID_OPENING_DAYS]-(authorization_0_after_this3:Settings)
+                OPTIONAL MATCH (authorization_0_after_this3)<-[:HAS_SETTINGS]-(authorization_0_after_this4:Tenant)
+                WITH *, count(authorization_0_after_this4) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_after_this4)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this5:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this5.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_0_0_0_0_after_this3) = 1 AS authorization_0_0_0_0_after_var2
+                WHERE (tenantCount <> 0 AND size([(authorization_0_after_this4)<-[:ADMIN_IN]-(authorization_0_after_this5:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this5.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_after_this3) = 1 AS authorization_0_after_var2
             }
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_after_var2 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_after_this1)<-[:ADMIN_IN]-(authorization_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_after_var2 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_openingDays_connect_OpeningDay0
             }
             WITH *
@@ -201,10 +201,10 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             	RETURN c AS this0_host_Tenant_unique_ignored
             }
             WITH *
-            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_0_0_0_after_this1:Tenant)
-            WITH *, count(authorization_0_0_0_0_after_this1) AS hostCount
+            OPTIONAL MATCH (this0)-[:HOSTED_BY]->(authorization_0_after_this1:Tenant)
+            WITH *, count(authorization_0_after_this1) AS hostCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (hostCount <> 0 AND size([(authorization_0_after_this1)<-[:ADMIN_IN]-(authorization_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -227,8 +227,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
                 \\"jwt\\": {},
                 \\"create_param2\\": \\"overlord\\",
                 \\"this0_host_connect0_node_param0\\": \\"userid\\",
-                \\"authorization_0_0_0_0_before_param2\\": \\"overlord\\",
-                \\"authorization_0_0_0_0_after_param2\\": \\"overlord\\",
+                \\"authorization_0_before_param2\\": \\"overlord\\",
+                \\"authorization_0_after_param2\\": \\"overlord\\",
                 \\"this0_openingDays_connect0_node_param0\\": \\"openingdayid\\",
                 \\"resolvedCallbacks\\": {}
             }"

--- a/packages/graphql/tests/tck/issues/4170.test.ts
+++ b/packages/graphql/tests/tck/issues/4170.test.ts
@@ -182,33 +182,33 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
             WITH *
             CALL {
                 WITH this0_settings0_node_openingDays0_node_open0_node
-                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_0_after_this1:OpeningDay)
+                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this1:OpeningDay)
                 CALL {
-                    WITH authorization_3_0_0_0_after_this1
-                    MATCH (authorization_3_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_0_after_this2:Settings)
-                    OPTIONAL MATCH (authorization_3_0_0_0_after_this2)<-[:HAS_SETTINGS]-(authorization_3_0_0_0_after_this3:Tenant)
-                    WITH *, count(authorization_3_0_0_0_after_this3) AS tenantCount
+                    WITH authorization_0_0_0_0_0_0_0_0_0_0_after_this1
+                    MATCH (authorization_0_0_0_0_0_0_0_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_0_0_0_0_0_0_0_0_0_0_after_this2)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this3:Tenant)
+                    WITH *, count(authorization_0_0_0_0_0_0_0_0_0_0_after_this3) AS tenantCount
                     WITH *
-                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
-                    RETURN count(authorization_3_0_0_0_after_this2) = 1 AS authorization_3_0_0_0_after_var5
+                    WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_0_0_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_0_0_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_0_0_0_0_0_0_0_0_0_0_after_this2) = 1 AS authorization_0_0_0_0_0_0_0_0_0_0_after_var5
                 }
                 WITH *
-                WHERE authorization_3_0_0_0_after_var5 = true
-                RETURN count(authorization_3_0_0_0_after_this1) = 1 AS authorization_3_0_0_0_after_var0
+                WHERE authorization_0_0_0_0_0_0_0_0_0_0_after_var5 = true
+                RETURN count(authorization_0_0_0_0_0_0_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_0_0_0_0_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays0_node
-                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_2_0_0_0_after_this1:Settings)
-                OPTIONAL MATCH (authorization_2_0_0_0_after_this1)<-[:HAS_SETTINGS]-(authorization_2_0_0_0_after_this2:Tenant)
-                WITH *, count(authorization_2_0_0_0_after_this2) AS tenantCount
+                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_0_0_after_this1:Settings)
+                OPTIONAL MATCH (authorization_0_0_0_0_0_0_0_after_this1)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_0_0_0_after_this2:Tenant)
+                WITH *, count(authorization_0_0_0_0_0_0_0_after_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_2_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_2_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_2_0_0_0_after_this1) = 1 AS authorization_2_0_0_0_after_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_0_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_0_0_after_var0
             }
-            OPTIONAL MATCH (this0_settings0_node)<-[:HAS_SETTINGS]-(authorization_1_0_0_0_after_this1:Tenant)
-            WITH *, count(authorization_1_0_0_0_after_this1) AS tenantCount
+            OPTIONAL MATCH (this0_settings0_node)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_after_this1:Tenant)
+            WITH *, count(authorization_0_0_0_0_after_this1) AS tenantCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_1_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_1_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_1_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_0_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_0_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {

--- a/packages/graphql/tests/tck/issues/4214.test.ts
+++ b/packages/graphql/tests/tck/issues/4214.test.ts
@@ -168,12 +168,12 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             CALL {
             	WITH this0
             	OPTIONAL MATCH (this0_transaction_connect0_node:Transaction)
-            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_0_0_0_before_this0:Store)
-            WITH *, count(authorization_0_0_0_0_before_this0) AS storeCount
-            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_0_0_0_before_this1:Store)
-            WITH *, count(authorization_0_0_0_0_before_this1) AS storeCount
+            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_before_this0:Store)
+            WITH *, count(authorization_0_before_this0) AS storeCount
+            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_before_this1:Store)
+            WITH *, count(authorization_0_before_this1) AS storeCount
             WITH *
-            	WHERE this0_transaction_connect0_node.id = $this0_transaction_connect0_node_param0 AND ((($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param3 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param4 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_0_0_before_this0.id = $jwt.store)))) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param5 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_before_param6 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_0_0_before_this1.id = $jwt.store))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            	WHERE this0_transaction_connect0_node.id = $this0_transaction_connect0_node_param0 AND ((($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_before_param2 IN $jwt.roles)) OR ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_before_param3 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_before_param4 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_before_this0.id = $jwt.store)))) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_before_param5 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_before_param6 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_before_this1.id = $jwt.store))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	CALL {
             		WITH *
             		WITH collect(this0_transaction_connect0_node) as connectedNodes, collect(this0) as parentNodes
@@ -188,17 +188,17 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             WITH *
             CALL {
                 WITH this0
-                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_0_0_0_after_this2:Transaction)
-                OPTIONAL MATCH (authorization_0_0_0_0_after_this2)-[:TRANSACTION]->(authorization_0_0_0_0_after_this3:Store)
-                WITH *, count(authorization_0_0_0_0_after_this3) AS storeCount
+                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_after_this2:Transaction)
+                OPTIONAL MATCH (authorization_0_after_this2)-[:TRANSACTION]->(authorization_0_after_this3:Store)
+                WITH *, count(authorization_0_after_this3) AS storeCount
                 WITH *
-                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_0_0_after_this3.id = $jwt.store))
-                RETURN count(authorization_0_0_0_0_after_this2) = 1 AS authorization_0_0_0_0_after_var0
+                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_after_this3.id = $jwt.store))
+                RETURN count(authorization_0_after_this2) = 1 AS authorization_0_after_var0
             }
-            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_0_0_0_after_this1:Store)
-            WITH *, count(authorization_0_0_0_0_after_this1) AS storeCount
+            OPTIONAL MATCH (this0_transaction_connect0_node)-[:TRANSACTION]->(authorization_0_after_this1:Store)
+            WITH *, count(authorization_0_after_this1) AS storeCount
             WITH *
-            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles)) AND authorization_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param4 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param5 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_0_0_after_this1.id = $jwt.store))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
+            WHERE (apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles)) AND authorization_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_after_param4 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_after_param5 IN $jwt.roles)) AND (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_after_this1.id = $jwt.store))), \\"@neo4j/graphql/FORBIDDEN\\", [0]))
             	RETURN count(*) AS connect_this0_transaction_connect_Transaction0
             }
             WITH *
@@ -212,15 +212,15 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             WITH *
             CALL {
                 WITH this0
-                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_0_0_0_after_this1:Transaction)
-                OPTIONAL MATCH (authorization_0_0_0_0_after_this1)-[:TRANSACTION]->(authorization_0_0_0_0_after_this2:Store)
-                WITH *, count(authorization_0_0_0_0_after_this2) AS storeCount
+                MATCH (this0)-[:ITEM_TRANSACTED]->(authorization_0_after_this1:Transaction)
+                OPTIONAL MATCH (authorization_0_after_this1)-[:TRANSACTION]->(authorization_0_after_this2:Store)
+                WITH *, count(authorization_0_after_this2) AS storeCount
                 WITH *
-                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_0_0_0_after_this2.id = $jwt.store))
-                RETURN count(authorization_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_after_var0
+                WHERE (storeCount <> 0 AND ($jwt.store IS NOT NULL AND authorization_0_after_this2.id = $jwt.store))
+                RETURN count(authorization_0_after_this1) = 1 AS authorization_0_after_var0
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param3 IN $jwt.roles)) AND authorization_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles) OR ($jwt.roles IS NOT NULL AND $authorization_0_after_param3 IN $jwt.roles)) AND authorization_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -265,15 +265,15 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
                     \\"high\\": 0
                 },
                 \\"this0_transaction_connect0_node_param0\\": \\"transactionid\\",
-                \\"authorization_0_0_0_0_before_param2\\": \\"admin\\",
-                \\"authorization_0_0_0_0_before_param3\\": \\"store-owner\\",
-                \\"authorization_0_0_0_0_before_param4\\": \\"employee\\",
-                \\"authorization_0_0_0_0_before_param5\\": \\"store-owner\\",
-                \\"authorization_0_0_0_0_before_param6\\": \\"employee\\",
-                \\"authorization_0_0_0_0_after_param2\\": \\"store-owner\\",
-                \\"authorization_0_0_0_0_after_param3\\": \\"employee\\",
-                \\"authorization_0_0_0_0_after_param4\\": \\"store-owner\\",
-                \\"authorization_0_0_0_0_after_param5\\": \\"employee\\",
+                \\"authorization_0_before_param2\\": \\"admin\\",
+                \\"authorization_0_before_param3\\": \\"store-owner\\",
+                \\"authorization_0_before_param4\\": \\"employee\\",
+                \\"authorization_0_before_param5\\": \\"store-owner\\",
+                \\"authorization_0_before_param6\\": \\"employee\\",
+                \\"authorization_0_after_param2\\": \\"store-owner\\",
+                \\"authorization_0_after_param3\\": \\"employee\\",
+                \\"authorization_0_after_param4\\": \\"store-owner\\",
+                \\"authorization_0_after_param5\\": \\"employee\\",
                 \\"resolvedCallbacks\\": {}
             }"
         `);

--- a/packages/graphql/tests/tck/issues/4223.test.ts
+++ b/packages/graphql/tests/tck/issues/4223.test.ts
@@ -219,42 +219,42 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
             WITH *
             CALL {
                 WITH this0_settings0_node_openingDays0_node_open0_node
-                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_0_after_this1:OpeningDay)
+                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this1:OpeningDay)
                 CALL {
-                    WITH authorization_3_0_0_0_after_this1
-                    MATCH (authorization_3_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_0_after_this2:Settings)
-                    OPTIONAL MATCH (authorization_3_0_0_0_after_this2)<-[:HAS_SETTINGS]-(authorization_3_0_0_0_after_this3:Tenant)
-                    WITH *, count(authorization_3_0_0_0_after_this3) AS tenantCount
+                    WITH authorization_0_0_0_0_0_0_0_0_0_0_after_this1
+                    MATCH (authorization_0_0_0_0_0_0_0_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_0_0_0_0_0_0_0_0_0_0_after_this2)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this3:Tenant)
+                    WITH *, count(authorization_0_0_0_0_0_0_0_0_0_0_after_this3) AS tenantCount
                     WITH *
-                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
-                    RETURN count(authorization_3_0_0_0_after_this2) = 1 AS authorization_3_0_0_0_after_var5
+                    WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_0_0_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_0_0_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_0_0_0_0_0_0_0_0_0_0_after_this2) = 1 AS authorization_0_0_0_0_0_0_0_0_0_0_after_var5
                 }
                 WITH *
-                WHERE authorization_3_0_0_0_after_var5 = true
-                RETURN count(authorization_3_0_0_0_after_this1) = 1 AS authorization_3_0_0_0_after_var0
+                WHERE authorization_0_0_0_0_0_0_0_0_0_0_after_var5 = true
+                RETURN count(authorization_0_0_0_0_0_0_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_0_0_0_0_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays0_node
-                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_2_0_0_0_after_this1:Settings)
-                OPTIONAL MATCH (authorization_2_0_0_0_after_this1)<-[:HAS_SETTINGS]-(authorization_2_0_0_0_after_this2:Tenant)
-                WITH *, count(authorization_2_0_0_0_after_this2) AS tenantCount
+                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_0_0_after_this1:Settings)
+                OPTIONAL MATCH (authorization_0_0_0_0_0_0_0_after_this1)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_0_0_0_after_this2:Tenant)
+                WITH *, count(authorization_0_0_0_0_0_0_0_after_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_2_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_2_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_2_0_0_0_after_this1) = 1 AS authorization_2_0_0_0_after_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_0_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_0_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_myWorkspace0_node
-                MATCH (this0_settings0_node_myWorkspace0_node)<-[:HAS_WORKSPACE_SETTINGS]-(authorization_2_1_0_0_after_this1:Settings)
-                OPTIONAL MATCH (authorization_2_1_0_0_after_this1)<-[:HAS_SETTINGS]-(authorization_2_1_0_0_after_this2:Tenant)
-                WITH *, count(authorization_2_1_0_0_after_this2) AS tenantCount
+                MATCH (this0_settings0_node_myWorkspace0_node)<-[:HAS_WORKSPACE_SETTINGS]-(authorization_0_0_0_0_1_0_0_after_this1:Settings)
+                OPTIONAL MATCH (authorization_0_0_0_0_1_0_0_after_this1)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_1_0_0_after_this2:Tenant)
+                WITH *, count(authorization_0_0_0_0_1_0_0_after_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_2_1_0_0_after_this2)<-[:ADMIN_IN]-(authorization_2_1_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_1_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_2_1_0_0_after_this1) = 1 AS authorization_2_1_0_0_after_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_1_0_0_after_this2)<-[:ADMIN_IN]-(authorization_0_0_0_0_1_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_1_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_0_0_1_0_0_after_this1) = 1 AS authorization_0_0_0_0_1_0_0_after_var0
             }
-            OPTIONAL MATCH (this0_settings0_node)<-[:HAS_SETTINGS]-(authorization_1_0_0_0_after_this1:Tenant)
-            WITH *, count(authorization_1_0_0_0_after_this1) AS tenantCount
+            OPTIONAL MATCH (this0_settings0_node)<-[:HAS_SETTINGS]-(authorization_0_0_0_0_after_this1:Tenant)
+            WITH *, count(authorization_0_0_0_0_after_this1) AS tenantCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_1_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_1_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_1_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_1_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_0_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_1_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_0_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {

--- a/packages/graphql/tests/tck/issues/4429.test.ts
+++ b/packages/graphql/tests/tck/issues/4429.test.ts
@@ -1,0 +1,436 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { gql } from "graphql-tag";
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, translateQuery, formatParams } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/4429", () => {
+    let neoSchema: Neo4jGraphQL;
+
+    const typeDefs = gql`
+        type JWT @jwt {
+            id: String
+            roles: [String]
+        }
+        type User @authorization(validate: [{ where: { node: { userId: "$jwt.id" } }, operations: [READ] }]) {
+            userId: String! @unique
+            adminAccess: [Tenant!]! @relationship(type: "ADMIN_IN", direction: OUT)
+        }
+
+        type Tenant @authorization(validate: [{ where: { node: { admins: { userId: "$jwt.id" } } } }]) {
+            id: ID! @id
+            admins: [User!]! @relationship(type: "ADMIN_IN", direction: IN)
+            settings: Settings @relationship(type: "VEHICLECARD_OWNER", direction: IN)
+        }
+
+        type Settings @authorization(validate: [{ where: { node: { tenant: { admins: { userId: "$jwt.id" } } } } }]) {
+            id: ID! @id
+            openingDays: [OpeningDay!]! @relationship(type: "VALID_GARAGES", direction: OUT)
+            myWorkspace: MyWorkspace! @relationship(type: "HAS_WORKSPACE_SETTINGS", direction: OUT)
+            tenant: Tenant! @relationship(type: "VEHICLECARD_OWNER", direction: OUT) # <---  this line
+        }
+
+        type OpeningDay
+            @authorization(
+                validate: [{ where: { node: { settings: { tenant: { admins: { userId: "$jwt.id" } } } } } }]
+            ) {
+            id: ID! @id
+            settings: Settings @relationship(type: "VALID_GARAGES", direction: IN)
+            open: [OpeningHoursInterval!]! @relationship(type: "HAS_OPEN_INTERVALS", direction: OUT)
+        }
+        type OpeningHoursInterval
+            @authorization(
+                validate: [
+                    { where: { node: { openingDay: { settings: { tenant: { admins: { userId: "$jwt.id" } } } } } } }
+                ]
+            ) {
+            name: String
+            openingDay: OpeningDay! @relationship(type: "HAS_OPEN_INTERVALS", direction: IN)
+            createdAt: DateTime! @timestamp(operations: [CREATE])
+            updatedAt: DateTime! @timestamp(operations: [CREATE, UPDATE])
+            updatedBy: String @populatedBy(callback: "getUserIDFromContext", operations: [CREATE, UPDATE])
+        }
+
+        type MyWorkspace
+            @authorization(
+                validate: [{ where: { node: { settings: { tenant: { admins: { userId: "$jwt.id" } } } } } }]
+            ) {
+            settings: Settings! @relationship(type: "HAS_WORKSPACE_SETTINGS", direction: IN)
+            workspace: String
+            updatedBy: String @populatedBy(callback: "getUserIDFromContext", operations: [CREATE, UPDATE])
+        }
+    `;
+
+    beforeAll(() => {
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {
+                populatedBy: {
+                    callbacks: {
+                        getUserIDFromContext: () => "hi",
+                    },
+                },
+            },
+        });
+    });
+
+    test("should include checks for auth jwt param is not null", async () => {
+        const query = gql`
+            mutation addTenant($input: [TenantCreateInput!]!) {
+                createTenants(input: $input) {
+                    tenants {
+                        id
+                        admins {
+                            userId
+                        }
+                        settings {
+                            openingDays {
+                                open {
+                                    name
+                                }
+                            }
+                            myWorkspace {
+                                workspace
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, {
+            variableValues: {
+                input: {
+                    settings: {
+                        create: {
+                            node: {
+                                openingDays: {
+                                    create: [
+                                        {
+                                            node: {
+                                                open: {
+                                                    create: [
+                                                        {
+                                                            node: {
+                                                                name: "hi",
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        },
+                                        {
+                                            node: {
+                                                open: {
+                                                    create: [
+                                                        {
+                                                            node: {
+                                                                name: "hi",
+                                                            },
+                                                        },
+                                                        {
+                                                            node: {
+                                                                name: "hi",
+                                                            },
+                                                        },
+                                                    ],
+                                                },
+                                            },
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+            CREATE (this0:Tenant)
+            SET this0.id = randomUUID()
+            WITH *
+            CREATE (this0_settings0_node:Settings)
+            SET this0_settings0_node.id = randomUUID()
+            WITH *
+            CREATE (this0_settings0_node_openingDays0_node:OpeningDay)
+            SET this0_settings0_node_openingDays0_node.id = randomUUID()
+            WITH *
+            CREATE (this0_settings0_node_openingDays0_node_open0_node:OpeningHoursInterval)
+            SET this0_settings0_node_openingDays0_node_open0_node.createdAt = datetime()
+            SET this0_settings0_node_openingDays0_node_open0_node.updatedAt = datetime()
+            SET this0_settings0_node_openingDays0_node_open0_node.updatedBy = $resolvedCallbacks.this0_settings0_node_openingDays0_node_open0_node_updatedBy_getUserIDFromContext
+            SET this0_settings0_node_openingDays0_node_open0_node.name = $this0_settings0_node_openingDays0_node_open0_node_name
+            MERGE (this0_settings0_node_openingDays0_node)-[:HAS_OPEN_INTERVALS]->(this0_settings0_node_openingDays0_node_open0_node)
+            WITH *
+            CALL {
+            	WITH this0_settings0_node_openingDays0_node_open0_node
+            	MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[this0_settings0_node_openingDays0_node_open0_node_openingDay_OpeningDay_unique:HAS_OPEN_INTERVALS]-(:OpeningDay)
+            	WITH count(this0_settings0_node_openingDays0_node_open0_node_openingDay_OpeningDay_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDOpeningHoursInterval.openingDay required exactly once', [0])
+            	RETURN c AS this0_settings0_node_openingDays0_node_open0_node_openingDay_OpeningDay_unique_ignored
+            }
+            MERGE (this0_settings0_node)-[:VALID_GARAGES]->(this0_settings0_node_openingDays0_node)
+            WITH *
+            CALL {
+            	WITH this0_settings0_node_openingDays0_node
+            	MATCH (this0_settings0_node_openingDays0_node)<-[this0_settings0_node_openingDays0_node_settings_Settings_unique:VALID_GARAGES]-(:Settings)
+            	WITH count(this0_settings0_node_openingDays0_node_settings_Settings_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDOpeningDay.settings must be less than or equal to one', [0])
+            	RETURN c AS this0_settings0_node_openingDays0_node_settings_Settings_unique_ignored
+            }
+            WITH *
+            CREATE (this0_settings0_node_openingDays1_node:OpeningDay)
+            SET this0_settings0_node_openingDays1_node.id = randomUUID()
+            WITH *
+            CREATE (this0_settings0_node_openingDays1_node_open0_node:OpeningHoursInterval)
+            SET this0_settings0_node_openingDays1_node_open0_node.createdAt = datetime()
+            SET this0_settings0_node_openingDays1_node_open0_node.updatedAt = datetime()
+            SET this0_settings0_node_openingDays1_node_open0_node.updatedBy = $resolvedCallbacks.this0_settings0_node_openingDays1_node_open0_node_updatedBy_getUserIDFromContext
+            SET this0_settings0_node_openingDays1_node_open0_node.name = $this0_settings0_node_openingDays1_node_open0_node_name
+            MERGE (this0_settings0_node_openingDays1_node)-[:HAS_OPEN_INTERVALS]->(this0_settings0_node_openingDays1_node_open0_node)
+            WITH *
+            CALL {
+            	WITH this0_settings0_node_openingDays1_node_open0_node
+            	MATCH (this0_settings0_node_openingDays1_node_open0_node)<-[this0_settings0_node_openingDays1_node_open0_node_openingDay_OpeningDay_unique:HAS_OPEN_INTERVALS]-(:OpeningDay)
+            	WITH count(this0_settings0_node_openingDays1_node_open0_node_openingDay_OpeningDay_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDOpeningHoursInterval.openingDay required exactly once', [0])
+            	RETURN c AS this0_settings0_node_openingDays1_node_open0_node_openingDay_OpeningDay_unique_ignored
+            }
+            WITH *
+            CREATE (this0_settings0_node_openingDays1_node_open1_node:OpeningHoursInterval)
+            SET this0_settings0_node_openingDays1_node_open1_node.createdAt = datetime()
+            SET this0_settings0_node_openingDays1_node_open1_node.updatedAt = datetime()
+            SET this0_settings0_node_openingDays1_node_open1_node.updatedBy = $resolvedCallbacks.this0_settings0_node_openingDays1_node_open1_node_updatedBy_getUserIDFromContext
+            SET this0_settings0_node_openingDays1_node_open1_node.name = $this0_settings0_node_openingDays1_node_open1_node_name
+            MERGE (this0_settings0_node_openingDays1_node)-[:HAS_OPEN_INTERVALS]->(this0_settings0_node_openingDays1_node_open1_node)
+            WITH *
+            CALL {
+            	WITH this0_settings0_node_openingDays1_node_open1_node
+            	MATCH (this0_settings0_node_openingDays1_node_open1_node)<-[this0_settings0_node_openingDays1_node_open1_node_openingDay_OpeningDay_unique:HAS_OPEN_INTERVALS]-(:OpeningDay)
+            	WITH count(this0_settings0_node_openingDays1_node_open1_node_openingDay_OpeningDay_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDOpeningHoursInterval.openingDay required exactly once', [0])
+            	RETURN c AS this0_settings0_node_openingDays1_node_open1_node_openingDay_OpeningDay_unique_ignored
+            }
+            MERGE (this0_settings0_node)-[:VALID_GARAGES]->(this0_settings0_node_openingDays1_node)
+            WITH *
+            CALL {
+            	WITH this0_settings0_node_openingDays1_node
+            	MATCH (this0_settings0_node_openingDays1_node)<-[this0_settings0_node_openingDays1_node_settings_Settings_unique:VALID_GARAGES]-(:Settings)
+            	WITH count(this0_settings0_node_openingDays1_node_settings_Settings_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDOpeningDay.settings must be less than or equal to one', [0])
+            	RETURN c AS this0_settings0_node_openingDays1_node_settings_Settings_unique_ignored
+            }
+            MERGE (this0)<-[:VEHICLECARD_OWNER]-(this0_settings0_node)
+            WITH *
+            CALL {
+            	WITH this0_settings0_node
+            	MATCH (this0_settings0_node)-[this0_settings0_node_myWorkspace_MyWorkspace_unique:HAS_WORKSPACE_SETTINGS]->(:MyWorkspace)
+            	WITH count(this0_settings0_node_myWorkspace_MyWorkspace_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDSettings.myWorkspace required exactly once', [0])
+            	RETURN c AS this0_settings0_node_myWorkspace_MyWorkspace_unique_ignored
+            }
+            CALL {
+            	WITH this0_settings0_node
+            	MATCH (this0_settings0_node)-[this0_settings0_node_tenant_Tenant_unique:VEHICLECARD_OWNER]->(:Tenant)
+            	WITH count(this0_settings0_node_tenant_Tenant_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDSettings.tenant required exactly once', [0])
+            	RETURN c AS this0_settings0_node_tenant_Tenant_unique_ignored
+            }
+            WITH *
+            CALL {
+            	WITH this0
+            	MATCH (this0)<-[this0_settings_Settings_unique:VEHICLECARD_OWNER]-(:Settings)
+            	WITH count(this0_settings_Settings_unique) as c
+            	WHERE apoc.util.validatePredicate(NOT (c <= 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDTenant.settings must be less than or equal to one', [0])
+            	RETURN c AS this0_settings_Settings_unique_ignored
+            }
+            WITH *
+            CALL {
+                WITH this0_settings0_node_openingDays0_node_open0_node
+                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_0_after_this1:OpeningDay)
+                CALL {
+                    WITH authorization_3_0_0_0_after_this1
+                    MATCH (authorization_3_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_3_0_0_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_3_0_0_0_after_this3:Tenant)
+                    WITH *, count(authorization_3_0_0_0_after_this3) AS tenantCount
+                    WITH *
+                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_3_0_0_0_after_this2) = 1 AS authorization_3_0_0_0_after_var5
+                }
+                WITH *
+                WHERE authorization_3_0_0_0_after_var5 = true
+                RETURN count(authorization_3_0_0_0_after_this1) = 1 AS authorization_3_0_0_0_after_var0
+            }
+            CALL {
+                WITH this0_settings0_node_openingDays0_node
+                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_2_0_0_0_after_this1:Settings)
+                OPTIONAL MATCH (authorization_2_0_0_0_after_this1)-[:VEHICLECARD_OWNER]->(authorization_2_0_0_0_after_this2:Tenant)
+                WITH *, count(authorization_2_0_0_0_after_this2) AS tenantCount
+                WITH *
+                WHERE (tenantCount <> 0 AND size([(authorization_2_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_2_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_2_0_0_0_after_this1) = 1 AS authorization_2_0_0_0_after_var0
+            }
+            CALL {
+                WITH this0_settings0_node_openingDays1_node_open0_node
+                MATCH (this0_settings0_node_openingDays1_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_0_after_this1:OpeningDay)
+                CALL {
+                    WITH authorization_3_0_0_0_after_this1
+                    MATCH (authorization_3_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_3_0_0_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_3_0_0_0_after_this3:Tenant)
+                    WITH *, count(authorization_3_0_0_0_after_this3) AS tenantCount
+                    WITH *
+                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_3_0_0_0_after_this2) = 1 AS authorization_3_0_0_0_after_var5
+                }
+                WITH *
+                WHERE authorization_3_0_0_0_after_var5 = true
+                RETURN count(authorization_3_0_0_0_after_this1) = 1 AS authorization_3_0_0_0_after_var0
+            }
+            CALL {
+                WITH this0_settings0_node_openingDays1_node_open1_node
+                MATCH (this0_settings0_node_openingDays1_node_open1_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_1_after_this1:OpeningDay)
+                CALL {
+                    WITH authorization_3_0_0_1_after_this1
+                    MATCH (authorization_3_0_0_1_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_1_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_3_0_0_1_after_this2)-[:VEHICLECARD_OWNER]->(authorization_3_0_0_1_after_this3:Tenant)
+                    WITH *, count(authorization_3_0_0_1_after_this3) AS tenantCount
+                    WITH *
+                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_1_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_1_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_1_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_3_0_0_1_after_this2) = 1 AS authorization_3_0_0_1_after_var5
+                }
+                WITH *
+                WHERE authorization_3_0_0_1_after_var5 = true
+                RETURN count(authorization_3_0_0_1_after_this1) = 1 AS authorization_3_0_0_1_after_var0
+            }
+            CALL {
+                WITH this0_settings0_node_openingDays1_node
+                MATCH (this0_settings0_node_openingDays1_node)<-[:VALID_GARAGES]-(authorization_2_0_0_1_after_this1:Settings)
+                OPTIONAL MATCH (authorization_2_0_0_1_after_this1)-[:VEHICLECARD_OWNER]->(authorization_2_0_0_1_after_this2:Tenant)
+                WITH *, count(authorization_2_0_0_1_after_this2) AS tenantCount
+                WITH *
+                WHERE (tenantCount <> 0 AND size([(authorization_2_0_0_1_after_this2)<-[:ADMIN_IN]-(authorization_2_0_0_1_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_0_0_1_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_2_0_0_1_after_this1) = 1 AS authorization_2_0_0_1_after_var0
+            }
+            OPTIONAL MATCH (this0_settings0_node)-[:VEHICLECARD_OWNER]->(authorization_1_0_0_0_after_this1:Tenant)
+            WITH *, count(authorization_1_0_0_0_after_this1) AS tenantCount
+            WITH *
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_1_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_0_0_1_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_1_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_1_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_1_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            RETURN this0
+            }
+            CALL {
+                WITH this0
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[create_this0:ADMIN_IN]-(create_this1:User)
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.id IS NOT NULL AND create_this1.userId = $jwt.id)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    WITH create_this1 { .userId } AS create_this1
+                    RETURN collect(create_this1) AS create_var2
+                }
+                CALL {
+                    WITH this0
+                    MATCH (this0)<-[create_this3:VEHICLECARD_OWNER]-(create_this4:Settings)
+                    OPTIONAL MATCH (create_this4)-[:VEHICLECARD_OWNER]->(create_this5:Tenant)
+                    WITH *, count(create_this5) AS tenantCount
+                    WITH *
+                    WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(create_this5)<-[:ADMIN_IN]-(create_this6:User) WHERE ($jwt.id IS NOT NULL AND create_this6.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                    CALL {
+                        WITH create_this4
+                        MATCH (create_this4)-[create_this7:VALID_GARAGES]->(create_this8:OpeningDay)
+                        CALL {
+                            WITH create_this8
+                            MATCH (create_this8)<-[:VALID_GARAGES]-(create_this9:Settings)
+                            OPTIONAL MATCH (create_this9)-[:VEHICLECARD_OWNER]->(create_this10:Tenant)
+                            WITH *, count(create_this10) AS tenantCount
+                            WITH *
+                            WHERE (tenantCount <> 0 AND size([(create_this10)<-[:ADMIN_IN]-(create_this11:User) WHERE ($jwt.id IS NOT NULL AND create_this11.userId = $jwt.id) | 1]) > 0)
+                            RETURN count(create_this9) = 1 AS create_var12
+                        }
+                        WITH *
+                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_var12 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        CALL {
+                            WITH create_this8
+                            MATCH (create_this8)-[create_this13:HAS_OPEN_INTERVALS]->(create_this14:OpeningHoursInterval)
+                            CALL {
+                                WITH create_this14
+                                MATCH (create_this14)<-[:HAS_OPEN_INTERVALS]-(create_this15:OpeningDay)
+                                CALL {
+                                    WITH create_this15
+                                    MATCH (create_this15)<-[:VALID_GARAGES]-(create_this16:Settings)
+                                    OPTIONAL MATCH (create_this16)-[:VEHICLECARD_OWNER]->(create_this17:Tenant)
+                                    WITH *, count(create_this17) AS tenantCount
+                                    WITH *
+                                    WHERE (tenantCount <> 0 AND size([(create_this17)<-[:ADMIN_IN]-(create_this18:User) WHERE ($jwt.id IS NOT NULL AND create_this18.userId = $jwt.id) | 1]) > 0)
+                                    RETURN count(create_this16) = 1 AS create_var19
+                                }
+                                WITH *
+                                WHERE create_var19 = true
+                                RETURN count(create_this15) = 1 AS create_var20
+                            }
+                            WITH *
+                            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_var20 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                            WITH create_this14 { .name } AS create_this14
+                            RETURN collect(create_this14) AS create_var21
+                        }
+                        WITH create_this8 { open: create_var21 } AS create_this8
+                        RETURN collect(create_this8) AS create_var22
+                    }
+                    CALL {
+                        WITH create_this4
+                        MATCH (create_this4)-[create_this23:HAS_WORKSPACE_SETTINGS]->(create_this24:MyWorkspace)
+                        CALL {
+                            WITH create_this24
+                            MATCH (create_this24)<-[:HAS_WORKSPACE_SETTINGS]-(create_this25:Settings)
+                            OPTIONAL MATCH (create_this25)-[:VEHICLECARD_OWNER]->(create_this26:Tenant)
+                            WITH *, count(create_this26) AS tenantCount
+                            WITH *
+                            WHERE (tenantCount <> 0 AND size([(create_this26)<-[:ADMIN_IN]-(create_this27:User) WHERE ($jwt.id IS NOT NULL AND create_this27.userId = $jwt.id) | 1]) > 0)
+                            RETURN count(create_this25) = 1 AS create_var28
+                        }
+                        WITH *
+                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_var28 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+                        WITH create_this24 { .workspace } AS create_this24
+                        RETURN head(collect(create_this24)) AS create_var29
+                    }
+                    WITH create_this4 { openingDays: create_var22, myWorkspace: create_var29 } AS create_this4
+                    RETURN head(collect(create_this4)) AS create_var30
+                }
+                RETURN this0 { .id, admins: create_var2, settings: create_var30 } AS create_var31
+            }
+            RETURN [create_var31] AS data"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`
+            "{
+                \\"isAuthenticated\\": false,
+                \\"jwt\\": {},
+                \\"this0_settings0_node_openingDays0_node_open0_node_name\\": \\"hi\\",
+                \\"this0_settings0_node_openingDays1_node_open0_node_name\\": \\"hi\\",
+                \\"this0_settings0_node_openingDays1_node_open1_node_name\\": \\"hi\\",
+                \\"resolvedCallbacks\\": {
+                    \\"this0_settings0_node_openingDays0_node_open0_node_updatedBy_getUserIDFromContext\\": \\"hi\\",
+                    \\"this0_settings0_node_openingDays1_node_open0_node_updatedBy_getUserIDFromContext\\": \\"hi\\",
+                    \\"this0_settings0_node_openingDays1_node_open1_node_updatedBy_getUserIDFromContext\\": \\"hi\\"
+                }
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/tck/issues/4429.test.ts
+++ b/packages/graphql/tests/tck/issues/4429.test.ts
@@ -43,7 +43,6 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
         type Settings @authorization(validate: [{ where: { node: { tenant: { admins: { userId: "$jwt.id" } } } } }]) {
             id: ID! @id
             openingDays: [OpeningDay!]! @relationship(type: "VALID_GARAGES", direction: OUT)
-            myWorkspace: MyWorkspace! @relationship(type: "HAS_WORKSPACE_SETTINGS", direction: OUT)
             tenant: Tenant! @relationship(type: "VEHICLECARD_OWNER", direction: OUT) # <---  this line
         }
 
@@ -65,15 +64,6 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
             openingDay: OpeningDay! @relationship(type: "HAS_OPEN_INTERVALS", direction: IN)
             createdAt: DateTime! @timestamp(operations: [CREATE])
             updatedAt: DateTime! @timestamp(operations: [CREATE, UPDATE])
-            updatedBy: String @populatedBy(callback: "getUserIDFromContext", operations: [CREATE, UPDATE])
-        }
-
-        type MyWorkspace
-            @authorization(
-                validate: [{ where: { node: { settings: { tenant: { admins: { userId: "$jwt.id" } } } } } }]
-            ) {
-            settings: Settings! @relationship(type: "HAS_WORKSPACE_SETTINGS", direction: IN)
-            workspace: String
             updatedBy: String @populatedBy(callback: "getUserIDFromContext", operations: [CREATE, UPDATE])
         }
     `;
@@ -105,9 +95,6 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
                                 open {
                                     name
                                 }
-                            }
-                            myWorkspace {
-                                workspace
                             }
                         }
                     }
@@ -243,13 +230,6 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
             WITH *
             CALL {
             	WITH this0_settings0_node
-            	MATCH (this0_settings0_node)-[this0_settings0_node_myWorkspace_MyWorkspace_unique:HAS_WORKSPACE_SETTINGS]->(:MyWorkspace)
-            	WITH count(this0_settings0_node_myWorkspace_MyWorkspace_unique) as c
-            	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDSettings.myWorkspace required exactly once', [0])
-            	RETURN c AS this0_settings0_node_myWorkspace_MyWorkspace_unique_ignored
-            }
-            CALL {
-            	WITH this0_settings0_node
             	MATCH (this0_settings0_node)-[this0_settings0_node_tenant_Tenant_unique:VEHICLECARD_OWNER]->(:Tenant)
             	WITH count(this0_settings0_node_tenant_Tenant_unique) as c
             	WHERE apoc.util.validatePredicate(NOT (c = 1), '@neo4j/graphql/RELATIONSHIP-REQUIREDSettings.tenant required exactly once', [0])
@@ -266,74 +246,74 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
             WITH *
             CALL {
                 WITH this0_settings0_node_openingDays0_node_open0_node
-                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_0_after_this1:OpeningDay)
+                MATCH (this0_settings0_node_openingDays0_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this1:OpeningDay)
                 CALL {
-                    WITH authorization_3_0_0_0_after_this1
-                    MATCH (authorization_3_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_0_after_this2:Settings)
-                    OPTIONAL MATCH (authorization_3_0_0_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_3_0_0_0_after_this3:Tenant)
-                    WITH *, count(authorization_3_0_0_0_after_this3) AS tenantCount
+                    WITH authorization_0_0_0_0_0_0_0_0_0_0_after_this1
+                    MATCH (authorization_0_0_0_0_0_0_0_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_0_0_0_0_0_0_0_0_0_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_0_0_0_0_0_0_0_0_0_0_after_this3:Tenant)
+                    WITH *, count(authorization_0_0_0_0_0_0_0_0_0_0_after_this3) AS tenantCount
                     WITH *
-                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
-                    RETURN count(authorization_3_0_0_0_after_this2) = 1 AS authorization_3_0_0_0_after_var5
+                    WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_0_0_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_0_0_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_0_0_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_0_0_0_0_0_0_0_0_0_0_after_this2) = 1 AS authorization_0_0_0_0_0_0_0_0_0_0_after_var5
                 }
                 WITH *
-                WHERE authorization_3_0_0_0_after_var5 = true
-                RETURN count(authorization_3_0_0_0_after_this1) = 1 AS authorization_3_0_0_0_after_var0
+                WHERE authorization_0_0_0_0_0_0_0_0_0_0_after_var5 = true
+                RETURN count(authorization_0_0_0_0_0_0_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_0_0_0_0_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays0_node
-                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_2_0_0_0_after_this1:Settings)
-                OPTIONAL MATCH (authorization_2_0_0_0_after_this1)-[:VEHICLECARD_OWNER]->(authorization_2_0_0_0_after_this2:Tenant)
-                WITH *, count(authorization_2_0_0_0_after_this2) AS tenantCount
+                MATCH (this0_settings0_node_openingDays0_node)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_0_0_after_this1:Settings)
+                OPTIONAL MATCH (authorization_0_0_0_0_0_0_0_after_this1)-[:VEHICLECARD_OWNER]->(authorization_0_0_0_0_0_0_0_after_this2:Tenant)
+                WITH *, count(authorization_0_0_0_0_0_0_0_after_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_2_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_2_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_2_0_0_0_after_this1) = 1 AS authorization_2_0_0_0_after_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_0_0_after_this2)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_0_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_0_0_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_0_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_0_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays1_node_open0_node
-                MATCH (this0_settings0_node_openingDays1_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_0_after_this1:OpeningDay)
+                MATCH (this0_settings0_node_openingDays1_node_open0_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_0_0_0_0_1_0_0_0_0_after_this1:OpeningDay)
                 CALL {
-                    WITH authorization_3_0_0_0_after_this1
-                    MATCH (authorization_3_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_0_after_this2:Settings)
-                    OPTIONAL MATCH (authorization_3_0_0_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_3_0_0_0_after_this3:Tenant)
-                    WITH *, count(authorization_3_0_0_0_after_this3) AS tenantCount
+                    WITH authorization_0_0_0_0_0_1_0_0_0_0_after_this1
+                    MATCH (authorization_0_0_0_0_0_1_0_0_0_0_after_this1)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_1_0_0_0_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_0_0_0_0_0_1_0_0_0_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_0_0_0_0_0_1_0_0_0_0_after_this3:Tenant)
+                    WITH *, count(authorization_0_0_0_0_0_1_0_0_0_0_after_this3) AS tenantCount
                     WITH *
-                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
-                    RETURN count(authorization_3_0_0_0_after_this2) = 1 AS authorization_3_0_0_0_after_var5
+                    WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_1_0_0_0_0_after_this3)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_1_0_0_0_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_1_0_0_0_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_0_0_0_0_0_1_0_0_0_0_after_this2) = 1 AS authorization_0_0_0_0_0_1_0_0_0_0_after_var5
                 }
                 WITH *
-                WHERE authorization_3_0_0_0_after_var5 = true
-                RETURN count(authorization_3_0_0_0_after_this1) = 1 AS authorization_3_0_0_0_after_var0
+                WHERE authorization_0_0_0_0_0_1_0_0_0_0_after_var5 = true
+                RETURN count(authorization_0_0_0_0_0_1_0_0_0_0_after_this1) = 1 AS authorization_0_0_0_0_0_1_0_0_0_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays1_node_open1_node
-                MATCH (this0_settings0_node_openingDays1_node_open1_node)<-[:HAS_OPEN_INTERVALS]-(authorization_3_0_0_1_after_this1:OpeningDay)
+                MATCH (this0_settings0_node_openingDays1_node_open1_node)<-[:HAS_OPEN_INTERVALS]-(authorization_0_0_0_0_0_1_0_0_1_0_after_this1:OpeningDay)
                 CALL {
-                    WITH authorization_3_0_0_1_after_this1
-                    MATCH (authorization_3_0_0_1_after_this1)<-[:VALID_GARAGES]-(authorization_3_0_0_1_after_this2:Settings)
-                    OPTIONAL MATCH (authorization_3_0_0_1_after_this2)-[:VEHICLECARD_OWNER]->(authorization_3_0_0_1_after_this3:Tenant)
-                    WITH *, count(authorization_3_0_0_1_after_this3) AS tenantCount
+                    WITH authorization_0_0_0_0_0_1_0_0_1_0_after_this1
+                    MATCH (authorization_0_0_0_0_0_1_0_0_1_0_after_this1)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_1_0_0_1_0_after_this2:Settings)
+                    OPTIONAL MATCH (authorization_0_0_0_0_0_1_0_0_1_0_after_this2)-[:VEHICLECARD_OWNER]->(authorization_0_0_0_0_0_1_0_0_1_0_after_this3:Tenant)
+                    WITH *, count(authorization_0_0_0_0_0_1_0_0_1_0_after_this3) AS tenantCount
                     WITH *
-                    WHERE (tenantCount <> 0 AND size([(authorization_3_0_0_1_after_this3)<-[:ADMIN_IN]-(authorization_3_0_0_1_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_3_0_0_1_after_this4.userId = $jwt.id) | 1]) > 0)
-                    RETURN count(authorization_3_0_0_1_after_this2) = 1 AS authorization_3_0_0_1_after_var5
+                    WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_1_0_0_1_0_after_this3)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_1_0_0_1_0_after_this4:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_1_0_0_1_0_after_this4.userId = $jwt.id) | 1]) > 0)
+                    RETURN count(authorization_0_0_0_0_0_1_0_0_1_0_after_this2) = 1 AS authorization_0_0_0_0_0_1_0_0_1_0_after_var5
                 }
                 WITH *
-                WHERE authorization_3_0_0_1_after_var5 = true
-                RETURN count(authorization_3_0_0_1_after_this1) = 1 AS authorization_3_0_0_1_after_var0
+                WHERE authorization_0_0_0_0_0_1_0_0_1_0_after_var5 = true
+                RETURN count(authorization_0_0_0_0_0_1_0_0_1_0_after_this1) = 1 AS authorization_0_0_0_0_0_1_0_0_1_0_after_var0
             }
             CALL {
                 WITH this0_settings0_node_openingDays1_node
-                MATCH (this0_settings0_node_openingDays1_node)<-[:VALID_GARAGES]-(authorization_2_0_0_1_after_this1:Settings)
-                OPTIONAL MATCH (authorization_2_0_0_1_after_this1)-[:VEHICLECARD_OWNER]->(authorization_2_0_0_1_after_this2:Tenant)
-                WITH *, count(authorization_2_0_0_1_after_this2) AS tenantCount
+                MATCH (this0_settings0_node_openingDays1_node)<-[:VALID_GARAGES]-(authorization_0_0_0_0_0_1_0_after_this1:Settings)
+                OPTIONAL MATCH (authorization_0_0_0_0_0_1_0_after_this1)-[:VEHICLECARD_OWNER]->(authorization_0_0_0_0_0_1_0_after_this2:Tenant)
+                WITH *, count(authorization_0_0_0_0_0_1_0_after_this2) AS tenantCount
                 WITH *
-                WHERE (tenantCount <> 0 AND size([(authorization_2_0_0_1_after_this2)<-[:ADMIN_IN]-(authorization_2_0_0_1_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_2_0_0_1_after_this3.userId = $jwt.id) | 1]) > 0)
-                RETURN count(authorization_2_0_0_1_after_this1) = 1 AS authorization_2_0_0_1_after_var0
+                WHERE (tenantCount <> 0 AND size([(authorization_0_0_0_0_0_1_0_after_this2)<-[:ADMIN_IN]-(authorization_0_0_0_0_0_1_0_after_this3:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_0_1_0_after_this3.userId = $jwt.id) | 1]) > 0)
+                RETURN count(authorization_0_0_0_0_0_1_0_after_this1) = 1 AS authorization_0_0_0_0_0_1_0_after_var0
             }
-            OPTIONAL MATCH (this0_settings0_node)-[:VEHICLECARD_OWNER]->(authorization_1_0_0_0_after_this1:Tenant)
-            WITH *, count(authorization_1_0_0_0_after_this1) AS tenantCount
+            OPTIONAL MATCH (this0_settings0_node)-[:VEHICLECARD_OWNER]->(authorization_0_0_0_0_after_this1:Tenant)
+            WITH *, count(authorization_0_0_0_0_after_this1) AS tenantCount
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_3_0_0_1_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_2_0_0_1_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_1_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_1_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_1_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_0_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_1_0_0_0_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_1_0_0_1_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND authorization_0_0_0_0_0_1_0_after_var0 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND (tenantCount <> 0 AND size([(authorization_0_0_0_0_after_this1)<-[:ADMIN_IN]-(authorization_0_0_0_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_0_0_0_after_this0.userId = $jwt.id) | 1]) > 0)), \\"@neo4j/graphql/FORBIDDEN\\", [0]) AND apoc.util.validatePredicate(NOT ($isAuthenticated = true AND size([(this0)<-[:ADMIN_IN]-(authorization_0_after_this0:User) WHERE ($jwt.id IS NOT NULL AND authorization_0_after_this0.userId = $jwt.id) | 1]) > 0), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -393,29 +373,12 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
                         WITH create_this8 { open: create_var21 } AS create_this8
                         RETURN collect(create_this8) AS create_var22
                     }
-                    CALL {
-                        WITH create_this4
-                        MATCH (create_this4)-[create_this23:HAS_WORKSPACE_SETTINGS]->(create_this24:MyWorkspace)
-                        CALL {
-                            WITH create_this24
-                            MATCH (create_this24)<-[:HAS_WORKSPACE_SETTINGS]-(create_this25:Settings)
-                            OPTIONAL MATCH (create_this25)-[:VEHICLECARD_OWNER]->(create_this26:Tenant)
-                            WITH *, count(create_this26) AS tenantCount
-                            WITH *
-                            WHERE (tenantCount <> 0 AND size([(create_this26)<-[:ADMIN_IN]-(create_this27:User) WHERE ($jwt.id IS NOT NULL AND create_this27.userId = $jwt.id) | 1]) > 0)
-                            RETURN count(create_this25) = 1 AS create_var28
-                        }
-                        WITH *
-                        WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND create_var28 = true), \\"@neo4j/graphql/FORBIDDEN\\", [0])
-                        WITH create_this24 { .workspace } AS create_this24
-                        RETURN head(collect(create_this24)) AS create_var29
-                    }
-                    WITH create_this4 { openingDays: create_var22, myWorkspace: create_var29 } AS create_this4
-                    RETURN head(collect(create_this4)) AS create_var30
+                    WITH create_this4 { openingDays: create_var22 } AS create_this4
+                    RETURN head(collect(create_this4)) AS create_var23
                 }
-                RETURN this0 { .id, admins: create_var2, settings: create_var30 } AS create_var31
+                RETURN this0 { .id, admins: create_var2, settings: create_var23 } AS create_var24
             }
-            RETURN [create_var31] AS data"
+            RETURN [create_var24] AS data"
         `);
 
         expect(formatParams(result.params)).toMatchInlineSnapshot(`

--- a/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
+++ b/packages/graphql/tests/tck/operations/batch/batch-create-auth.test.ts
@@ -310,7 +310,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this0_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this0
             }
             CALL {
@@ -339,7 +339,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this1_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this1
             }
             CALL {
@@ -358,7 +358,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this2_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this2
             }
             CALL {
@@ -391,7 +391,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this3_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this3
             }
             CALL {
@@ -415,7 +415,7 @@ describe("Batch Create, Auth", () => {
             	RETURN c AS this4_website_Website_unique_ignored
             }
             WITH *
-            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_0_0_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
+            WHERE apoc.util.validatePredicate(NOT ($isAuthenticated = true AND ($jwt.roles IS NOT NULL AND $authorization_0_after_param2 IN $jwt.roles)), \\"@neo4j/graphql/FORBIDDEN\\", [0])
             RETURN this4
             }
             CALL {
@@ -519,7 +519,7 @@ describe("Batch Create, Auth", () => {
                     \\"low\\": 2022,
                     \\"high\\": 0
                 },
-                \\"authorization_0_0_0_0_after_param2\\": \\"admin\\",
+                \\"authorization_0_after_param2\\": \\"admin\\",
                 \\"this1_id\\": \\"2\\",
                 \\"this1_actors0_node_name\\": \\"actor 2\\",
                 \\"this1_actors0_relationship_year\\": {


### PR DESCRIPTION
# Description

A much tidier fix for this was in place, but it fell apart the second you got too deep into the input because prefixes begun to get overwritten. This replaces it with a less tidy solution of appending at every level, but it won't suffer from collisions.

## Complexity

Complexity: Low

# Issue

Closes #4429
