### PR TITLE
4615 aggregations with no result returns null but the graphql type is nonnull

### DIFF
--- a/.changeset/fair-meals-reflect.md
+++ b/.changeset/fair-meals-reflect.md
@@ -1,0 +1,7 @@
+---
+"@neo4j/graphql": major
+---
+
+Makes aggregation types nullable, even if the original property is non-nullable.
+
+This is because, in case of no nodes existing in the database, a null value will be returned by the aggregation

--- a/packages/graphql/src/schema/aggregations/aggregation-types-mapper.ts
+++ b/packages/graphql/src/schema/aggregations/aggregation-types-mapper.ts
@@ -61,19 +61,19 @@ export class AggregationTypesMapper {
         nullable: boolean;
     }): Record<string, ObjectTypeComposer<unknown, unknown>> {
         const composeInt = {
-            type: this.makeNullable("Int", nullable),
+            type: "Int",
             resolve: numericalResolver,
             args: {},
         };
 
         const composeFloat = {
-            type: this.makeNullable("Float", nullable),
+            type: "Float",
             resolve: numericalResolver,
             args: {},
         };
 
         const composeId = {
-            type: this.makeNullable("ID", nullable),
+            type: "ID",
             resolve: idResolver,
             args: {},
         };
@@ -96,8 +96,8 @@ export class AggregationTypesMapper {
             {
                 name: "String",
                 fields: {
-                    shortest: this.makeNullable("String", nullable),
-                    longest: this.makeNullable("String", nullable),
+                    shortest: "String",
+                    longest: "String",
                 },
                 directives,
             },
@@ -124,10 +124,10 @@ export class AggregationTypesMapper {
             {
                 name: "BigInt",
                 fields: {
-                    max: this.makeNullable("BigInt", nullable),
-                    min: this.makeNullable("BigInt", nullable),
-                    average: this.makeNullable("BigInt", nullable),
-                    sum: this.makeNullable("BigInt", nullable),
+                    max: "BigInt",
+                    min: "BigInt",
+                    average: "BigInt",
+                    sum: "BigInt",
                 },
                 directives,
             },

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { graphql } from "graphql";
+import { type Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
+import { default as Neo4j } from "../neo4j";
+
+describe("https://github.com/neo4j/graphql/issues/4615", () => {
+    let driver: Driver;
+    let neo4j: Neo4j;
+    let neo4jGraphql: Neo4jGraphQL;
+
+    const Movie = new UniqueType("Movie");
+    const Series = new UniqueType("Series");
+    const Actor = new UniqueType("Actor");
+
+    beforeAll(async () => {
+        neo4j = new Neo4j();
+        driver = await neo4j.getDriver();
+        const typeDefs = /* GraphQL */ `
+            interface Show {
+                title: String!
+                actors: [${Actor}!]! @declareRelationship
+            }
+
+            type ${Movie} implements Show {
+                title: String!
+                runtime: Int
+                actors: [${Actor}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type ${Series} implements Show {
+                title: String!
+                episodes: Int
+                actors: [${Actor}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type ${Actor} {
+                name: String!
+                actedIn: [Show!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int
+            }
+        `;
+        neo4jGraphql = new Neo4jGraphQL({
+            typeDefs,
+            driver,
+        });
+
+        const session = await neo4j.getSession();
+        try {
+            await session.run(
+                `
+                // Create Movies
+                CREATE (m1:${Movie} { title: "The Movie One", cost: 10000000, runtime: 120 })
+                CREATE (m2:${Movie} { title: "The Movie Two", cost: 20000000, runtime: 90 })
+                CREATE (m3:${Movie} { title: "The Movie Three", cost: 12000000, runtime: 70 })
+                
+                // Create Series
+                CREATE (s1:${Series} { title: "The Series One", cost: 10000000, episodes: 10 })
+                CREATE (s2:${Series} { title: "The Series Two", cost: 20000000, episodes: 20 })
+                CREATE (s3:${Series} { title: "The Series Three", cost: 20000000, episodes: 15 })
+                
+                // Create Actors
+                CREATE (a1:${Actor} { name: "Actor One" })
+                CREATE (a2:${Actor} { name: "Actor Two" })
+                
+                // Associate Actor 1 with Movies and Series
+                CREATE (a1)-[:ACTED_IN { screenTime: 100 }]->(m1)
+                CREATE (a1)-[:ACTED_IN { screenTime: 82 }]->(s1)
+                CREATE (a1)-[:ACTED_IN { screenTime: 20 }]->(m3)
+                CREATE (a1)-[:ACTED_IN { screenTime: 22 }]->(s3)
+                
+                // Associate Actor 2 with Movies and Series
+                CREATE (a2)-[:ACTED_IN { screenTime: 240 }]->(m2)
+                CREATE (a2)-[:ACTED_IN { screenTime: 728 }]->(s2)
+                CREATE (a2)-[:ACTED_IN { screenTime: 728 }]->(m3)
+                CREATE (a2)-[:ACTED_IN { screenTime: 88 }]->(s3)
+                `,
+                {}
+            );
+        } finally {
+            await session.close();
+        }
+    });
+
+    afterAll(async () => {
+        const session = await neo4j.getSession();
+        try {
+            await cleanNodes(session, [Movie, Series, Actor]);
+        } finally {
+            await session.close();
+        }
+        await driver.close();
+    });
+
+    test("should return null aggregations", async () => {
+        const schema = await neo4jGraphql.getSchema();
+
+        const query = /* GraphQL */ `
+            query {
+                showsAggregate(where: { title_STARTS_WITH: "asdasdasd" }) {
+                    title {
+                        longest
+                    }
+                }
+            }
+        `;
+
+        const response = await graphql({
+            schema,
+            source: query,
+            contextValue: neo4j.getContextValues(),
+        });
+        expect(response.errors).toBeFalsy();
+        expect(response.data).toEqual({
+            showsAggregate: {
+                title: {
+                    longest: null,
+                },
+            },
+        });
+    });
+});

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -367,8 +367,8 @@ describe("Aggregations", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -351,15 +351,15 @@ describe("Arrays Methods", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {

--- a/packages/graphql/tests/schema/arrays.test.ts
+++ b/packages/graphql/tests/schema/arrays.test.ts
@@ -64,15 +64,15 @@ describe("Arrays", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -76,8 +76,8 @@ describe("Authorization", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -344,8 +344,8 @@ describe("Authorization", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -983,10 +983,10 @@ describe("Comments", () => {
                 }
 
                 type IntAggregateSelectionNonNullable {
-                  average: Float!
-                  max: Int!
-                  min: Int!
-                  sum: Int!
+                  average: Float
+                  max: Int
+                  min: Int
+                  sum: Int
                 }
 
                 type Movie implements Production {
@@ -1242,8 +1242,8 @@ describe("Comments", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -323,8 +323,8 @@ describe("connect or create with id", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -451,8 +451,8 @@ describe("connect or create with id", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -539,8 +539,8 @@ describe("connect or create with id", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -853,8 +853,8 @@ describe("connect or create with id", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -649,8 +649,8 @@ describe("Connect Or Create", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -483,8 +483,8 @@ describe("Connect Or Create", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -980,10 +980,10 @@ describe("Connect Or Create", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -1113,8 +1113,8 @@ describe("Connect Or Create", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -646,8 +646,8 @@ describe("Enums", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -231,10 +231,10 @@ describe("Connection with interfaces", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -894,8 +894,8 @@ describe("Connection with interfaces", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -510,8 +510,8 @@ describe("Sort", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -640,10 +640,10 @@ describe("Unions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Journal {
@@ -985,8 +985,8 @@ describe("Unions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateAuthorsMutationResponse {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -1162,10 +1162,10 @@ describe("Directive-preserve", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -1845,8 +1845,8 @@ describe("Directive-preserve", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -2167,10 +2167,10 @@ describe("Directive-preserve", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -2850,8 +2850,8 @@ describe("Directive-preserve", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -612,8 +612,8 @@ describe("Alias", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/schema/directives/autogenerate.test.ts
@@ -63,8 +63,8 @@ describe("Autogenerate", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -169,8 +169,8 @@ describe("Autogenerate", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -78,8 +78,8 @@ describe("@customResolver directive", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -113,8 +113,8 @@ describe("@customResolver directive", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -89,22 +89,22 @@ describe("@default directive", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             enum Location {
@@ -144,8 +144,8 @@ describe("@default directive", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -1662,8 +1662,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -2522,8 +2522,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -3344,8 +3344,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -4118,8 +4118,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -4980,8 +4980,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -5814,8 +5814,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -6587,8 +6587,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -7423,8 +7423,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -8259,8 +8259,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -9095,8 +9095,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -10327,8 +10327,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -11569,8 +11569,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -12811,8 +12811,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -318,8 +318,8 @@ describe("@populatedBy tests", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 \\"\\"\\"
@@ -404,10 +404,10 @@ describe("@populatedBy tests", () => {
                 }
 
                 type IntAggregateSelectionNonNullable {
-                  average: Float!
-                  max: Int!
-                  min: Int!
-                  sum: Int!
+                  average: Float
+                  max: Int
+                  min: Int
+                  sum: Int
                 }
 
                 type Movie {
@@ -821,8 +821,8 @@ describe("@populatedBy tests", () => {
                 }
 
                 type IDAggregateSelectionNonNullable {
-                  longest: ID!
-                  shortest: ID!
+                  longest: ID
+                  shortest: ID
                 }
 
                 type IDAggregateSelectionNullable {
@@ -1264,8 +1264,8 @@ describe("@populatedBy tests", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type UpdateGenresMutationResponse {
@@ -1428,8 +1428,8 @@ describe("@populatedBy tests", () => {
                 }
 
                 type IDAggregateSelectionNonNullable {
-                  longest: ID!
-                  shortest: ID!
+                  longest: ID
+                  shortest: ID
                 }
 
                 type IDAggregateSelectionNullable {
@@ -1438,10 +1438,10 @@ describe("@populatedBy tests", () => {
                 }
 
                 type IntAggregateSelectionNonNullable {
-                  average: Float!
-                  max: Int!
-                  min: Int!
-                  sum: Int!
+                  average: Float
+                  max: Int
+                  min: Int
+                  sum: Int
                 }
 
                 type Movie {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -627,8 +627,8 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1092,8 +1092,8 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1519,8 +1519,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -1955,8 +1955,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -2486,8 +2486,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -3019,8 +3019,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -2630,8 +2630,8 @@ describe("Relationship nested operations", () => {
                 }
 
                 type IDAggregateSelectionNonNullable {
-                  longest: ID!
-                  shortest: ID!
+                  longest: ID
+                  shortest: ID
                 }
 
                 type IDAggregateSelectionNullable {
@@ -7047,8 +7047,8 @@ describe("Relationship nested operations", () => {
                 }
 
                 type IDAggregateSelectionNonNullable {
-                  longest: ID!
-                  shortest: ID!
+                  longest: ID
+                  shortest: ID
                 }
 
                 type IDAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -421,10 +421,10 @@ describe("Relationship-properties", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -746,8 +746,8 @@ describe("Relationship-properties", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -1198,15 +1198,15 @@ describe("Relationship-properties", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -1546,8 +1546,8 @@ describe("Relationship-properties", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -1948,8 +1948,8 @@ describe("Relationship-properties", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -2260,8 +2260,8 @@ describe("Relationship-properties", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -171,8 +171,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -339,8 +339,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -501,8 +501,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -722,8 +722,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -1172,8 +1172,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1636,8 +1636,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2170,8 +2170,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2719,8 +2719,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3239,8 +3239,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3773,8 +3773,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -171,8 +171,8 @@ describe("@settable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -339,8 +339,8 @@ describe("@settable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -565,8 +565,8 @@ describe("@settable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -1026,8 +1026,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1477,8 +1477,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2110,8 +2110,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2751,8 +2751,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3281,8 +3281,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3799,8 +3799,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -4499,8 +4499,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -5215,8 +5215,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -5746,8 +5746,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -6262,8 +6262,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -7210,8 +7210,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -8189,8 +8189,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/comments.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/comments.test.ts
@@ -983,10 +983,10 @@ describe("Comments", () => {
                 }
 
                 type IntAggregateSelectionNonNullable {
-                  average: Float!
-                  max: Int!
-                  min: Int!
-                  sum: Int!
+                  average: Float
+                  max: Int
+                  min: Int
+                  sum: Int
                 }
 
                 type Movie implements Production {
@@ -1242,8 +1242,8 @@ describe("Comments", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/experimental-schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directive-preserve.test.ts
@@ -1162,10 +1162,10 @@ describe("Directive-preserve", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -1845,8 +1845,8 @@ describe("Directive-preserve", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -2167,10 +2167,10 @@ describe("Directive-preserve", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -2850,8 +2850,8 @@ describe("Directive-preserve", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/experimental-schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/customResolver.test.ts
@@ -78,8 +78,8 @@ describe("@customResolver directive", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -113,8 +113,8 @@ describe("@customResolver directive", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/default.test.ts
@@ -89,22 +89,22 @@ describe("@default directive", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             enum Location {
@@ -144,8 +144,8 @@ describe("@default directive", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/experimental-schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/filterable.test.ts
@@ -1662,8 +1662,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -2522,8 +2522,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -3344,8 +3344,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -4118,8 +4118,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -4980,8 +4980,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -5814,8 +5814,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -6587,8 +6587,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -7423,8 +7423,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -8259,8 +8259,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -9095,8 +9095,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -10327,8 +10327,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -11569,8 +11569,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -12811,8 +12811,8 @@ describe("@filterable directive", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/relationship-aggregate.test.ts
@@ -627,8 +627,8 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1092,8 +1092,8 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1519,8 +1519,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -1955,8 +1955,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -2486,8 +2486,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {
@@ -3019,8 +3019,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type StringAggregateSelectionNonNullable {
-                      longest: String!
-                      shortest: String!
+                      longest: String
+                      shortest: String
                     }
 
                     type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/relationship-nested-operations.test.ts
@@ -2630,8 +2630,8 @@ describe("Relationship nested operations", () => {
                 }
 
                 type IDAggregateSelectionNonNullable {
-                  longest: ID!
-                  shortest: ID!
+                  longest: ID
+                  shortest: ID
                 }
 
                 type IDAggregateSelectionNullable {
@@ -7047,8 +7047,8 @@ describe("Relationship nested operations", () => {
                 }
 
                 type IDAggregateSelectionNonNullable {
-                  longest: ID!
-                  shortest: ID!
+                  longest: ID
+                  shortest: ID
                 }
 
                 type IDAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/selectable.test.ts
@@ -171,8 +171,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -339,8 +339,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -501,8 +501,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -722,8 +722,8 @@ describe("@selectable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -1172,8 +1172,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1636,8 +1636,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2170,8 +2170,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2719,8 +2719,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3239,8 +3239,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3773,8 +3773,8 @@ describe("@selectable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/settable.test.ts
@@ -171,8 +171,8 @@ describe("@settable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -339,8 +339,8 @@ describe("@settable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -565,8 +565,8 @@ describe("@settable", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -1026,8 +1026,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -1477,8 +1477,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2110,8 +2110,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -2751,8 +2751,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3281,8 +3281,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -3799,8 +3799,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -4499,8 +4499,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -5215,8 +5215,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -5746,8 +5746,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -6262,8 +6262,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -7210,8 +7210,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {
@@ -8189,8 +8189,8 @@ describe("@settable", () => {
                 }
 
                 type StringAggregateSelectionNonNullable {
-                  longest: String!
-                  shortest: String!
+                  longest: String
+                  shortest: String
                 }
 
                 type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
@@ -304,10 +304,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -563,8 +563,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -1141,10 +1141,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -2141,8 +2141,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -2727,10 +2727,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -3783,8 +3783,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -4169,8 +4169,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -4885,10 +4885,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             interface Interface1 {
@@ -5235,8 +5235,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -5973,10 +5973,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             interface Interface1 {
@@ -6302,8 +6302,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/experimental-schema/interfaces/aggregations.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interfaces/aggregations.test.ts
@@ -69,17 +69,17 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -262,8 +262,8 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -569,17 +569,17 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -885,8 +885,8 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/experimental-schema/interfaces/typename-in.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interfaces/typename-in.test.ts
@@ -255,17 +255,17 @@ describe("typename_IN", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -571,8 +571,8 @@ describe("typename_IN", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/experimental-schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/2377.test.ts
@@ -116,8 +116,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {

--- a/packages/graphql/tests/schema/experimental-schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/2993.test.ts
@@ -112,8 +112,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -219,8 +219,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -518,8 +518,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -624,8 +624,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/experimental-schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/3439.test.ts
@@ -1265,8 +1265,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -2460,8 +2460,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -3253,8 +3253,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {

--- a/packages/graphql/tests/schema/experimental-schema/math.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/math.test.ts
@@ -67,10 +67,10 @@ describe("Algebraic", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -215,10 +215,10 @@ describe("Algebraic", () => {
             scalar BigInt
 
             type BigIntAggregateSelectionNonNullable {
-              average: BigInt!
-              max: BigInt!
-              min: BigInt!
-              sum: BigInt!
+              average: BigInt
+              max: BigInt
+              min: BigInt
+              sum: BigInt
             }
 
             \\"\\"\\"
@@ -410,10 +410,10 @@ describe("Algebraic", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNullable {
@@ -831,10 +831,10 @@ describe("Algebraic", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -1103,8 +1103,8 @@ describe("Algebraic", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateDirectorsMutationResponse {
@@ -1189,10 +1189,10 @@ describe("Algebraic", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -1710,8 +1710,8 @@ describe("Algebraic", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -2450,8 +2450,8 @@ describe("Algebraic", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/experimental-schema/nested-aggregation-on-interface.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/nested-aggregation-on-interface.test.ts
@@ -289,17 +289,17 @@ describe("nested aggregation on interface", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -605,8 +605,8 @@ describe("nested aggregation on interface", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -907,17 +907,17 @@ describe("nested aggregation on interface", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -1223,8 +1223,8 @@ describe("nested aggregation on interface", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/experimental-schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/subscriptions.test.ts
@@ -631,8 +631,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -3004,10 +3004,10 @@ describe("Subscriptions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type IntAggregateSelectionNullable {
@@ -3962,8 +3962,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -4410,10 +4410,10 @@ describe("Subscriptions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Mutation {
@@ -4448,8 +4448,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -5879,10 +5879,10 @@ describe("Subscriptions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -6619,8 +6619,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {

--- a/packages/graphql/tests/schema/experimental-schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/union-interface-relationship.test.ts
@@ -643,10 +643,10 @@ describe("Union Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type IntAggregateSelectionNullable {
@@ -1887,8 +1887,8 @@ describe("Union Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/experimental-schema/union-relationship-filtering.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/union-relationship-filtering.test.ts
@@ -645,8 +645,8 @@ describe("Union Relationships Filtering", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -349,8 +349,8 @@ describe("Apollo Federation", () => {
             }
 
             type StringAggregateSelectionNonNullable @shareable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -956,8 +956,8 @@ describe("Apollo Federation", () => {
             }
 
             type StringAggregateSelectionNonNullable @federation__shareable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/global-node.test.ts
+++ b/packages/graphql/tests/schema/global-node.test.ts
@@ -63,8 +63,8 @@ describe("Node Interface Types", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie implements Node {
@@ -184,8 +184,8 @@ describe("Node Interface Types", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -304,10 +304,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -563,8 +563,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -1141,10 +1141,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -2141,8 +2141,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -2727,10 +2727,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -3783,8 +3783,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {
@@ -4169,8 +4169,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -4885,10 +4885,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             interface Interface1 {
@@ -5235,8 +5235,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -5973,10 +5973,10 @@ describe("Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             interface Interface1 {
@@ -6302,8 +6302,8 @@ describe("Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -201,8 +201,8 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -544,8 +544,8 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -407,8 +407,8 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateCrewMembersMutationResponse {

--- a/packages/graphql/tests/schema/issues/200.test.ts
+++ b/packages/graphql/tests/schema/issues/200.test.ts
@@ -162,8 +162,8 @@ describe("200", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -195,8 +195,8 @@ describe("200", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateCategoriesMutationResponse {

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -116,8 +116,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -74,8 +74,8 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -331,8 +331,8 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -883,8 +883,8 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateBookTitleEnsMutationResponse {

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -112,8 +112,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {
@@ -219,8 +219,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/issues/3428.test.ts
+++ b/packages/graphql/tests/schema/issues/3428.test.ts
@@ -73,8 +73,8 @@ describe("Relationship nested operations", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type IDAggregateSelectionNullable {

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -1262,8 +1262,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -2455,8 +2455,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -3245,8 +3245,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {

--- a/packages/graphql/tests/schema/issues/3537.test.ts
+++ b/packages/graphql/tests/schema/issues/3537.test.ts
@@ -486,8 +486,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type StringAggregateSelectionNonNullable @shareable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable @shareable {
@@ -837,8 +837,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type StringAggregateSelectionNonNullable @shareable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable @shareable {

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -314,8 +314,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type StringAggregateSelectionNonNullable @shareable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             scalar _Any
@@ -727,8 +727,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type StringAggregateSelectionNonNullable @shareable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -538,8 +538,8 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateGenresMutationResponse {
@@ -1040,8 +1040,8 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateGenresMutationResponse {

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -118,8 +118,8 @@ describe("3817", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Mutation {

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -216,10 +216,10 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -956,8 +956,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -1,0 +1,1188 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { printSchemaWithDirectives } from "@graphql-tools/utils";
+import { gql } from "graphql-tag";
+import { lexicographicSortSchema } from "graphql/utilities";
+import { Neo4jGraphQL } from "../../../src";
+
+describe("https://github.com/neo4j/graphql/issues/4615", () => {
+    test("Aggregations should be nullable", async () => {
+        const typeDefs = gql`
+            interface Show {
+                title: String!
+                actors: [Actor!]! @declareRelationship
+            }
+
+            type Movie implements Show {
+                title: String!
+                runtime: Int
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type Series implements Show {
+                title: String!
+                episodes: Int
+                actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
+            }
+
+            type Actor {
+                name: String!
+                actedIn: [Show!]! @relationship(type: "ACTED_IN", direction: OUT, properties: "ActedIn")
+            }
+
+            type ActedIn @relationshipProperties {
+                screenTime: Int
+            }
+        `;
+        const neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+        const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
+
+        expect(printedSchema).toMatchInlineSnapshot(`
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
+
+            \\"\\"\\"
+            The edge properties for the following fields:
+            * Movie.actors
+            * Series.actors
+            * Actor.actedIn
+            \\"\\"\\"
+            type ActedIn {
+              screenTime: Int
+            }
+
+            input ActedInCreateInput {
+              screenTime: Int
+            }
+
+            input ActedInSort {
+              screenTime: SortDirection
+            }
+
+            input ActedInUpdateInput {
+              screenTime: Int
+              screenTime_DECREMENT: Int
+              screenTime_INCREMENT: Int
+            }
+
+            input ActedInWhere {
+              AND: [ActedInWhere!]
+              NOT: ActedInWhere
+              OR: [ActedInWhere!]
+              screenTime: Int
+              screenTime_GT: Int
+              screenTime_GTE: Int
+              screenTime_IN: [Int]
+              screenTime_LT: Int
+              screenTime_LTE: Int
+              screenTime_NOT: Int @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              screenTime_NOT_IN: [Int] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+            }
+
+            type Actor {
+              actedIn(directed: Boolean = true, options: ShowOptions, where: ShowWhere): [Show!]!
+              actedInAggregate(directed: Boolean = true, where: ShowWhere): ActorShowActedInAggregationSelection
+              actedInConnection(after: String, directed: Boolean = true, first: Int, sort: [ActorActedInConnectionSort!], where: ActorActedInConnectionWhere): ActorActedInConnection!
+              name: String!
+            }
+
+            input ActorActedInConnectFieldInput {
+              connect: ShowConnectInput
+              edge: ActedInCreateInput
+              where: ShowConnectWhere
+            }
+
+            type ActorActedInConnection {
+              edges: [ActorActedInRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ActorActedInConnectionSort {
+              edge: ActedInSort
+              node: ShowSort
+            }
+
+            input ActorActedInConnectionWhere {
+              AND: [ActorActedInConnectionWhere!]
+              NOT: ActorActedInConnectionWhere
+              OR: [ActorActedInConnectionWhere!]
+              edge: ActedInWhere
+              edge_NOT: ActedInWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              node: ShowWhere
+              node_NOT: ShowWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+            }
+
+            input ActorActedInCreateFieldInput {
+              edge: ActedInCreateInput
+              node: ShowCreateInput!
+            }
+
+            input ActorActedInDeleteFieldInput {
+              delete: ShowDeleteInput
+              where: ActorActedInConnectionWhere
+            }
+
+            input ActorActedInDisconnectFieldInput {
+              disconnect: ShowDisconnectInput
+              where: ActorActedInConnectionWhere
+            }
+
+            input ActorActedInFieldInput {
+              connect: [ActorActedInConnectFieldInput!]
+              create: [ActorActedInCreateFieldInput!]
+            }
+
+            type ActorActedInRelationship {
+              cursor: String!
+              node: Show!
+              properties: ActedIn!
+            }
+
+            input ActorActedInUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: ShowUpdateInput
+            }
+
+            input ActorActedInUpdateFieldInput {
+              connect: [ActorActedInConnectFieldInput!]
+              create: [ActorActedInCreateFieldInput!]
+              delete: [ActorActedInDeleteFieldInput!]
+              disconnect: [ActorActedInDisconnectFieldInput!]
+              update: ActorActedInUpdateConnectionInput
+              where: ActorActedInConnectionWhere
+            }
+
+            type ActorAggregateSelection {
+              count: Int!
+              name: StringAggregateSelectionNonNullable!
+            }
+
+            input ActorConnectInput {
+              actedIn: [ActorActedInConnectFieldInput!]
+            }
+
+            input ActorConnectWhere {
+              node: ActorWhere!
+            }
+
+            input ActorCreateInput {
+              actedIn: ActorActedInFieldInput
+              name: String!
+            }
+
+            input ActorDeleteInput {
+              actedIn: [ActorActedInDeleteFieldInput!]
+            }
+
+            input ActorDisconnectInput {
+              actedIn: [ActorActedInDisconnectFieldInput!]
+            }
+
+            type ActorEdge {
+              cursor: String!
+              node: Actor!
+            }
+
+            input ActorOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ActorSort objects to sort Actors by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ActorSort!]
+            }
+
+            input ActorRelationInput {
+              actedIn: [ActorActedInCreateFieldInput!]
+            }
+
+            type ActorShowActedInAggregationSelection {
+              count: Int!
+              edge: ActorShowActedInEdgeAggregateSelection
+              node: ActorShowActedInNodeAggregateSelection
+            }
+
+            type ActorShowActedInEdgeAggregateSelection {
+              screenTime: IntAggregateSelectionNullable!
+            }
+
+            type ActorShowActedInNodeAggregateSelection {
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            \\"\\"\\"
+            Fields to sort Actors by. The order in which sorts are applied is not guaranteed when specifying many fields in one ActorSort object.
+            \\"\\"\\"
+            input ActorSort {
+              name: SortDirection
+            }
+
+            input ActorUpdateInput {
+              actedIn: [ActorActedInUpdateFieldInput!]
+              name: String
+            }
+
+            input ActorWhere {
+              AND: [ActorWhere!]
+              NOT: ActorWhere
+              OR: [ActorWhere!]
+              actedInConnection: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_SOME\` instead.\\")
+              \\"\\"\\"
+              Return Actors where all of the related ActorActedInConnections match this filter
+              \\"\\"\\"
+              actedInConnection_ALL: ActorActedInConnectionWhere
+              \\"\\"\\"
+              Return Actors where none of the related ActorActedInConnections match this filter
+              \\"\\"\\"
+              actedInConnection_NONE: ActorActedInConnectionWhere
+              actedInConnection_NOT: ActorActedInConnectionWhere @deprecated(reason: \\"Use \`actedInConnection_NONE\` instead.\\")
+              \\"\\"\\"
+              Return Actors where one of the related ActorActedInConnections match this filter
+              \\"\\"\\"
+              actedInConnection_SINGLE: ActorActedInConnectionWhere
+              \\"\\"\\"
+              Return Actors where some of the related ActorActedInConnections match this filter
+              \\"\\"\\"
+              actedInConnection_SOME: ActorActedInConnectionWhere
+              name: String
+              name_CONTAINS: String
+              name_ENDS_WITH: String
+              name_IN: [String!]
+              name_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              name_STARTS_WITH: String
+            }
+
+            type ActorsConnection {
+              edges: [ActorEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type CreateActorsMutationResponse {
+              actors: [Actor!]!
+              info: CreateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
+
+            type CreateMoviesMutationResponse {
+              info: CreateInfo!
+              movies: [Movie!]!
+            }
+
+            type CreateSeriesMutationResponse {
+              info: CreateInfo!
+              series: [Series!]!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type IntAggregateSelectionNullable {
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
+            }
+
+            type Movie implements Show {
+              actors(directed: Boolean = true, options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsAggregate(directed: Boolean = true, where: ActorWhere): MovieActorActorsAggregationSelection
+              actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [ShowActorsConnectionSort!], where: ShowActorsConnectionWhere): ShowActorsConnection!
+              runtime: Int
+              title: String!
+            }
+
+            type MovieActorActorsAggregationSelection {
+              count: Int!
+              edge: MovieActorActorsEdgeAggregateSelection
+              node: MovieActorActorsNodeAggregateSelection
+            }
+
+            type MovieActorActorsEdgeAggregateSelection {
+              screenTime: IntAggregateSelectionNullable!
+            }
+
+            type MovieActorActorsNodeAggregateSelection {
+              name: StringAggregateSelectionNonNullable!
+            }
+
+            input MovieActorsAggregateInput {
+              AND: [MovieActorsAggregateInput!]
+              NOT: MovieActorsAggregateInput
+              OR: [MovieActorsAggregateInput!]
+              count: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: MovieActorsEdgeAggregationWhereInput
+              node: MovieActorsNodeAggregationWhereInput
+            }
+
+            input MovieActorsConnectFieldInput {
+              connect: [ActorConnectInput!]
+              edge: ActedInCreateInput
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: ActorConnectWhere
+            }
+
+            input MovieActorsCreateFieldInput {
+              edge: ActedInCreateInput
+              node: ActorCreateInput!
+            }
+
+            input MovieActorsEdgeAggregationWhereInput {
+              AND: [MovieActorsEdgeAggregationWhereInput!]
+              NOT: MovieActorsEdgeAggregationWhereInput
+              OR: [MovieActorsEdgeAggregationWhereInput!]
+              screenTime_AVERAGE_EQUAL: Float
+              screenTime_AVERAGE_GT: Float
+              screenTime_AVERAGE_GTE: Float
+              screenTime_AVERAGE_LT: Float
+              screenTime_AVERAGE_LTE: Float
+              screenTime_EQUAL: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_MAX_EQUAL: Int
+              screenTime_MAX_GT: Int
+              screenTime_MAX_GTE: Int
+              screenTime_MAX_LT: Int
+              screenTime_MAX_LTE: Int
+              screenTime_MIN_EQUAL: Int
+              screenTime_MIN_GT: Int
+              screenTime_MIN_GTE: Int
+              screenTime_MIN_LT: Int
+              screenTime_MIN_LTE: Int
+              screenTime_SUM_EQUAL: Int
+              screenTime_SUM_GT: Int
+              screenTime_SUM_GTE: Int
+              screenTime_SUM_LT: Int
+              screenTime_SUM_LTE: Int
+            }
+
+            input MovieActorsFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+            }
+
+            input MovieActorsNodeAggregationWhereInput {
+              AND: [MovieActorsNodeAggregationWhereInput!]
+              NOT: MovieActorsNodeAggregationWhereInput
+              OR: [MovieActorsNodeAggregationWhereInput!]
+              name_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_LENGTH_EQUAL: Float
+              name_AVERAGE_LENGTH_GT: Float
+              name_AVERAGE_LENGTH_GTE: Float
+              name_AVERAGE_LENGTH_LT: Float
+              name_AVERAGE_LENGTH_LTE: Float
+              name_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_LENGTH_EQUAL: Int
+              name_LONGEST_LENGTH_GT: Int
+              name_LONGEST_LENGTH_GTE: Int
+              name_LONGEST_LENGTH_LT: Int
+              name_LONGEST_LENGTH_LTE: Int
+              name_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_LENGTH_EQUAL: Int
+              name_SHORTEST_LENGTH_GT: Int
+              name_SHORTEST_LENGTH_GTE: Int
+              name_SHORTEST_LENGTH_LT: Int
+              name_SHORTEST_LENGTH_LTE: Int
+              name_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+            }
+
+            input MovieActorsUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: ActorUpdateInput
+            }
+
+            input MovieActorsUpdateFieldInput {
+              connect: [MovieActorsConnectFieldInput!]
+              create: [MovieActorsCreateFieldInput!]
+              delete: [ShowActorsDeleteFieldInput!]
+              disconnect: [ShowActorsDisconnectFieldInput!]
+              update: MovieActorsUpdateConnectionInput
+              where: ShowActorsConnectionWhere
+            }
+
+            type MovieAggregateSelection {
+              count: Int!
+              runtime: IntAggregateSelectionNullable!
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            input MovieConnectInput {
+              actors: [MovieActorsConnectFieldInput!]
+            }
+
+            input MovieCreateInput {
+              actors: MovieActorsFieldInput
+              runtime: Int
+              title: String!
+            }
+
+            input MovieDeleteInput {
+              actors: [ShowActorsDeleteFieldInput!]
+            }
+
+            input MovieDisconnectInput {
+              actors: [ShowActorsDisconnectFieldInput!]
+            }
+
+            type MovieEdge {
+              cursor: String!
+              node: Movie!
+            }
+
+            input MovieOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more MovieSort objects to sort Movies by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [MovieSort!]
+            }
+
+            input MovieRelationInput {
+              actors: [MovieActorsCreateFieldInput!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
+            \\"\\"\\"
+            input MovieSort {
+              runtime: SortDirection
+              title: SortDirection
+            }
+
+            input MovieUpdateInput {
+              actors: [MovieActorsUpdateFieldInput!]
+              runtime: Int
+              runtime_DECREMENT: Int
+              runtime_INCREMENT: Int
+              title: String
+            }
+
+            input MovieWhere {
+              AND: [MovieWhere!]
+              NOT: MovieWhere
+              OR: [MovieWhere!]
+              actors: ActorWhere @deprecated(reason: \\"Use \`actors_SOME\` instead.\\")
+              actorsAggregate: MovieActorsAggregateInput
+              actorsConnection: ShowActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_SOME\` instead.\\")
+              \\"\\"\\"
+              Return Movies where all of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_ALL: ShowActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where none of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_NONE: ShowActorsConnectionWhere
+              actorsConnection_NOT: ShowActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_NONE\` instead.\\")
+              \\"\\"\\"
+              Return Movies where one of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SINGLE: ShowActorsConnectionWhere
+              \\"\\"\\"
+              Return Movies where some of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SOME: ShowActorsConnectionWhere
+              \\"\\"\\"Return Movies where all of the related Actors match this filter\\"\\"\\"
+              actors_ALL: ActorWhere
+              \\"\\"\\"Return Movies where none of the related Actors match this filter\\"\\"\\"
+              actors_NONE: ActorWhere
+              actors_NOT: ActorWhere @deprecated(reason: \\"Use \`actors_NONE\` instead.\\")
+              \\"\\"\\"Return Movies where one of the related Actors match this filter\\"\\"\\"
+              actors_SINGLE: ActorWhere
+              \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
+              actors_SOME: ActorWhere
+              runtime: Int
+              runtime_GT: Int
+              runtime_GTE: Int
+              runtime_IN: [Int]
+              runtime_LT: Int
+              runtime_LTE: Int
+              runtime_NOT: Int @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              runtime_NOT_IN: [Int] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String!]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            type MoviesConnection {
+              edges: [MovieEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            type Mutation {
+              createActors(input: [ActorCreateInput!]!): CreateActorsMutationResponse!
+              createMovies(input: [MovieCreateInput!]!): CreateMoviesMutationResponse!
+              createSeries(input: [SeriesCreateInput!]!): CreateSeriesMutationResponse!
+              deleteActors(delete: ActorDeleteInput, where: ActorWhere): DeleteInfo!
+              deleteMovies(delete: MovieDeleteInput, where: MovieWhere): DeleteInfo!
+              deleteSeries(delete: SeriesDeleteInput, where: SeriesWhere): DeleteInfo!
+              updateActors(connect: ActorConnectInput, create: ActorRelationInput, delete: ActorDeleteInput, disconnect: ActorDisconnectInput, update: ActorUpdateInput, where: ActorWhere): UpdateActorsMutationResponse!
+              updateMovies(connect: MovieConnectInput, create: MovieRelationInput, delete: MovieDeleteInput, disconnect: MovieDisconnectInput, update: MovieUpdateInput, where: MovieWhere): UpdateMoviesMutationResponse!
+              updateSeries(connect: SeriesConnectInput, create: SeriesRelationInput, delete: SeriesDeleteInput, disconnect: SeriesDisconnectInput, update: SeriesUpdateInput, where: SeriesWhere): UpdateSeriesMutationResponse!
+            }
+
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
+
+            type Query {
+              actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsAggregate(where: ActorWhere): ActorAggregateSelection!
+              actorsConnection(after: String, first: Int, sort: [ActorSort], where: ActorWhere): ActorsConnection!
+              movies(options: MovieOptions, where: MovieWhere): [Movie!]!
+              moviesAggregate(where: MovieWhere): MovieAggregateSelection!
+              moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
+              series(options: SeriesOptions, where: SeriesWhere): [Series!]!
+              seriesAggregate(where: SeriesWhere): SeriesAggregateSelection!
+              seriesConnection(after: String, first: Int, sort: [SeriesSort], where: SeriesWhere): SeriesConnection!
+              shows(options: ShowOptions, where: ShowWhere): [Show!]!
+              showsAggregate(where: ShowWhere): ShowAggregateSelection!
+            }
+
+            type Series implements Show {
+              actors(directed: Boolean = true, options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsAggregate(directed: Boolean = true, where: ActorWhere): SeriesActorActorsAggregationSelection
+              actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [ShowActorsConnectionSort!], where: ShowActorsConnectionWhere): ShowActorsConnection!
+              episodes: Int
+              title: String!
+            }
+
+            type SeriesActorActorsAggregationSelection {
+              count: Int!
+              edge: SeriesActorActorsEdgeAggregateSelection
+              node: SeriesActorActorsNodeAggregateSelection
+            }
+
+            type SeriesActorActorsEdgeAggregateSelection {
+              screenTime: IntAggregateSelectionNullable!
+            }
+
+            type SeriesActorActorsNodeAggregateSelection {
+              name: StringAggregateSelectionNonNullable!
+            }
+
+            input SeriesActorsAggregateInput {
+              AND: [SeriesActorsAggregateInput!]
+              NOT: SeriesActorsAggregateInput
+              OR: [SeriesActorsAggregateInput!]
+              count: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: SeriesActorsEdgeAggregationWhereInput
+              node: SeriesActorsNodeAggregationWhereInput
+            }
+
+            input SeriesActorsConnectFieldInput {
+              connect: [ActorConnectInput!]
+              edge: ActedInCreateInput
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: ActorConnectWhere
+            }
+
+            input SeriesActorsCreateFieldInput {
+              edge: ActedInCreateInput
+              node: ActorCreateInput!
+            }
+
+            input SeriesActorsEdgeAggregationWhereInput {
+              AND: [SeriesActorsEdgeAggregationWhereInput!]
+              NOT: SeriesActorsEdgeAggregationWhereInput
+              OR: [SeriesActorsEdgeAggregationWhereInput!]
+              screenTime_AVERAGE_EQUAL: Float
+              screenTime_AVERAGE_GT: Float
+              screenTime_AVERAGE_GTE: Float
+              screenTime_AVERAGE_LT: Float
+              screenTime_AVERAGE_LTE: Float
+              screenTime_EQUAL: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              screenTime_MAX_EQUAL: Int
+              screenTime_MAX_GT: Int
+              screenTime_MAX_GTE: Int
+              screenTime_MAX_LT: Int
+              screenTime_MAX_LTE: Int
+              screenTime_MIN_EQUAL: Int
+              screenTime_MIN_GT: Int
+              screenTime_MIN_GTE: Int
+              screenTime_MIN_LT: Int
+              screenTime_MIN_LTE: Int
+              screenTime_SUM_EQUAL: Int
+              screenTime_SUM_GT: Int
+              screenTime_SUM_GTE: Int
+              screenTime_SUM_LT: Int
+              screenTime_SUM_LTE: Int
+            }
+
+            input SeriesActorsFieldInput {
+              connect: [SeriesActorsConnectFieldInput!]
+              create: [SeriesActorsCreateFieldInput!]
+            }
+
+            input SeriesActorsNodeAggregationWhereInput {
+              AND: [SeriesActorsNodeAggregationWhereInput!]
+              NOT: SeriesActorsNodeAggregationWhereInput
+              OR: [SeriesActorsNodeAggregationWhereInput!]
+              name_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_LENGTH_EQUAL: Float
+              name_AVERAGE_LENGTH_GT: Float
+              name_AVERAGE_LENGTH_GTE: Float
+              name_AVERAGE_LENGTH_LT: Float
+              name_AVERAGE_LENGTH_LTE: Float
+              name_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_LENGTH_EQUAL: Int
+              name_LONGEST_LENGTH_GT: Int
+              name_LONGEST_LENGTH_GTE: Int
+              name_LONGEST_LENGTH_LT: Int
+              name_LONGEST_LENGTH_LTE: Int
+              name_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_LENGTH_EQUAL: Int
+              name_SHORTEST_LENGTH_GT: Int
+              name_SHORTEST_LENGTH_GTE: Int
+              name_SHORTEST_LENGTH_LT: Int
+              name_SHORTEST_LENGTH_LTE: Int
+              name_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+            }
+
+            input SeriesActorsUpdateConnectionInput {
+              edge: ActedInUpdateInput
+              node: ActorUpdateInput
+            }
+
+            input SeriesActorsUpdateFieldInput {
+              connect: [SeriesActorsConnectFieldInput!]
+              create: [SeriesActorsCreateFieldInput!]
+              delete: [ShowActorsDeleteFieldInput!]
+              disconnect: [ShowActorsDisconnectFieldInput!]
+              update: SeriesActorsUpdateConnectionInput
+              where: ShowActorsConnectionWhere
+            }
+
+            type SeriesAggregateSelection {
+              count: Int!
+              episodes: IntAggregateSelectionNullable!
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            input SeriesConnectInput {
+              actors: [SeriesActorsConnectFieldInput!]
+            }
+
+            type SeriesConnection {
+              edges: [SeriesEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input SeriesCreateInput {
+              actors: SeriesActorsFieldInput
+              episodes: Int
+              title: String!
+            }
+
+            input SeriesDeleteInput {
+              actors: [ShowActorsDeleteFieldInput!]
+            }
+
+            input SeriesDisconnectInput {
+              actors: [ShowActorsDisconnectFieldInput!]
+            }
+
+            type SeriesEdge {
+              cursor: String!
+              node: Series!
+            }
+
+            input SeriesOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more SeriesSort objects to sort Series by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [SeriesSort!]
+            }
+
+            input SeriesRelationInput {
+              actors: [SeriesActorsCreateFieldInput!]
+            }
+
+            \\"\\"\\"
+            Fields to sort Series by. The order in which sorts are applied is not guaranteed when specifying many fields in one SeriesSort object.
+            \\"\\"\\"
+            input SeriesSort {
+              episodes: SortDirection
+              title: SortDirection
+            }
+
+            input SeriesUpdateInput {
+              actors: [SeriesActorsUpdateFieldInput!]
+              episodes: Int
+              episodes_DECREMENT: Int
+              episodes_INCREMENT: Int
+              title: String
+            }
+
+            input SeriesWhere {
+              AND: [SeriesWhere!]
+              NOT: SeriesWhere
+              OR: [SeriesWhere!]
+              actors: ActorWhere @deprecated(reason: \\"Use \`actors_SOME\` instead.\\")
+              actorsAggregate: SeriesActorsAggregateInput
+              actorsConnection: ShowActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_SOME\` instead.\\")
+              \\"\\"\\"
+              Return Series where all of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_ALL: ShowActorsConnectionWhere
+              \\"\\"\\"
+              Return Series where none of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_NONE: ShowActorsConnectionWhere
+              actorsConnection_NOT: ShowActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_NONE\` instead.\\")
+              \\"\\"\\"
+              Return Series where one of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SINGLE: ShowActorsConnectionWhere
+              \\"\\"\\"
+              Return Series where some of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SOME: ShowActorsConnectionWhere
+              \\"\\"\\"Return Series where all of the related Actors match this filter\\"\\"\\"
+              actors_ALL: ActorWhere
+              \\"\\"\\"Return Series where none of the related Actors match this filter\\"\\"\\"
+              actors_NONE: ActorWhere
+              actors_NOT: ActorWhere @deprecated(reason: \\"Use \`actors_NONE\` instead.\\")
+              \\"\\"\\"Return Series where one of the related Actors match this filter\\"\\"\\"
+              actors_SINGLE: ActorWhere
+              \\"\\"\\"Return Series where some of the related Actors match this filter\\"\\"\\"
+              actors_SOME: ActorWhere
+              episodes: Int
+              episodes_GT: Int
+              episodes_GTE: Int
+              episodes_IN: [Int]
+              episodes_LT: Int
+              episodes_LTE: Int
+              episodes_NOT: Int @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              episodes_NOT_IN: [Int] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String!]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+            }
+
+            interface Show {
+              actors(options: ActorOptions, where: ActorWhere): [Actor!]!
+              actorsConnection(after: String, first: Int, sort: [ShowActorsConnectionSort!], where: ShowActorsConnectionWhere): ShowActorsConnection!
+              title: String!
+            }
+
+            input ShowActorsAggregateInput {
+              AND: [ShowActorsAggregateInput!]
+              NOT: ShowActorsAggregateInput
+              OR: [ShowActorsAggregateInput!]
+              count: Int
+              count_GT: Int
+              count_GTE: Int
+              count_LT: Int
+              count_LTE: Int
+              edge: ShowActorsEdgeAggregationWhereInput
+              node: ShowActorsNodeAggregationWhereInput
+            }
+
+            input ShowActorsConnectFieldInput {
+              connect: [ActorConnectInput!]
+              edge: ShowActorsEdgeCreateInput
+              \\"\\"\\"
+              Whether or not to overwrite any matching relationship with the new properties.
+              \\"\\"\\"
+              overwrite: Boolean! = true
+              where: ActorConnectWhere
+            }
+
+            type ShowActorsConnection {
+              edges: [ShowActorsRelationship!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }
+
+            input ShowActorsConnectionSort {
+              edge: ShowActorsEdgeSort
+              node: ActorSort
+            }
+
+            input ShowActorsConnectionWhere {
+              AND: [ShowActorsConnectionWhere!]
+              NOT: ShowActorsConnectionWhere
+              OR: [ShowActorsConnectionWhere!]
+              edge: ShowActorsEdgeWhere
+              edge_NOT: ShowActorsEdgeWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              node: ActorWhere
+              node_NOT: ActorWhere @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+            }
+
+            input ShowActorsCreateFieldInput {
+              edge: ShowActorsEdgeCreateInput
+              node: ActorCreateInput!
+            }
+
+            input ShowActorsDeleteFieldInput {
+              delete: ActorDeleteInput
+              where: ShowActorsConnectionWhere
+            }
+
+            input ShowActorsDisconnectFieldInput {
+              disconnect: ActorDisconnectInput
+              where: ShowActorsConnectionWhere
+            }
+
+            input ShowActorsEdgeAggregationWhereInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              * Series
+              \\"\\"\\"
+              ActedIn: SeriesActorsEdgeAggregationWhereInput
+            }
+
+            input ShowActorsEdgeCreateInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              * Series
+              \\"\\"\\"
+              ActedIn: ActedInCreateInput
+            }
+
+            input ShowActorsEdgeSort {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              * Series
+              \\"\\"\\"
+              ActedIn: ActedInSort
+            }
+
+            input ShowActorsEdgeUpdateInput {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              * Series
+              \\"\\"\\"
+              ActedIn: ActedInUpdateInput
+            }
+
+            input ShowActorsEdgeWhere {
+              \\"\\"\\"
+              Relationship properties when source node is of type:
+              * Movie
+              * Series
+              \\"\\"\\"
+              ActedIn: ActedInWhere
+            }
+
+            input ShowActorsNodeAggregationWhereInput {
+              AND: [ShowActorsNodeAggregationWhereInput!]
+              NOT: ShowActorsNodeAggregationWhereInput
+              OR: [ShowActorsNodeAggregationWhereInput!]
+              name_AVERAGE_EQUAL: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_GT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_GTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_LENGTH_EQUAL: Float
+              name_AVERAGE_LENGTH_GT: Float
+              name_AVERAGE_LENGTH_GTE: Float
+              name_AVERAGE_LENGTH_LT: Float
+              name_AVERAGE_LENGTH_LTE: Float
+              name_AVERAGE_LT: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_AVERAGE_LTE: Float @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_EQUAL: String @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_GT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_GTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_LONGEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_LENGTH_EQUAL: Int
+              name_LONGEST_LENGTH_GT: Int
+              name_LONGEST_LENGTH_GTE: Int
+              name_LONGEST_LENGTH_LT: Int
+              name_LONGEST_LENGTH_LTE: Int
+              name_LONGEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LONGEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_LT: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_LTE: Int @deprecated(reason: \\"Aggregation filters that are not relying on an aggregating function will be deprecated.\\")
+              name_SHORTEST_EQUAL: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_GT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_GTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_LENGTH_EQUAL: Int
+              name_SHORTEST_LENGTH_GT: Int
+              name_SHORTEST_LENGTH_GTE: Int
+              name_SHORTEST_LENGTH_LT: Int
+              name_SHORTEST_LENGTH_LTE: Int
+              name_SHORTEST_LT: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+              name_SHORTEST_LTE: Int @deprecated(reason: \\"Please use the explicit _LENGTH version for string aggregation.\\")
+            }
+
+            type ShowActorsRelationship {
+              cursor: String!
+              node: Actor!
+              properties: ShowActorsRelationshipProperties!
+            }
+
+            union ShowActorsRelationshipProperties = ActedIn
+
+            input ShowActorsUpdateConnectionInput {
+              edge: ShowActorsEdgeUpdateInput
+              node: ActorUpdateInput
+            }
+
+            input ShowActorsUpdateFieldInput {
+              connect: [ShowActorsConnectFieldInput!]
+              create: [ShowActorsCreateFieldInput!]
+              delete: [ShowActorsDeleteFieldInput!]
+              disconnect: [ShowActorsDisconnectFieldInput!]
+              update: ShowActorsUpdateConnectionInput
+              where: ShowActorsConnectionWhere
+            }
+
+            type ShowAggregateSelection {
+              count: Int!
+              title: StringAggregateSelectionNonNullable!
+            }
+
+            input ShowConnectInput {
+              actors: [ShowActorsConnectFieldInput!]
+            }
+
+            input ShowConnectWhere {
+              node: ShowWhere!
+            }
+
+            input ShowCreateInput {
+              Movie: MovieCreateInput
+              Series: SeriesCreateInput
+            }
+
+            input ShowDeleteInput {
+              actors: [ShowActorsDeleteFieldInput!]
+            }
+
+            input ShowDisconnectInput {
+              actors: [ShowActorsDisconnectFieldInput!]
+            }
+
+            enum ShowImplementation {
+              Movie
+              Series
+            }
+
+            input ShowOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more ShowSort objects to sort Shows by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [ShowSort]
+            }
+
+            \\"\\"\\"
+            Fields to sort Shows by. The order in which sorts are applied is not guaranteed when specifying many fields in one ShowSort object.
+            \\"\\"\\"
+            input ShowSort {
+              title: SortDirection
+            }
+
+            input ShowUpdateInput {
+              actors: [ShowActorsUpdateFieldInput!]
+              title: String
+            }
+
+            input ShowWhere {
+              AND: [ShowWhere!]
+              NOT: ShowWhere
+              OR: [ShowWhere!]
+              actors: ActorWhere @deprecated(reason: \\"Use \`actors_SOME\` instead.\\")
+              actorsAggregate: ShowActorsAggregateInput
+              actorsConnection: ShowActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_SOME\` instead.\\")
+              \\"\\"\\"
+              Return Shows where all of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_ALL: ShowActorsConnectionWhere
+              \\"\\"\\"
+              Return Shows where none of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_NONE: ShowActorsConnectionWhere
+              actorsConnection_NOT: ShowActorsConnectionWhere @deprecated(reason: \\"Use \`actorsConnection_NONE\` instead.\\")
+              \\"\\"\\"
+              Return Shows where one of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SINGLE: ShowActorsConnectionWhere
+              \\"\\"\\"
+              Return Shows where some of the related ShowActorsConnections match this filter
+              \\"\\"\\"
+              actorsConnection_SOME: ShowActorsConnectionWhere
+              \\"\\"\\"Return Shows where all of the related Actors match this filter\\"\\"\\"
+              actors_ALL: ActorWhere
+              \\"\\"\\"Return Shows where none of the related Actors match this filter\\"\\"\\"
+              actors_NONE: ActorWhere
+              actors_NOT: ActorWhere @deprecated(reason: \\"Use \`actors_NONE\` instead.\\")
+              \\"\\"\\"Return Shows where one of the related Actors match this filter\\"\\"\\"
+              actors_SINGLE: ActorWhere
+              \\"\\"\\"Return Shows where some of the related Actors match this filter\\"\\"\\"
+              actors_SOME: ActorWhere
+              title: String
+              title_CONTAINS: String
+              title_ENDS_WITH: String
+              title_IN: [String!]
+              title_NOT: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_CONTAINS: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_ENDS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_IN: [String!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_NOT_STARTS_WITH: String @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              title_STARTS_WITH: String
+              typename_IN: [ShowImplementation!]
+            }
+
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
+
+            type StringAggregateSelectionNonNullable {
+              longest: String
+              shortest: String
+            }
+
+            type UpdateActorsMutationResponse {
+              actors: [Actor!]!
+              info: UpdateInfo!
+            }
+
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
+
+            type UpdateMoviesMutationResponse {
+              info: UpdateInfo!
+              movies: [Movie!]!
+            }
+
+            type UpdateSeriesMutationResponse {
+              info: UpdateInfo!
+              series: [Series!]!
+            }"
+        `);
+    });
+});

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -583,8 +583,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type Movie {
@@ -717,8 +717,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActor2sMutationResponse {

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -67,10 +67,10 @@ describe("Algebraic", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -215,10 +215,10 @@ describe("Algebraic", () => {
             scalar BigInt
 
             type BigIntAggregateSelectionNonNullable {
-              average: BigInt!
-              max: BigInt!
-              min: BigInt!
-              sum: BigInt!
+              average: BigInt
+              max: BigInt
+              min: BigInt
+              sum: BigInt
             }
 
             \\"\\"\\"
@@ -410,10 +410,10 @@ describe("Algebraic", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNullable {
@@ -831,10 +831,10 @@ describe("Algebraic", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -1103,8 +1103,8 @@ describe("Algebraic", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateDirectorsMutationResponse {
@@ -1189,10 +1189,10 @@ describe("Algebraic", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -1710,8 +1710,8 @@ describe("Algebraic", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -2450,8 +2450,8 @@ describe("Algebraic", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -424,17 +424,17 @@ describe("nested aggregation on interface", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -568,8 +568,8 @@ describe("nested aggregation on interface", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/graphql/tests/schema/null.test.ts
+++ b/packages/graphql/tests/schema/null.test.ts
@@ -82,22 +82,22 @@ describe("Null", () => {
             }
 
             type FloatAggregateSelectionNonNullable {
-              average: Float!
-              max: Float!
-              min: Float!
-              sum: Float!
+              average: Float
+              max: Float
+              min: Float
+              sum: Float
             }
 
             type IDAggregateSelectionNonNullable {
-              longest: ID!
-              shortest: ID!
+              longest: ID
+              shortest: ID
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie {
@@ -348,8 +348,8 @@ describe("Null", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -106,8 +106,8 @@ describe("Pluralize consistency", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type SuperFriendsConnection {

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -92,8 +92,8 @@ describe("Query Direction", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -422,8 +422,8 @@ describe("Query Direction", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"
@@ -752,8 +752,8 @@ describe("Query Direction", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             \\"\\"\\"

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -631,8 +631,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -3004,10 +3004,10 @@ describe("Subscriptions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type IntAggregateSelectionNullable {
@@ -3962,8 +3962,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {
@@ -4410,10 +4410,10 @@ describe("Subscriptions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Mutation {
@@ -4448,8 +4448,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type StringAggregateSelectionNullable {
@@ -5879,10 +5879,10 @@ describe("Subscriptions", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type Movie implements Production {
@@ -6619,8 +6619,8 @@ describe("Subscriptions", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type Subscription {

--- a/packages/graphql/tests/schema/types/bigint.test.ts
+++ b/packages/graphql/tests/schema/types/bigint.test.ts
@@ -45,10 +45,10 @@ describe("Bigint", () => {
             scalar BigInt
 
             type BigIntAggregateSelectionNonNullable {
-              average: BigInt!
-              max: BigInt!
-              min: BigInt!
-              sum: BigInt!
+              average: BigInt
+              max: BigInt
+              min: BigInt
+              sum: BigInt
             }
 
             type CreateFilesMutationResponse {
@@ -178,8 +178,8 @@ describe("Bigint", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateFilesMutationResponse {

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -643,10 +643,10 @@ describe("Union Interface Relationships", () => {
             }
 
             type IntAggregateSelectionNonNullable {
-              average: Float!
-              max: Int!
-              min: Int!
-              sum: Int!
+              average: Float
+              max: Int
+              min: Int
+              sum: Int
             }
 
             type IntAggregateSelectionNullable {
@@ -1887,8 +1887,8 @@ describe("Union Interface Relationships", () => {
             }
 
             type StringAggregateSelectionNonNullable {
-              longest: String!
-              shortest: String!
+              longest: String
+              shortest: String
             }
 
             type UpdateActorsMutationResponse {

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -1126,10 +1126,10 @@ describe("generate", () => {
 
             export type IntAggregateSelectionNonNullable = {
               __typename?: \\"IntAggregateSelectionNonNullable\\";
-              max: Scalars[\\"Int\\"][\\"output\\"];
-              min: Scalars[\\"Int\\"][\\"output\\"];
-              average: Scalars[\\"Float\\"][\\"output\\"];
-              sum: Scalars[\\"Int\\"][\\"output\\"];
+              max?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
+              min?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
+              average?: Maybe<Scalars[\\"Float\\"][\\"output\\"]>;
+              sum?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
             };
 
             export type Movie = {
@@ -1244,8 +1244,8 @@ describe("generate", () => {
 
             export type StringAggregateSelectionNonNullable = {
               __typename?: \\"StringAggregateSelectionNonNullable\\";
-              shortest: Scalars[\\"String\\"][\\"output\\"];
-              longest: Scalars[\\"String\\"][\\"output\\"];
+              shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
+              longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
 
             /** Information about the number of nodes and relationships created and deleted during an update mutation */
@@ -2100,8 +2100,8 @@ describe("generate", () => {
 
             export type IdAggregateSelectionNonNullable = {
               __typename?: \\"IDAggregateSelectionNonNullable\\";
-              shortest: Scalars[\\"ID\\"][\\"output\\"];
-              longest: Scalars[\\"ID\\"][\\"output\\"];
+              shortest?: Maybe<Scalars[\\"ID\\"][\\"output\\"]>;
+              longest?: Maybe<Scalars[\\"ID\\"][\\"output\\"]>;
             };
 
             export type IntAggregateSelectionNullable = {
@@ -2123,8 +2123,8 @@ describe("generate", () => {
 
             export type StringAggregateSelectionNonNullable = {
               __typename?: \\"StringAggregateSelectionNonNullable\\";
-              shortest: Scalars[\\"String\\"][\\"output\\"];
-              longest: Scalars[\\"String\\"][\\"output\\"];
+              shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
+              longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
 
             export type UpdateFaqEntriesMutationResponse = {


### PR DESCRIPTION
Makes aggregation types nullable, even if the original property is non-nullable.

This is because, in case of no nodes existing in the database, a null value will be returned by the aggregation

Schema tests had to be updated. New integration and schema tests added