### PR TITLE
Minimum node version 18 in version 5 of neo4j/graphql

### DIFF
--- a/.changeset/dry-cups-dream.md
+++ b/.changeset/dry-cups-dream.md
@@ -1,5 +1,4 @@
 ---
-"server_perf": major
 "@neo4j/graphql-toolbox": major
 "@neo4j/introspector": major
 "@neo4j/graphql": major

--- a/.changeset/dry-cups-dream.md
+++ b/.changeset/dry-cups-dream.md
@@ -1,0 +1,9 @@
+---
+"server_perf": major
+"@neo4j/graphql-toolbox": major
+"@neo4j/introspector": major
+"@neo4j/graphql": major
+"@neo4j/graphql-ogm": major
+---
+
+Node.js versions lower than 18 are no longer supported as Node.js 16 reached End of Life.

--- a/packages/graphql-toolbox/package.json
+++ b/packages/graphql-toolbox/package.json
@@ -13,7 +13,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "keywords": [
         "neo4j",

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "scripts": {
         "clean": "cd src/ && tsc --build --clean",

--- a/packages/introspector/package.json
+++ b/packages/introspector/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "scripts": {
         "clean": "cd src/ && tsc --build --clean",

--- a/packages/ogm/package.json
+++ b/packages/ogm/package.json
@@ -22,7 +22,7 @@
         "dist/**/*.js.map"
     ],
     "engines": {
-        "node": ">=16.0.0"
+        "node": ">=18.0.0"
     },
     "scripts": {
         "build": "tsc --build tsconfig.production.json",


### PR DESCRIPTION
# Description

Node.js 16's is [now considered End of Life](https://nodejs.org/en/blog/announcements/nodejs16-eol/), so we are dropping support for it in favour of LTS Node 18.

## Complexity

Low