### PR TITLE
Cleanup OGM tests

### DIFF
--- a/packages/ogm/package.json
+++ b/packages/ogm/package.json
@@ -49,7 +49,6 @@
         "@types/jest": "29.5.12",
         "@types/node": "20.11.19",
         "camelcase": "6.3.0",
-        "graphql-tag": "2.12.6",
         "jest": "29.7.0",
         "jsonwebtoken": "9.0.2",
         "libnpmsearch": "7.0.1",

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -17,12 +17,11 @@
  * limitations under the License.
  */
 
-import { generate as randomstring } from "randomstring";
 import * as fs from "fs";
 import * as path from "path";
+import { generate as randomstring } from "randomstring";
 import generate from "./generate";
 import { OGM } from "./index";
-import gql from "graphql-tag";
 
 describe("generate", () => {
     const filesToDelete: string[] = [];
@@ -1723,7 +1722,7 @@ describe("generate", () => {
     });
 
     test("https://github.com/neo4j/graphql/issues/3539", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type FAQ {
                 id: ID! @id @unique
                 activated: Boolean!

--- a/packages/ogm/tests/integration/additional-labels.int.test.ts
+++ b/packages/ogm/tests/integration/additional-labels.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { OGM } from "../../src";
 import { UniqueType } from "../utils/utils";
@@ -26,7 +25,7 @@ import neo4j from "./neo4j";
 describe("Additional Labels", () => {
     const secret = "secret";
     const taskType = new UniqueType("Task");
-    const typeDefs = gql`
+    const typeDefs = /* GraphQL */ `
         type ${taskType.name} @node(labels: ["${taskType.name}", "$jwt.tenant_id"]) {
             id: ID! @id
             string: String

--- a/packages/ogm/tests/integration/ogm.int.test.ts
+++ b/packages/ogm/tests/integration/ogm.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { OGM } from "../../src";
@@ -62,7 +61,7 @@ describe("OGM", () => {
     test("should specify the database via OGM construction", async () => {
         const session = driver.session();
 
-        const typeDefs = `
+        const typeDefs = /* GraphQL */ `
             type ${typeMovie} {
                 id: ID!
             }
@@ -80,7 +79,7 @@ describe("OGM", () => {
     test("should filter the document and remove directives such as authentication", async () => {
         const session = driver.session();
 
-        const typeDefs = `
+        const typeDefs = /* GraphQL */ `
             type ${typeMovie} @authentication {
                 id: ID
             }
@@ -116,7 +115,7 @@ describe("OGM", () => {
         test("find a single node", async () => {
             const session = driver.session();
 
-            const typeDefs = `
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     id: ID
                 }
@@ -150,7 +149,7 @@ describe("OGM", () => {
         test("should find and limit", async () => {
             const session = driver.session();
 
-            const typeDefs = `
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     id: ID
                 }
@@ -186,7 +185,7 @@ describe("OGM", () => {
         test("should find and populate relationship using custom selectionSet", async () => {
             const session = driver.session();
 
-            const typeDefs = `
+            const typeDefs = /* GraphQL */ `
                 type ${typeGenre} {
                     id: ID
                 }
@@ -236,7 +235,7 @@ describe("OGM", () => {
         test("should create a single node", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     id: ID
                 }
@@ -764,7 +763,7 @@ describe("OGM", () => {
         test("should delete a single node", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     id: ID
                     name: String
@@ -797,7 +796,7 @@ describe("OGM", () => {
         test("should delete movie and nested genre", async () => {
             const session = driver.session();
 
-            const typeDefs = `
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     id: ID
                     ${typeGenre.plural}: [${typeGenre}!]! @relationship(type: "IN_GENRE", direction: OUT)
@@ -842,7 +841,7 @@ describe("OGM", () => {
         test("should allow the use of private fields in the OGM", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type User {
                     id: ID
                     password: String @private
@@ -877,7 +876,7 @@ describe("OGM", () => {
         test("should return aggregated count on its own", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     testId: ID
                     title: String
@@ -921,7 +920,7 @@ describe("OGM", () => {
         test("should return aggregated fields", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type ${typeMovie} {
                     testId: ID
                     title: String
@@ -976,7 +975,7 @@ describe("OGM", () => {
         test("should create constraints with `assertIndexesAndConstraints` method", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type Book {
                     isbn: String! @unique
                     title: String
@@ -1023,7 +1022,7 @@ describe("OGM", () => {
         test("should allow the use of types requiring authentication in the OGM", async () => {
             const session = driver.session();
 
-            const typeDefs = gql`
+            const typeDefs = /* GraphQL */ `
                 type User @authentication {
                     id: ID
                     password: String

--- a/packages/ogm/tests/integration/ogm.int.test.ts
+++ b/packages/ogm/tests/integration/ogm.int.test.ts
@@ -20,7 +20,6 @@
 import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import type { Model } from "../../src";
 import { OGM } from "../../src";
 import { cleanNodes } from "../utils/clean-nodes";
 import { UniqueType } from "../utils/utils";
@@ -266,7 +265,7 @@ describe("OGM", () => {
                     { id }
                 );
 
-                expect((reFind.records[0].toObject() as any).m.properties).toMatchObject({ id });
+                expect(reFind.records[0].toObject().m.properties).toMatchObject({ id });
             } finally {
                 await session.close();
             }
@@ -444,7 +443,7 @@ describe("OGM", () => {
             `;
 
             const neo4jResult = await session.run(cypher, { id: product.id });
-            const neo4jProduct = (neo4jResult.records[0].toObject() as any).product;
+            const neo4jProduct = neo4jResult.records[0].toObject().product;
 
             expect(neo4jProduct.id).toMatch(product.id);
             expect(neo4jProduct.name).toMatch(product.name);
@@ -851,7 +850,7 @@ describe("OGM", () => {
             `;
 
             const ogm = new OGM({ typeDefs, driver });
-            const User = ogm.model("User") as unknown as Model;
+            const User = ogm.model("User");
 
             await ogm.init();
 
@@ -985,7 +984,7 @@ describe("OGM", () => {
             `;
 
             const ogm = new OGM({ typeDefs, driver });
-            const Book = ogm.model("Book") as unknown as Model;
+            const Book = ogm.model("Book");
 
             await ogm.init();
 
@@ -1032,7 +1031,7 @@ describe("OGM", () => {
             `;
 
             const ogm = new OGM({ typeDefs, driver });
-            const User = ogm.model("User") as unknown as Model;
+            const User = ogm.model("User");
 
             await ogm.init();
 

--- a/packages/ogm/tests/integration/pluralize-underscore.int.test.ts
+++ b/packages/ogm/tests/integration/pluralize-underscore.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { OGM } from "../../src";
@@ -27,7 +26,7 @@ import neo4j from "./neo4j";
 describe("pluralize with underscore", () => {
     const taskType = new UniqueType("super_task");
 
-    const typeDefs = gql`
+    const typeDefs = /* GraphQL */ `
         type ${taskType.name} {
             string: String
         }

--- a/packages/ogm/tests/integration/pluralize-underscore.int.test.ts
+++ b/packages/ogm/tests/integration/pluralize-underscore.int.test.ts
@@ -61,7 +61,7 @@ describe("pluralize with underscore", () => {
             charset: "alphabetic",
         });
 
-        const result = await Task?.create({ input: [{ string: testString }] });
+        const result = await Task.create({ input: [{ string: testString }] });
         expect(result[taskType.plural]).toEqual([{ string: testString }]);
 
         const reFind = await session.run(

--- a/packages/ogm/tests/integration/pluralize-underscore.int.test.ts
+++ b/packages/ogm/tests/integration/pluralize-underscore.int.test.ts
@@ -73,7 +73,7 @@ describe("pluralize with underscore", () => {
             { str: testString }
         );
 
-        expect((reFind.records[0].toObject() as any).m.properties).toMatchObject({ string: testString });
+        expect(reFind.records[0].toObject().m.properties).toMatchObject({ string: testString });
     });
 
     test("should find super_task", async () => {

--- a/packages/ogm/tests/integration/scalars.int.test.ts
+++ b/packages/ogm/tests/integration/scalars.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { DateTime, Duration, LocalDateTime, LocalTime, Date as Neo4jDate, Time } from "neo4j-driver";
 import { OGM } from "../../src";
@@ -27,7 +26,7 @@ import neo4j from "./neo4j";
 describe("Neo4j native types used with OGM", () => {
     const TestType = new UniqueType("TestType");
 
-    const typeDefs = gql`
+    const typeDefs = /* GraphQL */ `
         type ${TestType.name} {
             date: Date
             dateTime: DateTime

--- a/packages/ogm/tests/integration/scalars.int.test.ts
+++ b/packages/ogm/tests/integration/scalars.int.test.ts
@@ -78,8 +78,8 @@ describe("Neo4j native types used with OGM", () => {
 
         expect(result[TestType.plural]).toEqual([
             {
-                date: new Date((date as unknown as Neo4jDate).toString()).toISOString().split("T")[0],
-                dateTime: new Date((dateTime as unknown as DateTime).toString()).toISOString(),
+                date: new Date(date.toString()).toISOString().split("T")[0],
+                dateTime: new Date(dateTime.toString()).toISOString(),
                 duration: duration.toString(),
                 localDateTime: localDateTime.toString(),
                 localTime: localTime.toString(),

--- a/packages/ogm/tests/issues/1130.test.ts
+++ b/packages/ogm/tests/issues/1130.test.ts
@@ -41,10 +41,10 @@ describe("issues/1130", () => {
             driver: {},
         });
 
-        const generated = (await generate({
+        const generated = await generate({
             ogm,
             noWrite: true,
-        })) as string;
+        });
 
         expect(generated).toContain(`export interface SICIndustryAggregateSelectionInput`);
     });

--- a/packages/ogm/tests/issues/3773.test.ts
+++ b/packages/ogm/tests/issues/3773.test.ts
@@ -17,11 +17,10 @@
  * limitations under the License.
  */
 
-import gql from "graphql-tag";
+import type { Neo4jGraphQLContext } from "@neo4j/graphql/src";
+import type { Driver, Session } from "neo4j-driver";
 import { OGM } from "../../src";
 import neo4j from "../integration/neo4j";
-import type { Driver, Session } from "neo4j-driver";
-import type { Neo4jGraphQLContext } from "@neo4j/graphql/src";
 import { UniqueType } from "../utils/utils";
 
 describe("https://github.com/neo4j/graphql/issues/3773", () => {
@@ -50,7 +49,7 @@ describe("https://github.com/neo4j/graphql/issues/3773", () => {
     });
 
     test("should re-create issue and return types without throwing", async () => {
-        const typeDefs = gql`
+        const typeDefs = /* GraphQL */ `
             type ${EventType} {
                 name: String!
                 userAttending: Boolean!

--- a/packages/ogm/tests/issues/635.test.ts
+++ b/packages/ogm/tests/issues/635.test.ts
@@ -227,10 +227,10 @@ describe("issues/635", () => {
             driver: {},
         });
 
-        const generated = (await generate({
+        const generated = await generate({
             ogm,
             noWrite: true,
-        })) as string;
+        });
 
         expect(generated).not.toContain(`export interface CompanyClockSettingsAggregateInput`);
         expect(generated).toContain(`export interface CompanyClockSettingsAggregateSelectionInput`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3673,7 +3673,6 @@ __metadata:
     "@types/jest": "npm:29.5.12"
     "@types/node": "npm:20.11.19"
     camelcase: "npm:6.3.0"
-    graphql-tag: "npm:2.12.6"
     jest: "npm:29.7.0"
     jsonwebtoken: "npm:9.0.2"
     libnpmsearch: "npm:7.0.1"


### PR DESCRIPTION
- Removes usage of graphql-tag and `gql` in favour of `/* GraphQL */`
- Removes unnecessary type assertions