### PR TITLE
build: revert rabbitmq:3.12-management image hash

### DIFF
--- a/examples/neo-place/docker-compose.yml
+++ b/examples/neo-place/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
     rabbitmq:
-        image: rabbitmq:3.12-management@sha256:0da86e1b6744b9ec51565d15c9ee9d2d38bb1ba2c25bfebed65ac84d4988655a
+        image: rabbitmq:3.12-management@sha256:042adc850846c375f9c1202d2199baec63aaa7f1105811004d35c07c9b857d73
         ports:
             - "5672:5672"
             - "15672:15672"

--- a/examples/subscriptions/apollo_rabbitmq/docker-compose.yml
+++ b/examples/subscriptions/apollo_rabbitmq/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.5'
 services:
     rabbitmq:
-        image: rabbitmq:3.12-management@sha256:0da86e1b6744b9ec51565d15c9ee9d2d38bb1ba2c25bfebed65ac84d4988655a
+        image: rabbitmq:3.12-management@sha256:042adc850846c375f9c1202d2199baec63aaa7f1105811004d35c07c9b857d73
         ports:
             - "5672:5672"
             - "15672:15672"

--- a/packages/graphql-amqp-subscriptions-engine/docker-compose.yml
+++ b/packages/graphql-amqp-subscriptions-engine/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 # This is just for local testing
 services:
     rabbitmq:
-        image: rabbitmq:3.12-management@sha256:0da86e1b6744b9ec51565d15c9ee9d2d38bb1ba2c25bfebed65ac84d4988655a
+        image: rabbitmq:3.12-management@sha256:042adc850846c375f9c1202d2199baec63aaa7f1105811004d35c07c9b857d73
         ports:
             - "5672:5672"
             - "15672:15672"


### PR DESCRIPTION
# Description

https://github.com/neo4j/graphql/pull/4550 was merged automatically by renovate even though there were failing tests. https://github.com/neo4j/graphql/pull/4558 has been merged to hopefully address the cause of this, so this PR reverts 4450, to observe that the changes in 4558 work correctly.

## Complexity

Low