### PR TITLE
[Bugfix] augment sort for connection of an interface

### DIFF
--- a/.changeset/large-wolves-tap.md
+++ b/.changeset/large-wolves-tap.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+[Bugfix] Fixed a bug where the sort field for a connection of an interface is not created even though it has sortable fields

--- a/packages/graphql/src/schema/create-connection-fields.ts
+++ b/packages/graphql/src/schema/create-connection-fields.ts
@@ -50,12 +50,9 @@ function addConnectionSortField({
     relationshipAdapter: RelationshipAdapter;
     composeNodeArgs: ObjectTypeComposerArgumentConfigMapDefinition;
 }): InputTypeComposer | undefined {
-    // TODO: This probably just needs to be
-    // if (relationship.target.sortableFields.length) {}
-    // And not care about the type of entity
     const targetIsInterfaceWithSortableFields =
         relationshipAdapter.target instanceof InterfaceEntityAdapter &&
-        schemaComposer.has(relationshipAdapter.target.operations.sortInputTypeName);
+        relationshipAdapter.target.sortableFields.length;
 
     const targetIsConcreteWithSortableFields =
         relationshipAdapter.target instanceof ConcreteEntityAdapter && relationshipAdapter.target.sortableFields.length;

--- a/packages/graphql/tests/integration/issues/4520.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4520.int.test.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Driver } from "neo4j-driver";
+import Neo4j from "../neo4j";
+import { Neo4jGraphQL } from "../../../src";
+import { UniqueType } from "../../utils/graphql-types";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { graphql } from "graphql/index";
+import { generate } from "randomstring";
+
+const testLabel = generate({ charset: "alphabetic" });
+
+describe("https://github.com/neo4j/graphql/issues/4520", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neo4jGraphql: Neo4jGraphQL;
+
+    const Movie = new UniqueType("Movie");
+    const Serie = new UniqueType("Serie");
+    const FxEngineer = new UniqueType("FxEngineer");
+    const Actor = new UniqueType("Actor");
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        const typeDefs = /* GraphQL */ `
+            interface Production {
+                title: String!
+                crew: [Person!]! @relationship(type: "WORKED_AT", direction: IN)
+            }
+
+            interface Person {
+                name: String
+            }
+
+            type ${Movie} implements Production {
+                title: String!
+                crew: [Person!]! @relationship(type: "WORKED_AT", direction: IN)
+            }
+
+            type ${Serie} implements Production {
+                title: String!
+                crew: [Person!]! @relationship(type: "WORKED_AT", direction: IN)
+            }
+
+            type ${FxEngineer} implements Person {
+                name: String!
+            }
+
+            type ${Actor} implements Person {
+                name: String!
+            }
+
+            type Collection {
+                name: String!
+                productions: [Production!]! @relationship(type: "HAS_PRODUCTION", direction: OUT)
+            }
+        `;
+
+        neo4jGraphql = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+            experimental: true,
+        });
+
+        const session = await neo4j.getSession();
+        try {
+            await session.run(
+                `
+                    CREATE
+                        (m:${Movie}:${testLabel} {title: 'Test Movie'}),
+                        (s:${Serie}:${testLabel} {title: 'Test Serie'}),
+                        (f:${FxEngineer}:${testLabel} {name: 'Test FxEngineer'}),
+                        (a:${Actor}:${testLabel} {name: 'Test Actor'}),
+                        (m)<-[:WORKED_AT]-(f),
+                        (m)<-[:WORKED_AT]-(a),
+                        (s)<-[:WORKED_AT]-(f),
+                        (s)<-[:WORKED_AT]-(a)
+                `,
+                {}
+            );
+        } finally {
+            await session.close();
+        }
+    });
+
+    afterAll(async () => {
+        const session = await neo4j.getSession();
+        try {
+            await cleanNodes(session, [Movie, Serie, FxEngineer, Actor]);
+        } finally {
+            await session.close();
+        }
+        await driver.close();
+    });
+
+    test("sorting by interface", async () => {
+        const schema = await neo4jGraphql.getSchema();
+
+        const query = /* GraphQL */ `
+            query {
+                productions(where: { title: "Test Movie" }) {
+                    asc: crewConnection(sort: [{ node: { name: ASC } }]) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                    desc: crewConnection(sort: [{ node: { name: DESC } }]) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
+                }
+            }
+        `;
+
+        const response = await graphql({
+            schema,
+            source: query,
+            contextValue: neo4j.getContextValues(),
+        });
+
+        expect(response.errors).toBeFalsy();
+        expect(response.data).toEqual({
+            productions: [
+                {
+                    asc: {
+                        edges: [
+                            {
+                                node: {
+                                    name: "Test Actor",
+                                },
+                            },
+                            {
+                                node: {
+                                    name: "Test FxEngineer",
+                                },
+                            },
+                        ],
+                    },
+                    desc: {
+                        edges: [
+                            {
+                                node: {
+                                    name: "Test FxEngineer",
+                                },
+                            },
+                            {
+                                node: {
+                                    name: "Test Actor",
+                                },
+                            },
+                        ],
+                    },
+                },
+            ],
+        });
+    });
+});

--- a/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
@@ -2209,7 +2209,7 @@ describe("Interface Relationships", () => {
             interface Interface1 {
               field1: String!
               interface2(directed: Boolean = true, options: Interface2Options, where: Interface2Where): [Interface2!]!
-              interface2Connection(after: String, directed: Boolean = true, first: Int, where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+              interface2Connection(after: String, directed: Boolean = true, first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
             }
 
             type Interface1AggregateSelection {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -2159,7 +2159,7 @@ describe("Interface Relationships", () => {
             interface Interface1 {
               field1: String!
               interface2(directed: Boolean = true, options: Interface2Options, where: Interface2Where): [Interface2!]!
-              interface2Connection(after: String, directed: Boolean = true, first: Int, where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
+              interface2Connection(after: String, directed: Boolean = true, first: Int, sort: [Interface1Interface2ConnectionSort!], where: Interface1Interface2ConnectionWhere): Interface1Interface2Connection!
             }
 
             input Interface1ConnectInput {


### PR DESCRIPTION
# Description

Fixed a bug where the sort field for a connection of an interface is not created even though it has sortable fields

## Complexity

Complexity: Low

## Closes

closes #4520 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
