### PR TITLE
Fix artifact merge on integration tests and e2e tests

### DIFF
--- a/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem-nightly.yml
@@ -138,7 +138,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: integration-tests
     steps:
-      - name: Merge Artifacts
+      - if: ${{ env.CODECOV_TOKEN != '' && !inputs.disable-code-cov-upload }}
+        name: Merge Artifacts
         uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
         with:
           name: integration-nightly-coverage

--- a/.github/workflows/reusable-integration-tests-on-prem.yml
+++ b/.github/workflows/reusable-integration-tests-on-prem.yml
@@ -82,5 +82,16 @@ jobs:
         name: Archive coverage report
         uses: actions/upload-artifact@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
         with:
-          name: integration-coverage-${{ matrix.packages.package }}
+          name: integration-coverage-${{ matrix.packages.package }}-${{ matrix.packages.shard }}
           path: packages/${{ matrix.packages.package }}/coverage/
+
+  merge-integration-tests-results:
+    runs-on: ubuntu-latest
+    needs: integration-tests
+    steps:
+      - if: ${{ env.CODECOV_TOKEN != '' && !inputs.disable-code-cov-upload }}
+        name: Merge Artifacts
+        uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        with:
+          name: integration-coverage
+          pattern: integration-coverage-*

--- a/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
+++ b/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
@@ -60,3 +60,13 @@ jobs:
         with:
           name: e2e-coverage-graphql-amqp-subscriptions-engine-${{ matrix.graphql-version }}-${{ matrix.neo4j-version }}
           path: packages/graphql-amqp-subscriptions-engine/coverage/
+
+  merge-e2e-tests-results:
+    runs-on: ubuntu-latest
+    needs: e2e-tests
+    steps:
+        name: Merge Artifacts
+        uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        with:
+          name: e2e-coverage-graphql-amqp-subscriptions-engine
+          pattern: e2e-coverage-graphql-amqp-subscriptions-engine-*

--- a/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
+++ b/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
@@ -64,9 +64,9 @@ jobs:
   merge-e2e-tests-results:
     runs-on: ubuntu-latest
     needs: e2e-tests
-      steps:
-          name: Merge Artifacts
-          uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
-          with:
-            name: e2e-coverage-graphql-amqp-subscriptions-engine
-            pattern: e2e-coverage-graphql-amqp-subscriptions-engine-*
+    steps:
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+        with:
+          name: e2e-coverage-graphql-amqp-subscriptions-engine
+          pattern: e2e-coverage-graphql-amqp-subscriptions-engine-*

--- a/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
+++ b/.github/workflows/reusable-subscriptions-plugin-amqp-e2e-test.yml
@@ -64,9 +64,9 @@ jobs:
   merge-e2e-tests-results:
     runs-on: ubuntu-latest
     needs: e2e-tests
-    steps:
-        name: Merge Artifacts
-        uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
-        with:
-          name: e2e-coverage-graphql-amqp-subscriptions-engine
-          pattern: e2e-coverage-graphql-amqp-subscriptions-engine-*
+      steps:
+          name: Merge Artifacts
+          uses: actions/upload-artifact/merge@26f96dfa697d77e81fd5907df203aa23a56210a8 # v4
+          with:
+            name: e2e-coverage-graphql-amqp-subscriptions-engine
+            pattern: e2e-coverage-graphql-amqp-subscriptions-engine-*


### PR DESCRIPTION
Artifact upload was not working in nightly scheduled workflows. This PR ensures the artifact merge only occurs when conditions are right (i.e. on a scheduled run), and doesn't try to upload when an artifact is absent.

This change has also been made to the e2e tests.