### PR TITLE
Refactor: license-header-check removed from quality-gate job needs

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -93,15 +93,11 @@ jobs:
       - reviewdog-eslint
       - code-scanning
       - package-tests
-      - license-header-check
       - unit-tests
       - e2e-tests-plugins
       - api-library-tests
       - toolbox-tests
       - integration-tests-on-prem
-    if: >-
-      (needs.license-header-check.result == 'success' || needs.license-header-check.result == 'skipped')
-
 
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
# Description

Instead of this being part of the quality-gate, and causing the quality-gate to skip when the license-header-check is skipped, the license-header-check job will now be a required job in the repository settings.

A quality-gate can succeed or fail independently of the license-header-check, but if the license-header-check fails then the PR will not be able to be merged.

Similarly, if a license-header-check is skipped it will not stop the PR from being able to be merged.

## Complexity

Low