### PR TITLE
refactoring: Harmonizing AggregationSelection-types

### DIFF
--- a/.changeset/violet-walls-travel.md
+++ b/.changeset/violet-walls-travel.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": major
+---
+
+The old `*AggregateSelectionNonNullable`-types and `*AggregateSelectionNullable`-types are now merged into `*AggregateSelection`-types`.

--- a/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
+++ b/packages/graphql/src/schema-model/attribute/model-adapters/AttributeAdapter.ts
@@ -385,9 +385,8 @@ export class AttributeAdapter {
         };
     }
 
-    public getAggregateSelectionTypeName(nullable: boolean): string {
-        const nullableStr = nullable ? "Nullable" : "NonNullable";
-        return `${this.getFieldTypeName()}AggregateSelection${nullableStr}`;
+    public getAggregateSelectionTypeName(): string {
+        return `${this.getFieldTypeName()}AggregateSelection`;
     }
 }
 

--- a/packages/graphql/src/schema/aggregations/aggregations-types-mapper.test.ts
+++ b/packages/graphql/src/schema/aggregations/aggregations-types-mapper.test.ts
@@ -29,45 +29,24 @@ describe("AggregationTypesMapper", () => {
         typesMapper = new AggregationTypesMapper(composer);
     });
 
-    test("returns the correct non nullable type", () => {
-        const aggregationType = typesMapper.getAggregationType({
-            fieldName: "String",
-            nullable: false,
-        });
-
-        expect(aggregationType?.getTypeName()).toBe("StringAggregateSelectionNonNullable");
+    test("returns the correct type", () => {
+        const aggregationType = typesMapper.getAggregationType("String");
+        expect(aggregationType?.getTypeName()).toBe("StringAggregateSelection");
         expect(composer.get(aggregationType?.getTypeName())).toBeTruthy();
     });
 
     test("do not duplicate types", () => {
-        const beforeType = composer.get("StringAggregateSelectionNonNullable");
+        const beforeType = composer.get("StringAggregateSelection");
         const typesMapper2 = new AggregationTypesMapper(composer);
-        const aggregationType = typesMapper2.getAggregationType({
-            fieldName: "String",
-            nullable: false,
-        });
+        const aggregationType = typesMapper2.getAggregationType("String");
 
-        expect(aggregationType?.getTypeName()).toBe("StringAggregateSelectionNonNullable");
+        expect(aggregationType?.getTypeName()).toBe("StringAggregateSelection");
         expect(composer.get(aggregationType?.getTypeName())).toBeTruthy();
         expect(beforeType).toEqual(aggregationType);
     });
 
-    test("returns the correct nullable type", () => {
-        const aggregationType = typesMapper.getAggregationType({
-            fieldName: "String",
-            nullable: true,
-        });
-
-        expect(aggregationType?.getTypeName()).toBe("StringAggregateSelectionNullable");
-        expect(composer.get(aggregationType?.getTypeName())).toBeTruthy();
-    });
-
     test("returns undefined for invalid type", () => {
-        const aggregationType = typesMapper.getAggregationType({
-            fieldName: "this is a lovely typeeee",
-            nullable: true,
-        });
-
+        const aggregationType = typesMapper.getAggregationType("this is a lovely typeeee");
         expect(aggregationType).toBeUndefined();
     });
 });

--- a/packages/graphql/src/schema/aggregations/field-aggregation-composer.ts
+++ b/packages/graphql/src/schema/aggregations/field-aggregation-composer.ts
@@ -97,10 +97,7 @@ export class FieldAggregationComposer {
         entity: RelationshipAdapter | ConcreteEntityAdapter | InterfaceEntityAdapter
     ): Record<string, ObjectTypeComposer> {
         return entity.aggregableFields.reduce((res, field) => {
-            const objectTypeComposer = this.aggregationTypesMapper.getAggregationType({
-                fieldName: field.getTypeName(),
-                nullable: !field.typeHelper.isRequired(),
-            });
+            const objectTypeComposer = this.aggregationTypesMapper.getAggregationType(field.getTypeName());
 
             if (!objectTypeComposer) return res;
 

--- a/packages/graphql/src/schema/generation/aggregate-types.ts
+++ b/packages/graphql/src/schema/generation/aggregate-types.ts
@@ -72,10 +72,7 @@ function makeAggregableFields({
     const aggregableFields: ObjectTypeComposerFieldConfigMapDefinition<any, any> = {};
     const aggregableAttributes = entityAdapter.aggregableFields;
     for (const attribute of aggregableAttributes) {
-        const objectTypeComposer = aggregationTypesMapper.getAggregationType({
-            fieldName: attribute.getTypeName(),
-            nullable: !attribute.typeHelper.isRequired(),
-        });
+        const objectTypeComposer = aggregationTypesMapper.getAggregationType(attribute.getTypeName());
         if (objectTypeComposer) {
             aggregableFields[attribute.name] = objectTypeComposer.NonNull;
         }

--- a/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/FieldFactory.ts
@@ -146,10 +146,7 @@ export class FieldFactory {
                     const attribute = entity.findAttribute(field.name);
                     if (!attribute) throw new Error(`Attribute ${field.name} not found`);
 
-                    const aggregateFields =
-                        field.fieldsByTypeName[attribute.getAggregateSelectionTypeName(false)] ||
-                        field.fieldsByTypeName[attribute.getAggregateSelectionTypeName(true)] ||
-                        {};
+                    const aggregateFields = field.fieldsByTypeName[attribute.getAggregateSelectionTypeName()] || {};
 
                     const aggregationProjection = Object.values(aggregateFields).reduce((acc, f) => {
                         acc[f.name] = f.alias;

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -39,18 +39,21 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
         const typeDefs = /* GraphQL */ `
             interface Show {
                 title: String!
+                release: DateTime!
                 actors: [${Actor}!]! @declareRelationship
             }
 
             type ${Movie} implements Show {
                 title: String!
                 runtime: Int
+                release: DateTime!
                 actors: [${Actor}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
             type ${Series} implements Show {
                 title: String!
                 episodes: Int
+                release: DateTime!
                 actors: [${Actor}!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
@@ -73,25 +76,25 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             await session.run(
                 `
                 // Create Movies
-                CREATE (m1:${Movie} { title: "The Movie One", cost: 10000000, runtime: 120 })
-                CREATE (m2:${Movie} { title: "The Movie Two", cost: 20000000, runtime: 90 })
-                CREATE (m3:${Movie} { title: "The Movie Three", cost: 12000000, runtime: 70 })
-                
+                CREATE (m1:${Movie} { title: "The Movie One", cost: 10000000, runtime: 120, release: dateTime('2007-08-31T16:47+00:00') })
+                CREATE (m2:${Movie} { title: "The Movie Two", cost: 20000000, runtime: 90, release: dateTime('2009-08-31T16:47+00:00') })
+                CREATE (m3:${Movie} { title: "The Movie Three", cost: 12000000, runtime: 70, release: dateTime('2010-08-31T16:47+00:00') })
+
                 // Create Series
-                CREATE (s1:${Series} { title: "The Series One", cost: 10000000, episodes: 10 })
-                CREATE (s2:${Series} { title: "The Series Two", cost: 20000000, episodes: 20 })
-                CREATE (s3:${Series} { title: "The Series Three", cost: 20000000, episodes: 15 })
-                
+                CREATE (s1:${Series} { title: "The Series One", cost: 10000000, episodes: 10, release: dateTime('2011-08-31T16:47+00:00') })
+                CREATE (s2:${Series} { title: "The Series Two", cost: 20000000, episodes: 20, release: dateTime('2012-08-31T16:47+00:00') })
+                CREATE (s3:${Series} { title: "The Series Three", cost: 20000000, episodes: 15, release: dateTime('2013-08-31T16:47+00:00') })
+
                 // Create Actors
                 CREATE (a1:${Actor} { name: "Actor One" })
                 CREATE (a2:${Actor} { name: "Actor Two" })
-                
+
                 // Associate Actor 1 with Movies and Series
                 CREATE (a1)-[:ACTED_IN { screenTime: 100 }]->(m1)
                 CREATE (a1)-[:ACTED_IN { screenTime: 82 }]->(s1)
                 CREATE (a1)-[:ACTED_IN { screenTime: 20 }]->(m3)
                 CREATE (a1)-[:ACTED_IN { screenTime: 22 }]->(s3)
-                
+
                 // Associate Actor 2 with Movies and Series
                 CREATE (a2)-[:ACTED_IN { screenTime: 240 }]->(m2)
                 CREATE (a2)-[:ACTED_IN { screenTime: 728 }]->(s2)
@@ -124,6 +127,9 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
                     title {
                         longest
                     }
+                    release {
+                        min
+                    }
                 }
             }
         `;
@@ -138,6 +144,9 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             showsAggregate: {
                 title: {
                     longest: null,
+                },
+                release: {
+                    min: null,
                 },
             },
         });

--- a/packages/graphql/tests/schema/aggregations.test.ts
+++ b/packages/graphql/tests/schema/aggregations.test.ts
@@ -53,7 +53,7 @@ describe("Aggregations", () => {
             \\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -77,7 +77,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -94,24 +94,24 @@ describe("Aggregations", () => {
             \\"\\"\\"A duration, represented as an ISO 8601 duration string\\"\\"\\"
             scalar Duration
 
-            type DurationAggregateSelectionNullable {
+            type DurationAggregateSelection {
               max: Duration
               min: Duration
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -121,7 +121,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'\\"\\"\\"
             scalar LocalDateTime
 
-            type LocalDateTimeAggregateSelectionNullable {
+            type LocalDateTimeAggregateSelection {
               max: LocalDateTime
               min: LocalDateTime
             }
@@ -131,7 +131,7 @@ describe("Aggregations", () => {
             \\"\\"\\"
             scalar LocalTime
 
-            type LocalTimeAggregateSelectionNullable {
+            type LocalTimeAggregateSelection {
               max: LocalTime
               min: LocalTime
             }
@@ -152,17 +152,17 @@ describe("Aggregations", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
-              imdbRating: FloatAggregateSelectionNullable!
-              isbn: StringAggregateSelectionNonNullable!
-              screenTime: DurationAggregateSelectionNullable!
-              someBigInt: BigIntAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              imdbRating: FloatAggregateSelection!
+              isbn: StringAggregateSelection!
+              screenTime: DurationAggregateSelection!
+              someBigInt: BigIntAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someTime: TimeAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -366,12 +366,7 @@ describe("Aggregations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -379,7 +374,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A time, represented as an RFC3339 time string\\"\\"\\"
             scalar Time
 
-            type TimeAggregateSelectionNullable {
+            type TimeAggregateSelection {
               max: Time
               min: Time
             }
@@ -449,7 +444,7 @@ describe("Aggregations", () => {
             \\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -478,7 +473,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -495,24 +490,24 @@ describe("Aggregations", () => {
             \\"\\"\\"A duration, represented as an ISO 8601 duration string\\"\\"\\"
             scalar Duration
 
-            type DurationAggregateSelectionNullable {
+            type DurationAggregateSelection {
               max: Duration
               min: Duration
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -676,7 +671,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'\\"\\"\\"
             scalar LocalDateTime
 
-            type LocalDateTimeAggregateSelectionNullable {
+            type LocalDateTimeAggregateSelection {
               max: LocalDateTime
               min: LocalDateTime
             }
@@ -686,7 +681,7 @@ describe("Aggregations", () => {
             \\"\\"\\"
             scalar LocalTime
 
-            type LocalTimeAggregateSelectionNullable {
+            type LocalTimeAggregateSelection {
               max: LocalTime
               min: LocalTime
             }
@@ -717,7 +712,7 @@ describe("Aggregations", () => {
 
             type PostAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input PostConnectInput {
@@ -1249,29 +1244,29 @@ describe("Aggregations", () => {
             }
 
             type PostUserLikesEdgeAggregateSelection {
-              someBigInt: BigIntAggregateSelectionNullable!
-              someDateTime: DateTimeAggregateSelectionNullable!
-              someDuration: DurationAggregateSelectionNullable!
-              someFloat: FloatAggregateSelectionNullable!
-              someId: IDAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someString: StringAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someId: IDAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             type PostUserLikesNodeAggregateSelection {
-              someBigInt: BigIntAggregateSelectionNullable!
-              someDateTime: DateTimeAggregateSelectionNullable!
-              someDuration: DurationAggregateSelectionNullable!
-              someFloat: FloatAggregateSelectionNullable!
-              someId: IDAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someString: StringAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someId: IDAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             input PostWhere {
@@ -1342,7 +1337,7 @@ describe("Aggregations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1350,7 +1345,7 @@ describe("Aggregations", () => {
             \\"\\"\\"A time, represented as an RFC3339 time string\\"\\"\\"
             scalar Time
 
-            type TimeAggregateSelectionNullable {
+            type TimeAggregateSelection {
               max: Time
               min: Time
             }
@@ -1391,16 +1386,16 @@ describe("Aggregations", () => {
 
             type UserAggregateSelection {
               count: Int!
-              someBigInt: BigIntAggregateSelectionNullable!
-              someDateTime: DateTimeAggregateSelectionNullable!
-              someDuration: DurationAggregateSelectionNullable!
-              someFloat: FloatAggregateSelectionNullable!
-              someId: IDAggregateSelectionNullable!
-              someInt: IntAggregateSelectionNullable!
-              someLocalDateTime: LocalDateTimeAggregateSelectionNullable!
-              someLocalTime: LocalTimeAggregateSelectionNullable!
-              someString: StringAggregateSelectionNullable!
-              someTime: TimeAggregateSelectionNullable!
+              someBigInt: BigIntAggregateSelection!
+              someDateTime: DateTimeAggregateSelection!
+              someDuration: DurationAggregateSelection!
+              someFloat: FloatAggregateSelection!
+              someId: IDAggregateSelection!
+              someInt: IntAggregateSelection!
+              someLocalDateTime: LocalDateTimeAggregateSelection!
+              someLocalTime: LocalTimeAggregateSelection!
+              someString: StringAggregateSelection!
+              someTime: TimeAggregateSelection!
             }
 
             input UserConnectWhere {

--- a/packages/graphql/tests/schema/array-methods.test.ts
+++ b/packages/graphql/tests/schema/array-methods.test.ts
@@ -207,7 +207,7 @@ describe("Arrays Methods", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -242,8 +242,8 @@ describe("Arrays Methods", () => {
             }
 
             type ActorMovieActedInNodeAggregateSelection {
-              averageRating: FloatAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input ActorOptions {
@@ -350,14 +350,14 @@ describe("Arrays Methods", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -377,7 +377,7 @@ describe("Arrays Methods", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -505,9 +505,9 @@ describe("Arrays Methods", () => {
             }
 
             type MovieAggregateSelection {
-              averageRating: FloatAggregateSelectionNonNullable!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -669,7 +669,7 @@ describe("Arrays Methods", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/arrays.test.ts
+++ b/packages/graphql/tests/schema/arrays.test.ts
@@ -63,14 +63,14 @@ describe("Arrays", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -82,9 +82,9 @@ describe("Arrays", () => {
             }
 
             type MovieAggregateSelection {
-              averageRating: FloatAggregateSelectionNonNullable!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/authorization.test.ts
+++ b/packages/graphql/tests/schema/authorization.test.ts
@@ -75,7 +75,7 @@ describe("Authorization", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -107,8 +107,8 @@ describe("Authorization", () => {
 
             type PostAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostAuthorAggregateInput {
@@ -285,8 +285,8 @@ describe("Authorization", () => {
             }
 
             type PostUserAuthorNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -343,7 +343,7 @@ describe("Authorization", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -379,8 +379,8 @@ describe("Authorization", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -561,8 +561,8 @@ describe("Authorization", () => {
             }
 
             type UserUserPostsNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserWhere {

--- a/packages/graphql/tests/schema/comments.test.ts
+++ b/packages/graphql/tests/schema/comments.test.ts
@@ -91,7 +91,7 @@ describe("Comments", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -105,12 +105,12 @@ describe("Comments", () => {
               ROMANCE
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -135,10 +135,10 @@ describe("Comments", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -313,7 +313,7 @@ describe("Comments", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectWhere {
@@ -399,7 +399,7 @@ describe("Comments", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -418,7 +418,7 @@ describe("Comments", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -537,7 +537,7 @@ describe("Comments", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -672,7 +672,7 @@ describe("Comments", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -845,7 +845,7 @@ describe("Comments", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -886,11 +886,11 @@ describe("Comments", () => {
                 }
 
                 type ActorProductionActedInEdgeAggregateSelection {
-                  screenTime: IntAggregateSelectionNonNullable!
+                  screenTime: IntAggregateSelection!
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  title: StringAggregateSelectionNonNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -982,7 +982,7 @@ describe("Comments", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IntAggregateSelectionNonNullable {
+                type IntAggregateSelection {
                   average: Float
                   max: Int
                   min: Int
@@ -996,8 +996,8 @@ describe("Comments", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  runtime: IntAggregateSelectionNonNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  runtime: IntAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -1090,7 +1090,7 @@ describe("Comments", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  title: StringAggregateSelectionNonNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -1165,8 +1165,8 @@ describe("Comments", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  episodes: IntAggregateSelectionNonNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  episodes: IntAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -1241,7 +1241,7 @@ describe("Comments", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1331,7 +1331,7 @@ describe("Comments", () => {
 
                 type GenreAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input GenreConnectWhere {
@@ -1389,7 +1389,7 @@ describe("Comments", () => {
                   totalCount: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -1403,7 +1403,7 @@ describe("Comments", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {

--- a/packages/graphql/tests/schema/connect-or-create-id.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-id.test.ts
@@ -53,7 +53,7 @@ describe("connect or create with id", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -88,8 +88,8 @@ describe("connect or create with id", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -322,7 +322,7 @@ describe("connect or create with id", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -334,8 +334,8 @@ describe("connect or create with id", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -450,7 +450,7 @@ describe("connect or create with id", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -524,9 +524,9 @@ describe("connect or create with id", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -538,7 +538,7 @@ describe("connect or create with id", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -570,10 +570,10 @@ describe("connect or create with id", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PostConnectInput {
@@ -786,8 +786,8 @@ describe("connect or create with id", () => {
             }
 
             type PostUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -852,7 +852,7 @@ describe("connect or create with id", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -888,8 +888,8 @@ describe("connect or create with id", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -945,9 +945,9 @@ describe("connect or create with id", () => {
             }
 
             type UserPostPostsNodeAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input UserPostsAggregateInput {

--- a/packages/graphql/tests/schema/connect-or-create-unions.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create-unions.test.ts
@@ -273,7 +273,7 @@ describe("Connect Or Create", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -417,8 +417,8 @@ describe("Connect Or Create", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -555,8 +555,8 @@ describe("Connect Or Create", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectOrCreateWhere {
@@ -648,7 +648,7 @@ describe("Connect Or Create", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/connect-or-create.test.ts
+++ b/packages/graphql/tests/schema/connect-or-create.test.ts
@@ -53,7 +53,7 @@ describe("Connect Or Create", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -88,8 +88,8 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -363,8 +363,8 @@ describe("Connect Or Create", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -482,7 +482,7 @@ describe("Connect Or Create", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -595,7 +595,7 @@ describe("Connect Or Create", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -631,13 +631,13 @@ describe("Connect Or Create", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              characterName: StringAggregateSelectionNullable!
-              screentime: IntAggregateSelectionNonNullable!
+              characterName: StringAggregateSelection!
+              screentime: IntAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -979,7 +979,7 @@ describe("Connect Or Create", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -993,8 +993,8 @@ describe("Connect Or Create", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -1112,12 +1112,7 @@ describe("Connect Or Create", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/connections/enums.test.ts
+++ b/packages/graphql/tests/schema/connections/enums.test.ts
@@ -93,7 +93,7 @@ describe("Enums", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -128,7 +128,7 @@ describe("Enums", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -372,7 +372,7 @@ describe("Enums", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -501,7 +501,7 @@ describe("Enums", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -645,7 +645,7 @@ describe("Enums", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/connections/interfaces.test.ts
+++ b/packages/graphql/tests/schema/connections/interfaces.test.ts
@@ -94,7 +94,7 @@ describe("Connection with interfaces", () => {
 
             type CreatureAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input CreatureConnectInput {
@@ -225,12 +225,12 @@ describe("Connection with interfaces", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -247,8 +247,8 @@ describe("Connection with interfaces", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -267,7 +267,7 @@ describe("Connection with interfaces", () => {
             }
 
             type MovieCreatureDirectorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieDeleteInput {
@@ -432,7 +432,7 @@ describe("Connection with interfaces", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -509,7 +509,7 @@ describe("Connection with interfaces", () => {
             }
 
             type PersonProductionMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -554,7 +554,7 @@ describe("Connection with interfaces", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -721,9 +721,9 @@ describe("Connection with interfaces", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episode: IntAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -749,7 +749,7 @@ describe("Connection with interfaces", () => {
             }
 
             type SeriesCreatureDirectorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input SeriesDeleteInput {
@@ -893,7 +893,7 @@ describe("Connection with interfaces", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/connections/sort.test.ts
+++ b/packages/graphql/tests/schema/connections/sort.test.ts
@@ -89,7 +89,7 @@ describe("Sort", () => {
 
             type Node1AggregateSelection {
               count: Int!
-              property: StringAggregateSelectionNonNullable!
+              property: StringAggregateSelection!
             }
 
             input Node1ConnectInput {
@@ -310,7 +310,7 @@ describe("Sort", () => {
             }
 
             type Node2Node1RelatedToNodeAggregateSelection {
-              property: StringAggregateSelectionNonNullable!
+              property: StringAggregateSelection!
             }
 
             input Node2Options {
@@ -509,7 +509,7 @@ describe("Sort", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/connections/unions.test.ts
+++ b/packages/graphql/tests/schema/connections/unions.test.ts
@@ -63,7 +63,7 @@ describe("Unions", () => {
 
             type AuthorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input AuthorConnectInput {
@@ -331,7 +331,7 @@ describe("Unions", () => {
 
             type BookAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input BookAuthorAggregateInput {
@@ -354,11 +354,11 @@ describe("Unions", () => {
             }
 
             type BookAuthorAuthorEdgeAggregateSelection {
-              words: IntAggregateSelectionNonNullable!
+              words: IntAggregateSelection!
             }
 
             type BookAuthorAuthorNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input BookAuthorConnectFieldInput {
@@ -639,7 +639,7 @@ describe("Unions", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -655,7 +655,7 @@ describe("Unions", () => {
 
             type JournalAggregateSelection {
               count: Int!
-              subject: StringAggregateSelectionNonNullable!
+              subject: StringAggregateSelection!
             }
 
             input JournalAuthorAggregateInput {
@@ -678,11 +678,11 @@ describe("Unions", () => {
             }
 
             type JournalAuthorAuthorEdgeAggregateSelection {
-              words: IntAggregateSelectionNonNullable!
+              words: IntAggregateSelection!
             }
 
             type JournalAuthorAuthorNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input JournalAuthorConnectFieldInput {
@@ -984,7 +984,7 @@ describe("Unions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/custom-mutations.test.ts
+++ b/packages/graphql/tests/schema/custom-mutations.test.ts
@@ -85,7 +85,7 @@ describe("Custom-mutations", () => {
               id: ID
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -96,7 +96,7 @@ describe("Custom-mutations", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/directive-preserve.test.ts
@@ -68,7 +68,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -79,7 +79,7 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -230,7 +230,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -246,7 +246,7 @@ describe("Directive-preserve", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -281,9 +281,9 @@ describe("Directive-preserve", () => {
             }
 
             type GenreMovieMoviesNodeAggregateSelection {
-              imdbRating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input GenreMoviesAggregateInput {
@@ -529,7 +529,7 @@ describe("Directive-preserve", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -547,9 +547,9 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              imdbRating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -586,7 +586,7 @@ describe("Directive-preserve", () => {
             }
 
             type MovieGenreGenresNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenresAggregateInput {
@@ -842,7 +842,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1020,7 +1020,7 @@ describe("Directive-preserve", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -1065,11 +1065,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -1161,7 +1161,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1183,11 +1183,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1321,8 +1321,8 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1500,7 +1500,7 @@ describe("Directive-preserve", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -1583,11 +1583,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -1721,8 +1721,8 @@ describe("Directive-preserve", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1844,7 +1844,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2025,7 +2025,7 @@ describe("Directive-preserve", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -2070,11 +2070,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -2166,7 +2166,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -2188,11 +2188,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -2326,8 +2326,8 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -2505,7 +2505,7 @@ describe("Directive-preserve", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -2588,11 +2588,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -2726,8 +2726,8 @@ describe("Directive-preserve", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -2849,7 +2849,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2920,7 +2920,7 @@ describe("Directive-preserve", () => {
 
             type BlogAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input BlogConnectInput {
@@ -2964,7 +2964,7 @@ describe("Directive-preserve", () => {
             }
 
             type BlogPostPostsNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
             }
 
             input BlogPostsAggregateInput {
@@ -3213,7 +3213,7 @@ describe("Directive-preserve", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
             }
 
@@ -3299,7 +3299,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -3338,7 +3338,7 @@ describe("Directive-preserve", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {

--- a/packages/graphql/tests/schema/directives/alias.test.ts
+++ b/packages/graphql/tests/schema/directives/alias.test.ts
@@ -322,9 +322,9 @@ describe("Alias", () => {
             }
 
             type ActorAggregateSelection {
-              city: StringAggregateSelectionNullable!
+              city: StringAggregateSelection!
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -357,13 +357,13 @@ describe("Alias", () => {
             }
 
             type ActorMovieActedInEdgeAggregateSelection {
-              character: StringAggregateSelectionNonNullable!
-              screenTime: IntAggregateSelectionNullable!
+              character: StringAggregateSelection!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieActedInNodeAggregateSelection {
-              rating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              rating: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorOptions {
@@ -482,14 +482,14 @@ describe("Alias", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -503,8 +503,8 @@ describe("Alias", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              rating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              rating: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectWhere {
@@ -611,12 +611,7 @@ describe("Alias", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/autogenerate.test.ts
+++ b/packages/graphql/tests/schema/directives/autogenerate.test.ts
@@ -62,7 +62,7 @@ describe("Autogenerate", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -74,8 +74,8 @@ describe("Autogenerate", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -168,7 +168,7 @@ describe("Autogenerate", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/directives/customResolver.test.ts
@@ -77,7 +77,7 @@ describe("@customResolver directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -112,12 +112,7 @@ describe("@customResolver directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -148,9 +143,9 @@ describe("@customResolver directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -170,7 +165,7 @@ describe("@customResolver directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              customResolver: StringAggregateSelectionNullable!
+              customResolver: StringAggregateSelection!
             }
 
             enum UserInterfaceImplementation {

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -57,7 +57,7 @@ describe("Cypher", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorCreateInput {
@@ -139,7 +139,7 @@ describe("Cypher", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -151,7 +151,7 @@ describe("Cypher", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -239,7 +239,7 @@ describe("Cypher", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -310,7 +310,7 @@ describe("Cypher", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorCreateInput {
@@ -393,7 +393,7 @@ describe("Cypher", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -405,7 +405,7 @@ describe("Cypher", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -493,7 +493,7 @@ describe("Cypher", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/directives/default.test.ts
@@ -74,9 +74,9 @@ describe("@default directive", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -88,19 +88,19 @@ describe("@default directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -143,7 +143,7 @@ describe("@default directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -178,13 +178,13 @@ describe("@default directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              fromInterface: StringAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
-              numberOfFriends: IntAggregateSelectionNonNullable!
-              rating: FloatAggregateSelectionNonNullable!
-              toBeOverridden: StringAggregateSelectionNonNullable!
-              verifiedDate: DateTimeAggregateSelectionNonNullable!
+              fromInterface: StringAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              numberOfFriends: IntAggregateSelection!
+              rating: FloatAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
+              verifiedDate: DateTimeAggregateSelection!
             }
 
             input UserCreateInput {
@@ -211,8 +211,8 @@ describe("@default directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              fromInterface: StringAggregateSelectionNonNullable!
-              toBeOverridden: StringAggregateSelectionNonNullable!
+              fromInterface: StringAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
             }
 
             enum UserInterfaceImplementation {

--- a/packages/graphql/tests/schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/directives/filterable.test.ts
@@ -927,8 +927,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -985,7 +985,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -1277,8 +1277,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -1443,7 +1443,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -1661,12 +1661,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -1745,8 +1740,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -1803,7 +1798,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -2137,8 +2132,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -2303,7 +2298,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -2521,12 +2516,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -2605,8 +2595,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -2663,7 +2653,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -2987,8 +2977,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -3153,7 +3143,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -3343,12 +3333,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -3430,8 +3415,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -3488,7 +3473,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -3822,8 +3807,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsConnectFieldInput {
@@ -3900,7 +3885,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -4117,12 +4102,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -4203,8 +4183,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -4261,7 +4241,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -4595,8 +4575,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -4761,7 +4741,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -4979,12 +4959,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -5065,8 +5040,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -5123,7 +5098,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -5457,8 +5432,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -5623,7 +5598,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -5813,12 +5788,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -5899,8 +5869,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -5957,7 +5927,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -6291,8 +6261,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsConnectFieldInput {
@@ -6369,7 +6339,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -6586,12 +6556,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -6677,8 +6642,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -6731,7 +6696,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -7126,7 +7091,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -7190,7 +7155,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -7331,7 +7296,7 @@ describe("@filterable directive", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -7423,12 +7388,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -7514,8 +7474,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -7568,7 +7528,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -7963,7 +7923,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -8027,7 +7987,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -8168,7 +8128,7 @@ describe("@filterable directive", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -8260,12 +8220,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -8351,8 +8306,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -8405,7 +8360,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -8800,7 +8755,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -8864,7 +8819,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -9005,7 +8960,7 @@ describe("@filterable directive", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -9097,12 +9052,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -9192,8 +9142,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -9250,7 +9200,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -9545,8 +9495,8 @@ describe("@filterable directive", () => {
 
                     type AppearanceAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input AppearanceConnectInput {
@@ -9603,7 +9553,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input AppearanceMoviesAggregateInput {
@@ -10090,7 +10040,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -10329,12 +10279,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -10434,8 +10379,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -10492,7 +10437,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -10787,8 +10732,8 @@ describe("@filterable directive", () => {
 
                     type AppearanceAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input AppearanceConnectInput {
@@ -10845,7 +10790,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input AppearanceMoviesAggregateInput {
@@ -11332,7 +11277,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -11571,12 +11516,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -11676,8 +11616,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -11734,7 +11674,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -12029,8 +11969,8 @@ describe("@filterable directive", () => {
 
                     type AppearanceAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input AppearanceConnectInput {
@@ -12087,7 +12027,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input AppearanceMoviesAggregateInput {
@@ -12574,7 +12514,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -12813,12 +12753,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }

--- a/packages/graphql/tests/schema/directives/plural.test.ts
+++ b/packages/graphql/tests/schema/directives/plural.test.ts
@@ -93,7 +93,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -105,8 +105,8 @@ describe("Plural option", () => {
 
             type TechAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
-              value: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
+              value: StringAggregateSelection!
             }
 
             input TechCreateInput {
@@ -261,7 +261,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -273,8 +273,8 @@ describe("Plural option", () => {
 
             type TechAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
-              value: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
+              value: StringAggregateSelection!
             }
 
             input TechCreateInput {
@@ -429,7 +429,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -441,8 +441,8 @@ describe("Plural option", () => {
 
             type TechAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
-              value: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
+              value: StringAggregateSelection!
             }
 
             input TechCreateInput {
@@ -597,7 +597,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -608,7 +608,7 @@ describe("Plural option", () => {
 
             type TechsAggregateSelection {
               count: Int!
-              value: StringAggregateSelectionNullable!
+              value: StringAggregateSelection!
             }
 
             type TechsConnection {
@@ -750,7 +750,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -783,7 +783,7 @@ describe("Plural option", () => {
 
             type UserAggregateSelection {
               count: Int!
-              value: StringAggregateSelectionNullable!
+              value: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -903,7 +903,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -930,7 +930,7 @@ describe("Plural option", () => {
 
             type UserAggregateSelection {
               count: Int!
-              value: StringAggregateSelectionNullable!
+              value: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -1056,7 +1056,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1083,7 +1083,7 @@ describe("Plural option", () => {
 
             type UsersAggregateSelection {
               count: Int!
-              value: StringAggregateSelectionNullable!
+              value: StringAggregateSelection!
             }
 
             type UsersConnection {

--- a/packages/graphql/tests/schema/directives/populatedBy.test.ts
+++ b/packages/graphql/tests/schema/directives/populatedBy.test.ts
@@ -185,7 +185,7 @@ describe("@populatedBy tests", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -198,11 +198,11 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieAggregateSelection {
-                  callback1: StringAggregateSelectionNonNullable!
-                  callback2: StringAggregateSelectionNonNullable!
-                  callback3: StringAggregateSelectionNonNullable!
+                  callback1: StringAggregateSelection!
+                  callback2: StringAggregateSelection!
+                  callback3: StringAggregateSelection!
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -317,7 +317,7 @@ describe("@populatedBy tests", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -398,12 +398,12 @@ describe("@populatedBy tests", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
 
-                type IntAggregateSelectionNonNullable {
+                type IntAggregateSelection {
                   average: Float
                   max: Int
                   min: Int
@@ -418,11 +418,11 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieAggregateSelection {
-                  callback1: IntAggregateSelectionNonNullable!
-                  callback2: IntAggregateSelectionNonNullable!
-                  callback3: IntAggregateSelectionNonNullable!
+                  callback1: IntAggregateSelection!
+                  callback2: IntAggregateSelection!
+                  callback3: IntAggregateSelection!
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -762,7 +762,7 @@ describe("@populatedBy tests", () => {
 
                 type GenreAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input GenreConnectWhere {
@@ -820,12 +820,7 @@ describe("@populatedBy tests", () => {
                   totalCount: Int!
                 }
 
-                type IDAggregateSelectionNonNullable {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -839,7 +834,7 @@ describe("@populatedBy tests", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -871,14 +866,14 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieGenreGenresEdgeAggregateSelection {
-                  callback1: StringAggregateSelectionNonNullable!
-                  callback2: StringAggregateSelectionNonNullable!
-                  callback3: StringAggregateSelectionNonNullable!
-                  id: IDAggregateSelectionNonNullable!
+                  callback1: StringAggregateSelection!
+                  callback2: StringAggregateSelection!
+                  callback3: StringAggregateSelection!
+                  id: IDAggregateSelection!
                 }
 
                 type MovieGenreGenresNodeAggregateSelection {
-                  id: IDAggregateSelectionNonNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieGenresAggregateInput {
@@ -1263,7 +1258,7 @@ describe("@populatedBy tests", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1369,7 +1364,7 @@ describe("@populatedBy tests", () => {
 
                 type GenreAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input GenreConnectWhere {
@@ -1427,17 +1422,12 @@ describe("@populatedBy tests", () => {
                   totalCount: Int!
                 }
 
-                type IDAggregateSelectionNonNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
 
-                type IDAggregateSelectionNullable {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type IntAggregateSelectionNonNullable {
+                type IntAggregateSelection {
                   average: Float
                   max: Int
                   min: Int
@@ -1453,7 +1443,7 @@ describe("@populatedBy tests", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -1485,14 +1475,14 @@ describe("@populatedBy tests", () => {
                 }
 
                 type MovieGenreGenresEdgeAggregateSelection {
-                  callback1: IntAggregateSelectionNonNullable!
-                  callback2: IntAggregateSelectionNonNullable!
-                  callback3: IntAggregateSelectionNonNullable!
-                  id: IDAggregateSelectionNonNullable!
+                  callback1: IntAggregateSelection!
+                  callback2: IntAggregateSelection!
+                  callback3: IntAggregateSelection!
+                  id: IDAggregateSelection!
                 }
 
                 type MovieGenreGenresNodeAggregateSelection {
-                  id: IDAggregateSelectionNonNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieGenresAggregateInput {

--- a/packages/graphql/tests/schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/directives/private.test.ts
@@ -68,7 +68,7 @@ describe("@private directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -125,7 +125,7 @@ describe("@private directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input UserCreateInput {
@@ -143,7 +143,7 @@ describe("@private directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum UserInterfaceImplementation {
@@ -272,7 +272,7 @@ describe("@private directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -307,7 +307,7 @@ describe("@private directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -335,8 +335,8 @@ describe("@private directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              private: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              private: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -355,7 +355,7 @@ describe("@private directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum UserInterfaceImplementation {

--- a/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-aggregate.test.ts
@@ -234,8 +234,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  password: StringAggregateSelectionNonNullable!
-                  username: StringAggregateSelectionNonNullable!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
                 }
 
                 input ActorConnectWhere {
@@ -491,7 +491,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  title: StringAggregateSelectionNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -626,12 +626,7 @@ describe("@relationship directive, aggregate argument", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -688,8 +683,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  password: StringAggregateSelectionNonNullable!
-                  username: StringAggregateSelectionNonNullable!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
                 }
 
                 input ActorConnectWhere {
@@ -801,8 +796,8 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  password: StringAggregateSelectionNonNullable!
-                  username: StringAggregateSelectionNonNullable!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -956,7 +951,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  title: StringAggregateSelectionNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -1091,12 +1086,7 @@ describe("@relationship directive, aggregate argument", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1159,8 +1149,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorCreateInput {
@@ -1320,7 +1310,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -1434,8 +1424,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -1518,12 +1508,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -1584,8 +1569,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorCreateInput {
@@ -1746,7 +1731,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -1786,8 +1771,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -1870,8 +1855,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -1954,12 +1939,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -2024,8 +2004,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectWhere {
@@ -2274,7 +2254,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -2406,7 +2386,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      name: StringAggregateSelectionNonNullable!
+                      name: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -2485,12 +2465,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -2557,8 +2532,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectWhere {
@@ -2807,7 +2782,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -2939,7 +2914,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      name: StringAggregateSelectionNonNullable!
+                      name: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -3018,12 +2993,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }

--- a/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-nested-operations.test.ts
@@ -78,7 +78,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -168,7 +168,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -195,7 +195,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -289,7 +289,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -354,7 +354,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -430,7 +430,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -533,7 +533,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -561,7 +561,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieRelationInput {
@@ -660,7 +660,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -725,7 +725,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -801,7 +801,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -908,7 +908,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -940,7 +940,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -1035,7 +1035,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -1104,7 +1104,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1180,7 +1180,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -1279,7 +1279,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -1306,7 +1306,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -1401,7 +1401,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -1466,7 +1466,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1542,7 +1542,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -1641,7 +1641,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -1672,7 +1672,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -1767,7 +1767,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -1832,7 +1832,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1908,7 +1908,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -2007,7 +2007,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -2038,7 +2038,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -2133,7 +2133,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -2198,7 +2198,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2275,7 +2275,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -2365,7 +2365,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -2392,7 +2392,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -2486,7 +2486,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -2551,7 +2551,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2629,12 +2629,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNonNullable {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -2743,7 +2738,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectOrCreateInput {
@@ -2775,8 +2770,8 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  id: IDAggregateSelectionNonNullable!
-                  name: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -2872,8 +2867,8 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
-                  name: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectOrCreateWhere {
@@ -2961,7 +2956,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3038,7 +3033,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -3169,7 +3164,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -3210,7 +3205,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -3219,7 +3214,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieProducersAggregateInput {
@@ -3433,7 +3428,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -3502,7 +3497,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3579,7 +3574,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -3685,7 +3680,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -3717,7 +3712,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -3726,7 +3721,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieProducersAggregateInput {
@@ -3940,7 +3935,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -4005,7 +4000,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4099,7 +4094,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -4144,7 +4139,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -4254,7 +4249,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -4314,7 +4309,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -4400,7 +4395,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4492,7 +4487,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -4578,7 +4573,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -4694,7 +4689,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -4754,7 +4749,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -4840,7 +4835,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4932,7 +4927,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -5018,7 +5013,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -5134,7 +5129,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneConnectWhere {
@@ -5198,7 +5193,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoConnectWhere {
@@ -5288,7 +5283,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5380,7 +5375,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -5448,7 +5443,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -5559,7 +5554,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -5619,7 +5614,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -5705,7 +5700,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5797,7 +5792,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -5870,7 +5865,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -5985,7 +5980,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -6045,7 +6040,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -6131,7 +6126,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -6223,7 +6218,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -6296,7 +6291,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -6411,7 +6406,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -6471,7 +6466,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -6557,7 +6552,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -6650,7 +6645,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -6695,7 +6690,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -6805,7 +6800,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -6865,7 +6860,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -6951,7 +6946,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -7046,12 +7041,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNonNullable {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -7147,7 +7137,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectOrCreateInput {
@@ -7264,8 +7254,8 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
-                  name: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneConnectOrCreateWhere {
@@ -7349,8 +7339,8 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
-                  nameTwo: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoConnectOrCreateWhere {
@@ -7459,7 +7449,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -7552,7 +7542,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -7697,7 +7687,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -7915,7 +7905,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneConnectWhere {
@@ -7979,7 +7969,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoConnectWhere {
@@ -8069,7 +8059,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -8162,7 +8152,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -8250,7 +8240,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -8459,7 +8449,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -8519,7 +8509,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -8605,7 +8595,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -8707,7 +8697,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -8744,7 +8734,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -8771,7 +8761,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -8851,7 +8841,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -8866,7 +8856,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -8950,7 +8940,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -9043,7 +9033,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -9138,7 +9128,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -9188,7 +9178,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -9216,7 +9206,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieRelationInput {
@@ -9301,7 +9291,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -9321,7 +9311,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -9405,7 +9395,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -9498,7 +9488,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -9593,7 +9583,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -9643,7 +9633,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -9675,7 +9665,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -9756,7 +9746,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -9775,7 +9765,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -9859,7 +9849,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -9952,7 +9942,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -10047,7 +10037,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -10093,7 +10083,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -10120,7 +10110,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -10201,7 +10191,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -10216,7 +10206,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -10300,7 +10290,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -10397,7 +10387,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -10492,7 +10482,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -10538,7 +10528,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -10569,7 +10559,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -10650,7 +10640,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -10665,7 +10655,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -10749,7 +10739,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -10842,7 +10832,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -10937,7 +10927,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -10983,7 +10973,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -11014,7 +11004,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -11095,7 +11085,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -11110,7 +11100,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -11194,7 +11184,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -11287,7 +11277,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -11383,7 +11373,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -11457,7 +11447,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -11498,7 +11488,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -11507,7 +11497,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MovieProducersConnection {
@@ -11643,7 +11633,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -11667,7 +11657,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -11751,7 +11741,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -11848,7 +11838,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -11945,7 +11935,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -12003,7 +11993,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -12039,7 +12029,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -12048,7 +12038,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MovieProducersConnection {
@@ -12184,7 +12174,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -12204,7 +12194,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -12288,7 +12278,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -12381,7 +12371,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }

--- a/packages/graphql/tests/schema/directives/relationship-properties.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship-properties.test.ts
@@ -114,7 +114,7 @@ describe("Relationship-properties", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -150,11 +150,11 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -420,7 +420,7 @@ describe("Relationship-properties", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -441,11 +441,11 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -606,7 +606,7 @@ describe("Relationship-properties", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -745,7 +745,7 @@ describe("Relationship-properties", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -868,7 +868,7 @@ describe("Relationship-properties", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -904,13 +904,13 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              screenTime: IntAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              screenTime: IntAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -1183,9 +1183,9 @@ describe("Relationship-properties", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -1197,12 +1197,12 @@ describe("Relationship-properties", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1223,13 +1223,13 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              screenTime: IntAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              screenTime: IntAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1406,7 +1406,7 @@ describe("Relationship-properties", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1545,7 +1545,7 @@ describe("Relationship-properties", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1647,7 +1647,7 @@ describe("Relationship-properties", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -1683,12 +1683,12 @@ describe("Relationship-properties", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -1933,9 +1933,9 @@ describe("Relationship-properties", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -1947,7 +1947,7 @@ describe("Relationship-properties", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -1966,12 +1966,12 @@ describe("Relationship-properties", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              timestamp: DateTimeAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              timestamp: DateTimeAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -2120,7 +2120,7 @@ describe("Relationship-properties", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -2259,7 +2259,7 @@ describe("Relationship-properties", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/relationship.test.ts
+++ b/packages/graphql/tests/schema/directives/relationship.test.ts
@@ -49,7 +49,7 @@ describe("Relationship", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -135,7 +135,7 @@ describe("Relationship", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -153,7 +153,7 @@ describe("Relationship", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -272,7 +272,7 @@ describe("Relationship", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -407,7 +407,7 @@ describe("Relationship", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -465,7 +465,7 @@ describe("Relationship", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -500,7 +500,7 @@ describe("Relationship", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -690,7 +690,7 @@ describe("Relationship", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -708,7 +708,7 @@ describe("Relationship", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -830,7 +830,7 @@ describe("Relationship", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -969,7 +969,7 @@ describe("Relationship", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/directives/selectable.test.ts
@@ -74,8 +74,8 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -170,12 +170,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -243,7 +238,7 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -338,7 +333,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -405,7 +400,7 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -500,7 +495,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -576,8 +571,8 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -721,12 +716,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -919,7 +909,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -950,8 +940,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1065,8 +1055,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1171,12 +1161,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1383,7 +1368,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1414,8 +1399,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1529,8 +1514,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1635,12 +1620,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1824,7 +1804,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1964,8 +1944,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -2089,8 +2069,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -2169,12 +2149,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2373,7 +2348,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -2513,8 +2488,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -2638,8 +2613,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -2718,12 +2693,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2839,7 +2809,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -2879,8 +2849,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -2979,8 +2949,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -3074,8 +3044,8 @@ describe("@selectable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -3162,8 +3132,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -3238,12 +3208,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3373,7 +3338,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -3413,8 +3378,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -3513,8 +3478,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -3608,8 +3573,8 @@ describe("@selectable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -3696,8 +3661,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -3772,12 +3737,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }

--- a/packages/graphql/tests/schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/directives/settable.test.ts
@@ -75,8 +75,8 @@ describe("@settable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -170,12 +170,7 @@ describe("@settable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -243,8 +238,8 @@ describe("@settable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -338,12 +333,7 @@ describe("@settable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -420,8 +410,8 @@ describe("@settable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -564,12 +554,7 @@ describe("@settable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -774,7 +759,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -804,8 +789,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -919,8 +904,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1025,12 +1010,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1225,7 +1205,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1256,8 +1236,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1370,8 +1350,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1476,12 +1456,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1678,7 +1653,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1713,8 +1688,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1834,7 +1809,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -1956,8 +1931,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -2109,12 +2084,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2319,7 +2289,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -2353,8 +2323,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -2475,7 +2445,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -2597,8 +2567,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -2750,12 +2720,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2936,7 +2901,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -3075,8 +3040,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -3200,8 +3165,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -3280,12 +3245,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3454,7 +3414,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -3593,8 +3553,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -3718,8 +3678,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -3798,12 +3758,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3974,7 +3929,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -4124,7 +4079,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -4246,8 +4201,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -4418,8 +4373,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -4498,12 +4453,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4690,7 +4640,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -4840,7 +4790,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -4962,8 +4912,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -5134,8 +5084,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -5214,12 +5164,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5347,7 +5292,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -5386,8 +5331,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -5486,8 +5431,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -5581,8 +5526,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -5669,8 +5614,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -5745,12 +5690,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5868,7 +5808,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -5908,8 +5848,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -6007,8 +5947,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -6102,8 +6042,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -6185,8 +6125,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -6261,12 +6201,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -6388,7 +6323,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -6432,8 +6367,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -6538,7 +6473,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -6627,8 +6562,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -6866,8 +6801,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectInput {
@@ -6997,7 +6932,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesActorsAggregateInput {
@@ -7086,8 +7021,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input SeriesConnectInput {
@@ -7209,12 +7144,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -7344,7 +7274,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -7387,8 +7317,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -7494,7 +7424,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -7583,8 +7513,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -7839,8 +7769,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectInput {
@@ -7976,7 +7906,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesActorsAggregateInput {
@@ -8065,8 +7995,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input SeriesConnectInput {
@@ -8188,12 +8118,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }

--- a/packages/graphql/tests/schema/directives/timestamps.test.ts
+++ b/packages/graphql/tests/schema/directives/timestamps.test.ts
@@ -57,9 +57,9 @@ describe("Timestamps", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -71,7 +71,7 @@ describe("Timestamps", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -84,9 +84,9 @@ describe("Timestamps", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNullable!
-              updatedAt: DateTimeAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/experimental-schema/comments.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/comments.test.ts
@@ -91,7 +91,7 @@ describe("Comments", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -105,12 +105,12 @@ describe("Comments", () => {
               ROMANCE
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -135,10 +135,10 @@ describe("Comments", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -313,7 +313,7 @@ describe("Comments", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectWhere {
@@ -399,7 +399,7 @@ describe("Comments", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -418,7 +418,7 @@ describe("Comments", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -537,7 +537,7 @@ describe("Comments", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -672,7 +672,7 @@ describe("Comments", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -845,7 +845,7 @@ describe("Comments", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -886,11 +886,11 @@ describe("Comments", () => {
                 }
 
                 type ActorProductionActedInEdgeAggregateSelection {
-                  screenTime: IntAggregateSelectionNonNullable!
+                  screenTime: IntAggregateSelection!
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  title: StringAggregateSelectionNonNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -982,7 +982,7 @@ describe("Comments", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IntAggregateSelectionNonNullable {
+                type IntAggregateSelection {
                   average: Float
                   max: Int
                   min: Int
@@ -996,8 +996,8 @@ describe("Comments", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  runtime: IntAggregateSelectionNonNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  runtime: IntAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -1090,7 +1090,7 @@ describe("Comments", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  title: StringAggregateSelectionNonNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -1165,8 +1165,8 @@ describe("Comments", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  episodes: IntAggregateSelectionNonNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  episodes: IntAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -1241,7 +1241,7 @@ describe("Comments", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1331,7 +1331,7 @@ describe("Comments", () => {
 
                 type GenreAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input GenreConnectWhere {
@@ -1389,7 +1389,7 @@ describe("Comments", () => {
                   totalCount: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -1403,7 +1403,7 @@ describe("Comments", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {

--- a/packages/graphql/tests/schema/experimental-schema/directive-preserve.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directive-preserve.test.ts
@@ -68,7 +68,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -79,7 +79,7 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -230,7 +230,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -246,7 +246,7 @@ describe("Directive-preserve", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -281,9 +281,9 @@ describe("Directive-preserve", () => {
             }
 
             type GenreMovieMoviesNodeAggregateSelection {
-              imdbRating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input GenreMoviesAggregateInput {
@@ -529,7 +529,7 @@ describe("Directive-preserve", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -547,9 +547,9 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              imdbRating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -586,7 +586,7 @@ describe("Directive-preserve", () => {
             }
 
             type MovieGenreGenresNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenresAggregateInput {
@@ -842,7 +842,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1020,7 +1020,7 @@ describe("Directive-preserve", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -1065,11 +1065,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -1161,7 +1161,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1183,11 +1183,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1321,8 +1321,8 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1500,7 +1500,7 @@ describe("Directive-preserve", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -1583,11 +1583,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -1721,8 +1721,8 @@ describe("Directive-preserve", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1844,7 +1844,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2025,7 +2025,7 @@ describe("Directive-preserve", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -2070,11 +2070,11 @@ describe("Directive-preserve", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -2166,7 +2166,7 @@ describe("Directive-preserve", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -2188,11 +2188,11 @@ describe("Directive-preserve", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -2326,8 +2326,8 @@ describe("Directive-preserve", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -2505,7 +2505,7 @@ describe("Directive-preserve", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -2588,11 +2588,11 @@ describe("Directive-preserve", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              role: StringAggregateSelectionNonNullable!
+              role: StringAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -2726,8 +2726,8 @@ describe("Directive-preserve", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -2849,7 +2849,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2920,7 +2920,7 @@ describe("Directive-preserve", () => {
 
             type BlogAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input BlogConnectInput {
@@ -2964,7 +2964,7 @@ describe("Directive-preserve", () => {
             }
 
             type BlogPostPostsNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
             }
 
             input BlogPostsAggregateInput {
@@ -3213,7 +3213,7 @@ describe("Directive-preserve", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
             }
 
@@ -3299,7 +3299,7 @@ describe("Directive-preserve", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -3338,7 +3338,7 @@ describe("Directive-preserve", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {

--- a/packages/graphql/tests/schema/experimental-schema/directives/customResolver.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/customResolver.test.ts
@@ -77,7 +77,7 @@ describe("@customResolver directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -112,12 +112,7 @@ describe("@customResolver directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -148,9 +143,9 @@ describe("@customResolver directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -170,7 +165,7 @@ describe("@customResolver directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              customResolver: StringAggregateSelectionNullable!
+              customResolver: StringAggregateSelection!
             }
 
             enum UserInterfaceImplementation {

--- a/packages/graphql/tests/schema/experimental-schema/directives/default.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/default.test.ts
@@ -74,9 +74,9 @@ describe("@default directive", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -88,19 +88,19 @@ describe("@default directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -143,7 +143,7 @@ describe("@default directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -178,13 +178,13 @@ describe("@default directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              fromInterface: StringAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
-              numberOfFriends: IntAggregateSelectionNonNullable!
-              rating: FloatAggregateSelectionNonNullable!
-              toBeOverridden: StringAggregateSelectionNonNullable!
-              verifiedDate: DateTimeAggregateSelectionNonNullable!
+              fromInterface: StringAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              numberOfFriends: IntAggregateSelection!
+              rating: FloatAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
+              verifiedDate: DateTimeAggregateSelection!
             }
 
             input UserCreateInput {
@@ -211,8 +211,8 @@ describe("@default directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              fromInterface: StringAggregateSelectionNonNullable!
-              toBeOverridden: StringAggregateSelectionNonNullable!
+              fromInterface: StringAggregateSelection!
+              toBeOverridden: StringAggregateSelection!
             }
 
             enum UserInterfaceImplementation {

--- a/packages/graphql/tests/schema/experimental-schema/directives/filterable.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/filterable.test.ts
@@ -927,8 +927,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -985,7 +985,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -1277,8 +1277,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -1443,7 +1443,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -1661,12 +1661,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -1745,8 +1740,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -1803,7 +1798,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -2137,8 +2132,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -2303,7 +2298,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -2521,12 +2516,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -2605,8 +2595,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -2663,7 +2653,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -2987,8 +2977,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -3153,7 +3143,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -3343,12 +3333,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -3430,8 +3415,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -3488,7 +3473,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -3822,8 +3807,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsConnectFieldInput {
@@ -3900,7 +3885,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -4117,12 +4102,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -4203,8 +4183,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -4261,7 +4241,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -4595,8 +4575,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -4761,7 +4741,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -4979,12 +4959,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -5065,8 +5040,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -5123,7 +5098,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -5457,8 +5432,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsAggregateInput {
@@ -5623,7 +5598,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -5813,12 +5788,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -5899,8 +5869,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -5957,7 +5927,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -6291,8 +6261,8 @@ describe("@filterable directive", () => {
                     }
 
                     type MovieActorActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieActorsConnectFieldInput {
@@ -6369,7 +6339,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -6586,12 +6556,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -6677,8 +6642,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -6731,7 +6696,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -7126,7 +7091,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -7190,7 +7155,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -7331,7 +7296,7 @@ describe("@filterable directive", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -7423,12 +7388,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -7514,8 +7474,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -7568,7 +7528,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -7963,7 +7923,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -8027,7 +7987,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -8168,7 +8128,7 @@ describe("@filterable directive", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -8260,12 +8220,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -8351,8 +8306,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -8405,7 +8360,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -8800,7 +8755,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -8864,7 +8819,7 @@ describe("@filterable directive", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -9005,7 +8960,7 @@ describe("@filterable directive", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      username: StringAggregateSelectionNonNullable!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -9097,12 +9052,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -9192,8 +9142,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -9250,7 +9200,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -9545,8 +9495,8 @@ describe("@filterable directive", () => {
 
                     type AppearanceAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input AppearanceConnectInput {
@@ -9603,7 +9553,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input AppearanceMoviesAggregateInput {
@@ -10090,7 +10040,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -10329,12 +10279,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -10434,8 +10379,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -10492,7 +10437,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -10787,8 +10732,8 @@ describe("@filterable directive", () => {
 
                     type AppearanceAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input AppearanceConnectInput {
@@ -10845,7 +10790,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input AppearanceMoviesAggregateInput {
@@ -11332,7 +11277,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -11571,12 +11516,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -11676,8 +11616,8 @@ describe("@filterable directive", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectInput {
@@ -11734,7 +11674,7 @@ describe("@filterable directive", () => {
                     }
 
                     type ActorMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input ActorMoviesAggregateInput {
@@ -12029,8 +11969,8 @@ describe("@filterable directive", () => {
 
                     type AppearanceAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input AppearanceConnectInput {
@@ -12087,7 +12027,7 @@ describe("@filterable directive", () => {
                     }
 
                     type AppearanceMovieMoviesNodeAggregateSelection {
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input AppearanceMoviesAggregateInput {
@@ -12574,7 +12514,7 @@ describe("@filterable directive", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -12813,12 +12753,7 @@ describe("@filterable directive", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }

--- a/packages/graphql/tests/schema/experimental-schema/directives/private.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/private.test.ts
@@ -68,7 +68,7 @@ describe("@private directive", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -103,7 +103,7 @@ describe("@private directive", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -131,8 +131,8 @@ describe("@private directive", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              private: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              private: StringAggregateSelection!
             }
 
             input UserCreateInput {
@@ -151,7 +151,7 @@ describe("@private directive", () => {
 
             type UserInterfaceAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum UserInterfaceImplementation {
@@ -264,190 +264,190 @@ describe("@private directive", () => {
         const printedSchema = printSchemaWithDirectives(lexicographicSortSchema(await neoSchema.getSchema()));
 
         expect(printedSchema).toMatchInlineSnapshot(`
-                      "schema {
-                        query: Query
-                        mutation: Mutation
-                      }
+            "schema {
+              query: Query
+              mutation: Mutation
+            }
 
-                      \\"\\"\\"
-                      Information about the number of nodes and relationships created during a create mutation
-                      \\"\\"\\"
-                      type CreateInfo {
-                        bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
-                        nodesCreated: Int!
-                        relationshipsCreated: Int!
-                      }
+            \\"\\"\\"
+            Information about the number of nodes and relationships created during a create mutation
+            \\"\\"\\"
+            type CreateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              relationshipsCreated: Int!
+            }
 
-                      type CreateUsersMutationResponse {
-                        info: CreateInfo!
-                        users: [User!]!
-                      }
+            type CreateUsersMutationResponse {
+              info: CreateInfo!
+              users: [User!]!
+            }
 
-                      \\"\\"\\"
-                      Information about the number of nodes and relationships deleted during a delete mutation
-                      \\"\\"\\"
-                      type DeleteInfo {
-                        bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
-                        nodesDeleted: Int!
-                        relationshipsDeleted: Int!
-                      }
+            \\"\\"\\"
+            Information about the number of nodes and relationships deleted during a delete mutation
+            \\"\\"\\"
+            type DeleteInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesDeleted: Int!
+              relationshipsDeleted: Int!
+            }
 
-                      type IDAggregateSelectionNullable {
-                        longest: ID
-                        shortest: ID
-                      }
+            type IDAggregateSelection {
+              longest: ID
+              shortest: ID
+            }
 
-                      type Mutation {
-                        createUsers(input: [UserCreateInput!]!): CreateUsersMutationResponse!
-                        deleteUsers(where: UserWhere): DeleteInfo!
-                        updateUsers(update: UserUpdateInput, where: UserWhere): UpdateUsersMutationResponse!
-                      }
+            type Mutation {
+              createUsers(input: [UserCreateInput!]!): CreateUsersMutationResponse!
+              deleteUsers(where: UserWhere): DeleteInfo!
+              updateUsers(update: UserUpdateInput, where: UserWhere): UpdateUsersMutationResponse!
+            }
 
-                      \\"\\"\\"Pagination information (Relay)\\"\\"\\"
-                      type PageInfo {
-                        endCursor: String
-                        hasNextPage: Boolean!
-                        hasPreviousPage: Boolean!
-                        startCursor: String
-                      }
+            \\"\\"\\"Pagination information (Relay)\\"\\"\\"
+            type PageInfo {
+              endCursor: String
+              hasNextPage: Boolean!
+              hasPreviousPage: Boolean!
+              startCursor: String
+            }
 
-                      type Query {
-                        userInterfaces(options: UserInterfaceOptions, where: UserInterfaceWhere): [UserInterface!]!
-                        userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection!
-                        users(options: UserOptions, where: UserWhere): [User!]!
-                        usersAggregate(where: UserWhere): UserAggregateSelection!
-                        usersConnection(after: String, first: Int, sort: [UserSort], where: UserWhere): UsersConnection!
-                      }
+            type Query {
+              userInterfaces(options: UserInterfaceOptions, where: UserInterfaceWhere): [UserInterface!]!
+              userInterfacesAggregate(where: UserInterfaceWhere): UserInterfaceAggregateSelection!
+              users(options: UserOptions, where: UserWhere): [User!]!
+              usersAggregate(where: UserWhere): UserAggregateSelection!
+              usersConnection(after: String, first: Int, sort: [UserSort], where: UserWhere): UsersConnection!
+            }
 
-                      \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
-                      enum SortDirection {
-                        \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
-                        ASC
-                        \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
-                        DESC
-                      }
+            \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"
+            enum SortDirection {
+              \\"\\"\\"Sort by field values in ascending order.\\"\\"\\"
+              ASC
+              \\"\\"\\"Sort by field values in descending order.\\"\\"\\"
+              DESC
+            }
 
-                      \\"\\"\\"
-                      Information about the number of nodes and relationships created and deleted during an update mutation
-                      \\"\\"\\"
-                      type UpdateInfo {
-                        bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
-                        nodesCreated: Int!
-                        nodesDeleted: Int!
-                        relationshipsCreated: Int!
-                        relationshipsDeleted: Int!
-                      }
+            \\"\\"\\"
+            Information about the number of nodes and relationships created and deleted during an update mutation
+            \\"\\"\\"
+            type UpdateInfo {
+              bookmark: String @deprecated(reason: \\"This field has been deprecated because bookmarks are now handled by the driver.\\")
+              nodesCreated: Int!
+              nodesDeleted: Int!
+              relationshipsCreated: Int!
+              relationshipsDeleted: Int!
+            }
 
-                      type UpdateUsersMutationResponse {
-                        info: UpdateInfo!
-                        users: [User!]!
-                      }
+            type UpdateUsersMutationResponse {
+              info: UpdateInfo!
+              users: [User!]!
+            }
 
-                      type User implements UserInterface {
-                        id: ID
-                      }
+            type User implements UserInterface {
+              id: ID
+            }
 
-                      type UserAggregateSelection {
-                        count: Int!
-                        id: IDAggregateSelectionNullable!
-                      }
+            type UserAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection!
+            }
 
-                      input UserCreateInput {
-                        id: ID
-                      }
+            input UserCreateInput {
+              id: ID
+            }
 
-                      type UserEdge {
-                        cursor: String!
-                        node: User!
-                      }
+            type UserEdge {
+              cursor: String!
+              node: User!
+            }
 
-                      interface UserInterface {
-                        id: ID
-                      }
+            interface UserInterface {
+              id: ID
+            }
 
-                      type UserInterfaceAggregateSelection {
-                        count: Int!
-                        id: IDAggregateSelectionNullable!
-                      }
+            type UserInterfaceAggregateSelection {
+              count: Int!
+              id: IDAggregateSelection!
+            }
 
-                      enum UserInterfaceImplementation {
-                        User
-                      }
+            enum UserInterfaceImplementation {
+              User
+            }
 
-                      input UserInterfaceOptions {
-                        limit: Int
-                        offset: Int
-                        \\"\\"\\"
-                        Specify one or more UserInterfaceSort objects to sort UserInterfaces by. The sorts will be applied in the order in which they are arranged in the array.
-                        \\"\\"\\"
-                        sort: [UserInterfaceSort]
-                      }
+            input UserInterfaceOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more UserInterfaceSort objects to sort UserInterfaces by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [UserInterfaceSort]
+            }
 
-                      \\"\\"\\"
-                      Fields to sort UserInterfaces by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserInterfaceSort object.
-                      \\"\\"\\"
-                      input UserInterfaceSort {
-                        id: SortDirection
-                      }
+            \\"\\"\\"
+            Fields to sort UserInterfaces by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserInterfaceSort object.
+            \\"\\"\\"
+            input UserInterfaceSort {
+              id: SortDirection
+            }
 
-                      input UserInterfaceWhere {
-                        AND: [UserInterfaceWhere!]
-                        NOT: UserInterfaceWhere
-                        OR: [UserInterfaceWhere!]
-                        id: ID
-                        id_CONTAINS: ID
-                        id_ENDS_WITH: ID
-                        id_IN: [ID]
-                        id_NOT: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_CONTAINS: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_ENDS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_IN: [ID] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_STARTS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_STARTS_WITH: ID
-                        typename_IN: [UserInterfaceImplementation!]
-                      }
+            input UserInterfaceWhere {
+              AND: [UserInterfaceWhere!]
+              NOT: UserInterfaceWhere
+              OR: [UserInterfaceWhere!]
+              id: ID
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_IN: [ID]
+              id_NOT: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_CONTAINS: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_ENDS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_IN: [ID] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_STARTS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_STARTS_WITH: ID
+              typename_IN: [UserInterfaceImplementation!]
+            }
 
-                      input UserOptions {
-                        limit: Int
-                        offset: Int
-                        \\"\\"\\"
-                        Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
-                        \\"\\"\\"
-                        sort: [UserSort!]
-                      }
+            input UserOptions {
+              limit: Int
+              offset: Int
+              \\"\\"\\"
+              Specify one or more UserSort objects to sort Users by. The sorts will be applied in the order in which they are arranged in the array.
+              \\"\\"\\"
+              sort: [UserSort!]
+            }
 
-                      \\"\\"\\"
-                      Fields to sort Users by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserSort object.
-                      \\"\\"\\"
-                      input UserSort {
-                        id: SortDirection
-                      }
+            \\"\\"\\"
+            Fields to sort Users by. The order in which sorts are applied is not guaranteed when specifying many fields in one UserSort object.
+            \\"\\"\\"
+            input UserSort {
+              id: SortDirection
+            }
 
-                      input UserUpdateInput {
-                        id: ID
-                      }
+            input UserUpdateInput {
+              id: ID
+            }
 
-                      input UserWhere {
-                        AND: [UserWhere!]
-                        NOT: UserWhere
-                        OR: [UserWhere!]
-                        id: ID
-                        id_CONTAINS: ID
-                        id_ENDS_WITH: ID
-                        id_IN: [ID]
-                        id_NOT: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_CONTAINS: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_ENDS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_IN: [ID] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_NOT_STARTS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
-                        id_STARTS_WITH: ID
-                      }
+            input UserWhere {
+              AND: [UserWhere!]
+              NOT: UserWhere
+              OR: [UserWhere!]
+              id: ID
+              id_CONTAINS: ID
+              id_ENDS_WITH: ID
+              id_IN: [ID]
+              id_NOT: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_CONTAINS: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_ENDS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_IN: [ID] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_NOT_STARTS_WITH: ID @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              id_STARTS_WITH: ID
+            }
 
-                      type UsersConnection {
-                        edges: [UserEdge!]!
-                        pageInfo: PageInfo!
-                        totalCount: Int!
-                      }"
-              `);
+            type UsersConnection {
+              edges: [UserEdge!]!
+              pageInfo: PageInfo!
+              totalCount: Int!
+            }"
+        `);
     });
 });

--- a/packages/graphql/tests/schema/experimental-schema/directives/relationship-aggregate.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/relationship-aggregate.test.ts
@@ -234,8 +234,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  password: StringAggregateSelectionNonNullable!
-                  username: StringAggregateSelectionNonNullable!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
                 }
 
                 input ActorConnectWhere {
@@ -491,7 +491,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  title: StringAggregateSelectionNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -626,12 +626,7 @@ describe("@relationship directive, aggregate argument", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -688,8 +683,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  password: StringAggregateSelectionNonNullable!
-                  username: StringAggregateSelectionNonNullable!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
                 }
 
                 input ActorConnectWhere {
@@ -801,8 +796,8 @@ describe("@relationship directive, aggregate argument", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  password: StringAggregateSelectionNonNullable!
-                  username: StringAggregateSelectionNonNullable!
+                  password: StringAggregateSelection!
+                  username: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -956,7 +951,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  title: StringAggregateSelectionNullable!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -1091,12 +1086,7 @@ describe("@relationship directive, aggregate argument", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1159,8 +1149,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorCreateInput {
@@ -1320,7 +1310,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -1434,8 +1424,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -1518,12 +1508,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -1584,8 +1569,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorCreateInput {
@@ -1746,7 +1731,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -1786,8 +1771,8 @@ describe("@relationship directive, aggregate argument", () => {
                     }
 
                     type MoviePersonActorsNodeAggregateSelection {
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input MovieRelationInput {
@@ -1870,8 +1855,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -1954,12 +1939,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -2024,8 +2004,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectWhere {
@@ -2274,7 +2254,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -2406,7 +2386,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      name: StringAggregateSelectionNonNullable!
+                      name: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -2485,12 +2465,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }
@@ -2557,8 +2532,8 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type ActorAggregateSelection {
                       count: Int!
-                      password: StringAggregateSelectionNonNullable!
-                      username: StringAggregateSelectionNonNullable!
+                      password: StringAggregateSelection!
+                      username: StringAggregateSelection!
                     }
 
                     input ActorConnectWhere {
@@ -2807,7 +2782,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type MovieAggregateSelection {
                       count: Int!
-                      title: StringAggregateSelectionNullable!
+                      title: StringAggregateSelection!
                     }
 
                     input MovieConnectInput {
@@ -2939,7 +2914,7 @@ describe("@relationship directive, aggregate argument", () => {
 
                     type PersonAggregateSelection {
                       count: Int!
-                      name: StringAggregateSelectionNonNullable!
+                      name: StringAggregateSelection!
                     }
 
                     input PersonConnectWhere {
@@ -3018,12 +2993,7 @@ describe("@relationship directive, aggregate argument", () => {
                       DESC
                     }
 
-                    type StringAggregateSelectionNonNullable {
-                      longest: String
-                      shortest: String
-                    }
-
-                    type StringAggregateSelectionNullable {
+                    type StringAggregateSelection {
                       longest: String
                       shortest: String
                     }

--- a/packages/graphql/tests/schema/experimental-schema/directives/relationship-nested-operations.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/relationship-nested-operations.test.ts
@@ -78,7 +78,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -168,7 +168,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -195,7 +195,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -289,7 +289,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -354,7 +354,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -430,7 +430,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -533,7 +533,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -561,7 +561,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieRelationInput {
@@ -660,7 +660,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -725,7 +725,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -801,7 +801,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -908,7 +908,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -940,7 +940,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -1035,7 +1035,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -1104,7 +1104,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1180,7 +1180,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -1279,7 +1279,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -1306,7 +1306,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -1401,7 +1401,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -1466,7 +1466,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1542,7 +1542,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -1641,7 +1641,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -1672,7 +1672,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -1767,7 +1767,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -1832,7 +1832,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1908,7 +1908,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -2007,7 +2007,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -2038,7 +2038,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -2133,7 +2133,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -2198,7 +2198,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2275,7 +2275,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -2365,7 +2365,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -2392,7 +2392,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -2486,7 +2486,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -2551,7 +2551,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2629,12 +2629,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNonNullable {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -2743,7 +2738,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectOrCreateInput {
@@ -2775,8 +2770,8 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  id: IDAggregateSelectionNonNullable!
-                  name: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -2872,8 +2867,8 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
-                  name: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectOrCreateWhere {
@@ -2961,7 +2956,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3038,7 +3033,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -3169,7 +3164,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -3210,7 +3205,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -3219,7 +3214,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieProducersAggregateInput {
@@ -3433,7 +3428,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -3502,7 +3497,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3579,7 +3574,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -3685,7 +3680,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -3717,7 +3712,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -3726,7 +3721,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieProducersAggregateInput {
@@ -3940,7 +3935,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -4005,7 +4000,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4099,7 +4094,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -4144,7 +4139,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -4254,7 +4249,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -4314,7 +4309,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -4400,7 +4395,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4492,7 +4487,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -4578,7 +4573,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -4694,7 +4689,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -4754,7 +4749,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -4840,7 +4835,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4932,7 +4927,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -5018,7 +5013,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -5134,7 +5129,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneConnectWhere {
@@ -5198,7 +5193,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoConnectWhere {
@@ -5288,7 +5283,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5380,7 +5375,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -5448,7 +5443,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -5559,7 +5554,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -5619,7 +5614,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -5705,7 +5700,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5797,7 +5792,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -5870,7 +5865,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -5985,7 +5980,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -6045,7 +6040,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -6131,7 +6126,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -6223,7 +6218,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -6296,7 +6291,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -6411,7 +6406,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -6471,7 +6466,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -6557,7 +6552,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -6650,7 +6645,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -6695,7 +6690,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -6805,7 +6800,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -6865,7 +6860,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -6951,7 +6946,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -7046,12 +7041,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNonNullable {
-                  longest: ID
-                  shortest: ID
-                }
-
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -7147,7 +7137,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectOrCreateInput {
@@ -7264,8 +7254,8 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
-                  name: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneConnectOrCreateWhere {
@@ -7349,8 +7339,8 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNonNullable!
-                  nameTwo: StringAggregateSelectionNullable!
+                  id: IDAggregateSelection!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoConnectOrCreateWhere {
@@ -7459,7 +7449,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -7552,7 +7542,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -7697,7 +7687,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -7915,7 +7905,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneConnectWhere {
@@ -7979,7 +7969,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoConnectWhere {
@@ -8069,7 +8059,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -8162,7 +8152,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -8250,7 +8240,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -8459,7 +8449,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -8519,7 +8509,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  nameTwo: StringAggregateSelectionNullable!
+                  nameTwo: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -8605,7 +8595,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -8707,7 +8697,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -8744,7 +8734,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -8771,7 +8761,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -8851,7 +8841,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -8866,7 +8856,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -8950,7 +8940,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -9043,7 +9033,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -9138,7 +9128,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -9188,7 +9178,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -9216,7 +9206,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieRelationInput {
@@ -9301,7 +9291,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -9321,7 +9311,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -9405,7 +9395,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -9498,7 +9488,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -9593,7 +9583,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -9643,7 +9633,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -9675,7 +9665,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -9756,7 +9746,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -9775,7 +9765,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -9859,7 +9849,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -9952,7 +9942,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -10047,7 +10037,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -10093,7 +10083,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -10120,7 +10110,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -10201,7 +10191,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -10216,7 +10206,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -10300,7 +10290,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -10397,7 +10387,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -10492,7 +10482,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -10538,7 +10528,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -10569,7 +10559,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -10650,7 +10640,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -10665,7 +10655,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -10749,7 +10739,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -10842,7 +10832,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -10937,7 +10927,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -10983,7 +10973,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -11014,7 +11004,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 \\"\\"\\"
@@ -11095,7 +11085,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 enum PersonImplementation {
@@ -11110,7 +11100,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -11194,7 +11184,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -11287,7 +11277,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -11383,7 +11373,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -11457,7 +11447,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -11498,7 +11488,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -11507,7 +11497,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MovieProducersConnection {
@@ -11643,7 +11633,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonConnectWhere {
@@ -11667,7 +11657,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -11751,7 +11741,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -11848,7 +11838,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -11945,7 +11935,7 @@ describe("Relationship nested operations", () => {
                   relationshipsDeleted: Int!
                 }
 
-                type IDAggregateSelectionNullable {
+                type IDAggregateSelection {
                   longest: ID
                   shortest: ID
                 }
@@ -12003,7 +11993,7 @@ describe("Relationship nested operations", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  id: IDAggregateSelectionNullable!
+                  id: IDAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -12039,7 +12029,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MoviePersonProducersAggregationSelection {
@@ -12048,7 +12038,7 @@ describe("Relationship nested operations", () => {
                 }
 
                 type MoviePersonProducersNodeAggregateSelection {
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 type MovieProducersConnection {
@@ -12184,7 +12174,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonCreateInput {
@@ -12204,7 +12194,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonOneAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonOneCreateInput {
@@ -12288,7 +12278,7 @@ describe("Relationship nested operations", () => {
 
                 type PersonTwoAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input PersonTwoCreateInput {
@@ -12381,7 +12371,7 @@ describe("Relationship nested operations", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }

--- a/packages/graphql/tests/schema/experimental-schema/directives/selectable.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/selectable.test.ts
@@ -74,8 +74,8 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -170,12 +170,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -243,7 +238,7 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -338,7 +333,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -405,7 +400,7 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -500,7 +495,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -576,8 +571,8 @@ describe("@selectable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -721,12 +716,7 @@ describe("@selectable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -919,7 +909,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -950,8 +940,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1065,8 +1055,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1171,12 +1161,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1383,7 +1368,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1414,8 +1399,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1529,8 +1514,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1635,12 +1620,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1824,7 +1804,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1964,8 +1944,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -2089,8 +2069,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -2169,12 +2149,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2373,7 +2348,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -2513,8 +2488,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -2638,8 +2613,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -2718,12 +2693,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2839,7 +2809,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -2879,8 +2849,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -2979,8 +2949,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -3074,8 +3044,8 @@ describe("@selectable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -3162,8 +3132,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -3238,12 +3208,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3373,7 +3338,7 @@ describe("@selectable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -3413,8 +3378,8 @@ describe("@selectable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -3513,8 +3478,8 @@ describe("@selectable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -3608,8 +3573,8 @@ describe("@selectable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -3696,8 +3661,8 @@ describe("@selectable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -3772,12 +3737,7 @@ describe("@selectable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }

--- a/packages/graphql/tests/schema/experimental-schema/directives/settable.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/directives/settable.test.ts
@@ -75,8 +75,8 @@ describe("@settable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -170,12 +170,7 @@ describe("@settable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -243,8 +238,8 @@ describe("@settable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -338,12 +333,7 @@ describe("@settable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -420,8 +410,8 @@ describe("@settable", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -564,12 +554,7 @@ describe("@settable", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -774,7 +759,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -804,8 +789,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -919,8 +904,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1025,12 +1010,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1225,7 +1205,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1256,8 +1236,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1370,8 +1350,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -1476,12 +1456,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -1678,7 +1653,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -1713,8 +1688,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -1834,7 +1809,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -1956,8 +1931,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -2109,12 +2084,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2319,7 +2289,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -2353,8 +2323,8 @@ describe("@settable", () => {
                 }
 
                 type ActorMovieActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorOptions {
@@ -2475,7 +2445,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -2597,8 +2567,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -2750,12 +2720,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -2936,7 +2901,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -3075,8 +3040,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -3200,8 +3165,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -3280,12 +3245,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3454,7 +3414,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -3593,8 +3553,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectWhere {
@@ -3718,8 +3678,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -3798,12 +3758,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -3974,7 +3929,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -4124,7 +4079,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -4246,8 +4201,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -4418,8 +4373,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -4498,12 +4453,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -4690,7 +4640,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -4840,7 +4790,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -4962,8 +4912,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -5134,8 +5084,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  name: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesConnectWhere {
@@ -5214,12 +5164,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5347,7 +5292,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -5386,8 +5331,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -5486,8 +5431,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -5581,8 +5526,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -5669,8 +5614,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -5745,12 +5690,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -5868,7 +5808,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -5908,8 +5848,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -6007,8 +5947,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieCreateInput {
@@ -6102,8 +6042,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectWhere {
@@ -6185,8 +6125,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 type SeriesConnection {
@@ -6261,12 +6201,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -6388,7 +6323,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -6432,8 +6367,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -6538,7 +6473,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -6627,8 +6562,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -6866,8 +6801,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectInput {
@@ -6997,7 +6932,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesActorsAggregateInput {
@@ -7086,8 +7021,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input SeriesConnectInput {
@@ -7209,12 +7144,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }
@@ -7344,7 +7274,7 @@ describe("@settable", () => {
 
                 type ActorAggregateSelection {
                   count: Int!
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input ActorConnectInput {
@@ -7387,8 +7317,8 @@ describe("@settable", () => {
                 }
 
                 type ActorProductionActedInNodeAggregateSelection {
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ActorRelationInput {
@@ -7494,7 +7424,7 @@ describe("@settable", () => {
                 }
 
                 type MovieActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input MovieActorsAggregateInput {
@@ -7583,8 +7513,8 @@ describe("@settable", () => {
 
                 type MovieAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input MovieConnectInput {
@@ -7839,8 +7769,8 @@ describe("@settable", () => {
 
                 type ProductionAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input ProductionConnectInput {
@@ -7976,7 +7906,7 @@ describe("@settable", () => {
                 }
 
                 type SeriesActorActorsNodeAggregateSelection {
-                  name: StringAggregateSelectionNonNullable!
+                  name: StringAggregateSelection!
                 }
 
                 input SeriesActorsAggregateInput {
@@ -8065,8 +7995,8 @@ describe("@settable", () => {
 
                 type SeriesAggregateSelection {
                   count: Int!
-                  description: StringAggregateSelectionNullable!
-                  title: StringAggregateSelectionNonNullable!
+                  description: StringAggregateSelection!
+                  title: StringAggregateSelection!
                 }
 
                 input SeriesConnectInput {
@@ -8188,12 +8118,7 @@ describe("@settable", () => {
                   DESC
                 }
 
-                type StringAggregateSelectionNonNullable {
-                  longest: String
-                  shortest: String
-                }
-
-                type StringAggregateSelectionNullable {
+                type StringAggregateSelection {
                   longest: String
                   shortest: String
                 }

--- a/packages/graphql/tests/schema/experimental-schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/inheritance.test.ts
@@ -67,7 +67,7 @@ describe("inheritance", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -148,11 +148,11 @@ describe("inheritance", () => {
             }
 
             type ActorPersonFriendsEdgeAggregateSelection {
-              since: IntAggregateSelectionNullable!
+              since: IntAggregateSelection!
             }
 
             type ActorPersonFriendsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -270,7 +270,7 @@ describe("inheritance", () => {
               since_NOT_IN: [Int] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -299,7 +299,7 @@ describe("inheritance", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -494,7 +494,7 @@ describe("inheritance", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interface-relationships.test.ts
@@ -166,7 +166,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -207,11 +207,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -303,7 +303,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -317,8 +317,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -411,7 +411,7 @@ describe("Interface Relationships", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -486,8 +486,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -562,7 +562,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -752,7 +752,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -797,11 +797,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -907,7 +907,7 @@ describe("Interface Relationships", () => {
 
             type EpisodeAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input EpisodeConnectInput {
@@ -1084,8 +1084,8 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesSeriesNodeAggregateSelection {
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input EpisodeSeriesUpdateConnectionInput {
@@ -1140,7 +1140,7 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1162,11 +1162,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1290,8 +1290,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1603,7 +1603,7 @@ describe("Interface Relationships", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -1734,11 +1734,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -1862,8 +1862,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1909,7 +1909,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodeEpisodesNodeAggregateSelection {
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input SeriesEpisodesAggregateInput {
@@ -2140,7 +2140,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2338,7 +2338,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -2383,11 +2383,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -2493,7 +2493,7 @@ describe("Interface Relationships", () => {
 
             type EpisodeAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input EpisodeConnectInput {
@@ -2670,8 +2670,8 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesSeriesNodeAggregateSelection {
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input EpisodeSeriesUpdateConnectionInput {
@@ -2726,7 +2726,7 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -2748,11 +2748,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -2876,8 +2876,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -3209,7 +3209,7 @@ describe("Interface Relationships", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -3340,11 +3340,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              seasons: IntAggregateSelectionNonNullable!
+              seasons: IntAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -3468,8 +3468,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -3515,7 +3515,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodeEpisodesNodeAggregateSelection {
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input SeriesEpisodesAggregateInput {
@@ -3782,7 +3782,7 @@ describe("Interface Relationships", () => {
               seasons_NOT_IN: [Int!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -3915,7 +3915,7 @@ describe("Interface Relationships", () => {
 
             type Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Interface1ConnectInput {
@@ -4058,7 +4058,7 @@ describe("Interface Relationships", () => {
 
             type Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Interface2ConnectWhere {
@@ -4168,12 +4168,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -4187,7 +4182,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -4221,7 +4216,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -4294,7 +4289,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface1NodeAggregateSelection {
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2ConnectFieldInput {
@@ -4324,7 +4319,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2UpdateConnectionInput {
@@ -4429,7 +4424,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -4557,7 +4552,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -4609,7 +4604,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface1Interface2UpdateConnectionInput {
@@ -4696,7 +4691,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -4884,7 +4879,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -4899,7 +4894,7 @@ describe("Interface Relationships", () => {
 
             type Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Interface1ConnectInput {
@@ -5087,7 +5082,7 @@ describe("Interface Relationships", () => {
 
             type Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Interface2ConnectWhere {
@@ -5234,12 +5229,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -5253,7 +5243,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -5287,7 +5277,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -5360,7 +5350,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface1NodeAggregateSelection {
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2ConnectFieldInput {
@@ -5393,11 +5383,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface2Interface2EdgeAggregateSelection {
-              propsField: IntAggregateSelectionNonNullable!
+              propsField: IntAggregateSelection!
             }
 
             type Type1Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2UpdateConnectionInput {
@@ -5503,7 +5493,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -5631,7 +5621,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -5686,11 +5676,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Interface2Interface2EdgeAggregateSelection {
-              propsField: IntAggregateSelectionNonNullable!
+              propsField: IntAggregateSelection!
             }
 
             type Type2Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface1Interface2UpdateConnectionInput {
@@ -5778,7 +5768,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -5972,7 +5962,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -5987,7 +5977,7 @@ describe("Interface Relationships", () => {
 
             type Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Interface1ConnectInput {
@@ -6191,7 +6181,7 @@ describe("Interface Relationships", () => {
 
             type Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Interface2ConnectWhere {
@@ -6301,12 +6291,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -6320,7 +6305,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -6354,7 +6339,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -6427,7 +6412,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface1NodeAggregateSelection {
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2ConnectFieldInput {
@@ -6460,11 +6445,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface2Interface2EdgeAggregateSelection {
-              type1Field: IntAggregateSelectionNonNullable!
+              type1Field: IntAggregateSelection!
             }
 
             type Type1Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2UpdateConnectionInput {
@@ -6570,7 +6555,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -6734,7 +6719,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -6789,11 +6774,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Interface2Interface2EdgeAggregateSelection {
-              type2Field: IntAggregateSelectionNonNullable!
+              type2Field: IntAggregateSelection!
             }
 
             type Type2Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface1Interface2UpdateConnectionInput {
@@ -6881,7 +6866,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -7064,9 +7049,9 @@ describe("Interface Relationships", () => {
             }
 
             type CommentAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input CommentConnectInput {
@@ -7300,8 +7285,8 @@ describe("Interface Relationships", () => {
             }
 
             type CommentPostPostNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             type CommentPostRelationship {
@@ -7348,8 +7333,8 @@ describe("Interface Relationships", () => {
             }
 
             type CommentUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input CommentWhere {
@@ -7402,9 +7387,9 @@ describe("Interface Relationships", () => {
             }
 
             type ContentAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ContentConnectInput {
@@ -7634,7 +7619,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -7671,9 +7656,9 @@ describe("Interface Relationships", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             type PostCommentCommentsAggregationSelection {
@@ -7682,8 +7667,8 @@ describe("Interface Relationships", () => {
             }
 
             type PostCommentCommentsNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PostCommentsAggregateInput {
@@ -7955,8 +7940,8 @@ describe("Interface Relationships", () => {
             }
 
             type PostUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -8047,7 +8032,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -8088,8 +8073,8 @@ describe("Interface Relationships", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -8129,8 +8114,8 @@ describe("Interface Relationships", () => {
             }
 
             type UserContentContentNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input UserContentCreateFieldInput {

--- a/packages/graphql/tests/schema/experimental-schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interfaces.test.ts
@@ -77,7 +77,7 @@ describe("Interfaces", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -93,7 +93,7 @@ describe("Interfaces", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -128,7 +128,7 @@ describe("Interfaces", () => {
             }
 
             type MovieMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieMoviesAggregateInput {
@@ -190,7 +190,7 @@ describe("Interfaces", () => {
 
             type MovieNodeAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum MovieNodeImplementation {
@@ -492,7 +492,7 @@ describe("Interfaces", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -508,7 +508,7 @@ describe("Interfaces", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -543,7 +543,7 @@ describe("Interfaces", () => {
             }
 
             type MovieMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieMoviesAggregateInput {
@@ -605,7 +605,7 @@ describe("Interfaces", () => {
 
             type MovieNodeAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum MovieNodeImplementation {

--- a/packages/graphql/tests/schema/experimental-schema/interfaces/aggregations.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interfaces/aggregations.test.ts
@@ -68,14 +68,14 @@ describe("Interface Top Level Aggregations", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -89,10 +89,10 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type MovieAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -194,9 +194,9 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type ProductionAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             enum ProductionImplementation {
@@ -261,7 +261,7 @@ describe("Interface Top Level Aggregations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -430,7 +430,7 @@ describe("Interface Top Level Aggregations", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -471,12 +471,12 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -568,14 +568,14 @@ describe("Interface Top Level Aggregations", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -589,10 +589,10 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type MovieAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -700,9 +700,9 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type ProductionAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -791,10 +791,10 @@ describe("Interface Top Level Aggregations", () => {
             }
 
             type SeriesAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -884,7 +884,7 @@ describe("Interface Top Level Aggregations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/interfaces/typename-in.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/interfaces/typename-in.test.ts
@@ -121,7 +121,7 @@ describe("typename_IN", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -161,8 +161,8 @@ describe("typename_IN", () => {
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -254,14 +254,14 @@ describe("typename_IN", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -275,10 +275,10 @@ describe("typename_IN", () => {
             }
 
             type MovieAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -386,9 +386,9 @@ describe("typename_IN", () => {
             }
 
             type ProductionAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -477,10 +477,10 @@ describe("typename_IN", () => {
             }
 
             type SeriesAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -570,7 +570,7 @@ describe("typename_IN", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/2377.test.ts
@@ -101,9 +101,9 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -115,7 +115,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -168,10 +168,10 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             type ResourceAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
-              updatedAt: DateTimeAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
             }
 
             input ResourceConnectInput {
@@ -385,8 +385,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             type ResourceEntityAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             enum ResourceEntityImplementation {
@@ -479,10 +479,10 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourceResourceContainedByNodeAggregateSelection {
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
-              updatedAt: DateTimeAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
             }
 
             \\"\\"\\"
@@ -620,7 +620,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/2993.test.ts
@@ -67,9 +67,9 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               since_NOT_IN: [DateTime!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -137,8 +137,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type ProfileAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input ProfileConnectWhere {
@@ -218,7 +218,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -249,8 +249,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -353,12 +353,12 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type UserProfileFollowingEdgeAggregateSelection {
-              since: DateTimeAggregateSelectionNonNullable!
+              since: DateTimeAggregateSelection!
             }
 
             type UserProfileFollowingNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input UserRelationInput {
@@ -473,9 +473,9 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -517,7 +517,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               since_NOT_IN: [DateTime!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -543,8 +543,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type ProfileAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input ProfileConnectWhere {
@@ -623,7 +623,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -654,8 +654,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -758,12 +758,12 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type UserProfileFollowingEdgeAggregateSelection {
-              since: DateTimeAggregateSelectionNonNullable!
+              since: DateTimeAggregateSelection!
             }
 
             type UserProfileFollowingNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input UserRelationInput {

--- a/packages/graphql/tests/schema/experimental-schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/issues/3439.test.ts
@@ -127,7 +127,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -186,8 +186,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreIProductProductNodeAggregateSelection {
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input GenreOnCreateInput {
@@ -393,7 +393,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type INodeAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
             }
 
             enum INodeImplementation {
@@ -442,8 +442,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type IProductAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input IProductConnectWhere {
@@ -551,8 +551,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -681,7 +681,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenreNodeAggregationWhereInput {
@@ -927,8 +927,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1063,7 +1063,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesGenreNodeAggregationWhereInput {
@@ -1265,7 +1265,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1414,7 +1414,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -1473,8 +1473,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreIProductProductNodeAggregateSelection {
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input GenreOnCreateInput {
@@ -1682,8 +1682,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type IProductAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input IProductConnectWhere {
@@ -1833,8 +1833,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1926,7 +1926,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenreNodeAggregationWhereInput {
@@ -2165,8 +2165,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -2264,7 +2264,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesGenreNodeAggregationWhereInput {
@@ -2461,7 +2461,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2610,7 +2610,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -2661,8 +2661,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreIProductProductNodeAggregateSelection {
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input GenreOptions {
@@ -2862,8 +2862,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type IProductAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input IProductConnectWhere {
@@ -2969,8 +2969,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -3129,8 +3129,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -3255,7 +3255,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/math.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/math.test.ts
@@ -61,12 +61,12 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -80,8 +80,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -214,7 +214,7 @@ describe("Algebraic", () => {
             \\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNonNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -244,7 +244,7 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -256,8 +256,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: BigIntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: BigIntAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -409,14 +409,14 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -428,8 +428,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: FloatAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: FloatAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -602,7 +602,7 @@ describe("Algebraic", () => {
 
             type DirectorAggregateSelection {
               count: Int!
-              lastName: StringAggregateSelectionNonNullable!
+              lastName: StringAggregateSelection!
             }
 
             input DirectorConnectInput {
@@ -745,8 +745,8 @@ describe("Algebraic", () => {
             }
 
             type DirectorMovieDirectsNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input DirectorOptions {
@@ -825,12 +825,12 @@ describe("Algebraic", () => {
               totalCount: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -847,8 +847,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -992,7 +992,7 @@ describe("Algebraic", () => {
             }
 
             type MovieDirectorDirectedByNodeAggregateSelection {
-              lastName: StringAggregateSelectionNonNullable!
+              lastName: StringAggregateSelection!
             }
 
             input MovieDisconnectInput {
@@ -1102,7 +1102,7 @@ describe("Algebraic", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1183,12 +1183,12 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1205,8 +1205,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1247,7 +1247,7 @@ describe("Algebraic", () => {
             }
 
             type MoviePersonWorkersNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieRelationInput {
@@ -1478,7 +1478,7 @@ describe("Algebraic", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -1522,7 +1522,7 @@ describe("Algebraic", () => {
             }
 
             type PersonProductionWorksInProductionNodeAggregateSelection {
-              viewers: IntAggregateSelectionNonNullable!
+              viewers: IntAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -1638,7 +1638,7 @@ describe("Algebraic", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              viewers: IntAggregateSelectionNonNullable!
+              viewers: IntAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -1709,7 +1709,7 @@ describe("Algebraic", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1840,7 +1840,7 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -2012,7 +2012,7 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -2057,11 +2057,11 @@ describe("Algebraic", () => {
             }
 
             type MoviePersonActorsEdgeAggregateSelection {
-              pay: FloatAggregateSelectionNullable!
+              pay: FloatAggregateSelection!
             }
 
             type MoviePersonActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieRelationInput {
@@ -2319,7 +2319,7 @@ describe("Algebraic", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -2355,11 +2355,11 @@ describe("Algebraic", () => {
             }
 
             type PersonMovieActedInMoviesEdgeAggregateSelection {
-              pay: FloatAggregateSelectionNullable!
+              pay: FloatAggregateSelection!
             }
 
             type PersonMovieActedInMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input PersonOptions {
@@ -2449,7 +2449,7 @@ describe("Algebraic", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/nested-aggregation-on-interface.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/nested-aggregation-on-interface.test.ts
@@ -150,7 +150,7 @@ describe("nested aggregation on interface", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -191,12 +191,12 @@ describe("nested aggregation on interface", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -288,14 +288,14 @@ describe("nested aggregation on interface", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -309,10 +309,10 @@ describe("nested aggregation on interface", () => {
             }
 
             type MovieAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -420,9 +420,9 @@ describe("nested aggregation on interface", () => {
             }
 
             type ProductionAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -511,10 +511,10 @@ describe("nested aggregation on interface", () => {
             }
 
             type SeriesAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -604,7 +604,7 @@ describe("nested aggregation on interface", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -783,7 +783,7 @@ describe("nested aggregation on interface", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -906,14 +906,14 @@ describe("nested aggregation on interface", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -927,10 +927,10 @@ describe("nested aggregation on interface", () => {
             }
 
             type MovieAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -1038,9 +1038,9 @@ describe("nested aggregation on interface", () => {
             }
 
             type ProductionAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -1129,10 +1129,10 @@ describe("nested aggregation on interface", () => {
             }
 
             type SeriesAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -1222,7 +1222,7 @@ describe("nested aggregation on interface", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/plural.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/plural.test.ts
@@ -55,7 +55,7 @@ describe("Plural option", () => {
 
             type AnimalAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             enum AnimalImplementation {
@@ -101,7 +101,7 @@ describe("Plural option", () => {
 
             type CatAggregateSelection {
               count: Int!
-              queenOf: StringAggregateSelectionNullable!
+              queenOf: StringAggregateSelection!
             }
 
             input CatCreateInput {
@@ -189,9 +189,9 @@ describe("Plural option", () => {
             }
 
             type DogAggregateSelection {
-              breed: StringAggregateSelectionNullable!
+              breed: StringAggregateSelection!
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input DogCreateInput {
@@ -308,7 +308,7 @@ describe("Plural option", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/subscriptions.test.ts
@@ -65,7 +65,7 @@ describe("Subscriptions", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -198,19 +198,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -233,7 +233,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -359,10 +359,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -630,7 +630,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -755,9 +755,9 @@ describe("Subscriptions", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -1026,19 +1026,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1131,10 +1131,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1514,19 +1514,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1679,10 +1679,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1988,9 +1988,9 @@ describe("Subscriptions", () => {
             }
 
             type PersonMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PersonMoviesAggregateInput {
@@ -2299,9 +2299,9 @@ describe("Subscriptions", () => {
             }
 
             type StarMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input StarMoviesAggregateInput {
@@ -2720,9 +2720,9 @@ describe("Subscriptions", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -2991,26 +2991,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float
-              max: Int
-              min: Int
-              sum: Int
-            }
-
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -3033,7 +3026,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -3158,10 +3151,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -3504,7 +3497,7 @@ describe("Subscriptions", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -3637,19 +3630,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -3672,7 +3665,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -3790,10 +3783,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -3961,7 +3954,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -4032,8 +4025,8 @@ describe("Subscriptions", () => {
 
             type AgreementAggregateSelection {
               count: Int!
-              id: IntAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input AgreementConnectInput {
@@ -4339,8 +4332,8 @@ describe("Subscriptions", () => {
             }
 
             type AgreementUserOwnerNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
-              username: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input AgreementWhere {
@@ -4409,7 +4402,7 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -4447,12 +4440,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -4488,8 +4476,8 @@ describe("Subscriptions", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
-              username: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserConnectWhere {
@@ -4677,19 +4665,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -4842,10 +4830,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -5151,9 +5139,9 @@ describe("Subscriptions", () => {
             }
 
             type PersonMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PersonMoviesAggregateInput {
@@ -5448,9 +5436,9 @@ describe("Subscriptions", () => {
             }
 
             type StarMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input StarMoviesAggregateInput {
@@ -5873,12 +5861,12 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -5895,8 +5883,8 @@ describe("Subscriptions", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -6151,7 +6139,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonProductionMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -6213,7 +6201,7 @@ describe("Subscriptions", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -6381,9 +6369,9 @@ describe("Subscriptions", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episode: IntAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -6619,7 +6607,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/union-interface-relationship.test.ts
@@ -127,8 +127,8 @@ describe("Union Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              id: IntAggregateSelectionNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -173,12 +173,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              imdbId: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -560,9 +560,9 @@ describe("Union Interface Relationships", () => {
 
             type InfluencerAggregateSelection {
               count: Int!
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
-              url: StringAggregateSelectionNonNullable!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
+              url: StringAggregateSelection!
             }
 
             input InfluencerCreateInput {
@@ -642,14 +642,7 @@ describe("Union Interface Relationships", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float
-              max: Int
-              min: Int
-              sum: Int
-            }
-
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -676,12 +669,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              id: IntAggregateSelectionNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -879,8 +872,8 @@ describe("Union Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              imdbId: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1134,12 +1127,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieReviewerReviewersEdgeAggregateSelection {
-              score: IntAggregateSelectionNonNullable!
+              score: IntAggregateSelection!
             }
 
             type MovieReviewerReviewersNodeAggregateSelection {
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             input MovieReviewersConnectFieldInput {
@@ -1374,10 +1367,10 @@ describe("Union Interface Relationships", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              id: IntAggregateSelectionNullable!
-              name: StringAggregateSelectionNonNullable!
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -1424,12 +1417,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type PersonMovieMoviesEdgeAggregateSelection {
-              score: IntAggregateSelectionNonNullable!
+              score: IntAggregateSelection!
             }
 
             type PersonMovieMoviesNodeAggregateSelection {
-              imdbId: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input PersonMoviesAggregateInput {
@@ -1811,8 +1804,8 @@ describe("Union Interface Relationships", () => {
 
             type ReviewerAggregateSelection {
               count: Int!
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             input ReviewerConnectWhere {
@@ -1886,7 +1879,7 @@ describe("Union Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/experimental-schema/union-relationship-filtering.test.ts
+++ b/packages/graphql/tests/schema/experimental-schema/union-relationship-filtering.test.ts
@@ -269,7 +269,7 @@ describe("Union Relationships Filtering", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -413,8 +413,8 @@ describe("Union Relationships Filtering", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -551,8 +551,8 @@ describe("Union Relationships Filtering", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              isan: StringAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              isan: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectOrCreateWhere {
@@ -644,7 +644,7 @@ describe("Union Relationships Filtering", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/extend.test.ts
+++ b/packages/graphql/tests/schema/extend.test.ts
@@ -65,7 +65,7 @@ describe("Extend", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -77,8 +77,8 @@ describe("Extend", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -173,7 +173,7 @@ describe("Extend", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/federation.test.ts
+++ b/packages/graphql/tests/schema/federation.test.ts
@@ -122,7 +122,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
               count: Int!
             }
 
@@ -300,7 +300,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostUserAuthorNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -348,7 +348,7 @@ describe("Apollo Federation", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable @shareable {
+            type StringAggregateSelection @shareable {
               longest: String
               shortest: String
             }
@@ -383,7 +383,7 @@ describe("Apollo Federation", () => {
 
             type UserAggregateSelection @shareable {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -427,7 +427,7 @@ describe("Apollo Federation", () => {
             }
 
             type UserPostPostsNodeAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
             }
 
             input UserPostsAggregateInput {
@@ -735,7 +735,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
               count: Int!
             }
 
@@ -906,7 +906,7 @@ describe("Apollo Federation", () => {
             }
 
             type PostUserAuthorNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -955,7 +955,7 @@ describe("Apollo Federation", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable @federation__shareable {
+            type StringAggregateSelection @federation__shareable {
               longest: String
               shortest: String
             }
@@ -987,7 +987,7 @@ describe("Apollo Federation", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectWhere {

--- a/packages/graphql/tests/schema/fulltext.test.ts
+++ b/packages/graphql/tests/schema/fulltext.test.ts
@@ -82,8 +82,8 @@ describe("@fulltext schema", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              description: StringAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
+              description: StringAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -239,7 +239,7 @@ describe("@fulltext schema", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/global-node.test.ts
+++ b/packages/graphql/tests/schema/global-node.test.ts
@@ -62,7 +62,7 @@ describe("Node Interface Types", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -75,8 +75,8 @@ describe("Node Interface Types", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              imdb: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdb: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -183,7 +183,7 @@ describe("Node Interface Types", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/inheritance.test.ts
+++ b/packages/graphql/tests/schema/inheritance.test.ts
@@ -67,7 +67,7 @@ describe("inheritance", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -148,11 +148,11 @@ describe("inheritance", () => {
             }
 
             type ActorPersonFriendsEdgeAggregateSelection {
-              since: IntAggregateSelectionNullable!
+              since: IntAggregateSelection!
             }
 
             type ActorPersonFriendsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -270,7 +270,7 @@ describe("inheritance", () => {
               since_NOT_IN: [Int] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -299,7 +299,7 @@ describe("inheritance", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -494,7 +494,7 @@ describe("inheritance", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/inputs.test.ts
+++ b/packages/graphql/tests/schema/inputs.test.ts
@@ -69,7 +69,7 @@ describe("Inputs", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -80,7 +80,7 @@ describe("Inputs", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/interface-relationships.test.ts
+++ b/packages/graphql/tests/schema/interface-relationships.test.ts
@@ -166,7 +166,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -207,11 +207,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -303,7 +303,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -317,8 +317,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -411,7 +411,7 @@ describe("Interface Relationships", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -486,8 +486,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -562,7 +562,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -752,7 +752,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -797,11 +797,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -907,7 +907,7 @@ describe("Interface Relationships", () => {
 
             type EpisodeAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input EpisodeConnectInput {
@@ -1084,8 +1084,8 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesSeriesNodeAggregateSelection {
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input EpisodeSeriesUpdateConnectionInput {
@@ -1140,7 +1140,7 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1162,11 +1162,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1290,8 +1290,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1603,7 +1603,7 @@ describe("Interface Relationships", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -1734,11 +1734,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -1862,8 +1862,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1909,7 +1909,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodeEpisodesNodeAggregateSelection {
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input SeriesEpisodesAggregateInput {
@@ -2140,7 +2140,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2338,7 +2338,7 @@ describe("Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -2383,11 +2383,11 @@ describe("Interface Relationships", () => {
             }
 
             type ActorProductionActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorProductionActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorRelationInput {
@@ -2493,7 +2493,7 @@ describe("Interface Relationships", () => {
 
             type EpisodeAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input EpisodeConnectInput {
@@ -2670,8 +2670,8 @@ describe("Interface Relationships", () => {
             }
 
             type EpisodeSeriesSeriesNodeAggregateSelection {
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input EpisodeSeriesUpdateConnectionInput {
@@ -2726,7 +2726,7 @@ describe("Interface Relationships", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -2748,11 +2748,11 @@ describe("Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -2876,8 +2876,8 @@ describe("Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -3209,7 +3209,7 @@ describe("Interface Relationships", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -3340,11 +3340,11 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              seasons: IntAggregateSelectionNonNullable!
+              seasons: IntAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -3468,8 +3468,8 @@ describe("Interface Relationships", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodeCount: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodeCount: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -3515,7 +3515,7 @@ describe("Interface Relationships", () => {
             }
 
             type SeriesEpisodeEpisodesNodeAggregateSelection {
-              runtime: IntAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
             }
 
             input SeriesEpisodesAggregateInput {
@@ -3782,7 +3782,7 @@ describe("Interface Relationships", () => {
               seasons_NOT_IN: [Int!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -3915,7 +3915,7 @@ describe("Interface Relationships", () => {
 
             type Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Interface1ConnectInput {
@@ -4058,7 +4058,7 @@ describe("Interface Relationships", () => {
 
             type Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Interface2ConnectWhere {
@@ -4168,12 +4168,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -4187,7 +4182,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -4221,7 +4216,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -4294,7 +4289,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface1NodeAggregateSelection {
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2ConnectFieldInput {
@@ -4324,7 +4319,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2UpdateConnectionInput {
@@ -4429,7 +4424,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -4557,7 +4552,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -4609,7 +4604,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface1Interface2UpdateConnectionInput {
@@ -4696,7 +4691,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -4884,7 +4879,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -4899,7 +4894,7 @@ describe("Interface Relationships", () => {
 
             type Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Interface1ConnectInput {
@@ -5087,7 +5082,7 @@ describe("Interface Relationships", () => {
 
             type Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Interface2ConnectWhere {
@@ -5234,12 +5229,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -5253,7 +5243,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -5287,7 +5277,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -5360,7 +5350,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface1NodeAggregateSelection {
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2ConnectFieldInput {
@@ -5393,11 +5383,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface2Interface2EdgeAggregateSelection {
-              propsField: IntAggregateSelectionNonNullable!
+              propsField: IntAggregateSelection!
             }
 
             type Type1Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2UpdateConnectionInput {
@@ -5503,7 +5493,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -5631,7 +5621,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -5686,11 +5676,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Interface2Interface2EdgeAggregateSelection {
-              propsField: IntAggregateSelectionNonNullable!
+              propsField: IntAggregateSelection!
             }
 
             type Type2Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface1Interface2UpdateConnectionInput {
@@ -5778,7 +5768,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -5972,7 +5962,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -5987,7 +5977,7 @@ describe("Interface Relationships", () => {
 
             type Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Interface1ConnectInput {
@@ -6191,7 +6181,7 @@ describe("Interface Relationships", () => {
 
             type Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Interface2ConnectWhere {
@@ -6301,12 +6291,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -6320,7 +6305,7 @@ describe("Interface Relationships", () => {
 
             type Type1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1ConnectInput {
@@ -6354,7 +6339,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1ConnectFieldInput {
@@ -6427,7 +6412,7 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface1NodeAggregateSelection {
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2ConnectFieldInput {
@@ -6460,11 +6445,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type1Interface1Interface2Interface2EdgeAggregateSelection {
-              type1Field: IntAggregateSelectionNonNullable!
+              type1Field: IntAggregateSelection!
             }
 
             type Type1Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface1Interface2UpdateConnectionInput {
@@ -6570,7 +6555,7 @@ describe("Interface Relationships", () => {
 
             type Type1Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type1Interface2CreateInput {
@@ -6734,7 +6719,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface1AggregateSelection {
               count: Int!
-              field1: StringAggregateSelectionNonNullable!
+              field1: StringAggregateSelection!
             }
 
             input Type2Interface1ConnectInput {
@@ -6789,11 +6774,11 @@ describe("Interface Relationships", () => {
             }
 
             type Type2Interface1Interface2Interface2EdgeAggregateSelection {
-              type2Field: IntAggregateSelectionNonNullable!
+              type2Field: IntAggregateSelection!
             }
 
             type Type2Interface1Interface2Interface2NodeAggregateSelection {
-              field2: StringAggregateSelectionNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface1Interface2UpdateConnectionInput {
@@ -6881,7 +6866,7 @@ describe("Interface Relationships", () => {
 
             type Type2Interface2AggregateSelection {
               count: Int!
-              field2: StringAggregateSelectionNonNullable!
+              field2: StringAggregateSelection!
             }
 
             input Type2Interface2CreateInput {
@@ -7064,9 +7049,9 @@ describe("Interface Relationships", () => {
             }
 
             type CommentAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input CommentConnectInput {
@@ -7300,8 +7285,8 @@ describe("Interface Relationships", () => {
             }
 
             type CommentPostPostNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             type CommentPostRelationship {
@@ -7348,8 +7333,8 @@ describe("Interface Relationships", () => {
             }
 
             type CommentUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input CommentWhere {
@@ -7402,9 +7387,9 @@ describe("Interface Relationships", () => {
             }
 
             type ContentAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ContentConnectInput {
@@ -7634,7 +7619,7 @@ describe("Interface Relationships", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -7671,9 +7656,9 @@ describe("Interface Relationships", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNullable!
+              content: StringAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             type PostCommentCommentsAggregationSelection {
@@ -7682,8 +7667,8 @@ describe("Interface Relationships", () => {
             }
 
             type PostCommentCommentsNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PostCommentsAggregateInput {
@@ -7955,8 +7940,8 @@ describe("Interface Relationships", () => {
             }
 
             type PostUserCreatorNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -8047,7 +8032,7 @@ describe("Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -8088,8 +8073,8 @@ describe("Interface Relationships", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -8129,8 +8114,8 @@ describe("Interface Relationships", () => {
             }
 
             type UserContentContentNodeAggregateSelection {
-              content: StringAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              content: StringAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input UserContentCreateFieldInput {

--- a/packages/graphql/tests/schema/interfaces.test.ts
+++ b/packages/graphql/tests/schema/interfaces.test.ts
@@ -77,7 +77,7 @@ describe("Interfaces", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -93,7 +93,7 @@ describe("Interfaces", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -128,7 +128,7 @@ describe("Interfaces", () => {
             }
 
             type MovieMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieMoviesAggregateInput {
@@ -190,7 +190,7 @@ describe("Interfaces", () => {
 
             type MovieNodeAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum MovieNodeImplementation {
@@ -492,7 +492,7 @@ describe("Interfaces", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -508,7 +508,7 @@ describe("Interfaces", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -543,7 +543,7 @@ describe("Interfaces", () => {
             }
 
             type MovieMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieMoviesAggregateInput {
@@ -605,7 +605,7 @@ describe("Interfaces", () => {
 
             type MovieNodeAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             enum MovieNodeImplementation {

--- a/packages/graphql/tests/schema/issues/1038.test.ts
+++ b/packages/graphql/tests/schema/issues/1038.test.ts
@@ -50,8 +50,8 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             }
 
             type AWSAccountAggregateSelection {
-              accountName: StringAggregateSelectionNullable!
-              code: StringAggregateSelectionNullable!
+              accountName: StringAggregateSelection!
+              code: StringAggregateSelection!
               count: Int!
             }
 
@@ -144,9 +144,9 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
             }
 
             type DNSZoneAggregateSelection {
-              awsId: StringAggregateSelectionNullable!
+              awsId: StringAggregateSelection!
               count: Int!
-              zoneType: StringAggregateSelectionNullable!
+              zoneType: StringAggregateSelection!
             }
 
             input DNSZoneCreateInput {
@@ -256,7 +256,7 @@ describe("https://github.com/neo4j/graphql/issues/1038", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/1182.test.ts
+++ b/packages/graphql/tests/schema/issues/1182.test.ts
@@ -56,9 +56,9 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              dob: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              dob: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectOrCreateWhere {
@@ -186,9 +186,9 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -200,7 +200,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -219,9 +219,9 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              dob: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              dob: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -367,8 +367,8 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -543,7 +543,7 @@ describe("https://github.com/neo4j/graphql/issues/1182", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/1614.test.ts
+++ b/packages/graphql/tests/schema/issues/1614.test.ts
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
             }
 
             type CrewMemberMovieMoviesNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input CrewMemberMoviesAggregateInput {
@@ -314,7 +314,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectWhere {
@@ -406,7 +406,7 @@ describe("https://github.com/neo4j/graphql/issues/1614", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/162.test.ts
+++ b/packages/graphql/tests/schema/issues/162.test.ts
@@ -81,12 +81,12 @@ describe("162", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -139,7 +139,7 @@ describe("162", () => {
 
             type TigerAggregateSelection {
               count: Int!
-              x: IntAggregateSelectionNullable!
+              x: IntAggregateSelection!
             }
 
             input TigerConnectWhere {
@@ -164,7 +164,7 @@ describe("162", () => {
 
             type TigerJawLevel2AggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input TigerJawLevel2ConnectInput {
@@ -219,7 +219,7 @@ describe("162", () => {
 
             type TigerJawLevel2Part1AggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input TigerJawLevel2Part1ConnectFieldInput {
@@ -423,7 +423,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2Part1TigerTigerNodeAggregateSelection {
-              x: IntAggregateSelectionNullable!
+              x: IntAggregateSelection!
             }
 
             input TigerJawLevel2Part1TigerUpdateConnectionInput {
@@ -501,7 +501,7 @@ describe("162", () => {
             }
 
             type TigerJawLevel2TigerJawLevel2Part1Part1NodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input TigerJawLevel2UpdateInput {

--- a/packages/graphql/tests/schema/issues/200.test.ts
+++ b/packages/graphql/tests/schema/issues/200.test.ts
@@ -55,10 +55,10 @@ describe("200", () => {
             }
 
             type CategoryAggregateSelection {
-              categoryId: IDAggregateSelectionNonNullable!
+              categoryId: IDAggregateSelection!
               count: Int!
-              description: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              description: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input CategoryCreateInput {
@@ -161,7 +161,7 @@ describe("200", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -194,7 +194,7 @@ describe("200", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/2187.test.ts
+++ b/packages/graphql/tests/schema/issues/2187.test.ts
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -127,9 +127,9 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type GenreMovieMoviesNodeAggregateSelection {
-              imdbRating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input GenreMoviesAggregateInput {
@@ -375,7 +375,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -393,9 +393,9 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              imdbRating: FloatAggregateSelectionNullable!
-              title: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              imdbRating: FloatAggregateSelection!
+              title: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -432,7 +432,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
             }
 
             type MovieGenreGenresNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenresAggregateInput {
@@ -688,7 +688,7 @@ describe("https://github.com/neo4j/graphql/issues/2187", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/2377.test.ts
+++ b/packages/graphql/tests/schema/issues/2377.test.ts
@@ -101,9 +101,9 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -115,7 +115,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -168,10 +168,10 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             type ResourceAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
-              updatedAt: DateTimeAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
             }
 
             input ResourceConnectInput {
@@ -385,8 +385,8 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
 
             type ResourceEntityAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             enum ResourceEntityImplementation {
@@ -479,10 +479,10 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
             }
 
             type ResourceResourceContainedByNodeAggregateSelection {
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
-              updatedAt: DateTimeAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
+              updatedAt: DateTimeAggregateSelection!
             }
 
             \\"\\"\\"
@@ -620,7 +620,7 @@ describe("https://github.com/neo4j/graphql/issues/2377", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/2969.test.ts
+++ b/packages/graphql/tests/schema/issues/2969.test.ts
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type PostAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
               count: Int!
             }
 
@@ -282,8 +282,8 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type PostUserAuthorNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PostWhere {
@@ -330,7 +330,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -366,8 +366,8 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -412,7 +412,7 @@ describe("https://github.com/neo4j/graphql/issues/2969", () => {
             }
 
             type UserPostPostsNodeAggregateSelection {
-              content: StringAggregateSelectionNonNullable!
+              content: StringAggregateSelection!
             }
 
             input UserPostsAggregateInput {

--- a/packages/graphql/tests/schema/issues/2981.test.ts
+++ b/packages/graphql/tests/schema/issues/2981.test.ts
@@ -61,8 +61,8 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             type BookAggregateSelection {
               count: Int!
-              isbn: StringAggregateSelectionNonNullable!
-              originalTitle: StringAggregateSelectionNonNullable!
+              isbn: StringAggregateSelection!
+              originalTitle: StringAggregateSelection!
             }
 
             input BookConnectInput {
@@ -141,7 +141,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             type BookTitle_ENAggregateSelection {
               count: Int!
-              value: StringAggregateSelectionNonNullable!
+              value: StringAggregateSelection!
             }
 
             input BookTitle_ENBookAggregateInput {
@@ -162,8 +162,8 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookTitle_ENBookBookNodeAggregateSelection {
-              isbn: StringAggregateSelectionNonNullable!
-              originalTitle: StringAggregateSelectionNonNullable!
+              isbn: StringAggregateSelection!
+              originalTitle: StringAggregateSelection!
             }
 
             input BookTitle_ENBookConnectFieldInput {
@@ -387,7 +387,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
 
             type BookTitle_SVAggregateSelection {
               count: Int!
-              value: StringAggregateSelectionNonNullable!
+              value: StringAggregateSelection!
             }
 
             input BookTitle_SVBookAggregateInput {
@@ -408,8 +408,8 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
             }
 
             type BookTitle_SVBookBookNodeAggregateSelection {
-              isbn: StringAggregateSelectionNonNullable!
-              originalTitle: StringAggregateSelectionNonNullable!
+              isbn: StringAggregateSelection!
+              originalTitle: StringAggregateSelection!
             }
 
             input BookTitle_SVBookConnectFieldInput {
@@ -882,7 +882,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/2993.test.ts
+++ b/packages/graphql/tests/schema/issues/2993.test.ts
@@ -67,9 +67,9 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               since_NOT_IN: [DateTime!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -137,8 +137,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type ProfileAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input ProfileConnectWhere {
@@ -218,7 +218,7 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -249,8 +249,8 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
 
             type UserAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -353,12 +353,12 @@ describe("https://github.com/neo4j/graphql/issues/2993", () => {
             }
 
             type UserProfileFollowingEdgeAggregateSelection {
-              since: DateTimeAggregateSelectionNonNullable!
+              since: DateTimeAggregateSelection!
             }
 
             type UserProfileFollowingNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              userName: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              userName: StringAggregateSelection!
             }
 
             input UserRelationInput {

--- a/packages/graphql/tests/schema/issues/3428.test.ts
+++ b/packages/graphql/tests/schema/issues/3428.test.ts
@@ -72,12 +72,7 @@ describe("Relationship nested operations", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
-              longest: ID
-              shortest: ID
-            }
-
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -168,7 +163,7 @@ describe("Relationship nested operations", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -195,8 +190,8 @@ describe("Relationship nested operations", () => {
             }
 
             type MoviePersonActorsNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             \\"\\"\\"
@@ -291,8 +286,8 @@ describe("Relationship nested operations", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input PersonCreateInput {
@@ -368,7 +363,7 @@ describe("Relationship nested operations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -455,7 +450,7 @@ describe("Relationship nested operations", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -500,7 +495,7 @@ describe("Relationship nested operations", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -610,7 +605,7 @@ describe("Relationship nested operations", () => {
 
             type PersonOneAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonOneCreateInput {
@@ -670,7 +665,7 @@ describe("Relationship nested operations", () => {
 
             type PersonTwoAggregateSelection {
               count: Int!
-              nameTwo: StringAggregateSelectionNullable!
+              nameTwo: StringAggregateSelection!
             }
 
             input PersonTwoCreateInput {
@@ -756,7 +751,7 @@ describe("Relationship nested operations", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/3439.test.ts
+++ b/packages/graphql/tests/schema/issues/3439.test.ts
@@ -124,7 +124,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -183,8 +183,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreIProductProductNodeAggregateSelection {
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input GenreOnCreateInput {
@@ -390,7 +390,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type INodeAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
             }
 
             enum INodeImplementation {
@@ -439,8 +439,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type IProductAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input IProductConnectWhere {
@@ -548,8 +548,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -678,7 +678,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenreNodeAggregationWhereInput {
@@ -924,8 +924,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1060,7 +1060,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesGenreNodeAggregationWhereInput {
@@ -1262,7 +1262,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1409,7 +1409,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -1468,8 +1468,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreIProductProductNodeAggregateSelection {
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input GenreOnCreateInput {
@@ -1677,8 +1677,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type IProductAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input IProductConnectWhere {
@@ -1828,8 +1828,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1921,7 +1921,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type MovieGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenreNodeAggregationWhereInput {
@@ -2160,8 +2160,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -2259,7 +2259,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type SeriesGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesGenreNodeAggregationWhereInput {
@@ -2456,7 +2456,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -2602,7 +2602,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -2653,8 +2653,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
             }
 
             type GenreIProductProductNodeAggregateSelection {
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input GenreOptions {
@@ -2854,8 +2854,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type IProductAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input IProductConnectWhere {
@@ -2961,8 +2961,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -3121,8 +3121,8 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              id: StringAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: StringAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             type SeriesConnection {
@@ -3247,7 +3247,7 @@ describe("https://github.com/neo4j/graphql/issues/3439", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/3537.test.ts
+++ b/packages/graphql/tests/schema/issues/3537.test.ts
@@ -349,8 +349,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             type ActorEdge {
@@ -413,7 +413,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             type MovieEdge {
@@ -485,12 +485,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable @shareable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable @shareable {
+            type StringAggregateSelection @shareable {
               longest: String
               shortest: String
             }
@@ -572,8 +567,8 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              password: StringAggregateSelectionNonNullable!
-              username: StringAggregateSelectionNonNullable!
+              password: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input ActorCreateInput {
@@ -720,7 +715,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -836,12 +831,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable @shareable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable @shareable {
+            type StringAggregateSelection @shareable {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/3541.test.ts
+++ b/packages/graphql/tests/schema/issues/3541.test.ts
@@ -71,7 +71,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             type ActorEdge {
@@ -130,7 +130,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -211,7 +211,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type MovieAggregateSelection @shareable {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             type MovieEdge @shareable {
@@ -313,7 +313,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable @shareable {
+            type StringAggregateSelection @shareable {
               longest: String
               shortest: String
             }
@@ -393,7 +393,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -493,7 +493,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -726,7 +726,7 @@ describe("Extending the schema in when using getSubgraphSchema", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable @shareable {
+            type StringAggregateSelection @shareable {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/3816.test.ts
+++ b/packages/graphql/tests/schema/issues/3816.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -117,7 +117,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenreMovieMoviesNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreMoviesAggregateInput {
@@ -321,7 +321,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -400,7 +400,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MovieGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenreNodeAggregationWhereInput {
@@ -537,7 +537,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -624,7 +624,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreConnectInput {
@@ -655,7 +655,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type GenreMovieMoviesNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input GenreMoviesAggregateInput {
@@ -857,7 +857,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieConnectWhere {
@@ -909,7 +909,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
             }
 
             type MovieGenreGenreNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieGenreNodeAggregationWhereInput {
@@ -1039,7 +1039,7 @@ describe("https://github.com/neo4j/graphql/issues/3816", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/3817.test.ts
+++ b/packages/graphql/tests/schema/issues/3817.test.ts
@@ -117,7 +117,7 @@ describe("3817", () => {
               id_STARTS_WITH: String
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -151,7 +151,7 @@ describe("3817", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -350,11 +350,11 @@ describe("3817", () => {
             }
 
             type PersonPersonFriendsEdgeAggregateSelection {
-              id: StringAggregateSelectionNullable!
+              id: StringAggregateSelection!
             }
 
             type PersonPersonFriendsNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -435,7 +435,7 @@ describe("3817", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/4511.test.ts
+++ b/packages/graphql/tests/schema/issues/4511.test.ts
@@ -210,12 +210,12 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               UPDATE
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -232,8 +232,8 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -488,7 +488,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
             }
 
             type PersonProductionMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -550,7 +550,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -718,9 +718,9 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episode: IntAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -956,7 +956,7 @@ describe("https://github.com/neo4j/graphql/issues/4511", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/4615.test.ts
+++ b/packages/graphql/tests/schema/issues/4615.test.ts
@@ -33,6 +33,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             type Movie implements Show {
                 title: String!
                 runtime: Int
+                release: DateTime!
                 actors: [Actor!]! @relationship(type: "ACTED_IN", direction: IN, properties: "ActedIn")
             }
 
@@ -176,7 +177,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -225,11 +226,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type ActorShowActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorShowActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             \\"\\"\\"
@@ -308,6 +309,14 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               series: [Series!]!
             }
 
+            \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
+            scalar DateTime
+
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
+            }
+
             \\"\\"\\"
             Information about the number of nodes and relationships deleted during a delete mutation
             \\"\\"\\"
@@ -317,7 +326,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -328,6 +337,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               actors(directed: Boolean = true, options: ActorOptions, where: ActorWhere): [Actor!]!
               actorsAggregate(directed: Boolean = true, where: ActorWhere): MovieActorActorsAggregationSelection
               actorsConnection(after: String, directed: Boolean = true, first: Int, sort: [ShowActorsConnectionSort!], where: ShowActorsConnectionWhere): ShowActorsConnection!
+              release: DateTime!
               runtime: Int
               title: String!
             }
@@ -339,11 +349,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -467,8 +477,9 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              runtime: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              release: DateTimeAggregateSelection!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -477,6 +488,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
 
             input MovieCreateInput {
               actors: MovieActorsFieldInput
+              release: DateTime!
               runtime: Int
               title: String!
             }
@@ -511,12 +523,14 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             Fields to sort Movies by. The order in which sorts are applied is not guaranteed when specifying many fields in one MovieSort object.
             \\"\\"\\"
             input MovieSort {
+              release: SortDirection
               runtime: SortDirection
               title: SortDirection
             }
 
             input MovieUpdateInput {
               actors: [MovieActorsUpdateFieldInput!]
+              release: DateTime
               runtime: Int
               runtime_DECREMENT: Int
               runtime_INCREMENT: Int
@@ -556,6 +570,14 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               actors_SINGLE: ActorWhere
               \\"\\"\\"Return Movies where some of the related Actors match this filter\\"\\"\\"
               actors_SOME: ActorWhere
+              release: DateTime
+              release_GT: DateTime
+              release_GTE: DateTime
+              release_IN: [DateTime!]
+              release_LT: DateTime
+              release_LTE: DateTime
+              release_NOT: DateTime @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              release_NOT_IN: [DateTime!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
               runtime: Int
               runtime_GT: Int
               runtime_GTE: Int
@@ -631,11 +653,11 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
 
             type SeriesActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type SeriesActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input SeriesActorsAggregateInput {
@@ -759,8 +781,8 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episodes: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              episodes: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -1049,7 +1071,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
 
             type ShowAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input ShowConnectInput {
@@ -1153,7 +1175,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/609.test.ts
+++ b/packages/graphql/tests/schema/issues/609.test.ts
@@ -67,7 +67,7 @@ describe("609", () => {
 
             type DeprecatedAggregateSelection {
               count: Int!
-              deprecatedField: StringAggregateSelectionNullable!
+              deprecatedField: StringAggregateSelection!
             }
 
             input DeprecatedCreateInput {
@@ -149,7 +149,7 @@ describe("609", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/issues/872.test.ts
+++ b/packages/graphql/tests/schema/issues/872.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             type Actor2AggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input Actor2ConnectInput {
@@ -100,8 +100,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type Actor2MovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input Actor2MoviesAggregateInput {
@@ -308,7 +308,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -343,8 +343,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -582,7 +582,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -594,8 +594,8 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectOrCreateWhere {
@@ -716,7 +716,7 @@ describe("https://github.com/neo4j/graphql/issues/872", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/lowercase-type-names.test.ts
+++ b/packages/graphql/tests/schema/lowercase-type-names.test.ts
@@ -78,7 +78,7 @@ describe("lower case type names", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -92,7 +92,7 @@ describe("lower case type names", () => {
               relationshipsDeleted: Int!
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -139,7 +139,7 @@ describe("lower case type names", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -176,9 +176,9 @@ describe("lower case type names", () => {
 
             type actorAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              createdAt: DateTimeAggregateSelection!
+              name: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input actorConnectInput {
@@ -499,10 +499,10 @@ describe("lower case type names", () => {
             }
 
             type actormovieMoviesNodeAggregateSelection {
-              createdAt: DateTimeAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
-              testId: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              createdAt: DateTimeAggregateSelection!
+              name: StringAggregateSelection!
+              testId: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             type movie {
@@ -674,10 +674,10 @@ describe("lower case type names", () => {
 
             type movieAggregateSelection {
               count: Int!
-              createdAt: DateTimeAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
-              testId: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              createdAt: DateTimeAggregateSelection!
+              name: StringAggregateSelection!
+              testId: StringAggregateSelection!
+              year: IntAggregateSelection!
             }
 
             input movieConnectInput {
@@ -819,9 +819,9 @@ describe("lower case type names", () => {
             }
 
             type movieactorActorsNodeAggregateSelection {
-              createdAt: DateTimeAggregateSelectionNullable!
-              name: StringAggregateSelectionNullable!
-              year: IntAggregateSelectionNullable!
+              createdAt: DateTimeAggregateSelection!
+              name: StringAggregateSelection!
+              year: IntAggregateSelection!
             }"
         `);
     });

--- a/packages/graphql/tests/schema/math.test.ts
+++ b/packages/graphql/tests/schema/math.test.ts
@@ -61,12 +61,12 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -80,8 +80,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -214,7 +214,7 @@ describe("Algebraic", () => {
             \\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNonNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -244,7 +244,7 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -256,8 +256,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: BigIntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: BigIntAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -409,14 +409,14 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -428,8 +428,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: FloatAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: FloatAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -602,7 +602,7 @@ describe("Algebraic", () => {
 
             type DirectorAggregateSelection {
               count: Int!
-              lastName: StringAggregateSelectionNonNullable!
+              lastName: StringAggregateSelection!
             }
 
             input DirectorConnectInput {
@@ -745,8 +745,8 @@ describe("Algebraic", () => {
             }
 
             type DirectorMovieDirectsNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input DirectorOptions {
@@ -825,12 +825,12 @@ describe("Algebraic", () => {
               totalCount: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -847,8 +847,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -992,7 +992,7 @@ describe("Algebraic", () => {
             }
 
             type MovieDirectorDirectedByNodeAggregateSelection {
-              lastName: StringAggregateSelectionNonNullable!
+              lastName: StringAggregateSelection!
             }
 
             input MovieDisconnectInput {
@@ -1102,7 +1102,7 @@ describe("Algebraic", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1183,12 +1183,12 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1205,8 +1205,8 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              viewers: IntAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              viewers: IntAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1247,7 +1247,7 @@ describe("Algebraic", () => {
             }
 
             type MoviePersonWorkersNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieRelationInput {
@@ -1478,7 +1478,7 @@ describe("Algebraic", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -1522,7 +1522,7 @@ describe("Algebraic", () => {
             }
 
             type PersonProductionWorksInProductionNodeAggregateSelection {
-              viewers: IntAggregateSelectionNonNullable!
+              viewers: IntAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -1638,7 +1638,7 @@ describe("Algebraic", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              viewers: IntAggregateSelectionNonNullable!
+              viewers: IntAggregateSelection!
             }
 
             input ProductionConnectWhere {
@@ -1709,7 +1709,7 @@ describe("Algebraic", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -1840,7 +1840,7 @@ describe("Algebraic", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
@@ -2012,7 +2012,7 @@ describe("Algebraic", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -2057,11 +2057,11 @@ describe("Algebraic", () => {
             }
 
             type MoviePersonActorsEdgeAggregateSelection {
-              pay: FloatAggregateSelectionNullable!
+              pay: FloatAggregateSelection!
             }
 
             type MoviePersonActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieRelationInput {
@@ -2319,7 +2319,7 @@ describe("Algebraic", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -2355,11 +2355,11 @@ describe("Algebraic", () => {
             }
 
             type PersonMovieActedInMoviesEdgeAggregateSelection {
-              pay: FloatAggregateSelectionNullable!
+              pay: FloatAggregateSelection!
             }
 
             type PersonMovieActedInMoviesNodeAggregateSelection {
-              title: StringAggregateSelectionNonNullable!
+              title: StringAggregateSelection!
             }
 
             input PersonOptions {
@@ -2449,7 +2449,7 @@ describe("Algebraic", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
+++ b/packages/graphql/tests/schema/nested-aggregation-on-type.test.ts
@@ -278,7 +278,7 @@ describe("nested aggregation on interface", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -310,13 +310,13 @@ describe("nested aggregation on interface", () => {
             }
 
             type ActorMovieActedInEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieActedInNodeAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorOptions {
@@ -423,14 +423,14 @@ describe("nested aggregation on interface", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -444,10 +444,10 @@ describe("nested aggregation on interface", () => {
             }
 
             type MovieAggregateSelection {
-              cost: FloatAggregateSelectionNonNullable!
+              cost: FloatAggregateSelection!
               count: Int!
-              runtime: IntAggregateSelectionNonNullable!
-              title: StringAggregateSelectionNonNullable!
+              runtime: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectWhere {
@@ -567,7 +567,7 @@ describe("nested aggregation on interface", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/null.test.ts
+++ b/packages/graphql/tests/schema/null.test.ts
@@ -67,9 +67,9 @@ describe("Null", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNonNullable {
-              max: DateTime!
-              min: DateTime!
+            type DateTimeAggregateSelection {
+              max: DateTime
+              min: DateTime
             }
 
             \\"\\"\\"
@@ -81,19 +81,19 @@ describe("Null", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNonNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNonNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -117,12 +117,12 @@ describe("Null", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNonNullable!
-              averageRating: FloatAggregateSelectionNonNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              createdAt: DateTimeAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNonNullable!
+              createdAt: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -347,7 +347,7 @@ describe("Null", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/pluralize-consistency.test.ts
+++ b/packages/graphql/tests/schema/pluralize-consistency.test.ts
@@ -105,7 +105,7 @@ describe("Pluralize consistency", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -149,7 +149,7 @@ describe("Pluralize consistency", () => {
 
             type super_friendAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input super_friendConnectWhere {
@@ -210,7 +210,7 @@ describe("Pluralize consistency", () => {
 
             type super_userAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input super_userConnectInput {
@@ -433,7 +433,7 @@ describe("Pluralize consistency", () => {
             }
 
             type super_usersuper_friendMy_friendNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }"
         `);
     });

--- a/packages/graphql/tests/schema/query-direction.test.ts
+++ b/packages/graphql/tests/schema/query-direction.test.ts
@@ -91,7 +91,7 @@ describe("Query Direction", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -121,7 +121,7 @@ describe("Query Direction", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -298,7 +298,7 @@ describe("Query Direction", () => {
             }
 
             type UserUserFriendsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserWhere {
@@ -421,7 +421,7 @@ describe("Query Direction", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -451,7 +451,7 @@ describe("Query Direction", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -628,7 +628,7 @@ describe("Query Direction", () => {
             }
 
             type UserUserFriendsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserWhere {
@@ -751,7 +751,7 @@ describe("Query Direction", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -781,7 +781,7 @@ describe("Query Direction", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserConnectInput {
@@ -958,7 +958,7 @@ describe("Query Direction", () => {
             }
 
             type UserUserFriendsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input UserWhere {

--- a/packages/graphql/tests/schema/scalar.test.ts
+++ b/packages/graphql/tests/schema/scalar.test.ts
@@ -68,7 +68,7 @@ describe("Scalar", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -82,7 +82,7 @@ describe("Scalar", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/simple.test.ts
+++ b/packages/graphql/tests/schema/simple.test.ts
@@ -64,19 +64,19 @@ describe("Simple", () => {
               relationshipsDeleted: Int!
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -91,10 +91,10 @@ describe("Simple", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/string-comparators.test.ts
+++ b/packages/graphql/tests/schema/string-comparators.test.ts
@@ -79,7 +79,7 @@ describe("String Comparators", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -165,7 +165,7 @@ describe("String Comparators", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -234,7 +234,7 @@ describe("String Comparators", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -316,7 +316,7 @@ describe("String Comparators", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -394,7 +394,7 @@ describe("String Comparators", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -478,7 +478,7 @@ describe("String Comparators", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -755,7 +755,7 @@ describe("String Comparators", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -791,11 +791,11 @@ describe("String Comparators", () => {
             }
 
             type ActorMovieActedInEdgeAggregateSelection {
-              screenTime: StringAggregateSelectionNullable!
+              screenTime: StringAggregateSelection!
             }
 
             type ActorMovieActedInNodeAggregateSelection {
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input ActorOptions {
@@ -920,11 +920,11 @@ describe("String Comparators", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: StringAggregateSelectionNullable!
+              screenTime: StringAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -1095,7 +1095,7 @@ describe("String Comparators", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              title: StringAggregateSelectionNullable!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1238,7 +1238,7 @@ describe("String Comparators", () => {
               DESC
             }
 
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/subscriptions.test.ts
+++ b/packages/graphql/tests/schema/subscriptions.test.ts
@@ -65,7 +65,7 @@ describe("Subscriptions", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -198,19 +198,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -233,7 +233,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -359,10 +359,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -630,7 +630,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -755,9 +755,9 @@ describe("Subscriptions", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -1026,19 +1026,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1131,10 +1131,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1514,19 +1514,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -1679,10 +1679,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1988,9 +1988,9 @@ describe("Subscriptions", () => {
             }
 
             type PersonMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PersonMoviesAggregateInput {
@@ -2299,9 +2299,9 @@ describe("Subscriptions", () => {
             }
 
             type StarMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input StarMoviesAggregateInput {
@@ -2720,9 +2720,9 @@ describe("Subscriptions", () => {
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -2991,26 +2991,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float
-              max: Int
-              min: Int
-              sum: Int
-            }
-
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -3033,7 +3026,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -3158,10 +3151,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -3504,7 +3497,7 @@ describe("Subscriptions", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectWhere {
@@ -3637,19 +3630,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -3672,7 +3665,7 @@ describe("Subscriptions", () => {
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              name: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -3790,10 +3783,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -3961,7 +3954,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -4032,8 +4025,8 @@ describe("Subscriptions", () => {
 
             type AgreementAggregateSelection {
               count: Int!
-              id: IntAggregateSelectionNonNullable!
-              name: StringAggregateSelectionNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input AgreementConnectInput {
@@ -4339,8 +4332,8 @@ describe("Subscriptions", () => {
             }
 
             type AgreementUserOwnerNodeAggregateSelection {
-              name: StringAggregateSelectionNullable!
-              username: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input AgreementWhere {
@@ -4409,7 +4402,7 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -4447,12 +4440,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
-              longest: String
-              shortest: String
-            }
-
-            type StringAggregateSelectionNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }
@@ -4488,8 +4476,8 @@ describe("Subscriptions", () => {
 
             type UserAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNullable!
-              username: StringAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
+              username: StringAggregateSelection!
             }
 
             input UserConnectWhere {
@@ -4677,19 +4665,19 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type FloatAggregateSelectionNullable {
+            type FloatAggregateSelection {
               average: Float
               max: Float
               min: Float
               sum: Float
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -4842,10 +4830,10 @@ describe("Subscriptions", () => {
             }
 
             type MovieAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -5151,9 +5139,9 @@ describe("Subscriptions", () => {
             }
 
             type PersonMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input PersonMoviesAggregateInput {
@@ -5448,9 +5436,9 @@ describe("Subscriptions", () => {
             }
 
             type StarMovieMoviesNodeAggregateSelection {
-              actorCount: IntAggregateSelectionNullable!
-              averageRating: FloatAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              actorCount: IntAggregateSelection!
+              averageRating: FloatAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input StarMoviesAggregateInput {
@@ -5873,12 +5861,12 @@ describe("Subscriptions", () => {
               UPDATE
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
 
-            type IntAggregateSelectionNonNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -5895,8 +5883,8 @@ describe("Subscriptions", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -6151,7 +6139,7 @@ describe("Subscriptions", () => {
             }
 
             type PersonProductionMoviesNodeAggregateSelection {
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input PersonRelationInput {
@@ -6213,7 +6201,7 @@ describe("Subscriptions", () => {
 
             type ProductionAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input ProductionConnectInput {
@@ -6381,9 +6369,9 @@ describe("Subscriptions", () => {
 
             type SeriesAggregateSelection {
               count: Int!
-              episode: IntAggregateSelectionNonNullable!
-              id: IDAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              episode: IntAggregateSelection!
+              id: IDAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input SeriesConnectInput {
@@ -6619,7 +6607,7 @@ describe("Subscriptions", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/types/bigint.test.ts
+++ b/packages/graphql/tests/schema/types/bigint.test.ts
@@ -44,7 +44,7 @@ describe("Bigint", () => {
             \\"\\"\\"
             scalar BigInt
 
-            type BigIntAggregateSelectionNonNullable {
+            type BigIntAggregateSelection {
               average: BigInt
               max: BigInt
               min: BigInt
@@ -81,8 +81,8 @@ describe("Bigint", () => {
 
             type FileAggregateSelection {
               count: Int!
-              name: StringAggregateSelectionNonNullable!
-              size: BigIntAggregateSelectionNonNullable!
+              name: StringAggregateSelection!
+              size: BigIntAggregateSelection!
             }
 
             input FileCreateInput {
@@ -177,7 +177,7 @@ describe("Bigint", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/types/date.test.ts
+++ b/packages/graphql/tests/schema/types/date.test.ts
@@ -65,7 +65,7 @@ describe("Date", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -77,7 +77,7 @@ describe("Date", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/datetime.test.ts
+++ b/packages/graphql/tests/schema/types/datetime.test.ts
@@ -56,7 +56,7 @@ describe("Datetime", () => {
             \\"\\"\\"A date and time, represented as an ISO-8601 string\\"\\"\\"
             scalar DateTime
 
-            type DateTimeAggregateSelectionNullable {
+            type DateTimeAggregateSelection {
               max: DateTime
               min: DateTime
             }
@@ -70,7 +70,7 @@ describe("Datetime", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -82,8 +82,8 @@ describe("Datetime", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              datetime: DateTimeAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              datetime: DateTimeAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/duration.test.ts
+++ b/packages/graphql/tests/schema/types/duration.test.ts
@@ -65,12 +65,12 @@ describe("Duration", () => {
             \\"\\"\\"A duration, represented as an ISO 8601 duration string\\"\\"\\"
             scalar Duration
 
-            type DurationAggregateSelectionNullable {
+            type DurationAggregateSelection {
               max: Duration
               min: Duration
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -82,8 +82,8 @@ describe("Duration", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              duration: DurationAggregateSelectionNullable!
-              id: IDAggregateSelectionNullable!
+              duration: DurationAggregateSelection!
+              id: IDAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/localdatetime.test.ts
+++ b/packages/graphql/tests/schema/types/localdatetime.test.ts
@@ -62,7 +62,7 @@ describe("Localdatetime", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -70,7 +70,7 @@ describe("Localdatetime", () => {
             \\"\\"\\"A local datetime, represented as 'YYYY-MM-DDTHH:MM:SS'\\"\\"\\"
             scalar LocalDateTime
 
-            type LocalDateTimeAggregateSelectionNullable {
+            type LocalDateTimeAggregateSelection {
               max: LocalDateTime
               min: LocalDateTime
             }
@@ -82,8 +82,8 @@ describe("Localdatetime", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              localDT: LocalDateTimeAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              localDT: LocalDateTimeAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/localtime.test.ts
+++ b/packages/graphql/tests/schema/types/localtime.test.ts
@@ -62,7 +62,7 @@ describe("Localtime", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -72,7 +72,7 @@ describe("Localtime", () => {
             \\"\\"\\"
             scalar LocalTime
 
-            type LocalTimeAggregateSelectionNullable {
+            type LocalTimeAggregateSelection {
               max: LocalTime
               min: LocalTime
             }
@@ -84,8 +84,8 @@ describe("Localtime", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              time: LocalTimeAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              time: LocalTimeAggregateSelection!
             }
 
             input MovieCreateInput {

--- a/packages/graphql/tests/schema/types/time.test.ts
+++ b/packages/graphql/tests/schema/types/time.test.ts
@@ -62,7 +62,7 @@ describe("Time", () => {
               relationshipsDeleted: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -74,8 +74,8 @@ describe("Time", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
-              time: TimeAggregateSelectionNullable!
+              id: IDAggregateSelection!
+              time: TimeAggregateSelection!
             }
 
             input MovieCreateInput {
@@ -171,7 +171,7 @@ describe("Time", () => {
             \\"\\"\\"A time, represented as an RFC3339 time string\\"\\"\\"
             scalar Time
 
-            type TimeAggregateSelectionNullable {
+            type TimeAggregateSelection {
               max: Time
               min: Time
             }

--- a/packages/graphql/tests/schema/union-interface-relationship.test.ts
+++ b/packages/graphql/tests/schema/union-interface-relationship.test.ts
@@ -127,8 +127,8 @@ describe("Union Interface Relationships", () => {
 
             type ActorAggregateSelection {
               count: Int!
-              id: IntAggregateSelectionNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input ActorConnectInput {
@@ -173,12 +173,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type ActorMovieMoviesEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type ActorMovieMoviesNodeAggregateSelection {
-              imdbId: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input ActorMoviesAggregateInput {
@@ -560,9 +560,9 @@ describe("Union Interface Relationships", () => {
 
             type InfluencerAggregateSelection {
               count: Int!
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
-              url: StringAggregateSelectionNonNullable!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
+              url: StringAggregateSelection!
             }
 
             input InfluencerCreateInput {
@@ -642,14 +642,7 @@ describe("Union Interface Relationships", () => {
               totalCount: Int!
             }
 
-            type IntAggregateSelectionNonNullable {
-              average: Float
-              max: Int
-              min: Int
-              sum: Int
-            }
-
-            type IntAggregateSelectionNullable {
+            type IntAggregateSelection {
               average: Float
               max: Int
               min: Int
@@ -676,12 +669,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieActorActorsEdgeAggregateSelection {
-              screenTime: IntAggregateSelectionNonNullable!
+              screenTime: IntAggregateSelection!
             }
 
             type MovieActorActorsNodeAggregateSelection {
-              id: IntAggregateSelectionNullable!
-              name: StringAggregateSelectionNonNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
             }
 
             input MovieActorsAggregateInput {
@@ -879,8 +872,8 @@ describe("Union Interface Relationships", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              imdbId: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input MovieConnectInput {
@@ -1134,12 +1127,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type MovieReviewerReviewersEdgeAggregateSelection {
-              score: IntAggregateSelectionNonNullable!
+              score: IntAggregateSelection!
             }
 
             type MovieReviewerReviewersNodeAggregateSelection {
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             input MovieReviewersConnectFieldInput {
@@ -1374,10 +1367,10 @@ describe("Union Interface Relationships", () => {
 
             type PersonAggregateSelection {
               count: Int!
-              id: IntAggregateSelectionNullable!
-              name: StringAggregateSelectionNonNullable!
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
+              id: IntAggregateSelection!
+              name: StringAggregateSelection!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             input PersonConnectInput {
@@ -1424,12 +1417,12 @@ describe("Union Interface Relationships", () => {
             }
 
             type PersonMovieMoviesEdgeAggregateSelection {
-              score: IntAggregateSelectionNonNullable!
+              score: IntAggregateSelection!
             }
 
             type PersonMovieMoviesNodeAggregateSelection {
-              imdbId: IntAggregateSelectionNullable!
-              title: StringAggregateSelectionNonNullable!
+              imdbId: IntAggregateSelection!
+              title: StringAggregateSelection!
             }
 
             input PersonMoviesAggregateInput {
@@ -1811,8 +1804,8 @@ describe("Union Interface Relationships", () => {
 
             type ReviewerAggregateSelection {
               count: Int!
-              reputation: IntAggregateSelectionNonNullable!
-              reviewerId: IntAggregateSelectionNullable!
+              reputation: IntAggregateSelection!
+              reviewerId: IntAggregateSelection!
             }
 
             input ReviewerConnectWhere {
@@ -1886,7 +1879,7 @@ describe("Union Interface Relationships", () => {
               DESC
             }
 
-            type StringAggregateSelectionNonNullable {
+            type StringAggregateSelection {
               longest: String
               shortest: String
             }

--- a/packages/graphql/tests/schema/unions.test.ts
+++ b/packages/graphql/tests/schema/unions.test.ts
@@ -80,7 +80,7 @@ describe("Unions", () => {
 
             type GenreAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input GenreConnectWhere {
@@ -138,7 +138,7 @@ describe("Unions", () => {
               totalCount: Int!
             }
 
-            type IDAggregateSelectionNullable {
+            type IDAggregateSelection {
               longest: ID
               shortest: ID
             }
@@ -152,7 +152,7 @@ describe("Unions", () => {
 
             type MovieAggregateSelection {
               count: Int!
-              id: IDAggregateSelectionNullable!
+              id: IDAggregateSelection!
             }
 
             input MovieConnectInput {

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -167,8 +167,8 @@ describe("generate", () => {
               endCursor?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
@@ -198,7 +198,7 @@ describe("generate", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UserEdge = {
@@ -255,13 +255,9 @@ describe("generate", () => {
               NOT?: InputMaybe<UserWhere>;
             };
 
-            export interface StringAggregateInputNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface UserAggregateSelectionInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: boolean;
             }
 
             export declare class UserModel {
@@ -464,8 +460,8 @@ describe("generate", () => {
               endCursor?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
@@ -495,7 +491,7 @@ describe("generate", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UserEdge = {
@@ -585,13 +581,9 @@ describe("generate", () => {
               NOT?: InputMaybe<UserWhere>;
             };
 
-            export interface StringAggregateInputNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface UserAggregateSelectionInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: boolean;
             }
 
             export declare class UserModel {
@@ -789,8 +781,8 @@ describe("generate", () => {
               endCursor?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
@@ -820,7 +812,7 @@ describe("generate", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UserEdge = {
@@ -877,13 +869,9 @@ describe("generate", () => {
               NOT?: InputMaybe<UserWhere>;
             };
 
-            export interface StringAggregateInputNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface UserAggregateSelectionInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: boolean;
             }
 
             export declare class UserModel {
@@ -1124,8 +1112,8 @@ describe("generate", () => {
               relationshipsDeleted: Scalars[\\"Int\\"][\\"output\\"];
             };
 
-            export type IntAggregateSelectionNonNullable = {
-              __typename?: \\"IntAggregateSelectionNonNullable\\";
+            export type IntAggregateSelection = {
+              __typename?: \\"IntAggregateSelection\\";
               max?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
               min?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
               average?: Maybe<Scalars[\\"Float\\"][\\"output\\"]>;
@@ -1176,7 +1164,7 @@ describe("generate", () => {
             export type MovieAggregateSelection = {
               __typename?: \\"MovieAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              title: StringAggregateSelectionNonNullable;
+              title: StringAggregateSelection;
             };
 
             export type MovieEdge = {
@@ -1194,12 +1182,12 @@ describe("generate", () => {
 
             export type MoviePersonActorsEdgeAggregateSelection = {
               __typename?: \\"MoviePersonActorsEdgeAggregateSelection\\";
-              screenTime: IntAggregateSelectionNonNullable;
+              screenTime: IntAggregateSelection;
             };
 
             export type MoviePersonActorsNodeAggregateSelection = {
               __typename?: \\"MoviePersonActorsNodeAggregateSelection\\";
-              name: StringAggregateSelectionNonNullable;
+              name: StringAggregateSelection;
             };
 
             export type MoviesConnection = {
@@ -1233,7 +1221,7 @@ describe("generate", () => {
             export type PersonAggregateSelection = {
               __typename?: \\"PersonAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              name: StringAggregateSelectionNonNullable;
+              name: StringAggregateSelection;
             };
 
             export type PersonEdge = {
@@ -1242,8 +1230,8 @@ describe("generate", () => {
               node: Person;
             };
 
-            export type StringAggregateSelectionNonNullable = {
-              __typename?: \\"StringAggregateSelectionNonNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
@@ -1596,13 +1584,9 @@ describe("generate", () => {
               NOT?: InputMaybe<PersonWhere>;
             };
 
-            export interface StringAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface MovieAggregateSelectionInput {
               count?: boolean;
-              title?: StringAggregateInputNonNullable;
+              title?: boolean;
             }
 
             export declare class MovieModel {
@@ -1649,13 +1633,9 @@ describe("generate", () => {
               }): Promise<MovieAggregateSelection>;
             }
 
-            export interface StringAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface PersonAggregateSelectionInput {
               count?: boolean;
-              name?: StringAggregateInputNonNullable;
+              name?: boolean;
             }
 
             export declare class PersonModel {
@@ -1956,8 +1936,8 @@ describe("generate", () => {
             export type FaqAggregateSelection = {
               __typename?: \\"FAQAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              id: IdAggregateSelectionNonNullable;
-              name: StringAggregateSelectionNonNullable;
+              id: IdAggregateSelection;
+              name: StringAggregateSelection;
             };
 
             export type FaqEdge = {
@@ -2019,9 +1999,9 @@ describe("generate", () => {
             export type FaqEntryAggregateSelection = {
               __typename?: \\"FAQEntryAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              id: IdAggregateSelectionNonNullable;
-              title: StringAggregateSelectionNonNullable;
-              body: StringAggregateSelectionNonNullable;
+              id: IdAggregateSelection;
+              title: StringAggregateSelection;
+              body: StringAggregateSelection;
             };
 
             export type FaqEntryEdge = {
@@ -2039,13 +2019,13 @@ describe("generate", () => {
 
             export type FaqEntryFaqInFaQsEdgeAggregateSelection = {
               __typename?: \\"FAQEntryFAQInFAQsEdgeAggregateSelection\\";
-              position: IntAggregateSelectionNullable;
+              position: IntAggregateSelection;
             };
 
             export type FaqEntryFaqInFaQsNodeAggregateSelection = {
               __typename?: \\"FAQEntryFAQInFAQsNodeAggregateSelection\\";
-              id: IdAggregateSelectionNonNullable;
-              name: StringAggregateSelectionNonNullable;
+              id: IdAggregateSelection;
+              name: StringAggregateSelection;
             };
 
             /**
@@ -2081,14 +2061,14 @@ describe("generate", () => {
 
             export type FaqfaqEntryEntriesEdgeAggregateSelection = {
               __typename?: \\"FAQFAQEntryEntriesEdgeAggregateSelection\\";
-              position: IntAggregateSelectionNullable;
+              position: IntAggregateSelection;
             };
 
             export type FaqfaqEntryEntriesNodeAggregateSelection = {
               __typename?: \\"FAQFAQEntryEntriesNodeAggregateSelection\\";
-              id: IdAggregateSelectionNonNullable;
-              title: StringAggregateSelectionNonNullable;
-              body: StringAggregateSelectionNonNullable;
+              id: IdAggregateSelection;
+              title: StringAggregateSelection;
+              body: StringAggregateSelection;
             };
 
             export type FaqsConnection = {
@@ -2098,14 +2078,14 @@ describe("generate", () => {
               edges: Array<FaqEdge>;
             };
 
-            export type IdAggregateSelectionNonNullable = {
-              __typename?: \\"IDAggregateSelectionNonNullable\\";
+            export type IdAggregateSelection = {
+              __typename?: \\"IDAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"ID\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"ID\\"][\\"output\\"]>;
             };
 
-            export type IntAggregateSelectionNullable = {
-              __typename?: \\"IntAggregateSelectionNullable\\";
+            export type IntAggregateSelection = {
+              __typename?: \\"IntAggregateSelection\\";
               max?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
               min?: Maybe<Scalars[\\"Int\\"][\\"output\\"]>;
               average?: Maybe<Scalars[\\"Float\\"][\\"output\\"]>;
@@ -2121,8 +2101,8 @@ describe("generate", () => {
               endCursor?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
 
-            export type StringAggregateSelectionNonNullable = {
-              __typename?: \\"StringAggregateSelectionNonNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
@@ -2867,18 +2847,10 @@ describe("generate", () => {
               entriesConnection_SOME?: InputMaybe<FaqEntriesConnectionWhere>;
             };
 
-            export interface IdAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
-            export interface StringAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface FAQAggregateSelectionInput {
               count?: boolean;
-              id?: IdAggregateInputNonNullable;
-              name?: StringAggregateInputNonNullable;
+              id?: boolean;
+              name?: boolean;
             }
 
             export declare class FAQModel {
@@ -2925,19 +2897,11 @@ describe("generate", () => {
               }): Promise<FaqAggregateSelection>;
             }
 
-            export interface IdAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
-            export interface StringAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface FAQEntryAggregateSelectionInput {
               count?: boolean;
-              id?: IdAggregateInputNonNullable;
-              title?: StringAggregateInputNonNullable;
-              body?: StringAggregateInputNonNullable;
+              id?: boolean;
+              title?: boolean;
+              body?: boolean;
             }
 
             export declare class FAQEntryModel {

--- a/packages/ogm/tests/issues/3591.test.ts
+++ b/packages/ogm/tests/issues/3591.test.ts
@@ -229,10 +229,10 @@ describe("issues/3591", () => {
             export type CompanyAggregateSelection = {
               __typename?: \\"CompanyAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              id: IdAggregateSelectionNonNullable;
-              field1: StringAggregateSelectionNullable;
-              field2: StringAggregateSelectionNullable;
-              field3: StringAggregateSelectionNullable;
+              id: IdAggregateSelection;
+              field1: StringAggregateSelection;
+              field2: StringAggregateSelection;
+              field3: StringAggregateSelection;
             };
 
             export type CompanyEdge = {
@@ -277,8 +277,8 @@ describe("issues/3591", () => {
               relationshipsDeleted: Scalars[\\"Int\\"][\\"output\\"];
             };
 
-            export type IdAggregateSelectionNonNullable = {
-              __typename?: \\"IDAggregateSelectionNonNullable\\";
+            export type IdAggregateSelection = {
+              __typename?: \\"IDAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"ID\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"ID\\"][\\"output\\"]>;
             };
@@ -300,7 +300,7 @@ describe("issues/3591", () => {
             export type RestaurantAggregateSelection = {
               __typename?: \\"RestaurantAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type RestaurantEdge = {
@@ -316,8 +316,8 @@ describe("issues/3591", () => {
               edges: Array<RestaurantEdge>;
             };
 
-            export type StringAggregateSelectionNullable = {
-              __typename?: \\"StringAggregateSelectionNullable\\";
+            export type StringAggregateSelection = {
+              __typename?: \\"StringAggregateSelection\\";
               shortest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
               longest?: Maybe<Scalars[\\"String\\"][\\"output\\"]>;
             };
@@ -403,7 +403,7 @@ describe("issues/3591", () => {
             export type UserAggregateSelection = {
               __typename?: \\"UserAggregateSelection\\";
               count: Scalars[\\"Int\\"][\\"output\\"];
-              id: IdAggregateSelectionNonNullable;
+              id: IdAggregateSelection;
             };
 
             export type UserCompanyCompanyAggregationSelection = {
@@ -414,10 +414,10 @@ describe("issues/3591", () => {
 
             export type UserCompanyCompanyNodeAggregateSelection = {
               __typename?: \\"UserCompanyCompanyNodeAggregateSelection\\";
-              id: IdAggregateSelectionNonNullable;
-              field1: StringAggregateSelectionNullable;
-              field2: StringAggregateSelectionNullable;
-              field3: StringAggregateSelectionNullable;
+              id: IdAggregateSelection;
+              field1: StringAggregateSelection;
+              field2: StringAggregateSelection;
+              field3: StringAggregateSelection;
             };
 
             export type UserCompanyConnection = {
@@ -460,7 +460,7 @@ describe("issues/3591", () => {
 
             export type UserRestaurantFavoriteRestaurantsNodeAggregateSelection = {
               __typename?: \\"UserRestaurantFavoriteRestaurantsNodeAggregateSelection\\";
-              name: StringAggregateSelectionNullable;
+              name: StringAggregateSelection;
             };
 
             export type UsersConnection = {
@@ -1091,13 +1091,9 @@ describe("issues/3591", () => {
               favoriteRestaurantsConnection_SOME?: InputMaybe<UserFavoriteRestaurantsConnectionWhere>;
             };
 
-            export interface IdAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface UserAggregateSelectionInput {
               count?: boolean;
-              id?: IdAggregateInputNonNullable;
+              id?: boolean;
             }
 
             export declare class UserModel {
@@ -1144,20 +1140,12 @@ describe("issues/3591", () => {
               }): Promise<UserAggregateSelection>;
             }
 
-            export interface IdAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
-            export interface StringAggregateInputNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface CompanyAggregateSelectionInput {
               count?: boolean;
-              id?: IdAggregateInputNonNullable;
-              field1?: StringAggregateInputNullable;
-              field2?: StringAggregateInputNullable;
-              field3?: StringAggregateInputNullable;
+              id?: boolean;
+              field1?: boolean;
+              field2?: boolean;
+              field3?: boolean;
             }
 
             export declare class CompanyModel {
@@ -1201,17 +1189,9 @@ describe("issues/3591", () => {
               }): Promise<CompanyAggregateSelection>;
             }
 
-            export interface IdAggregateInputNonNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
-            export interface StringAggregateInputNullable {
-              shortest?: boolean;
-              longest?: boolean;
-            }
             export interface RestaurantAggregateSelectionInput {
               count?: boolean;
-              name?: StringAggregateInputNullable;
+              name?: boolean;
             }
 
             export declare class RestaurantModel {


### PR DESCRIPTION
# Description

After #4623 the `*AggregateSelectioNonNullable` types, have no more differences to the `*AggregateSelectioNullable` types. This Commit removes the `(Non)Nullable`-suffix from the augmented types.

## Complexity

Complexity: low

# Issue

Closes #4615

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [x] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
