### PR TITLE
`Neo4jGraphQLError` should extend `GraphQLError`

### DIFF
--- a/packages/graphql/src/classes/Error.ts
+++ b/packages/graphql/src/classes/Error.ts
@@ -17,7 +17,9 @@
  * limitations under the License.
  */
 
-export class Neo4jGraphQLError extends Error {
+import { GraphQLError } from "graphql";
+
+export class Neo4jGraphQLError extends GraphQLError {
     readonly name;
 
     constructor(message: string) {


### PR DESCRIPTION
# Description

`Neo4jGraphQLError` should extend `GraphQLError` - without this, Yoga will not send error details to the client.

## Complexity

Complexity: Low
