### PR TITLE
build: quality gate runs even on skipped jobs

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -89,6 +89,7 @@ jobs:
     uses: ./.github/workflows/reusable-federation-tests.yml
 
   quality-gate:
+    if: ${{ !(failure() || cancelled()) }}
     needs:
       - reviewdog-eslint
       - code-scanning


### PR DESCRIPTION
We want the `quality-gate` job to run even if the `license-header-check` job is skipped. This is the case when a dependency is updated, as the `license-header-check` job only runs for changes in our source code.

This change makes it so that `quality-gate` will run when there are no failures or when a job is skipped.