### PR TITLE
Build: add federation tests to quality gate check

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -99,6 +99,7 @@ jobs:
       - api-library-tests
       - toolbox-tests
       - integration-tests-on-prem
+      - federation-tests
 
     runs-on: ubuntu-latest
 
@@ -112,6 +113,7 @@ jobs:
             [ ${{ needs.e2e-tests-plugins.result }} != 'success' ] ||
             [ ${{ needs.api-library-tests.result }} != 'success' ] ||
             [ ${{ needs.toolbox-tests.result }} != 'success' ] ||
+            [ ${{ needs.federation-tests.result }} != 'success' ] ||
             [ ${{ needs.integration-tests-on-prem.result }} != 'success' ]; then
             echo "One or more jobs failed"
             exit 1


### PR DESCRIPTION
# Description

We want failing federation tests to cause PRs to be unable to be merged. This change adds the federation-tests job to the list of needed jobs in the quality gate.

## Complexity

Low