### PR TITLE
Rename cleanNodes to cleanNodesUsingSession

### DIFF
--- a/packages/graphql/tests/e2e/subscriptions/authorization/authentication.int.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/authorization/authentication.int.test.ts
@@ -22,7 +22,7 @@ import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
@@ -747,7 +747,7 @@ describe("Subscription authentication", () => {
         afterEach(async () => {
             await wsClient.close();
             const session = driver.session();
-            await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+            await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
             await server.close();
         });
 
@@ -5037,7 +5037,7 @@ describe("Subscription authentication", () => {
         afterEach(async () => {
             await wsClient.close();
             const session = driver.session();
-            await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+            await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
             await server.close();
         });
 

--- a/packages/graphql/tests/e2e/subscriptions/create-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create-relationship.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -125,7 +125,7 @@ describe("Create Relationship Subscription", () => {
         await wsClient2.close();
 
         const session = driver.session();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-complex.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-complex.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -119,7 +119,7 @@ describe("Delete Subscriptions - with interfaces, unions and nested operations",
         await wsClient2.close();
 
         const session = driver.session();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-additional-labels.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-additional-labels.e2e.test.ts
@@ -25,7 +25,7 @@ import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
 import { WebSocketTestClient } from "../setup/ws-client";
 import Neo4j from "../setup/neo4j";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 
 describe("Delete Subscriptions when only nodes are targeted - when nodes employ @node directive to configure db label and additionalLabels", () => {
@@ -116,7 +116,7 @@ describe("Delete Subscriptions when only nodes are targeted - when nodes employ 
         await wsClient2.close();
 
         const session = driver.session();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeFilm, typeSeries, typeProduction]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeFilm, typeSeries, typeProduction]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-with-relationships.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-with-relationships.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -120,7 +120,7 @@ describe("Delete Subscriptions when relationships are targeted- with interfaces,
         await wsClient2.close();
 
         const session = driver.session();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -119,7 +119,7 @@ describe("Delete Subscriptions when only nodes are targeted - with interfaces, u
         await wsClient2.close();
 
         const session = driver.session();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -126,7 +126,7 @@ describe("Delete Relationship Subscription", () => {
         await wsClient.close();
         await wsClient2.close();
 
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await session.close();

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship-same-type.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship-same-type.e2e.test.ts
@@ -23,7 +23,7 @@ import type { Neo4jGraphQLSubscriptionsEngine } from "../../../../src";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../../src/utils/utils";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
@@ -110,7 +110,7 @@ describe.each([
         await wsClient2.close();
         subscriptionEngine.close();
         const session = driver.session();
-        await cleanNodes(session, [typePerson, typeArticle]);
+        await cleanNodesUsingSession(session, [typePerson, typeArticle]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship.e2e.test.ts
@@ -23,7 +23,7 @@ import type { Neo4jGraphQLSubscriptionsEngine } from "../../../../src";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../../src/utils/utils";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
@@ -143,7 +143,7 @@ describe.each([
         await wsClient2.close();
         subscriptionEngine.close();
         const session = driver.session();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
 import { createBearerToken } from "../../../../utils/create-bearer-token";
@@ -27,7 +27,7 @@ import { createBearerToken } from "../../../../utils/create-bearer-token";
 describe(`Field Level Authorization Where Requests`, () => {
     let neoSchema: Neo4jGraphQL;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
@@ -49,7 +49,7 @@ describe(`Field Level Authorization Where Requests`, () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 
 describe("Field Level Aggregations Auth", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
@@ -48,7 +48,7 @@ describe("Field Level Aggregations Auth", () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
@@ -22,13 +22,13 @@ import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../src";
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 import { UniqueType } from "../../../../utils/graphql-types";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("Field Level Aggregations Field Authorization", () => {
     const secret = "the-secret";
 
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     const Series = new UniqueType("Series");
@@ -37,7 +37,7 @@ describe("Field Level Aggregations Field Authorization", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
 import { createBearerToken } from "../../../../utils/create-bearer-token";
@@ -28,7 +28,7 @@ describe(`Field Level Authorization Where Requests`, () => {
     let neoSchema: Neo4jGraphQL;
     let token: string;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
@@ -50,7 +50,7 @@ describe(`Field Level Authorization Where Requests`, () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Field Level Aggregations Graphql alias", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -35,7 +35,7 @@ describe("Field Level Aggregations Graphql alias", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Field Level Aggregations", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -35,7 +35,7 @@ describe("Field Level Aggregations", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Nested Field Level Aggregations", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -35,7 +35,7 @@ describe("Nested Field Level Aggregations", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("Field Level Aggregations Where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -35,7 +35,7 @@ describe("Field Level Aggregations Where", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
@@ -20,18 +20,18 @@
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
 describe("aggregations-top_level-alias", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let typeMovie: UniqueType;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
@@ -23,15 +23,15 @@ import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("aggregations-top_level authorization", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
@@ -19,16 +19,16 @@
 
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
 describe("aggregations-top_level-basic", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
@@ -20,18 +20,18 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
 describe("aggregations-top_level-bigint", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const bigInt = "2147483647";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
 describe("Aggregate -> count", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("aggregations-top_level-datetime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import neo4jDriver from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("aggregations-top_level-duration", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("aggregations-top_level-float", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("aggregations-top_level-id", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("aggregations-top_level-int", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
@@ -20,18 +20,18 @@
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
 describe("aggregations-top_level-many", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let typeMovie: UniqueType;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
@@ -22,11 +22,11 @@ import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("aggregations-top_level-string", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let typeMovie: UniqueType;
     let session: Session;
 
@@ -39,7 +39,7 @@ describe("aggregations-top_level-string", () => {
     );
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 
 describe("Nested within AND/OR", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -45,7 +45,7 @@ describe("Nested within AND/OR", () => {
     const content5 = "Some more content";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -86,7 +86,7 @@ describe("Nested within AND/OR", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("aggregations-where-count", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
@@ -21,16 +21,16 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-bigint", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const bigInt = "2147483647";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-datetime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-duration", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     const User = new UniqueType("User");
@@ -34,7 +34,7 @@ describe("aggregations-where-edge-duration", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-float", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-id", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
@@ -22,14 +22,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-int", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
@@ -22,14 +22,14 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-edge-string", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../../../neo4j";
+import Neo4jHelper from "../../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import { cleanNodes } from "../../../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
 
 describe("Delete using top level aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -45,7 +45,7 @@ describe("Delete using top level aggregate where", () => {
     const content5 = "Some more content";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -86,7 +86,7 @@ describe("Delete using top level aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
-import { cleanNodes } from "../../../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import Neo4j from "../../../../neo4j";
+import Neo4jHelper from "../../../../neo4j";
 
 describe("Connect using aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let userType: UniqueType;
@@ -44,7 +44,7 @@ describe("Connect using aggregate where", () => {
     const date3 = new Date("2022-08-11T10:06:25.000Z");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -89,7 +89,7 @@ describe("Connect using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 
@@ -342,7 +342,7 @@ describe("Connect using aggregate where", () => {
 
 describe("Connect UNIONs using aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let userType: UniqueType;
@@ -366,7 +366,7 @@ describe("Connect UNIONs using aggregate where", () => {
     const content3 = "Post 3 has some long content";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -425,7 +425,7 @@ describe("Connect UNIONs using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType, specialUserType]);
+        await cleanNodesUsingSession(session, [userType, postType, specialUserType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
-import { cleanNodes } from "../../../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import Neo4j from "../../../../neo4j";
+import Neo4jHelper from "../../../../neo4j";
 
 describe("Disconnect using aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let userType: UniqueType;
@@ -42,7 +42,7 @@ describe("Disconnect using aggregate where", () => {
     const date3 = new Date("2022-08-11T10:06:25.000Z");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -83,7 +83,7 @@ describe("Disconnect using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 
@@ -261,7 +261,7 @@ describe("Disconnect using aggregate where", () => {
 
 describe("Disconnect UNIONs using aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let userType: UniqueType;
@@ -285,7 +285,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
     const content3 = "Post 3 has some long content";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -344,7 +344,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType, specialUserType]);
+        await cleanNodesUsingSession(session, [userType, postType, specialUserType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../../../neo4j";
+import Neo4jHelper from "../../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import { cleanNodes } from "../../../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
 
 describe("Delete using top level aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -46,7 +46,7 @@ describe("Delete using top level aggregate where", () => {
     const updatedContent = "This has been updated;";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -88,7 +88,7 @@ describe("Delete using top level aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
-import { cleanNodes } from "../../../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import Neo4j from "../../../../neo4j";
+import Neo4jHelper from "../../../../neo4j";
 
 describe("Update using aggregate where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let userType: UniqueType;
@@ -44,7 +44,7 @@ describe("Update using aggregate where", () => {
     const date3 = new Date("2022-08-11T10:06:25.000Z");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -89,7 +89,7 @@ describe("Update using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
@@ -20,17 +20,17 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 
 describe("aggregations-where-node-bigint", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const bigInt = "2147483647";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 
 describe("aggregations-where-node-datetime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 
 describe("aggregations-where-node-float", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 
 describe("aggregations-where-node-id", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
@@ -22,14 +22,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-node-int", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
@@ -22,14 +22,14 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../../src/classes";
 import { UniqueType } from "../../../../utils/graphql-types";
-import Neo4j from "../../../neo4j";
+import Neo4jHelper from "../../../neo4j";
 
 describe("aggregations-where-node-string", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/aliasing.int.test.ts
+++ b/packages/graphql/tests/integration/aliasing.int.test.ts
@@ -21,14 +21,14 @@ import type { Driver } from "neo4j-driver";
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("Aliasing", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let schema: GraphQLSchema;
 
     const typeDefs = `
@@ -44,7 +44,7 @@ describe("Aliasing", () => {
     const boxOffice = 465.3;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
         const neoSchema = new Neo4jGraphQL({ typeDefs });

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
@@ -26,16 +26,16 @@ import { IncomingMessage } from "http";
 import { Socket } from "net";
 
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("array-pop-and-push", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
@@ -22,17 +22,17 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("array-pop-and-push", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
@@ -27,15 +27,15 @@ import { generate } from "randomstring";
 
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("array-pop-errors", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
@@ -25,15 +25,15 @@ import { generate } from "randomstring";
 
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("array-pop", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
@@ -27,14 +27,14 @@ import { generate } from "randomstring";
 
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("array-push", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
@@ -25,15 +25,15 @@ import { generate } from "randomstring";
 
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("array-push", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
@@ -23,11 +23,11 @@ import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("array-subscription", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
     let plugin: TestSubscriptionsEngine;
@@ -36,7 +36,7 @@ describe("array-subscription", () => {
     let typeMovie: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/composite-where.int.test.ts
+++ b/packages/graphql/tests/integration/composite-where.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("composite-where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/config-options/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/query-options.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("query options", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/config-options/startup-validation.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/startup-validation.int.test.ts
@@ -18,13 +18,13 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { GraphQLError } from "graphql";
 
 describe("Startup Validation", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typePointAlreadyExistsErrors = [
         new GraphQLError(
@@ -104,7 +104,7 @@ describe("Startup Validation", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/connect-or-create/connect-or-create-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/connect-or-create-authorization.int.test.ts
@@ -21,7 +21,7 @@ import { gql } from "graphql-tag";
 import type { Driver, Session, Integer } from "neo4j-driver";
 import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
@@ -30,7 +30,7 @@ import { createBearerToken } from "../../utils/create-bearer-token";
 describe("connectOrCreate", () => {
     describe("Update -> ConnectOrCreate", () => {
         let driver: Driver;
-        let neo4j: Neo4j;
+        let neo4j: Neo4jHelper;
         let session: Session;
         let typeDefs: DocumentNode;
         let queryUpdate: DocumentNode;
@@ -42,7 +42,7 @@ describe("connectOrCreate", () => {
         let neoSchema: Neo4jGraphQL;
 
         beforeAll(async () => {
-            neo4j = new Neo4j();
+            neo4j = new Neo4jHelper();
             driver = await neo4j.getDriver();
 
             typeDefs = gql`
@@ -176,7 +176,7 @@ describe("connectOrCreate", () => {
 
     describe("authorization rules on source and target types", () => {
         let driver: Driver;
-        let neo4j: Neo4j;
+        let neo4j: Neo4jHelper;
         let session: Session;
         let typeDefs: DocumentNode;
         let queryUpdate: DocumentNode;
@@ -188,7 +188,7 @@ describe("connectOrCreate", () => {
         let neoSchema: Neo4jGraphQL;
 
         beforeAll(async () => {
-            neo4j = new Neo4j();
+            neo4j = new Neo4jHelper();
             driver = await neo4j.getDriver();
 
             typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/connect-or-create-id.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/connect-or-create-id.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 import { getQuerySource } from "../../utils/get-query-source";
 
 describe("connect-or-create with @id", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -39,7 +39,7 @@ describe("connect-or-create with @id", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/create-connect-or-create-union.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/create-connect-or-create-union.int.test.ts
@@ -24,11 +24,11 @@ import type { Driver, Integer, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Create -> ConnectOrCreate Union", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -39,7 +39,7 @@ describe("Create -> ConnectOrCreate Union", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/create-connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/create-connect-or-create.int.test.ts
@@ -25,11 +25,11 @@ import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
 import { runAndParseRecords } from "../../utils/run-and-parse-records";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Create -> ConnectOrCreate", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -39,7 +39,7 @@ describe("Create -> ConnectOrCreate", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-top-level.int.test.ts
@@ -24,11 +24,11 @@ import type { Driver, Integer, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Update -> ConnectOrCreate Top Level", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -38,7 +38,7 @@ describe("Update -> ConnectOrCreate Top Level", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union-top-level.int.test.ts
@@ -24,11 +24,11 @@ import type { Driver, Integer, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Update -> ConnectOrCreate union top level", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -39,7 +39,7 @@ describe("Update -> ConnectOrCreate union top level", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union.int.test.ts
@@ -24,11 +24,11 @@ import type { Driver, Integer, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Update -> ConnectOrCreate Union", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -39,7 +39,7 @@ describe("Update -> ConnectOrCreate Union", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create.int.test.ts
@@ -24,11 +24,11 @@ import type { Driver, Integer, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Update -> ConnectOrCreate", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
 
@@ -38,7 +38,7 @@ describe("Update -> ConnectOrCreate", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/connection-resolvers-int.test.ts
+++ b/packages/graphql/tests/integration/connection-resolvers-int.test.ts
@@ -22,14 +22,14 @@ import { offsetToCursor } from "graphql-relay";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Connection Resolvers", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/connections/alias.int.test.ts
+++ b/packages/graphql/tests/integration/connections/alias.int.test.ts
@@ -23,17 +23,17 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Connections Alias", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/connections/enums.int.test.ts
+++ b/packages/graphql/tests/integration/connections/enums.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Enum Relationship Properties", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/connections/filtering.int.test.ts
+++ b/packages/graphql/tests/integration/connections/filtering.int.test.ts
@@ -21,20 +21,20 @@ import type { Driver, Session } from "neo4j-driver";
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("Connections Filtering", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let schema: GraphQLSchema;
     let session: Session;
     let actorType: UniqueType;
     let movieType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/connections/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/connections/interfaces.int.test.ts
@@ -22,11 +22,11 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Connections -> Interfaces", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeMovie = new UniqueType("Movie");
     const typeSeries = new UniqueType("Series");
@@ -72,7 +72,7 @@ describe("Connections -> Interfaces", () => {
     const movie2ScreenTime = 120;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/connections/nested.int.test.ts
+++ b/packages/graphql/tests/integration/connections/nested.int.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Connections Alias", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let schema: GraphQLSchema;
 
@@ -39,7 +39,7 @@ describe("Connections Alias", () => {
     const screenTime = 120;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/connections/sort.int.test.ts
+++ b/packages/graphql/tests/integration/connections/sort.int.test.ts
@@ -24,13 +24,13 @@ import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("connections sort", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let schema: GraphQLSchema;
     let session: Session;
 
@@ -127,7 +127,7 @@ describe("connections sort", () => {
     ];
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session2 = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/connections/unions.int.test.ts
+++ b/packages/graphql/tests/integration/connections/unions.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Connections -> Unions", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeDefs = gql`
         union Publication = Book | Journal
@@ -62,7 +62,7 @@ describe("Connections -> Unions", () => {
     const journalWordCount = 3413;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/create.int.test.ts
+++ b/packages/graphql/tests/integration/create.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("create", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/custom-directives.int.test.ts
+++ b/packages/graphql/tests/integration/custom-directives.int.test.ts
@@ -24,14 +24,14 @@ import { graphql, defaultFieldResolver } from "graphql";
 import { getDirective, MapperKind, mapSchema } from "@graphql-tools/utils";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Custom Directives", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/custom-resolvers.int.test.ts
@@ -21,14 +21,14 @@ import { createSourceEventStream, graphql, parse } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Custom Resolvers", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/custom-scalar-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/custom-scalar-filtering.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
 
 describe("Custom Scalar Filtering", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/cypher-params.int.test.ts
+++ b/packages/graphql/tests/integration/cypher-params.int.test.ts
@@ -21,14 +21,14 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("cypherParams", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/default-values.int.test.ts
+++ b/packages/graphql/tests/integration/default-values.int.test.ts
@@ -21,14 +21,14 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Default values", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/delete-interface.int.test.ts
+++ b/packages/graphql/tests/integration/delete-interface.int.test.ts
@@ -23,13 +23,13 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src";
-import { cleanNodes } from "../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../utils/clean-nodes";
 import { UniqueType } from "../utils/graphql-types";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("delete interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -56,7 +56,7 @@ describe("delete interface relationships", () => {
     let nestedMovieActorScreenTime: number;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             type ${episodeType.name} {
@@ -172,7 +172,7 @@ describe("delete interface relationships", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [episodeType, movieType, seriesType, actorType]);
+        await cleanNodesUsingSession(session, [episodeType, movieType, seriesType, actorType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/delete-union.int.test.ts
+++ b/packages/graphql/tests/integration/delete-union.int.test.ts
@@ -23,13 +23,13 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src";
-import { cleanNodes } from "../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../utils/clean-nodes";
 import { UniqueType } from "../utils/graphql-types";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("delete union relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -56,7 +56,7 @@ describe("delete union relationships", () => {
     let nestedMovieActorScreenTime: number;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             type ${episodeType.name} {
@@ -169,7 +169,7 @@ describe("delete union relationships", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [episodeType, movieType, seriesType, actorType]);
+        await cleanNodesUsingSession(session, [episodeType, movieType, seriesType, actorType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/delete.int.test.ts
+++ b/packages/graphql/tests/integration/delete.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("delete", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/alias.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias.int.test.ts
@@ -24,11 +24,11 @@ import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("@alias directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
     const dbName = generate({ charset: "alphabetic" });
@@ -42,7 +42,7 @@ describe("@alias directive", () => {
     const ProtectedUser = new UniqueType("ProtectedUser");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
             type JWTPayload @jwt {

--- a/packages/graphql/tests/integration/directives/alias/connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/connect-or-create.int.test.ts
@@ -20,13 +20,13 @@
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 
 describe("@alias directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -34,7 +34,7 @@ describe("@alias directive", () => {
     let typeMovie: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -64,7 +64,7 @@ describe("@alias directive", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [typeMovie, typeActor]);
+        await cleanNodesUsingSession(session, [typeMovie, typeActor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/alias/nodes.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/nodes.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("@alias directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -34,7 +34,7 @@ describe("@alias directive", () => {
     let typeDirector: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -69,7 +69,7 @@ describe("@alias directive", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [typeMovie, typeDirector]);
+        await cleanNodesUsingSession(session, [typeMovie, typeDirector]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/alias/unions.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/unions.int.test.ts
@@ -21,13 +21,13 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("@alias directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -36,7 +36,7 @@ describe("@alias directive", () => {
     let typeActor: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -78,7 +78,7 @@ describe("@alias directive", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [typeMovie, typeSeries, typeActor]);
+        await cleanNodesUsingSession(session, [typeMovie, typeSeries, typeActor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/allow-unauthenticated.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/allow-unauthenticated.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { IncomingMessage } from "http";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
@@ -31,12 +31,12 @@ import { UniqueType } from "../../../utils/graphql-types";
 // Reference: https://github.com/neo4j/graphql/pull/342#issuecomment-884061188
 describe("auth/allow-unauthenticated", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let Post: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/allow.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/allow.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/allow", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     const secret = "secret";
 
@@ -37,7 +37,7 @@ describe("auth/allow", () => {
     let commentType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -54,7 +54,7 @@ describe("auth/allow", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/bind.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/bind.int.test.ts
@@ -20,17 +20,17 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/bind", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/custom-cypher.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/custom-cypher.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("should inject the auth into cypher directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/custom-resolvers.int.test.ts
@@ -20,17 +20,17 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/custom-resolvers", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
@@ -22,17 +22,17 @@ import { graphql } from "graphql";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { runCypher } from "../../../utils/run-cypher";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 
 describe("auth/is-authenticated", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let Product: UniqueType;
     let User: UniqueType;
@@ -40,7 +40,7 @@ describe("auth/is-authenticated", () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -4056,7 +4056,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [Product]);
+                await cleanNodesUsingSession(session, [Product]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4140,7 +4140,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User]);
+                await cleanNodesUsingSession(session, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4228,7 +4228,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User]);
+                await cleanNodesUsingSession(session, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4326,7 +4326,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User, Post]);
+                await cleanNodesUsingSession(session, [User, Post]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4449,7 +4449,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User, Post]);
+                await cleanNodesUsingSession(session, [User, Post]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4572,7 +4572,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User, Post]);
+                await cleanNodesUsingSession(session, [User, Post]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4685,7 +4685,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User]);
+                await cleanNodesUsingSession(session, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4772,7 +4772,7 @@ describe("auth/is-authenticated", () => {
 
             afterEach(async () => {
                 const session = driver.session();
-                await cleanNodes(session, [User]);
+                await cleanNodesUsingSession(session, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {

--- a/packages/graphql/tests/integration/directives/authorization/jwks-endpoint.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/jwks-endpoint.int.test.ts
@@ -27,17 +27,17 @@ import Koa from "koa";
 import Router from "koa-router";
 import jwt from "koa-jwt";
 import jwksRsa from "jwks-rsa";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 
 describe("auth/jwks-endpoint", () => {
     let jwksMock: JWKSMock;
     let server: any;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/object-path.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/object-path.int.test.ts
@@ -20,20 +20,20 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/object-path", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/roles.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/roles.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { runCypher } from "../../../utils/run-cypher";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/roles", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     let typeUser: UniqueType;
@@ -39,7 +39,7 @@ describe("auth/roles", () => {
     let typeHistory: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -66,7 +66,7 @@ describe("auth/roles", () => {
 
     afterEach(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [typeProduct, typeUser]);
+        await cleanNodesUsingSession(session, [typeProduct, typeUser]);
     });
 
     describe("read", () => {

--- a/packages/graphql/tests/integration/directives/authorization/where.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/where.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/where", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/coalesce.int.test.ts
+++ b/packages/graphql/tests/integration/directives/coalesce.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql, GraphQLError } from "graphql";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("@coalesce directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/customResolver.int.test.ts
+++ b/packages/graphql/tests/integration/directives/customResolver.int.test.ts
@@ -23,14 +23,14 @@ import gql from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { INVALID_REQUIRED_FIELD_ERROR } from "../../../src/schema/get-custom-resolver-meta";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("@customResolver directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const user = {
         id: "An-ID",
@@ -51,7 +51,7 @@ describe("@customResolver directive", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -303,7 +303,7 @@ describe("@customResolver directive", () => {
 
 describe("Related Fields", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let Publication: UniqueType;
     let Author: UniqueType;
@@ -368,7 +368,7 @@ describe("Related Fields", () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -386,7 +386,7 @@ describe("Related Fields", () => {
     afterEach(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Publication, Author, Book, Journal, User, Address, City, State]);
+            await cleanNodesUsingSession(session, [Publication, Author, Book, Journal, User, Address, City, State]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/directives/cypher/column-name.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/column-name.int.test.ts
@@ -21,17 +21,17 @@ import type { Driver } from "neo4j-driver";
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("cypher with columnName argument", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/cypher/cypher.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/cypher.int.test.ts
@@ -21,17 +21,17 @@ import type { Driver } from "neo4j-driver";
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("cypher", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/default.int.test.ts
+++ b/packages/graphql/tests/integration/directives/default.int.test.ts
@@ -20,14 +20,14 @@
 import { GraphQLError } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("@default directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/fulltext/fulltext-argument.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext/fulltext-argument.int.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { delay } from "../../../../src/utils/utils";
@@ -29,12 +29,12 @@ import { isMultiDbUnsupportedError } from "../../../utils/is-multi-db-unsupporte
 
 describe("@fulltext directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let databaseName: string;
     let MULTIDB_SUPPORT = true;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         databaseName = generate({ readable: true, charset: "alphabetic" });

--- a/packages/graphql/tests/integration/directives/fulltext/fulltext-index.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext/fulltext-index.int.test.ts
@@ -20,7 +20,7 @@
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { delay } from "../../../../src/utils/utils";
@@ -28,12 +28,12 @@ import { isMultiDbUnsupportedError } from "../../../utils/is-multi-db-unsupporte
 
 describe("@fulltext directive - indexes constraints", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let databaseName: string;
     let MULTIDB_SUPPORT = true;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         databaseName = generate({ readable: true, charset: "alphabetic" });

--- a/packages/graphql/tests/integration/directives/fulltext/fulltext-query.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext/fulltext-query.int.test.ts
@@ -29,7 +29,7 @@ import { delay } from "../../../../src/utils/utils";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import { isMultiDbUnsupportedError } from "../../../utils/is-multi-db-unsupported-error";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 function generatedTypeDefs(personType: UniqueType, movieType: UniqueType): string {
     return `
@@ -49,12 +49,12 @@ function generatedTypeDefs(personType: UniqueType, movieType: UniqueType): strin
 
 describe("@fulltext directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let databaseName: string;
     let MULTIDB_SUPPORT = true;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         databaseName = generate({ readable: true, charset: "alphabetic" });

--- a/packages/graphql/tests/integration/directives/id.int.test.ts
+++ b/packages/graphql/tests/integration/directives/id.int.test.ts
@@ -22,14 +22,14 @@ import isUUID from "is-uuid";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("@id directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/node/label.int.test.ts
+++ b/packages/graphql/tests/integration/directives/node/label.int.test.ts
@@ -19,20 +19,20 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("Node directive labels", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     const typeFilm = new UniqueType("Film");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/directives/populatedBy.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy.int.test.ts
@@ -23,14 +23,14 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("@populatedBy directive", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/relationship/nestedOperations.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/nestedOperations.int.test.ts
@@ -19,20 +19,20 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
 
 describe("@relationhip - nestedOperations", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let Movie: UniqueType;
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-database-name.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-database-name.int.test.ts
@@ -20,16 +20,16 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { toGlobalId } from "../../../../src/utils/global-ids";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { generate } from "randomstring";
 
 describe("RelayId projection with different database name", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
     let movieDatabaseID: string;
@@ -41,7 +41,7 @@ describe("RelayId projection with different database name", () => {
     const Actor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `
@@ -93,7 +93,7 @@ describe("RelayId projection with different database name", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Genre, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Genre, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-field-alias.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-field-alias.int.test.ts
@@ -20,17 +20,17 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { toGlobalId } from "../../../../src/utils/global-ids";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { generate } from "randomstring";
 
 // used to confirm the issue: https://github.com/neo4j/graphql/issues/4158
 describe("RelayId projection with GraphQL field alias", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
     let movieDatabaseID: string;
@@ -42,7 +42,7 @@ describe("RelayId projection with GraphQL field alias", () => {
     const Actor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `
@@ -94,7 +94,7 @@ describe("RelayId projection with GraphQL field alias", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Genre, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Genre, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection.int.test.ts
@@ -20,16 +20,16 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { toGlobalId } from "../../../../src/utils/global-ids";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { generate } from "randomstring";
 
 describe("RelayId projection", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
     let movieDatabaseID: string;
@@ -41,7 +41,7 @@ describe("RelayId projection", () => {
     const Actor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `
@@ -93,7 +93,7 @@ describe("RelayId projection", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Genre, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Genre, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/timestamp/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/directives/timestamp/datetime.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { DateTime, Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("timestamp/datetime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/timestamp/time.int.test.ts
+++ b/packages/graphql/tests/integration/directives/timestamp/time.int.test.ts
@@ -22,14 +22,14 @@ import type { Driver, Integer } from "neo4j-driver";
 import { isTime } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("timestamp/time", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/directives/unique.int.test.ts
+++ b/packages/graphql/tests/integration/directives/unique.int.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
@@ -31,13 +31,13 @@ import { Executor } from "../../../src/classes/Executor";
 
 describe("assertIndexesAndConstraints/unique", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let databaseName: string;
     let MULTIDB_SUPPORT = true;
     let dbInfo: Neo4jDatabaseInfo;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         dbInfo = await getNeo4jDatabaseInfo(new Executor({ executionContext: driver }));
 

--- a/packages/graphql/tests/integration/enums.int.test.ts
+++ b/packages/graphql/tests/integration/enums.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("enums", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-field-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-field-level-with-auth.int.test.ts
@@ -23,13 +23,13 @@ import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Interface Field Level Aggregations with authorization", () => {
     const secret = "the-secret";
 
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -41,7 +41,7 @@ describe("Interface Field Level Aggregations with authorization", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `

--- a/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-field-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-field-level.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Interface Field Level Aggregations", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -37,7 +37,7 @@ describe("Interface Field Level Aggregations", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `

--- a/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Top-level interface query fields with authorization", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -46,7 +46,7 @@ describe("Top-level interface query fields with authorization", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `
@@ -98,7 +98,7 @@ describe("Top-level interface query fields with authorization", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series]);
+        await cleanNodesUsingSession(session, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Top-level interface query fields", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -46,7 +46,7 @@ describe("Top-level interface query fields", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `
@@ -91,7 +91,7 @@ describe("Top-level interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series]);
+        await cleanNodesUsingSession(session, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level-with-auth.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Field-level filter interface query fields with authorization", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -48,7 +48,7 @@ describe("Field-level filter interface query fields with authorization", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `
@@ -130,7 +130,7 @@ describe("Field-level filter interface query fields with authorization", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series]);
+        await cleanNodesUsingSession(session, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Field-level filter interface query fields", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -48,7 +48,7 @@ describe("Field-level filter interface query fields", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `
@@ -123,7 +123,7 @@ describe("Field-level filter interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series]);
+        await cleanNodesUsingSession(session, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Top-level filter interface query fields with authorization", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -48,7 +48,7 @@ describe("Top-level filter interface query fields with authorization", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `
@@ -130,7 +130,7 @@ describe("Top-level filter interface query fields with authorization", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series]);
+        await cleanNodesUsingSession(session, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Top-level filter interface query fields", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -46,7 +46,7 @@ describe("Top-level filter interface query fields", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `
@@ -91,7 +91,7 @@ describe("Top-level filter interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series]);
+        await cleanNodesUsingSession(session, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/interface-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/interface-filtering.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Interface filtering", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -47,7 +47,7 @@ describe("Interface filtering", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `
@@ -114,7 +114,7 @@ describe("Interface filtering", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Series, Actor]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/interfaces-top-level.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Top-level interface query fields", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -48,7 +48,7 @@ describe("Top-level interface query fields", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `
@@ -112,7 +112,12 @@ describe("Top-level interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [SomeNodeType, OtherNodeType, MyImplementationType, MyOtherImplementationType]);
+        await cleanNodesUsingSession(session, [
+            SomeNodeType,
+            OtherNodeType,
+            MyImplementationType,
+            MyOtherImplementationType,
+        ]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/typename-in-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/typename-in-auth.int.test.ts
@@ -21,14 +21,14 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("typename_IN with auth", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
     const secret = "secret";
@@ -47,7 +47,7 @@ describe("typename_IN with auth", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `
@@ -100,7 +100,7 @@ describe("typename_IN with auth", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series, Cartoon]);
+        await cleanNodesUsingSession(session, [Movie, Series, Cartoon]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/typename-in.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/typename-in.int.test.ts
@@ -21,13 +21,13 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("typename_IN", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -45,7 +45,7 @@ describe("typename_IN", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `
@@ -104,7 +104,7 @@ describe("typename_IN", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series, Cartoon]);
+        await cleanNodesUsingSession(session, [Movie, Series, Cartoon]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/union-relationship-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/union-relationship-filtering.int.test.ts
@@ -21,16 +21,16 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Union filtering", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let typeDefs: string;
 
@@ -47,7 +47,7 @@ describe("Union filtering", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = /* GraphQL */ `
@@ -111,7 +111,7 @@ describe("Union filtering", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Series, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Series, Actor]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/unions-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/unions-top-level.int.test.ts
@@ -22,11 +22,11 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Top-level union query fields", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let GenreType: UniqueType;
     let MovieType: UniqueType;
@@ -34,7 +34,7 @@ describe("Top-level union query fields", () => {
     let typeDefs: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/field-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/field-filtering.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("field-filtering", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
@@ -23,14 +23,14 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Advanced Filtering", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         process.env.NEO4J_GRAPHQL_ENABLE_REGEX = "true";
     });

--- a/packages/graphql/tests/integration/filtering/operations.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/operations.int.test.ts
@@ -19,7 +19,7 @@
 
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -30,10 +30,10 @@ describe("Filtering Operations", () => {
     let driver: Driver;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
 
         const typeDefs = `
         type ${personType} {

--- a/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
@@ -19,7 +19,7 @@
 
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -30,10 +30,10 @@ describe("Single relationship (1-*) filtering", () => {
     let driver: Driver;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
 
         const typeDefs = `
         type ${Person} {

--- a/packages/graphql/tests/integration/find.int.test.ts
+++ b/packages/graphql/tests/integration/find.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("find", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/fragments.int.test.ts
+++ b/packages/graphql/tests/integration/fragments.int.test.ts
@@ -25,13 +25,13 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
 import { getQuerySource } from "../utils/get-query-source";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("fragments", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let schema: GraphQLSchema;
 
     const typeDefs = gql`
@@ -86,7 +86,7 @@ describe("fragments", () => {
     const seriesScreenTime = faker.number.int({ max: 100000 });
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/global-node.int.test.ts
+++ b/packages/graphql/tests/integration/global-node.int.test.ts
@@ -20,7 +20,7 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { toGlobalId } from "../../src/utils/global-ids";
 import { UniqueType } from "../utils/graphql-types";
@@ -28,14 +28,14 @@ import { createBearerToken } from "../utils/create-bearer-token";
 
 describe("Global node resolution", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     const typeFilm = new UniqueType("Film");
     const typeUser = new UniqueType("User");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/info.int.test.ts
+++ b/packages/graphql/tests/integration/info.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("info", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/create/connect.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/create/connect.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/create/create.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-filters.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-filters.int.test.ts
@@ -22,13 +22,13 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface filters of declared relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -51,7 +51,7 @@ describe("interface filters of declared relationships", () => {
     let episodeNr;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -144,7 +144,7 @@ describe("interface filters of declared relationships", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Series, Actor, Episode]);
+        await cleanNodesUsingSession(session, [Movie, Series, Actor, Episode]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-one-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-one-level-chain.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface implementing interface with declared relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -37,7 +37,7 @@ describe("interface implementing interface with declared relationships", () => {
     let Episode: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-simple.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-simple.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface with declared relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -37,7 +37,7 @@ describe("interface with declared relationships", () => {
     let Episode: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-three-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-three-level-chain.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface implementing interface with declared relationships - three level interface chain", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -37,7 +37,7 @@ describe("interface implementing interface with declared relationships - three l
     let Episode: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-two-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-two-level-chain.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface implementing interface with declared relationships - two level interface chain", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -37,7 +37,7 @@ describe("interface implementing interface with declared relationships - two lev
     let Episode: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/type-narrowing-mutations.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/type-narrowing-mutations.test.ts
@@ -23,12 +23,12 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 // TODO: maybe use type-narrowing-connections
 describe("type narrowing - mutations setup", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -38,7 +38,7 @@ describe("type narrowing - mutations setup", () => {
     let UntrainedPerson: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/type-narrowing-nested.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/type-narrowing-nested.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("type narrowing nested connections", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
     let gqlQuery: string | Source;
@@ -49,7 +49,7 @@ describe("type narrowing nested connections", () => {
     let sceneNr: number;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         actorName = "actor1";

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/type-narrowing.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/type-narrowing.test.ts
@@ -23,11 +23,11 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("type narrowing - simple case", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -37,7 +37,7 @@ describe("type narrowing - simple case", () => {
     let UntrainedPerson: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/delete/delete.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/read.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/read.int.test.ts
@@ -25,11 +25,11 @@ import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -38,7 +38,7 @@ describe("interface relationships", () => {
     let typeActor: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/interface-relationships/update/connect.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/connect.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/update/create.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/create.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/update/delete.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/delete.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/update/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/disconnect.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interface-relationships/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/update/update.int.test.ts
@@ -23,15 +23,15 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces.int.test.ts
@@ -23,13 +23,13 @@ import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../src";
 import { createBearerToken } from "../utils/create-bearer-token";
 import { UniqueType } from "../utils/graphql-types";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Interfaces tests", () => {
     const secret = "the-secret";
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -46,7 +46,7 @@ describe("Interfaces tests", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1049.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1049.int.test.ts
@@ -22,11 +22,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1049", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -44,7 +44,7 @@ describe("https://github.com/neo4j/graphql/issues/1049", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1050.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1050.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src";
@@ -35,11 +35,11 @@ describe("https://github.com/neo4j/graphql/issues/1050", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/1115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1115.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 import { runCypher } from "../../utils/run-cypher";
@@ -32,10 +32,10 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1121.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1121.int.test.ts
@@ -22,11 +22,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1121", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -44,7 +44,7 @@ describe("https://github.com/neo4j/graphql/issues/1121", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1127.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1127.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -31,10 +31,10 @@ describe("https://github.com/neo4j/graphql/issues/1127", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1132.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1132.int.test.ts
@@ -21,7 +21,7 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src";
@@ -31,11 +31,11 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
     const secret = "secret";
 
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/1150.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1150.int.test.ts
@@ -23,16 +23,16 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1150", () => {
     const secret = "secret";
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/1221.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1221.int.test.ts
@@ -22,13 +22,13 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1221", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const testMain = new UniqueType("Main");
     const testSeries = new UniqueType("Series");
     const testNameDetails = new UniqueType("NameDetails");
@@ -68,7 +68,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/1249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1249.int.test.ts
@@ -21,12 +21,12 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1249", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeDefs = `
         type Bulk
@@ -57,7 +57,7 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/1287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1287.int.test.ts
@@ -22,13 +22,13 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1287", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const screeningsType = new UniqueType("Screening");
     const norwegianScreenable = new UniqueType("NorwegianScreenableMeta");
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/1287", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/1320.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1320.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -32,10 +32,10 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/1364.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1364.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -31,7 +31,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     async function graphqlQuery(query: string) {
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1414.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1414.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1414", () => {
     const testProduct = new UniqueType("Product");
@@ -32,7 +32,7 @@ describe("https://github.com/neo4j/graphql/issues/1414", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     async function graphqlQuery(query: string) {
         return graphql({
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/1414", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1430.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1430.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1430", () => {
     const testAbce = new UniqueType("ABCE");
@@ -30,11 +30,11 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
     const testChildTwo = new UniqueType("ChildTwo");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1528.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1528.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -31,7 +31,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
     const testGenre = new UniqueType("Genre");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -44,7 +44,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/1535.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1535.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -30,7 +30,7 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
 
     let driver: Driver;
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     async function graphqlQuery(query: string) {
@@ -42,7 +42,7 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1536.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1536.int.test.ts
@@ -22,11 +22,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1536", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/1536", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1551.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1551.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql, GraphQLError } from "graphql";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -28,7 +28,7 @@ describe("https://github.com/neo4j/graphql/issues/1551", () => {
     const testType = new UniqueType("AttribValue");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
 
     async function graphqlQuery(query: string) {
@@ -40,7 +40,7 @@ describe("https://github.com/neo4j/graphql/issues/1551", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1566.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1566.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -30,11 +30,11 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
     const testCommunity = new UniqueType("Community");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1640.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1640.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -29,12 +29,12 @@ describe("https://github.com/neo4j/graphql/issues/1640", () => {
     const testOrganization = new UniqueType("Organization");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1683.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1683.int.test.ts
@@ -22,14 +22,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1683", () => {
     const systemType = new UniqueType("System");
     const governedDataTest = new UniqueType("GovernedData");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
 
     async function graphqlQuery(query: string) {
@@ -41,7 +41,7 @@ describe("https://github.com/neo4j/graphql/issues/1683", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1686.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1686.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1686", () => {
     const productionType = new UniqueType("Production");
@@ -30,7 +30,7 @@ describe("https://github.com/neo4j/graphql/issues/1686", () => {
     const genreType = new UniqueType("Genre");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
 
     async function graphqlQuery(query: string) {
@@ -42,7 +42,7 @@ describe("https://github.com/neo4j/graphql/issues/1686", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1687.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1687.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1687", () => {
     const productionType = new UniqueType("Production");
@@ -30,7 +30,7 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
     const genreType = new UniqueType("Genre");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
 
     async function graphqlQuery(query: string) {
@@ -42,7 +42,7 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1735.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1735.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1735", () => {
     const actorType = new UniqueType("Actor");
@@ -30,10 +30,10 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
           type MovieActorEdgeProperties @relationshipProperties {

--- a/packages/graphql/tests/integration/issues/1751.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1751.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1735", () => {
     const organizationType = new UniqueType("Organization");
@@ -30,10 +30,10 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
         type ${organizationType} {

--- a/packages/graphql/tests/integration/issues/1756.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1756.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1756", () => {
     const productType = new UniqueType("Product");
@@ -30,10 +30,10 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
         interface INode {

--- a/packages/graphql/tests/integration/issues/1760.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1760.int.test.ts
@@ -23,17 +23,17 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { getQuerySource } from "../../utils/get-query-source";
 import { Neo4jGraphQL } from "../../../src";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/1760", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             type JWTPayload @jwt {

--- a/packages/graphql/tests/integration/issues/1761.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1761.int.test.ts
@@ -19,21 +19,21 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/1761", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
     let myType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -61,7 +61,7 @@ describe("https://github.com/neo4j/graphql/issues/1761", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [myType]);
+        await cleanNodesUsingSession(session, [myType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/1779.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1779.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1779", () => {
     const personType = new UniqueType("Person");
@@ -30,10 +30,10 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
             type ${personType.name} {

--- a/packages/graphql/tests/integration/issues/1782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1782.int.test.ts
@@ -21,14 +21,14 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1782", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     const testMain = new UniqueType("Main");
@@ -70,7 +70,7 @@ describe("https://github.com/neo4j/graphql/issues/1782", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/1782", () => {
 
     afterEach(async () => {
         try {
-            await cleanNodes(session, [testMain, testSeries, testNameDetails, testMasterData]);
+            await cleanNodesUsingSession(session, [testMain, testSeries, testNameDetails, testMasterData]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/1783.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1783.int.test.ts
@@ -22,12 +22,12 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1783", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const testMain = new UniqueType("Main");
     const testSeries = new UniqueType("Series");
     const testNameDetails = new UniqueType("NameDetails");
@@ -58,7 +58,7 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/1817.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1817.int.test.ts
@@ -22,12 +22,12 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1817", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const TypeContainerType = new UniqueType("ContainerType");
     const TypeContainer = new UniqueType("Container");
@@ -63,7 +63,7 @@ describe("https://github.com/neo4j/graphql/issues/1817", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/1848.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1848.int.test.ts
@@ -20,13 +20,13 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("https://github.com/neo4j/graphql/issues/1848", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeDefs = `
         type ContentPiece @node(labels: ["ContentPiece", "UNIVERSAL"]) {
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/1848", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/190.int.test.ts
+++ b/packages/graphql/tests/integration/issues/190.int.test.ts
@@ -20,12 +20,12 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/190", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type User {
             client_id: String
@@ -42,7 +42,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/issues/1933.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1933.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1933", () => {
     const employeeType = new UniqueType("Employee");
@@ -30,11 +30,11 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/200.int.test.ts
+++ b/packages/graphql/tests/integration/issues/200.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/200", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2022.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2022.int.test.ts
@@ -20,13 +20,13 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/2022", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/2068.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2068.int.test.ts
@@ -23,16 +23,16 @@ import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/pull/2068", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/207.int.test.ts
+++ b/packages/graphql/tests/integration/issues/207.int.test.ts
@@ -20,12 +20,12 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/207", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         union Result = Book | Author
 
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/207", () => {
     };
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2100.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2100.int.test.ts
@@ -22,11 +22,11 @@ import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2100", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let token: string;
 
     const BacentaType = new UniqueType("Bacenta");
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
         `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/issues/2189.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2189.int.test.ts
@@ -19,20 +19,20 @@
 
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/2189", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     let Test_Item: UniqueType;
     let Test_Feedback: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2249.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2249", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
     let Influencer: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2250.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2250.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2250", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2250", () => {
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2250", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Actor, Movie, Person]);
+        await cleanNodesUsingSession(session, [Actor, Movie, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2261.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2261.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2261", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -33,7 +33,7 @@ describe("https://github.com/neo4j/graphql/issues/2261", () => {
     let Edition: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2262.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2262.int.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/2262", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -33,7 +33,7 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
     let Process: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2267.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2267.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2267", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
     let Story: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Place, Post, Story]);
+        await cleanNodesUsingSession(session, [Place, Post, Story]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/227.int.test.ts
+++ b/packages/graphql/tests/integration/issues/227.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/227", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/235.int.test.ts
+++ b/packages/graphql/tests/integration/issues/235.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/235", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2388.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/2388", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let PartAddress: UniqueType;
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/2388", () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -99,7 +99,7 @@ describe("https://github.com/neo4j/graphql/issues/2388", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [PartAddress, PartUsage, Part]);
+        await cleanNodesUsingSession(session, [PartAddress, PartUsage, Part]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2396.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2396.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/2396", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -38,7 +38,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
     let Estate: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -722,7 +722,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
     });
 
     afterAll(async () => {
-        await cleanNodes(session, [PostalCode, Address, Mandate, Valuation, Estate]);
+        await cleanNodesUsingSession(session, [PostalCode, Address, Mandate, Valuation, Estate]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/2437.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2437.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/2437", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
     let Valuation: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Agent, Valuation]);
+        await cleanNodesUsingSession(session, [Agent, Valuation]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/247.int.test.ts
+++ b/packages/graphql/tests/integration/issues/247.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/247", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2474.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2474.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { int } from "neo4j-driver";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let PostalCode: UniqueType;
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let Valuation: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -119,7 +119,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [PostalCode, Address, Estate, Mandate, Valuation]);
+        await cleanNodesUsingSession(session, [PostalCode, Address, Estate, Mandate, Valuation]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2548.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2548.int.test.ts
@@ -21,15 +21,15 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2548", () => {
     const secret = "secret";
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let User: UniqueType;
 
@@ -38,7 +38,7 @@ describe("https://github.com/neo4j/graphql/issues/2548", () => {
     let query: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         User = new UniqueType("User");
 
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/2548", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [User]);
+        await cleanNodesUsingSession(session, [User]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -19,26 +19,26 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/2560", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let User: UniqueType;
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [User, Person]);
+        await cleanNodesUsingSession(session, [User, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2574.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2574.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2574", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2574", () => {
     let D: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2574", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [A, B, D]);
+        await cleanNodesUsingSession(session, [A, B, D]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2581.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2581.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2581", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
     let Sales: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -101,7 +101,7 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Book, Author, Sales]);
+        await cleanNodesUsingSession(session, [Book, Author, Sales]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2630.int.test.ts
@@ -22,12 +22,12 @@ import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
-import { cleanNodes } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2630", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -38,7 +38,7 @@ describe("https://github.com/neo4j/graphql/issues/2630", () => {
     let PostSubject: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/2630", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Post, User]);
+        await cleanNodesUsingSession(session, [Post, User]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2652.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2652.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2652", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/2652", () => {
     let reviewType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -63,7 +63,7 @@ describe("https://github.com/neo4j/graphql/issues/2652", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [locationType, reviewType]);
+        await cleanNodesUsingSession(session, [locationType, reviewType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2662.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2662.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2662", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -46,7 +46,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
     const post1Average = (someString1.length + someString2.length) / 2;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2669.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2669.int.test.ts
@@ -21,11 +21,11 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2669", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2669", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/2670.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2670.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2670", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -52,7 +52,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     const genre2AverageTitleLength = (movieTitle4.length + movieTitle2.length) / 2;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [movieType, genreType, seriesType]);
+        await cleanNodesUsingSession(session, [movieType, genreType, seriesType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2697.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2697.int.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/2697", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: string;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2697", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/2708.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2708.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2708", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -52,7 +52,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     const genre2AverageTitleLength = (movieTitle4.length + movieTitle2.length) / 2;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [movieType, genreType, seriesType]);
+        await cleanNodesUsingSession(session, [movieType, genreType, seriesType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2709.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2709.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2709", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
     let Netflix: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -119,7 +119,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Netflix, Dishney]);
+        await cleanNodesUsingSession(session, [Movie, Netflix, Dishney]);
         await session.close();
     });
 
@@ -184,7 +184,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
 
 describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -194,7 +194,7 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
     let Publisher: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -287,7 +287,7 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Netflix, Dishney, Publisher]);
+        await cleanNodesUsingSession(session, [Movie, Netflix, Dishney, Publisher]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2713.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2713.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2713", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -47,7 +47,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     const intValue5 = 42;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [movieType, genreType]);
+        await cleanNodesUsingSession(session, [movieType, genreType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2766.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2766.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2766", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2782.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2782", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
     let Photo: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Product, Color, Photo]);
+        await cleanNodesUsingSession(session, [Product, Color, Photo]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2803.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2803.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2803", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -102,7 +102,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
     const updatedName = "a new name!";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -175,7 +175,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2812.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2812.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/2812", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2820.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2820.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2820", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         Movie = new UniqueType("Movie");
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
 
     afterAll(async () => {
         session = await neo4j.getSession();
-        await cleanNodes(session, [Movie, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Actor]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/283.int.test.ts
+++ b/packages/graphql/tests/integration/issues/283.int.test.ts
@@ -21,12 +21,12 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/283", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type Mutation {
             login: String
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/283", () => {
     };
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2847.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2847", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2847", () => {
     let Product: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/2847", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Actor]);
+        await cleanNodesUsingSession(session, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2871.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2871.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2871", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -72,7 +72,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
     };
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -134,7 +134,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [FirstLevel, SecondLevel, ThirdLevel]);
+        await cleanNodesUsingSession(session, [FirstLevel, SecondLevel, ThirdLevel]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/288.int.test.ts
@@ -21,12 +21,12 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/288", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type USER {
             USERID: String
@@ -40,7 +40,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/2889.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2889.int.test.ts
@@ -19,21 +19,21 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2889", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
     let MyEnumHolder: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/2889", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [MyEnumHolder]);
+        await cleanNodesUsingSession(session, [MyEnumHolder]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2981.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2981.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2981", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
     let BookTitle_EN: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Book, BookTitle_EN, BookTitle_SV]);
+        await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2982.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2982.int.test.ts
@@ -22,12 +22,12 @@ import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
-import { cleanNodes } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2982", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/2982", () => {
     let BlogArticle: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2982", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [User, Post, BlogArticle, Comment]);
+        await cleanNodesUsingSession(session, [User, Post, BlogArticle, Comment]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3009.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3009.int.test.ts
@@ -20,14 +20,14 @@
 import { graphql } from "graphql";
 import type { Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3009", () => {
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(() => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
     });
 
     beforeEach(async () => {

--- a/packages/graphql/tests/integration/issues/3015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3015.int.test.ts
@@ -21,10 +21,10 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3015", () => {
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let driver: Driver;
 
@@ -33,7 +33,7 @@ describe("https://github.com/neo4j/graphql/issues/3015", () => {
     let Connected: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/3027.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3027.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/3027", () => {
     describe("union", () => {
         let driver: Driver;
-        let neo4j: Neo4j;
+        let neo4j: Neo4jHelper;
         let neoSchema: Neo4jGraphQL;
         let session: Session;
 
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         let BookTitle_EN: UniqueType;
 
         beforeAll(async () => {
-            neo4j = new Neo4j();
+            neo4j = new Neo4jHelper();
             driver = await neo4j.getDriver();
         });
 
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         });
 
         afterEach(async () => {
-            await cleanNodes(session, [Book, BookTitle_EN, BookTitle_SV]);
+            await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
             await session.close();
         });
 
@@ -130,7 +130,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
 
     describe("interface", () => {
         let driver: Driver;
-        let neo4j: Neo4j;
+        let neo4j: Neo4jHelper;
         let neoSchema: Neo4jGraphQL;
         let session: Session;
 
@@ -139,7 +139,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         let BookTitle_EN: UniqueType;
 
         beforeAll(async () => {
-            neo4j = new Neo4j();
+            neo4j = new Neo4jHelper();
             driver = await neo4j.getDriver();
         });
 
@@ -179,7 +179,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         });
 
         afterEach(async () => {
-            await cleanNodes(session, [Book, BookTitle_EN, BookTitle_SV]);
+            await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
             await session.close();
         });
 

--- a/packages/graphql/tests/integration/issues/315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/315.int.test.ts
@@ -21,12 +21,12 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/315", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         union Content = Post
 
@@ -64,7 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/315", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/3165.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3165.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import type { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3165", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
     let BookTitle_EN: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Book, BookTitle_EN, BookTitle_SV]);
+        await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3251.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3251.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/3251", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
     let Genre: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Genre]);
+        await cleanNodesUsingSession(session, [Movie, Genre]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/326.int.test.ts
+++ b/packages/graphql/tests/integration/issues/326.int.test.ts
@@ -20,21 +20,21 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/326", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
     let User: UniqueType;
     let id: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         User = new UniqueType("User");
         const session = await neo4j.getSession();
@@ -56,7 +56,7 @@ describe("https://github.com/neo4j/graphql/issues/326", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [User]);
+            await cleanNodesUsingSession(session, [User]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/330.int.test.ts
+++ b/packages/graphql/tests/integration/issues/330.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
@@ -30,11 +30,11 @@ describe("unauthenticated-requests", () => {
     const secret = "secret";
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let User: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/3355.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3355.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
 
 describe("https://github.com/neo4j/graphql/issues/3355", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/3394.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3394.int.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/3394", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
     const Employee = new UniqueType("Employee");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `#graphql

--- a/packages/graphql/tests/integration/issues/3428.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3428.int.test.ts
@@ -19,20 +19,20 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/3428", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let Movie: UniqueType;
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/349.int.test.ts
+++ b/packages/graphql/tests/integration/issues/349.int.test.ts
@@ -23,14 +23,14 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/349", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/350", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/354.int.test.ts
+++ b/packages/graphql/tests/integration/issues/354.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/354", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/360.int.test.ts
+++ b/packages/graphql/tests/integration/issues/360.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("360", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/369.int.test.ts
+++ b/packages/graphql/tests/integration/issues/369.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("369", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/3765.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3765.int.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/3765", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
     const User = new UniqueType("User");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `#graphql

--- a/packages/graphql/tests/integration/issues/387.int.test.ts
+++ b/packages/graphql/tests/integration/issues/387.int.test.ts
@@ -22,14 +22,14 @@ import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/387", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let name: string;
     let url: string;
     let typeDefs: DocumentNode;
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
     const Place = new UniqueType("Place");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         name = generate({
@@ -96,7 +96,7 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Place]);
+            await cleanNodesUsingSession(session, [Place]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/388.int.test.ts
@@ -21,12 +21,12 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/388", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         union Content = Post
 
@@ -64,7 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/388", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/3888.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3888.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/3888", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
     let User: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -70,7 +70,7 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Post, User]);
+        await cleanNodesUsingSession(session, [Post, User]);
         await session.close();
     });
 
@@ -136,5 +136,4 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
             },
         });
     });
-
 });

--- a/packages/graphql/tests/integration/issues/3901.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3901.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/3901", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
     let User: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -115,7 +115,7 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Serie, Season, User]);
+        await cleanNodesUsingSession(session, [Serie, Season, User]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3912.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3912.int.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/3912", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -33,7 +33,7 @@ describe("https://github.com/neo4j/graphql/issues/3912", () => {
     const Event = new UniqueType("Event");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = /* GraphQL */ `

--- a/packages/graphql/tests/integration/issues/3929.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3929.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/3929", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [User, Group, Person]);
+        await cleanNodesUsingSession(session, [User, Group, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3932.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3932.int.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/3932", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/3932", () => {
     const Invite = new UniqueType("Invite");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = /* GraphQL */ `

--- a/packages/graphql/tests/integration/issues/3938.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3938.int.test.ts
@@ -19,15 +19,15 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/3938", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/3938", () => {
     let Invitee: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/3938", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Group, Invitee]);
+        await cleanNodesUsingSession(session, [Group, Invitee]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4004.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4004.int.test.ts
@@ -20,19 +20,19 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/4004", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeEpisode = new UniqueType("Episode");
     const typeSeries = new UniqueType("Series");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/4007.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4007.int.test.ts
@@ -21,19 +21,19 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/4007", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/4015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4015.int.test.ts
@@ -21,19 +21,19 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/4007", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/402.int.test.ts
+++ b/packages/graphql/tests/integration/issues/402.int.test.ts
@@ -20,15 +20,15 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/402", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/4056.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4056.int.test.ts
@@ -18,16 +18,16 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import type { GraphQLResponse } from "@apollo/server";
 import { ApolloServer } from "@apollo/server";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4056", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const User = new UniqueType("User");
     const Tenant = new UniqueType("Tenant");
@@ -117,7 +117,7 @@ describe("https://github.com/neo4j/graphql/issues/4056", () => {
     let myUserId: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -162,7 +162,7 @@ describe("https://github.com/neo4j/graphql/issues/4056", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodes(session, [User, Tenant, Settings, OpeningDay]);
+        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4077.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4077.int.test.ts
@@ -20,14 +20,14 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4077", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
     let PreviewClip: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -114,7 +114,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [User, Video, PreviewClip]);
+        await cleanNodesUsingSession(session, [User, Video, PreviewClip]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4099.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4099.int.test.ts
@@ -20,14 +20,14 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4099", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [User, Person]);
+        await cleanNodesUsingSession(session, [User, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4110.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4110.int.test.ts
@@ -20,14 +20,14 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4110", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -36,7 +36,7 @@ describe("https://github.com/neo4j/graphql/issues/4110", () => {
     let InBetween: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/4110", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Company, InBetween]);
+        await cleanNodesUsingSession(session, [Company, InBetween]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4112.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4112.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import gql from "graphql-tag";
 import { createBearerToken } from "../../utils/create-bearer-token";
@@ -27,11 +27,11 @@ import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/4112", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const Category = new UniqueType("Category");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const session = await neo4j.getSession();

--- a/packages/graphql/tests/integration/issues/4113.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4113.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("https://github.com/neo4j/graphql/issues/4113", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
     const TransactionItem = new UniqueType("TransactionItem");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = /* GraphQL */ `
@@ -244,7 +244,7 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
 
 describe("replicates the test for relationship to interface so that multiple refNodes are target", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -256,7 +256,7 @@ describe("replicates the test for relationship to interface so that multiple ref
     const TransactionItem2 = new UniqueType("TransactionItem2");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = /* GraphQL */ `

--- a/packages/graphql/tests/integration/issues/4115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4115.int.test.ts
@@ -20,14 +20,14 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4115", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         session = await neo4j.getSession();
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
     });
 
     afterAll(async () => {
-        await cleanNodes(session, [User, Family, Person]);
+        await cleanNodesUsingSession(session, [User, Family, Person]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/4118.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4118.int.test.ts
@@ -18,16 +18,16 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import gql from "graphql-tag";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4118", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const User = new UniqueType("User");
     const Tenant = new UniqueType("Tenant");
@@ -122,7 +122,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
     let myUserId: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -161,7 +161,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodes(session, [User, Tenant, Settings, OpeningDay, LOL]);
+        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, LOL]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/413.int.test.ts
+++ b/packages/graphql/tests/integration/issues/413.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("413", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/4170.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4170.int.test.ts
@@ -18,16 +18,16 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import gql from "graphql-tag";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4170", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const User = new UniqueType("User");
     const Tenant = new UniqueType("Tenant");
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
     let myUserId: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -141,7 +141,7 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodes(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
+        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4196.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4196.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4196", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/4196", () => {
     let FooBar: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/4196", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Foo, Bar, FooBar]);
+        await cleanNodesUsingSession(session, [Foo, Bar, FooBar]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4214.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4214.int.test.ts
@@ -20,14 +20,14 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4214", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     const secret = "secret";
@@ -37,7 +37,7 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
     let Person: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         session = await neo4j.getSession();
@@ -174,7 +174,7 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
     });
 
     afterAll(async () => {
-        await cleanNodes(session, [User, Family, Person]);
+        await cleanNodesUsingSession(session, [User, Family, Person]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/4223.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4223.int.test.ts
@@ -18,16 +18,16 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
 import gql from "graphql-tag";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4223", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const User = new UniqueType("User");
     const Tenant = new UniqueType("Tenant");
@@ -128,7 +128,7 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
     let myUserId: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -175,7 +175,7 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodes(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval, MyWorkspace]);
+        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval, MyWorkspace]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4239.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4239.int.test.ts
@@ -18,21 +18,21 @@
  */
 
 import { type Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import gql from "graphql-tag";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4239", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
     const Movie = new UniqueType("Movie");
     const Person = new UniqueType("Person");
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
                 type ${Movie.name}
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Movie.name]);
+            await cleanNodesUsingSession(session, [Movie.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4268.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4268.int.test.ts
@@ -18,21 +18,21 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import gql from "graphql-tag";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4268", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
     const Movie = new UniqueType("Movie");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
         type JWT @jwt {
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Movie.name]);
+            await cleanNodesUsingSession(session, [Movie.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4287.int.test.ts
@@ -21,13 +21,13 @@ import { graphql } from "graphql";
 import gql from "graphql-tag";
 import { type Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4287", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
 
     const Actor = new UniqueType("Actor");
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
     const Series = new UniqueType("Series");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             type ${Actor} {
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Movie, Actor, Series]);
+            await cleanNodesUsingSession(session, [Movie, Actor, Series]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4292.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4292.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4292", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
     const User = new UniqueType("User");
     const Group = new UniqueType("Group");
@@ -35,7 +35,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
     const Contributor = new UniqueType("Contributor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = /* GraphQL */ `
             type JWT @jwt {
@@ -197,7 +197,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [User.name, Group.name, Person.name, Admin.name, Contributor.name]);
+            await cleanNodesUsingSession(session, [User.name, Group.name, Person.name, Admin.name, Contributor.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/433.int.test.ts
+++ b/packages/graphql/tests/integration/issues/433.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("433", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/440.int.test.ts
+++ b/packages/graphql/tests/integration/issues/440.int.test.ts
@@ -21,13 +21,13 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
 
 describe("https://github.com/neo4j/graphql/issues/440", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type Video {
             id: ID! @unique
@@ -41,7 +41,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/4405.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4405.int.test.ts
@@ -18,21 +18,21 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4405", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
     const Movie = new UniqueType("Movie");
     const Actor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = /* GraphQL */ `
             type ${Movie.name} {
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Movie.name, Actor.name]);
+            await cleanNodesUsingSession(session, [Movie.name, Actor.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4429.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4429.int.test.ts
@@ -18,16 +18,16 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { graphql } from "graphql";
 import { UniqueType } from "../../utils/graphql-types";
 import gql from "graphql-tag";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4429", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const User = new UniqueType("User");
     const Tenant = new UniqueType("Tenant");
@@ -108,7 +108,7 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
     let myUserId: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -170,7 +170,7 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodes(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
+        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4450.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4450.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4450", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
 
     const Actor = new UniqueType("Actor");
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/4450", () => {
     const Location = new UniqueType("Location");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = /* GraphQL */ `
             type ${Actor} {
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4450", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Actor, Scene, Location]);
+            await cleanNodesUsingSession(session, [Actor, Scene, Location]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4477.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4477.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4477", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
 
     const Brand = new UniqueType("Brand");
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
     const Collection = new UniqueType("Collection");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = /* GraphQL */ `
             type ${Brand} {
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Brand, Service, Collection]);
+            await cleanNodesUsingSession(session, [Brand, Service, Collection]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4520.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4520.int.test.ts
@@ -21,15 +21,15 @@ import { graphql } from "graphql/index";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("https://github.com/neo4j/graphql/issues/4520", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
 
     const Movie = new UniqueType("Movie");
@@ -38,7 +38,7 @@ describe("https://github.com/neo4j/graphql/issues/4520", () => {
     const Actor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = /* GraphQL */ `
             interface Production {
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/4520", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Movie, Serie, FxEngineer, Actor]);
+            await cleanNodesUsingSession(session, [Movie, Serie, FxEngineer, Actor]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4532.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4532.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import { type Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { default as Neo4j } from "../neo4j";
+import { default as Neo4jHelper } from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4532", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
 
     describe("order-by relationship property", () => {
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         const Scenario = new UniqueType("Scenario");
 
         beforeAll(async () => {
-            neo4j = new Neo4j();
+            neo4j = new Neo4jHelper();
             driver = await neo4j.getDriver();
             const typeDefs = /* GraphQL */ `
                 type ${Inventory} {
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         afterAll(async () => {
             const session = await neo4j.getSession();
             try {
-                await cleanNodes(session, [Inventory, Scenario]);
+                await cleanNodesUsingSession(session, [Inventory, Scenario]);
             } finally {
                 await session.close();
             }
@@ -149,7 +149,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         const Video = new UniqueType("Video");
 
         beforeAll(async () => {
-            neo4j = new Neo4j();
+            neo4j = new Neo4jHelper();
             driver = await neo4j.getDriver();
             const typeDefs = /* GraphQL */ `
                 type ${Inventory} {
@@ -200,7 +200,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         afterAll(async () => {
             const session = await neo4j.getSession();
             try {
-                await cleanNodes(session, [Inventory, Image, Video]);
+                await cleanNodesUsingSession(session, [Inventory, Image, Video]);
             } finally {
                 await session.close();
             }

--- a/packages/graphql/tests/integration/issues/4583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4583.int.test.ts
@@ -21,14 +21,14 @@ import { faker } from "@faker-js/faker";
 import { graphql } from "graphql";
 import gql from "graphql-tag";
 import { Neo4jGraphQL } from "../../../src";
-import Neo4j from "../../integration/neo4j";
+import Neo4jHelper from "../../integration/neo4j";
 import { UniqueType } from "../../utils/graphql-types";
 import type { Driver, Session } from "neo4j-driver";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4583", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -52,7 +52,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
     let sameTitle;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -149,7 +149,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Series, Actor, Episode]);
+        await cleanNodesUsingSession(session, [Movie, Series, Actor, Episode]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -20,13 +20,13 @@
 import { graphql } from "graphql";
 import { type Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { default as Neo4j } from "../neo4j";
+import { default as Neo4jHelper } from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4615", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neo4jGraphql: Neo4jGraphQL;
 
     const Movie = new UniqueType("Movie");
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
     const Actor = new UniqueType("Actor");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = /* GraphQL */ `
             interface Show {
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [Movie, Series, Actor]);
+            await cleanNodesUsingSession(session, [Movie, Series, Actor]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4617.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4617.int.test.ts
@@ -20,22 +20,22 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/4617", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
     let User: UniqueType;
     let Post: UniqueType;
     let id: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         User = new UniqueType("User");
         Post = new UniqueType("Post");
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodes(session, [User, Post]);
+            await cleanNodesUsingSession(session, [User, Post]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/464.int.test.ts
+++ b/packages/graphql/tests/integration/issues/464.int.test.ts
@@ -22,13 +22,13 @@ import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/464", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let typeAuthor: UniqueType;
     let typeBook: UniqueType;
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/464", () => {
     let queryBooks: string;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/4704.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4704.int.test.ts
@@ -22,13 +22,13 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import Neo4jGraphQL from "../../../src/classes/Neo4jGraphQL";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4704", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
     let episodeNr;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -157,7 +157,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [Movie, Series, Actor, Episode]);
+        await cleanNodesUsingSession(session, [Movie, Series, Actor, Episode]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/487.int.test.ts
+++ b/packages/graphql/tests/integration/issues/487.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/487", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/488.int.test.ts
+++ b/packages/graphql/tests/integration/issues/488.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/488", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/505.int.test.ts
+++ b/packages/graphql/tests/integration/issues/505.int.test.ts
@@ -21,13 +21,13 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/505", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const userType = new UniqueType("User");
     const workspaceType = new UniqueType("Workspace");
@@ -98,7 +98,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/526.int.test.ts
+++ b/packages/graphql/tests/integration/issues/526.int.test.ts
@@ -20,12 +20,12 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/526 - Int Argument on Custom Query Converted to Float", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type Movie {
             title: String
@@ -52,7 +52,7 @@ describe("https://github.com/neo4j/graphql/issues/526 - Int Argument on Custom Q
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/issues/549.int.test.ts
+++ b/packages/graphql/tests/integration/issues/549.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/549", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/556.int.test.ts
+++ b/packages/graphql/tests/integration/issues/556.int.test.ts
@@ -20,12 +20,12 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/556 - Input Object type ArticleCreateInput must define one or more fields", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type User556 {
             name: String!
@@ -38,7 +38,7 @@ describe("https://github.com/neo4j/graphql/issues/556 - Input Object type Articl
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/560.int.test.ts
@@ -21,17 +21,17 @@ import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/560", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/572.int.test.ts
+++ b/packages/graphql/tests/integration/issues/572.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("Revert https://github.com/neo4j/graphql/pull/572", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/579.int.test.ts
+++ b/packages/graphql/tests/integration/issues/579.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("579", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/582.int.test.ts
+++ b/packages/graphql/tests/integration/issues/582.int.test.ts
@@ -21,14 +21,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/582", () => {
     let driver: Driver;
     let type: UniqueType;
     let typeDefs: string;
     let query: string;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
         type = new UniqueType("Entity");
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/582", () => {
             }
         `;
 
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/issues/583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/583.int.test.ts
@@ -23,14 +23,14 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("583", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let schema: GraphQLSchema;
 
     const typeDefs = gql`
@@ -85,7 +85,7 @@ describe("583", () => {
     };
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/issues/594.int.test.ts
+++ b/packages/graphql/tests/integration/issues/594.int.test.ts
@@ -20,13 +20,13 @@
 import { gql } from "graphql-tag";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src";
 
 describe("https://github.com/neo4j/graphql/issues/594", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/594", () => {
     const typePerson = new UniqueType("Person");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             type ${typeMovie.name} {

--- a/packages/graphql/tests/integration/issues/619.int.test.ts
+++ b/packages/graphql/tests/integration/issues/619.int.test.ts
@@ -20,18 +20,18 @@
 import { gql } from "graphql-tag";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { getQuerySource } from "../../utils/get-query-source";
 
 describe("https://github.com/neo4j/graphql/issues/619", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             type FooIsARandomName {

--- a/packages/graphql/tests/integration/issues/620.int.test.ts
+++ b/packages/graphql/tests/integration/issues/620.int.test.ts
@@ -20,13 +20,13 @@
 import { gql } from "graphql-tag";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/620", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/620", () => {
     const typeBusiness = new UniqueType("Business");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/630.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -29,10 +29,10 @@ describe("https://github.com/neo4j/graphql/issues/630", () => {
     const typeMovie = new UniqueType("Movie");
     const typeActor = new UniqueType("Actor");
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/832.int.test.ts
+++ b/packages/graphql/tests/integration/issues/832.int.test.ts
@@ -20,13 +20,13 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("https://github.com/neo4j/graphql/issues/832", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/847.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
@@ -31,10 +31,10 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/894.int.test.ts
+++ b/packages/graphql/tests/integration/issues/894.int.test.ts
@@ -21,7 +21,7 @@ import type { DocumentNode, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
@@ -31,7 +31,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
     const testOrganization = new UniqueType("Organization");
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     async function graphqlQuery(query: DocumentNode) {
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/915.int.test.ts
+++ b/packages/graphql/tests/integration/issues/915.int.test.ts
@@ -23,7 +23,7 @@ import { generate } from "randomstring";
 import type { ValueNode } from "graphql";
 import { graphql, GraphQLError, GraphQLScalarType, Kind } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { delay } from "../../../src/utils/utils";
 import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
@@ -79,12 +79,12 @@ const PositiveInt = new GraphQLScalarType({
 
 describe("https://github.com/neo4j/graphql/issues/915", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let databaseName: string;
     let MULTIDB_SUPPORT = true;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         databaseName = generate({ readable: true, charset: "alphabetic" });

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session, Integer } from "neo4j-driver";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src";
@@ -32,11 +32,11 @@ describe("https://github.com/neo4j/graphql/issues/923", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/976.int.test.ts
+++ b/packages/graphql/tests/integration/issues/976.int.test.ts
@@ -21,7 +21,7 @@ import type { DocumentNode, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Integer, Session } from "neo4j-driver";
 import { gql } from "graphql-tag";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { getQuerySource } from "../../utils/get-query-source";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
@@ -31,7 +31,7 @@ describe("https://github.com/neo4j/graphql/issues/976", () => {
     const testConcept = new UniqueType("Concept");
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     async function graphqlQuery(query: DocumentNode) {
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/976", () => {
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/988.int.test.ts
+++ b/packages/graphql/tests/integration/issues/988.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/988", () => {
     const seriesType = new UniqueType("Series");
@@ -31,11 +31,11 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
 
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/bind-any.int.test.ts
+++ b/packages/graphql/tests/integration/issues/bind-any.int.test.ts
@@ -19,14 +19,14 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql, GraphQLError } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let User: UniqueType;
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let Group: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [User, Organization, Group]);
+        await cleanNodesUsingSession(session, [User, Organization, Group]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -19,13 +19,13 @@
 
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("context-variable-not-always-resolved-on-cypher-queries", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     let neoSchema: Neo4jGraphQL;
@@ -35,7 +35,7 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
     const resourceType = new UniqueType("ResourceType");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `#graphql

--- a/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
+++ b/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("587: Dates in edges can cause wrongly generated cypher", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
+++ b/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
@@ -20,13 +20,13 @@
 import { gql } from "graphql-tag";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("Empty fields on unions due to escaped labels", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
@@ -35,7 +35,7 @@ describe("Empty fields on unions due to escaped labels", () => {
     const typeUser = new UniqueType("User");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = gql`
             union Content = Blog | Post

--- a/packages/graphql/tests/integration/issues/interface-post-multi-create.ts
+++ b/packages/graphql/tests/integration/issues/interface-post-multi-create.ts
@@ -20,13 +20,13 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("Projecting interface relationships following create of multiple nodes", () => {
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
@@ -43,7 +43,7 @@ describe("Projecting interface relationships following create of multiple nodes"
     }
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
+++ b/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src";
 import { UniqueType } from "../../utils/graphql-types";
 import { createBearerToken } from "../../utils/create-bearer-token";
@@ -28,11 +28,11 @@ import { createBearerToken } from "../../utils/create-bearer-token";
 describe("Label cypher injection", () => {
     let schema: GraphQLSchema;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/issues/only-info.int.test.ts
+++ b/packages/graphql/tests/integration/issues/only-info.int.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("https://github.com/neo4j/graphql/issues/567", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/limit.int.test.ts
+++ b/packages/graphql/tests/integration/limit.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src";
 import { UniqueType } from "../utils/graphql-types";
 
@@ -29,12 +29,12 @@ describe("https://github.com/neo4j/graphql/issues/1628", () => {
     const titleType = new UniqueType("Title");
 
     let schema: GraphQLSchema;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let driver: Driver;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/mass-delete.int.test.ts
+++ b/packages/graphql/tests/integration/mass-delete.int.test.ts
@@ -20,16 +20,16 @@
 import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import { cleanNodes } from "../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../utils/clean-nodes";
 import { Neo4jGraphQL } from "../../src";
 import { UniqueType } from "../utils/graphql-types";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { gql } from "graphql-tag";
 
 describe("Mass Delete", () => {
     let driver: Driver;
     let session: Session;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     let typeDefs: DocumentNode;
@@ -37,7 +37,7 @@ describe("Mass Delete", () => {
     let movieType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -78,7 +78,7 @@ describe("Mass Delete", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [movieType, personType]);
+        await cleanNodesUsingSession(session, [movieType, personType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/math.int.test.ts
+++ b/packages/graphql/tests/integration/math.int.test.ts
@@ -24,17 +24,17 @@ import { int } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Mathematical operations tests", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     const largestSafeSigned32BitInteger = Number(2 ** 31 - 1);
     const largestSafeSigned64BitBigInt = BigInt(2 ** 63 - 1).toString();
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/middleware.int.test.ts
+++ b/packages/graphql/tests/integration/middleware.int.test.ts
@@ -22,14 +22,14 @@ import { graphql } from "graphql";
 import { applyMiddleware } from "graphql-middleware";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("Middleware Resolvers", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/multi-database.int.test.ts
+++ b/packages/graphql/tests/integration/multi-database.int.test.ts
@@ -20,13 +20,13 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { isMultiDbUnsupportedError } from "../utils/is-multi-db-unsupported-error";
 
 describe("multi-database", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const id = generate({
         charset: "alphabetic",
     });
@@ -34,7 +34,7 @@ describe("multi-database", () => {
     const dbName = "non-default-db-name";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         try {

--- a/packages/graphql/tests/integration/neo4j.ts
+++ b/packages/graphql/tests/integration/neo4j.ts
@@ -23,7 +23,7 @@ import type { Neo4jGraphQLContext } from "../../src";
 
 const INT_TEST_DB_NAME = "neo4jgraphqlinttestdatabase";
 
-class Neo4j {
+class Neo4jHelper {
     private driver: neo4j.Driver | undefined;
     private hasIntegrationTestDb: boolean;
 
@@ -109,4 +109,4 @@ class Neo4j {
     }
 }
 
-export default Neo4j;
+export default Neo4jHelper;

--- a/packages/graphql/tests/integration/nested-unions.int.test.ts
+++ b/packages/graphql/tests/integration/nested-unions.int.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 
 describe("Nested unions", () => {
@@ -52,10 +52,10 @@ describe("Nested unions", () => {
     `;
 
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
@@ -22,13 +22,13 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - connect with and without `overwrite` argument", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let typeDefs: DocumentNode;
     let neoSchema: Neo4jGraphQL;
 
@@ -36,7 +36,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
     let typeMovie: UniqueType;
 
     beforeEach(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -100,7 +100,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
         });
 
         afterEach(async () => {
-            await cleanNodes(session, [typeActor, typeMovie]);
+            await cleanNodesUsingSession(session, [typeActor, typeMovie]);
             await session.close();
         });
 
@@ -347,7 +347,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
         });
 
         afterEach(async () => {
-            await cleanNodes(session, [typeActor, typeMovie]);
+            await cleanNodesUsingSession(session, [typeActor, typeMovie]);
             await session.close();
         });
 
@@ -1413,7 +1413,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
         });
 
         afterEach(async () => {
-            await cleanNodes(session, [typeActor, typeMovie]);
+            await cleanNodesUsingSession(session, [typeActor, typeMovie]);
             await session.close();
         });
 

--- a/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - connect", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - create", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - delete", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - disconnect", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/error-if-missing-relationship-properties.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/error-if-missing-relationship-properties.int.test.ts
@@ -21,14 +21,14 @@ import gql from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { getErrorAsync } from "../../utils/get-error";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Throw error if missing @relationshipProperties", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
@@ -24,14 +24,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import { runCypher } from "../../utils/run-cypher";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - read", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
@@ -44,7 +44,7 @@ describe("Relationship properties - read", () => {
     const actorD = `d${generate({ charset: "alphabetic" })}`;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -85,7 +85,7 @@ describe("Relationship properties - read", () => {
 
     afterEach(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [typeMovie, typeActor]);
+        await cleanNodesUsingSession(session, [typeMovie, typeActor]);
     });
 
     test("Projecting node and relationship properties with no arguments", async () => {

--- a/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
@@ -22,11 +22,11 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Relationship properties - update", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const typeDefs = gql`
         type Movie {
             title: String!
@@ -48,7 +48,7 @@ describe("Relationship properties - update", () => {
     const actor3 = generate({ charset: "alphabetic" });
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import type { JWKSMock } from "mock-jwks";
 import createJWKSMock from "mock-jwks";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import type { Neo4jGraphQLAuthenticationError } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
@@ -29,7 +29,7 @@ import { UniqueType } from "../../utils/graphql-types";
 describe("Global authentication - Authorization JWKS plugin", () => {
     let jwksMock: JWKSMock;
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const testMovie = new UniqueType("Movie");
 
@@ -49,7 +49,7 @@ describe("Global authentication - Authorization JWKS plugin", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import type { Neo4jGraphQLAuthenticationError } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
@@ -27,7 +27,7 @@ import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("Global authentication - Authorization JWT plugin", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     const secret = "secret";
     const testMovie = new UniqueType("Movie");
@@ -48,7 +48,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
     `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("integration/rfcs/query-limits", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
@@ -21,15 +21,15 @@ import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("integration/rfc/003", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/root-connections.int.test.ts
+++ b/packages/graphql/tests/integration/root-connections.int.test.ts
@@ -20,13 +20,13 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
 
 describe("root-connections", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
 
     const pilotType = new UniqueType("Pilot");
@@ -46,7 +46,7 @@ describe("root-connections", () => {
         `;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         neoSchema = new Neo4jGraphQL({ typeDefs, driver });
         await neoSchema.checkNeo4jCompat();

--- a/packages/graphql/tests/integration/scalars.int.test.ts
+++ b/packages/graphql/tests/integration/scalars.int.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import { graphql, GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
 
@@ -53,10 +53,10 @@ const GraphQLUpperCaseString = new GraphQLScalarType({
 
 describe("scalars", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/sort.int.test.ts
+++ b/packages/graphql/tests/integration/sort.int.test.ts
@@ -24,13 +24,13 @@ import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("sort", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let schema: GraphQLSchema;
     let session: Session;
 
@@ -122,7 +122,7 @@ describe("sort", () => {
     ] as const;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const session2 = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
@@ -20,16 +20,16 @@
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/allow", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let plugin: TestSubscriptionsEngine;
     const secret = "secret";
@@ -39,7 +39,7 @@ describe("auth/allow", () => {
     let commentType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -57,7 +57,7 @@ describe("auth/allow", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
@@ -21,13 +21,13 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Subscriptions connect with create", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let plugin: TestSubscriptionsEngine;
 
@@ -38,7 +38,7 @@ describe("Subscriptions connect with create", () => {
     let typeInfluencer: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         plugin = new TestSubscriptionsEngine();
     });
@@ -107,7 +107,7 @@ describe("Subscriptions connect with create", () => {
 
     afterEach(async () => {
         const session = await neo4j.getSession();
-        await cleanNodes(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/create/connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/connect-or-create.int.test.ts
@@ -26,11 +26,11 @@ import type { Neo4jGraphQLSubscriptionsEngine } from "../../../../src/types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { getQuerySource } from "../../../utils/get-query-source";
 import { UniqueType } from "../../../utils/graphql-types";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Create -> ConnectOrCreate", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let typeDefs: DocumentNode;
     let plugin: Neo4jGraphQLSubscriptionsEngine;
@@ -41,7 +41,7 @@ describe("Create -> ConnectOrCreate", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/subscriptions/create/create-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create-authorization.int.test.ts
@@ -20,18 +20,18 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("auth/bind", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
@@ -23,11 +23,11 @@ import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Subscriptions create", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let plugin: TestSubscriptionsEngine;
 
@@ -35,7 +35,7 @@ describe("Subscriptions create", () => {
     const typeMovie = new UniqueType("Movie");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         plugin = new TestSubscriptionsEngine();
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
@@ -25,18 +25,18 @@ import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("interface relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let subscriptionsPlugin: TestSubscriptionsEngine;
     let typeDefs: DocumentNode;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
 
         typeDefs = gql`

--- a/packages/graphql/tests/integration/subscriptions/delete/delete-auth.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete-auth.int.test.ts
@@ -23,16 +23,16 @@ import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 
 describe("Subscriptions delete", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let plugin: TestSubscriptionsEngine;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
@@ -23,11 +23,11 @@ import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Subscriptions delete", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
     let plugin: TestSubscriptionsEngine;
@@ -36,7 +36,7 @@ describe("Subscriptions delete", () => {
     let typeMovie: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
@@ -22,12 +22,12 @@ import { graphql } from "graphql";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodes } from "../../../utils/clean-nodes";
-import Neo4j from "../../neo4j";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import Neo4jHelper from "../../neo4j";
 
 describe("Delete using top level aggregate where - subscriptions enabled", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let plugin: TestSubscriptionsEngine;
@@ -47,7 +47,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
     const content5 = "Some more content";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -92,7 +92,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
@@ -23,19 +23,19 @@ import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import type { EventMeta } from "../../../src/types";
 
 describe("Subscriptions Single Instance Plugin", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let plugin: Neo4jGraphQLSubscriptionsDefaultEngine;
 
     const typeMovie = new UniqueType("Movie");
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         plugin = new Neo4jGraphQLSubscriptionsDefaultEngine();
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -23,14 +23,14 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodes } from "../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Subscriptions to spatial types", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
     let plugin: TestSubscriptionsEngine;
@@ -38,7 +38,7 @@ describe("Subscriptions to spatial types", () => {
     const typeMovie = new UniqueType("Movie");
 
     beforeEach(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         plugin = new TestSubscriptionsEngine();
         const typeDefs = gql`
@@ -60,7 +60,7 @@ describe("Subscriptions to spatial types", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [typeMovie]);
+        await cleanNodesUsingSession(session, [typeMovie]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
@@ -23,12 +23,12 @@ import { graphql } from "graphql";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodes } from "../../../utils/clean-nodes";
-import Neo4j from "../../neo4j";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import Neo4jHelper from "../../neo4j";
 
 describe("Delete using top level aggregate where - subscriptions enabled", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let neoSchema: Neo4jGraphQL;
     let session: Session;
     let plugin: TestSubscriptionsEngine;
@@ -49,7 +49,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
     const updatedContent = "This has been updated;";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -95,7 +95,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [userType, postType]);
+        await cleanNodesUsingSession(session, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
@@ -20,15 +20,15 @@
 import { gql } from "graphql-tag";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import { cleanNodes } from "../../../utils/clean-nodes";
+import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { Neo4jGraphQL } from "../../../../src";
 import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import Neo4j from "../../neo4j";
+import Neo4jHelper from "../../neo4j";
 
 describe("Subscriptions update", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
     let plugin: TestSubscriptionsEngine;
@@ -37,7 +37,7 @@ describe("Subscriptions update", () => {
     let typeMovie: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 
@@ -72,7 +72,7 @@ describe("Subscriptions update", () => {
     });
 
     afterEach(async () => {
-        await cleanNodes(session, [typeActor, typeMovie]);
+        await cleanNodesUsingSession(session, [typeActor, typeMovie]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/teardown.ts
+++ b/packages/graphql/tests/integration/teardown.ts
@@ -23,10 +23,10 @@
  *   `ts-node tests/integration/teardown.ts`
  */
 
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 const teardown = async () => {
-    const neo4j = new Neo4j();
+    const neo4j = new Neo4jHelper();
     const driver = await neo4j.getDriver();
     const session = await neo4j.getSession();
 

--- a/packages/graphql/tests/integration/types/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/types/bigint.int.test.ts
@@ -22,14 +22,14 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("BigInt", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/date.int.test.ts
+++ b/packages/graphql/tests/integration/types/date.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import neo4jDriver from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("Date", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/datetime.int.test.ts
@@ -21,16 +21,16 @@ import type { Driver } from "neo4j-driver";
 import neo4jDriver from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 
 describe("DateTime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/duration.int.test.ts
+++ b/packages/graphql/tests/integration/types/duration.int.test.ts
@@ -21,16 +21,16 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { parseDuration } from "../../../src/graphql/scalars/Duration";
 
 describe("Duration", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/float.int.test.ts
+++ b/packages/graphql/tests/integration/types/float.int.test.ts
@@ -21,17 +21,17 @@ import type { Driver } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 
 describe("Float", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const imdbRatingFloat = 4.0;
     const imdbRatingInt = 4;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/localdatetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localdatetime.int.test.ts
@@ -24,14 +24,14 @@ import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { parseLocalDateTime } from "../../../src/graphql/scalars/LocalDateTime";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("LocalDateTime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/localtime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localtime.int.test.ts
@@ -24,14 +24,14 @@ import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { parseLocalTime } from "../../../src/graphql/scalars/LocalTime";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("LocalTime", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
@@ -22,16 +22,16 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("CartesianPoint", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
             type Part {

--- a/packages/graphql/tests/integration/types/point.int.test.ts
+++ b/packages/graphql/tests/integration/types/point.int.test.ts
@@ -22,16 +22,16 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Point", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
             type Photograph {

--- a/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
@@ -22,16 +22,16 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("[CartesianPoint]", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
             type Part {

--- a/packages/graphql/tests/integration/types/points.int.test.ts
+++ b/packages/graphql/tests/integration/types/points.int.test.ts
@@ -22,16 +22,16 @@ import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("[Point]", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
         const typeDefs = `
             type Route {

--- a/packages/graphql/tests/integration/types/time.int.test.ts
+++ b/packages/graphql/tests/integration/types/time.int.test.ts
@@ -24,14 +24,14 @@ import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { parseTime } from "../../../src/graphql/scalars/Time";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("Time", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/undirected-relationships.test.ts
+++ b/packages/graphql/tests/integration/undirected-relationships.test.ts
@@ -20,18 +20,18 @@
 import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { getQuerySource } from "../utils/get-query-source";
 import { UniqueType } from "../utils/graphql-types";
 
 describe("undirected relationships", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     let session: Session;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/unions.int.test.ts
+++ b/packages/graphql/tests/integration/unions.int.test.ts
@@ -22,20 +22,20 @@ import type { Driver } from "neo4j-driver";
 import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
 import { createBearerToken } from "../utils/create-bearer-token";
 
 describe("unions", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     let GenreType: UniqueType;
     let MovieType: UniqueType;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
@@ -20,7 +20,7 @@
 import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { generate } from "randomstring";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
 import { createBearerToken } from "../../utils/create-bearer-token";
@@ -32,11 +32,11 @@ import { createBearerToken } from "../../utils/create-bearer-token";
 
 describe("unwind-create field-level auth rules", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
     const secret = "secret";
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
@@ -23,14 +23,14 @@ import { int } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { UniqueType } from "../../utils/graphql-types";
-import Neo4j from "../neo4j";
+import Neo4jHelper from "../neo4j";
 
 describe("unwind-create", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/integration/update.int.test.ts
+++ b/packages/graphql/tests/integration/update.int.test.ts
@@ -22,14 +22,14 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src/classes";
-import Neo4j from "./neo4j";
+import Neo4jHelper from "./neo4j";
 
 describe("update", () => {
     let driver: Driver;
-    let neo4j: Neo4j;
+    let neo4j: Neo4jHelper;
 
     beforeAll(async () => {
-        neo4j = new Neo4j();
+        neo4j = new Neo4jHelper();
         driver = await neo4j.getDriver();
     });
 

--- a/packages/graphql/tests/tck/utils/tck-test-utils.ts
+++ b/packages/graphql/tests/tck/utils/tck-test-utils.ts
@@ -23,7 +23,7 @@ import { Neo4jError } from "neo4j-driver";
 import type { Neo4jGraphQL } from "../../../src";
 import { DriverBuilder } from "../../utils/builders/driver-builder";
 import { Neo4jDatabaseInfo } from "../../../src/classes/Neo4jDatabaseInfo";
-import Neo4j from "../../integration/neo4j";
+import Neo4jHelper from "../../integration/neo4j";
 
 export function setTestEnvVars(envVars: string | undefined): void {
     if (envVars) {
@@ -108,7 +108,7 @@ export async function translateQuery(
     const [cypher, params] = driverBuilder.runFunction.calls[0] as [string, Record<string, any>];
 
     if (process.env.VERIFY_TCK) {
-        const neo4j = new Neo4j();
+        const neo4j = new Neo4jHelper();
         const session = await neo4j.getSession();
         try {
             await session.run(`EXPLAIN ${cypher}`, params);


### PR DESCRIPTION
We should switch over to `cleanNodes` passing in a driver instead of a session.