### PR TITLE
refactor: replace usage of cleanNodesUsingSession with cleanNodes

### DIFF
--- a/packages/graphql/tests/e2e/subscriptions/authorization/authentication.int.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/authorization/authentication.int.test.ts
@@ -22,7 +22,7 @@ import type { Response } from "supertest";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
@@ -746,8 +746,7 @@ describe("Subscription authentication", () => {
 
         afterEach(async () => {
             await wsClient.close();
-            const session = driver.session();
-            await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+            await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
             await server.close();
         });
 
@@ -5036,8 +5035,7 @@ describe("Subscription authentication", () => {
 
         afterEach(async () => {
             await wsClient.close();
-            const session = driver.session();
-            await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+            await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
             await server.close();
         });
 

--- a/packages/graphql/tests/e2e/subscriptions/create-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/create-relationship.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -124,8 +124,7 @@ describe("Create Relationship Subscription", () => {
         await wsClient.close();
         await wsClient2.close();
 
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-complex.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-complex.e2e.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -118,8 +118,7 @@ describe("Delete Subscriptions - with interfaces, unions and nested operations",
         await wsClient.close();
         await wsClient2.close();
 
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-additional-labels.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-additional-labels.e2e.test.ts
@@ -20,13 +20,13 @@
 import type { Driver } from "neo4j-driver";
 import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
-import { WebSocketTestClient } from "../setup/ws-client";
 import Neo4j from "../setup/neo4j";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
-import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
+import { WebSocketTestClient } from "../setup/ws-client";
 
 describe("Delete Subscriptions when only nodes are targeted - when nodes employ @node directive to configure db label and additionalLabels", () => {
     let neo4j: Neo4j;
@@ -115,8 +115,7 @@ describe("Delete Subscriptions when only nodes are targeted - when nodes employ 
         await wsClient.close();
         await wsClient2.close();
 
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeFilm, typeSeries, typeProduction]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeFilm, typeSeries, typeProduction]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-with-relationships.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete-with-relationships.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -119,8 +119,7 @@ describe("Delete Subscriptions when relationships are targeted- with interfaces,
         await wsClient.close();
         await wsClient2.close();
 
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship-via-delete.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -118,8 +118,7 @@ describe("Delete Subscriptions when only nodes are targeted - with interfaces, u
         await wsClient.close();
         await wsClient2.close();
 
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/delete-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/delete-relationship.e2e.test.ts
@@ -22,7 +22,7 @@ import supertest from "supertest";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../src/utils/utils";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import type { TestGraphQLServer } from "../setup/apollo-server";
 import { ApolloTestServer } from "../setup/apollo-server";
@@ -126,7 +126,7 @@ describe("Delete Relationship Subscription", () => {
         await wsClient.close();
         await wsClient2.close();
 
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await session.close();

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship-same-type.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship-same-type.e2e.test.ts
@@ -23,7 +23,7 @@ import type { Neo4jGraphQLSubscriptionsEngine } from "../../../../src";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../../src/utils/utils";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
@@ -109,8 +109,7 @@ describe.each([
         await wsClient.close();
         await wsClient2.close();
         subscriptionEngine.close();
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typePerson, typeArticle]);
+        await cleanNodes(driver, [typePerson, typeArticle]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship.e2e.test.ts
+++ b/packages/graphql/tests/e2e/subscriptions/filtering/create-relationship.e2e.test.ts
@@ -23,7 +23,7 @@ import type { Neo4jGraphQLSubscriptionsEngine } from "../../../../src";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import { delay } from "../../../../src/utils/utils";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import type { TestGraphQLServer } from "../../setup/apollo-server";
 import { ApolloTestServer } from "../../setup/apollo-server";
@@ -142,8 +142,7 @@ describe.each([
         await wsClient.close();
         await wsClient2.close();
         subscriptionEngine.close();
-        const session = driver.session();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
 
         await server.close();
         await driver.close();

--- a/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import Neo4jHelper from "../../neo4j";
 
 describe("Nested within AND/OR", () => {
     let driver: Driver;
@@ -86,7 +86,7 @@ describe("Nested within AND/OR", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../../../../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
+import { cleanNodes } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
+import Neo4jHelper from "../../../../neo4j";
 
 describe("Delete using top level aggregate where", () => {
     let driver: Driver;
@@ -86,7 +86,7 @@ describe("Delete using top level aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
+import { cleanNodes } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
 import Neo4jHelper from "../../../../neo4j";
 
@@ -89,7 +89,7 @@ describe("Connect using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 
@@ -425,7 +425,7 @@ describe("Connect UNIONs using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType, specialUserType]);
+        await cleanNodes(driver, [userType, postType, specialUserType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
+import { cleanNodes } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
 import Neo4jHelper from "../../../../neo4j";
 
@@ -83,7 +83,7 @@ describe("Disconnect using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 
@@ -344,7 +344,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType, specialUserType]);
+        await cleanNodes(driver, [userType, postType, specialUserType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../../../../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
+import { cleanNodes } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
+import Neo4jHelper from "../../../../neo4j";
 
 describe("Delete using top level aggregate where", () => {
     let driver: Driver;
@@ -88,7 +88,7 @@ describe("Delete using top level aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../../../utils/clean-nodes";
+import { cleanNodes } from "../../../../../utils/clean-nodes";
 import { UniqueType } from "../../../../../utils/graphql-types";
 import Neo4jHelper from "../../../../neo4j";
 
@@ -89,7 +89,7 @@ describe("Update using aggregate where", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/delete-interface.int.test.ts
+++ b/packages/graphql/tests/integration/delete-interface.int.test.ts
@@ -23,7 +23,7 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src";
-import { cleanNodesUsingSession } from "../utils/clean-nodes";
+import { cleanNodes } from "../utils/clean-nodes";
 import { UniqueType } from "../utils/graphql-types";
 import Neo4jHelper from "./neo4j";
 
@@ -172,7 +172,7 @@ describe("delete interface relationships", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [episodeType, movieType, seriesType, actorType]);
+        await cleanNodes(driver, [episodeType, movieType, seriesType, actorType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/delete-union.int.test.ts
+++ b/packages/graphql/tests/integration/delete-union.int.test.ts
@@ -23,7 +23,7 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../src";
-import { cleanNodesUsingSession } from "../utils/clean-nodes";
+import { cleanNodes } from "../utils/clean-nodes";
 import { UniqueType } from "../utils/graphql-types";
 import Neo4jHelper from "./neo4j";
 
@@ -169,7 +169,7 @@ describe("delete union relationships", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [episodeType, movieType, seriesType, actorType]);
+        await cleanNodes(driver, [episodeType, movieType, seriesType, actorType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/alias/connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/connect-or-create.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../../src/classes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
-import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 
 describe("@alias directive", () => {
     let driver: Driver;
@@ -64,7 +64,7 @@ describe("@alias directive", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [typeMovie, typeActor]);
+        await cleanNodes(driver, [typeMovie, typeActor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/alias/nodes.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/nodes.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
@@ -69,7 +69,7 @@ describe("@alias directive", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [typeMovie, typeDirector]);
+        await cleanNodes(driver, [typeMovie, typeDirector]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/alias/unions.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/unions.int.test.ts
@@ -21,7 +21,7 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
@@ -78,7 +78,7 @@ describe("@alias directive", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [typeMovie, typeSeries, typeActor]);
+        await cleanNodes(driver, [typeMovie, typeSeries, typeActor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/allow.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/allow.int.test.ts
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
-import { UniqueType } from "../../../utils/graphql-types";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
+import { UniqueType } from "../../../utils/graphql-types";
+import Neo4jHelper from "../../neo4j";
 
 describe("auth/allow", () => {
     let driver: Driver;
@@ -54,7 +54,7 @@ describe("auth/allow", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
@@ -17,18 +17,18 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
 import { IncomingMessage } from "http";
+import type { Driver } from "neo4j-driver";
 import { Socket } from "net";
 import { generate } from "randomstring";
-import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { runCypher } from "../../../utils/run-cypher";
-import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
+import { runCypher } from "../../../utils/run-cypher";
+import Neo4jHelper from "../../neo4j";
 
 describe("auth/is-authenticated", () => {
     let driver: Driver;
@@ -4055,8 +4055,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [Product]);
+                await cleanNodes(driver, [Product]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4139,8 +4138,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User]);
+                await cleanNodes(driver, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4227,8 +4225,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User]);
+                await cleanNodes(driver, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4325,8 +4322,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User, Post]);
+                await cleanNodes(driver, [User, Post]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4448,8 +4444,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User, Post]);
+                await cleanNodes(driver, [User, Post]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4571,8 +4566,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User, Post]);
+                await cleanNodes(driver, [User, Post]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4684,8 +4678,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User]);
+                await cleanNodes(driver, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {
@@ -4771,8 +4764,7 @@ describe("auth/is-authenticated", () => {
             });
 
             afterEach(async () => {
-                const session = driver.session();
-                await cleanNodesUsingSession(session, [User]);
+                await cleanNodes(driver, [User]);
             });
 
             test("should throw if not authenticated type definition", async () => {

--- a/packages/graphql/tests/integration/directives/authorization/roles.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/roles.int.test.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import { runCypher } from "../../../utils/run-cypher";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
-import { createBearerToken } from "../../../utils/create-bearer-token";
+import Neo4jHelper from "../../neo4j";
 
 describe("auth/roles", () => {
     let driver: Driver;
@@ -65,8 +65,7 @@ describe("auth/roles", () => {
     });
 
     afterEach(async () => {
-        const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [typeProduct, typeUser]);
+        await cleanNodes(driver, [typeProduct, typeUser]);
     });
 
     describe("read", () => {

--- a/packages/graphql/tests/integration/directives/customResolver.int.test.ts
+++ b/packages/graphql/tests/integration/directives/customResolver.int.test.ts
@@ -23,7 +23,7 @@ import gql from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
 import { INVALID_REQUIRED_FIELD_ERROR } from "../../../src/schema/get-custom-resolver-meta";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -386,7 +386,7 @@ describe("Related Fields", () => {
     afterEach(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Publication, Author, Book, Journal, User, Address, City, State]);
+            await cleanNodes(driver, [Publication, Author, Book, Journal, User, Address, City, State]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-database-name.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-database-name.int.test.ts
@@ -20,12 +20,12 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4jHelper from "../../neo4j";
-import { Neo4jGraphQL } from "../../../../src";
-import { UniqueType } from "../../../utils/graphql-types";
-import { toGlobalId } from "../../../../src/utils/global-ids";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { generate } from "randomstring";
+import { Neo4jGraphQL } from "../../../../src";
+import { toGlobalId } from "../../../../src/utils/global-ids";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
+import Neo4jHelper from "../../neo4j";
 
 describe("RelayId projection with different database name", () => {
     let schema: GraphQLSchema;
@@ -93,7 +93,7 @@ describe("RelayId projection with different database name", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Genre, Actor]);
+        await cleanNodes(driver, [Movie, Genre, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-field-alias.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-field-alias.int.test.ts
@@ -20,12 +20,12 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4jHelper from "../../neo4j";
-import { Neo4jGraphQL } from "../../../../src";
-import { UniqueType } from "../../../utils/graphql-types";
-import { toGlobalId } from "../../../../src/utils/global-ids";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { generate } from "randomstring";
+import { Neo4jGraphQL } from "../../../../src";
+import { toGlobalId } from "../../../../src/utils/global-ids";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
+import Neo4jHelper from "../../neo4j";
 
 // used to confirm the issue: https://github.com/neo4j/graphql/issues/4158
 describe("RelayId projection with GraphQL field alias", () => {
@@ -94,7 +94,7 @@ describe("RelayId projection with GraphQL field alias", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Genre, Actor]);
+        await cleanNodes(driver, [Movie, Genre, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection.int.test.ts
@@ -20,12 +20,12 @@
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import Neo4jHelper from "../../neo4j";
-import { Neo4jGraphQL } from "../../../../src";
-import { UniqueType } from "../../../utils/graphql-types";
-import { toGlobalId } from "../../../../src/utils/global-ids";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { generate } from "randomstring";
+import { Neo4jGraphQL } from "../../../../src";
+import { toGlobalId } from "../../../../src/utils/global-ids";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
+import Neo4jHelper from "../../neo4j";
 
 describe("RelayId projection", () => {
     let schema: GraphQLSchema;
@@ -93,7 +93,7 @@ describe("RelayId projection", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Genre, Actor]);
+        await cleanNodes(driver, [Movie, Genre, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
@@ -98,7 +98,7 @@ describe("Top-level interface query fields with authorization", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series]);
+        await cleanNodes(driver, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/aggregation-interfaces-top-level.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
@@ -91,7 +91,7 @@ describe("Top-level interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series]);
+        await cleanNodes(driver, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level-with-auth.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
@@ -130,7 +130,7 @@ describe("Field-level filter interface query fields with authorization", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series]);
+        await cleanNodes(driver, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-field-level.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
@@ -123,7 +123,7 @@ describe("Field-level filter interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series]);
+        await cleanNodes(driver, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLError, GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
@@ -130,7 +130,7 @@ describe("Top-level filter interface query fields with authorization", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series]);
+        await cleanNodes(driver, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/aggegations/filter-aggregation-interfaces-top-level.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
@@ -91,7 +91,7 @@ describe("Top-level filter interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series]);
+        await cleanNodes(driver, [Movie, Series]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/interface-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/interface-filtering.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -114,7 +114,7 @@ describe("Interface filtering", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series, Actor]);
+        await cleanNodes(driver, [Movie, Series, Actor]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/interfaces-top-level.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -112,12 +112,7 @@ describe("Top-level interface query fields", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [
-            SomeNodeType,
-            OtherNodeType,
-            MyImplementationType,
-            MyOtherImplementationType,
-        ]);
+        await cleanNodes(driver, [SomeNodeType, OtherNodeType, MyImplementationType, MyOtherImplementationType]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/typename-in-auth.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/typename-in-auth.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -100,7 +100,7 @@ describe("typename_IN with auth", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series, Cartoon]);
+        await cleanNodes(driver, [Movie, Series, Cartoon]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/typename-in.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/typename-in.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -104,7 +104,7 @@ describe("typename_IN", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series, Cartoon]);
+        await cleanNodes(driver, [Movie, Series, Cartoon]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/experimental/union-relationship-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/experimental/union-relationship-filtering.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -111,7 +111,7 @@ describe("Union filtering", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Series, Actor]);
+        await cleanNodes(driver, [Movie, Series, Actor]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-filters.int.test.ts
+++ b/packages/graphql/tests/integration/interface-relationships/declare-relationship/interface-filters.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src/classes";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
@@ -144,7 +144,7 @@ describe("interface filters of declared relationships", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Series, Actor, Episode]);
+        await cleanNodes(driver, [Movie, Series, Actor, Episode]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/1761.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1761.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/1761", () => {
     let driver: Driver;
@@ -61,7 +61,7 @@ describe("https://github.com/neo4j/graphql/issues/1761", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [myType]);
+        await cleanNodes(driver, [myType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/1782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1782.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/1782", () => {
 
     afterEach(async () => {
         try {
-            await cleanNodesUsingSession(session, [testMain, testSeries, testNameDetails, testMasterData]);
+            await cleanNodes(driver, [testMain, testSeries, testNameDetails, testMasterData]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/2250.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2250.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2250", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Actor, Movie, Person]);
+        await cleanNodes(driver, [Actor, Movie, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2267.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2267.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2267", () => {
     let driver: Driver;
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Place, Post, Story]);
+        await cleanNodes(driver, [Place, Post, Story]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2388.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2388", () => {
     let driver: Driver;
@@ -99,7 +99,7 @@ describe("https://github.com/neo4j/graphql/issues/2388", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [PartAddress, PartUsage, Part]);
+        await cleanNodes(driver, [PartAddress, PartUsage, Part]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2396.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2396.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2396", () => {
     let driver: Driver;
@@ -722,7 +722,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
     });
 
     afterAll(async () => {
-        await cleanNodesUsingSession(session, [PostalCode, Address, Mandate, Valuation, Estate]);
+        await cleanNodes(driver, [PostalCode, Address, Mandate, Valuation, Estate]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/2437.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2437.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
-import { UniqueType } from "../../utils/graphql-types";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2437", () => {
     let driver: Driver;
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Agent, Valuation]);
+        await cleanNodes(driver, [Agent, Valuation]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2474.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2474.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let driver: Driver;
@@ -119,7 +119,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [PostalCode, Address, Estate, Mandate, Valuation]);
+        await cleanNodes(driver, [PostalCode, Address, Estate, Mandate, Valuation]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2548.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2548.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/2548", () => {
 
     afterAll(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [User]);
+        await cleanNodes(driver, [User]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2560", () => {
     let driver: Driver;
@@ -38,7 +38,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [User, Person]);
+        await cleanNodes(driver, [User, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2574.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2574.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2574", () => {
     let driver: Driver;
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2574", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [A, B, D]);
+        await cleanNodes(driver, [A, B, D]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2581.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2581.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2581", () => {
     let driver: Driver;
@@ -101,7 +101,7 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Book, Author, Sales]);
+        await cleanNodes(driver, [Book, Author, Sales]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2630.int.test.ts
@@ -20,10 +20,10 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
-import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2630", () => {
     let driver: Driver;
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/2630", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Post, User]);
+        await cleanNodes(driver, [Post, User]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2652.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2652.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2652", () => {
     let driver: Driver;
@@ -63,7 +63,7 @@ describe("https://github.com/neo4j/graphql/issues/2652", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [locationType, reviewType]);
+        await cleanNodes(driver, [locationType, reviewType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2662.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2662.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2670.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2670.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [movieType, genreType, seriesType]);
+        await cleanNodes(driver, [movieType, genreType, seriesType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2708.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2708.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [movieType, genreType, seriesType]);
+        await cleanNodes(driver, [movieType, genreType, seriesType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2709.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2709.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -119,7 +119,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Netflix, Dishney]);
+        await cleanNodes(driver, [Movie, Netflix, Dishney]);
         await session.close();
     });
 
@@ -287,7 +287,7 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Netflix, Dishney, Publisher]);
+        await cleanNodes(driver, [Movie, Netflix, Dishney, Publisher]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2713.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2713.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [movieType, genreType]);
+        await cleanNodes(driver, [movieType, genreType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2766.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2766.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2766", () => {
     let driver: Driver;
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Actor]);
+        await cleanNodes(driver, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2782.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2782", () => {
     let driver: Driver;
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Product, Color, Photo]);
+        await cleanNodes(driver, [Product, Color, Photo]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2803.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2803.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -175,7 +175,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Actor]);
+        await cleanNodes(driver, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2812.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2812.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2812", () => {
     let driver: Driver;
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Actor]);
+        await cleanNodes(driver, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2820.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2820.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2820", () => {
     let driver: Driver;
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
 
     afterAll(async () => {
         session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [Movie, Actor]);
+        await cleanNodes(driver, [Movie, Actor]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/2847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2847.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2847", () => {
     let driver: Driver;
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/2847", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Actor]);
+        await cleanNodes(driver, [Movie, Actor]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2871.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2871.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2871", () => {
     let driver: Driver;
@@ -134,7 +134,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [FirstLevel, SecondLevel, ThirdLevel]);
+        await cleanNodes(driver, [FirstLevel, SecondLevel, ThirdLevel]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2889.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2889.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2889", () => {
     let driver: Driver;
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/2889", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [MyEnumHolder]);
+        await cleanNodes(driver, [MyEnumHolder]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2981.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2981.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2981", () => {
     let driver: Driver;
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
+        await cleanNodes(driver, [Book, BookTitle_EN, BookTitle_SV]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/2982.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2982.int.test.ts
@@ -20,10 +20,10 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
-import { UniqueType } from "../../utils/graphql-types";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/2982", () => {
     let driver: Driver;
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2982", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [User, Post, BlogArticle, Comment]);
+        await cleanNodes(driver, [User, Post, BlogArticle, Comment]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3027.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3027.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3027", () => {
     describe("union", () => {
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         });
 
         afterEach(async () => {
-            await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
+            await cleanNodes(driver, [Book, BookTitle_EN, BookTitle_SV]);
             await session.close();
         });
 
@@ -179,7 +179,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         });
 
         afterEach(async () => {
-            await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
+            await cleanNodes(driver, [Book, BookTitle_EN, BookTitle_SV]);
             await session.close();
         });
 

--- a/packages/graphql/tests/integration/issues/3165.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3165.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import type { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Book, BookTitle_EN, BookTitle_SV]);
+        await cleanNodes(driver, [Book, BookTitle_EN, BookTitle_SV]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3251.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3251.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3251", () => {
     let driver: Driver;
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Genre]);
+        await cleanNodes(driver, [Movie, Genre]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/326.int.test.ts
+++ b/packages/graphql/tests/integration/issues/326.int.test.ts
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/326", () => {
     let driver: Driver;
@@ -56,7 +56,7 @@ describe("https://github.com/neo4j/graphql/issues/326", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [User]);
+            await cleanNodes(driver, [User]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/387.int.test.ts
+++ b/packages/graphql/tests/integration/issues/387.int.test.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import { type Driver } from "neo4j-driver";
 import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
+import { type Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/387", () => {
     let driver: Driver;
@@ -96,7 +96,7 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Place]);
+            await cleanNodes(driver, [Place]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/3888.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3888.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3888", () => {
     let driver: Driver;
@@ -70,7 +70,7 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Post, User]);
+        await cleanNodes(driver, [Post, User]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3901.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3901.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3901", () => {
     let driver: Driver;
@@ -115,7 +115,7 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Serie, Season, User]);
+        await cleanNodes(driver, [Serie, Season, User]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3929.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3929.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3929", () => {
     let driver: Driver;
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [User, Group, Person]);
+        await cleanNodes(driver, [User, Group, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/3938.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3938.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
-import Neo4jHelper from "../neo4j";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/3938", () => {
     let driver: Driver;
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/3938", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Group, Invitee]);
+        await cleanNodes(driver, [Group, Invitee]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4056.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4056.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
 import type { GraphQLResponse } from "@apollo/server";
 import { ApolloServer } from "@apollo/server";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4056", () => {
     let driver: Driver;
@@ -162,7 +162,7 @@ describe("https://github.com/neo4j/graphql/issues/4056", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay]);
+        await cleanNodes(driver, [User, Tenant, Settings, OpeningDay]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4077.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4077.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -114,7 +114,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [User, Video, PreviewClip]);
+        await cleanNodes(driver, [User, Video, PreviewClip]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4099.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4099.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [User, Person]);
+        await cleanNodes(driver, [User, Person]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4110.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4110.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/4110", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Company, InBetween]);
+        await cleanNodes(driver, [Company, InBetween]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4115.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
     });
 
     afterAll(async () => {
-        await cleanNodesUsingSession(session, [User, Family, Person]);
+        await cleanNodes(driver, [User, Family, Person]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/4118.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4118.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
-import gql from "graphql-tag";
 import { graphql } from "graphql";
+import gql from "graphql-tag";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4118", () => {
     let driver: Driver;
@@ -161,7 +161,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, LOL]);
+        await cleanNodes(driver, [User, Tenant, Settings, OpeningDay, LOL]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4170.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4170.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
-import gql from "graphql-tag";
 import { graphql } from "graphql";
+import gql from "graphql-tag";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4170", () => {
     let driver: Driver;
@@ -141,7 +141,7 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
+        await cleanNodes(driver, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4196.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4196.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/4196", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Foo, Bar, FooBar]);
+        await cleanNodes(driver, [Foo, Bar, FooBar]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4214.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4214.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
@@ -174,7 +174,7 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
     });
 
     afterAll(async () => {
-        await cleanNodesUsingSession(session, [User, Family, Person]);
+        await cleanNodes(driver, [User, Family, Person]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/issues/4223.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4223.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
 import { graphql } from "graphql";
-import { UniqueType } from "../../utils/graphql-types";
 import gql from "graphql-tag";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4223", () => {
     let driver: Driver;
@@ -175,7 +175,7 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval, MyWorkspace]);
+        await cleanNodes(driver, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval, MyWorkspace]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4239.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4239.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import { type Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
-import gql from "graphql-tag";
 import { graphql } from "graphql";
+import gql from "graphql-tag";
+import { type Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4239", () => {
     let driver: Driver;
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Movie.name]);
+            await cleanNodes(driver, [Movie.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4268.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4268.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
-import gql from "graphql-tag";
 import { graphql } from "graphql";
+import gql from "graphql-tag";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4268", () => {
     let driver: Driver;
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Movie.name]);
+            await cleanNodes(driver, [Movie.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4287.int.test.ts
@@ -21,7 +21,7 @@ import { graphql } from "graphql";
 import gql from "graphql-tag";
 import { type Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Movie, Actor, Series]);
+            await cleanNodes(driver, [Movie, Actor, Series]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4292.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4292.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -197,7 +197,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [User.name, Group.name, Person.name, Admin.name, Contributor.name]);
+            await cleanNodes(driver, [User.name, Group.name, Person.name, Admin.name, Contributor.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4405.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4405.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
 import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4405", () => {
     let driver: Driver;
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Movie.name, Actor.name]);
+            await cleanNodes(driver, [Movie.name, Actor.name]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4429.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4429.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
-import Neo4jHelper from "../neo4j";
-import { Neo4jGraphQL } from "../../../src/classes";
 import { graphql } from "graphql";
-import { UniqueType } from "../../utils/graphql-types";
 import gql from "graphql-tag";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4429", () => {
     let driver: Driver;
@@ -170,7 +170,7 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodesUsingSession(session, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
+        await cleanNodes(driver, [User, Tenant, Settings, OpeningDay, OpeningHoursInterval]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4450.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4450.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4450", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Actor, Scene, Location]);
+            await cleanNodes(driver, [Actor, Scene, Location]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4477.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4477.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Brand, Service, Collection]);
+            await cleanNodes(driver, [Brand, Service, Collection]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4520.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4520.int.test.ts
@@ -21,7 +21,7 @@ import { graphql } from "graphql/index";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/4520", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Movie, Serie, FxEngineer, Actor]);
+            await cleanNodes(driver, [Movie, Serie, FxEngineer, Actor]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4532.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4532.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import { type Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import { default as Neo4jHelper } from "../neo4j";
 
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         afterAll(async () => {
             const session = await neo4j.getSession();
             try {
-                await cleanNodesUsingSession(session, [Inventory, Scenario]);
+                await cleanNodes(driver, [Inventory, Scenario]);
             } finally {
                 await session.close();
             }
@@ -200,7 +200,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         afterAll(async () => {
             const session = await neo4j.getSession();
             try {
-                await cleanNodesUsingSession(session, [Inventory, Image, Video]);
+                await cleanNodes(driver, [Inventory, Image, Video]);
             } finally {
                 await session.close();
             }

--- a/packages/graphql/tests/integration/issues/4583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4583.int.test.ts
@@ -20,11 +20,11 @@
 import { faker } from "@faker-js/faker";
 import { graphql } from "graphql";
 import gql from "graphql-tag";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
 import Neo4jHelper from "../../integration/neo4j";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import type { Driver, Session } from "neo4j-driver";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 
 describe("https://github.com/neo4j/graphql/issues/4583", () => {
     let driver: Driver;
@@ -149,7 +149,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Series, Actor, Episode]);
+        await cleanNodes(driver, [Movie, Series, Actor, Episode]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -20,7 +20,7 @@
 import { graphql } from "graphql";
 import { type Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import { default as Neo4jHelper } from "../neo4j";
 
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [Movie, Series, Actor]);
+            await cleanNodes(driver, [Movie, Series, Actor]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4617.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4617.int.test.ts
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/4617", () => {
     let driver: Driver;
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
     afterAll(async () => {
         const session = await neo4j.getSession();
         try {
-            await cleanNodesUsingSession(session, [User, Post]);
+            await cleanNodes(driver, [User, Post]);
         } finally {
             await session.close();
         }

--- a/packages/graphql/tests/integration/issues/4704.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4704.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import Neo4jGraphQL from "../../../src/classes/Neo4jGraphQL";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -157,7 +157,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [Movie, Series, Actor, Episode]);
+        await cleanNodes(driver, [Movie, Series, Actor, Episode]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/issues/bind-any.int.test.ts
+++ b/packages/graphql/tests/integration/issues/bind-any.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
+import { GraphQLError, graphql } from "graphql";
 import type { Driver, Session } from "neo4j-driver";
-import { graphql, GraphQLError } from "graphql";
-import Neo4jHelper from "../neo4j";
 import { Neo4jGraphQL } from "../../../src/classes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import Neo4jHelper from "../neo4j";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let driver: Driver;
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [User, Organization, Group]);
+        await cleanNodes(driver, [User, Organization, Group]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/mass-delete.int.test.ts
+++ b/packages/graphql/tests/integration/mass-delete.int.test.ts
@@ -19,12 +19,12 @@
 
 import type { DocumentNode } from "graphql";
 import { graphql } from "graphql";
+import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
-import { cleanNodesUsingSession } from "../utils/clean-nodes";
 import { Neo4jGraphQL } from "../../src";
+import { cleanNodes } from "../utils/clean-nodes";
 import { UniqueType } from "../utils/graphql-types";
 import Neo4jHelper from "./neo4j";
-import { gql } from "graphql-tag";
 
 describe("Mass Delete", () => {
     let driver: Driver;
@@ -78,7 +78,7 @@ describe("Mass Delete", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [movieType, personType]);
+        await cleanNodes(driver, [movieType, personType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
@@ -22,7 +22,7 @@ import { graphql } from "graphql";
 import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
@@ -100,7 +100,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
         });
 
         afterEach(async () => {
-            await cleanNodesUsingSession(session, [typeActor, typeMovie]);
+            await cleanNodes(driver, [typeActor, typeMovie]);
             await session.close();
         });
 
@@ -347,7 +347,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
         });
 
         afterEach(async () => {
-            await cleanNodesUsingSession(session, [typeActor, typeMovie]);
+            await cleanNodes(driver, [typeActor, typeMovie]);
             await session.close();
         });
 
@@ -1413,7 +1413,7 @@ describe("Relationship properties - connect with and without `overwrite` argumen
         });
 
         afterEach(async () => {
-            await cleanNodesUsingSession(session, [typeActor, typeMovie]);
+            await cleanNodes(driver, [typeActor, typeMovie]);
             await session.close();
         });
 

--- a/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
@@ -24,7 +24,7 @@ import { gql } from "graphql-tag";
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { Neo4jGraphQL } from "../../../src/classes";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { cleanNodes } from "../../utils/clean-nodes";
 import { UniqueType } from "../../utils/graphql-types";
 import { runCypher } from "../../utils/run-cypher";
 import Neo4jHelper from "../neo4j";
@@ -84,8 +84,7 @@ describe("Relationship properties - read", () => {
     });
 
     afterEach(async () => {
-        const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [typeMovie, typeActor]);
+        await cleanNodes(driver, [typeMovie, typeActor]);
     });
 
     test("Projecting node and relationship properties with no arguments", async () => {

--- a/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
@@ -17,15 +17,15 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "../../neo4j";
 import { Neo4jGraphQL } from "../../../../src/classes";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
-import { UniqueType } from "../../../utils/graphql-types";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { createBearerToken } from "../../../utils/create-bearer-token";
+import { UniqueType } from "../../../utils/graphql-types";
+import Neo4jHelper from "../../neo4j";
 
 describe("auth/allow", () => {
     let driver: Driver;
@@ -57,7 +57,7 @@ describe("auth/allow", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
@@ -21,7 +21,7 @@ import { graphql } from "graphql";
 import type { Driver } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
 import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
@@ -107,7 +107,7 @@ describe("Subscriptions connect with create", () => {
 
     afterEach(async () => {
         const session = await neo4j.getSession();
-        await cleanNodesUsingSession(session, [typeActor, typeMovie, typePerson, typeInfluencer]);
+        await cleanNodes(driver, [typeActor, typeMovie, typePerson, typeInfluencer]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../../src";
-import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
 describe("Delete using top level aggregate where - subscriptions enabled", () => {
@@ -92,7 +92,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -23,9 +23,9 @@ import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
 import { int } from "neo4j-driver";
 import { Neo4jGraphQL } from "../../../src";
-import { cleanNodesUsingSession } from "../../utils/clean-nodes";
-import { UniqueType } from "../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
+import { cleanNodes } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
 import Neo4jHelper from "../neo4j";
 
 describe("Subscriptions to spatial types", () => {
@@ -60,7 +60,7 @@ describe("Subscriptions to spatial types", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [typeMovie]);
+        await cleanNodes(driver, [typeMovie]);
         await session.close();
         await driver.close();
     });

--- a/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import type { Driver, Session } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver, Session } from "neo4j-driver";
 
 import { Neo4jGraphQL } from "../../../../src";
-import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
 describe("Delete using top level aggregate where - subscriptions enabled", () => {
@@ -95,7 +95,7 @@ describe("Delete using top level aggregate where - subscriptions enabled", () =>
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [userType, postType]);
+        await cleanNodes(driver, [userType, postType]);
         await session.close();
     });
 

--- a/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
@@ -17,13 +17,13 @@
  * limitations under the License.
  */
 
-import { gql } from "graphql-tag";
 import { graphql } from "graphql";
+import { gql } from "graphql-tag";
 import type { Driver, Session } from "neo4j-driver";
-import { cleanNodesUsingSession } from "../../../utils/clean-nodes";
 import { Neo4jGraphQL } from "../../../../src";
-import { UniqueType } from "../../../utils/graphql-types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
+import { cleanNodes } from "../../../utils/clean-nodes";
+import { UniqueType } from "../../../utils/graphql-types";
 import Neo4jHelper from "../../neo4j";
 
 describe("Subscriptions update", () => {
@@ -72,7 +72,7 @@ describe("Subscriptions update", () => {
     });
 
     afterEach(async () => {
-        await cleanNodesUsingSession(session, [typeActor, typeMovie]);
+        await cleanNodes(driver, [typeActor, typeMovie]);
         await session.close();
     });
 

--- a/packages/graphql/tests/utils/clean-nodes.ts
+++ b/packages/graphql/tests/utils/clean-nodes.ts
@@ -18,9 +18,8 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Driver, Result, Session } from "neo4j-driver";
+import type { Driver, Result } from "neo4j-driver";
 import type { UniqueType } from "./graphql-types";
-import { runCypher } from "./run-cypher";
 
 /** Removes all nodes with the given labels from the database */
 export async function cleanNodes(driver: Driver, labels: Array<string | UniqueType>): Promise<Result> {
@@ -35,22 +34,4 @@ export async function cleanNodes(driver: Driver, labels: Array<string | UniqueTy
     const query = new Cypher.Match(nodeRef).where(nodeHasAnyLabelPredicate).detachDelete(nodeRef);
     const { cypher } = query.build();
     return driver.executeQuery(cypher);
-}
-
-/**
- * Removes all nodes with the given labels from the database
- * @deprecated Use {@link cleanNodes} instead
- */
-export async function cleanNodesUsingSession(session: Session, labels: Array<string | UniqueType>): Promise<Result> {
-    const nodeRef = new Cypher.Node({});
-
-    const nodeHasLabelPredicates = labels.map((l) => {
-        return nodeRef.hasLabel(`${l}`);
-    });
-
-    const nodeHasAnyLabelPredicate = Cypher.or(...nodeHasLabelPredicates);
-
-    const query = new Cypher.Match(nodeRef).where(nodeHasAnyLabelPredicate).detachDelete(nodeRef);
-    const { cypher } = query.build();
-    return runCypher(session, cypher);
 }

--- a/packages/ogm/src/generate.test.ts
+++ b/packages/ogm/src/generate.test.ts
@@ -18,7 +18,6 @@
  */
 
 import * as fs from "fs";
-import gql from "graphql-tag";
 import * as path from "path";
 import { generate as randomstring } from "randomstring";
 import generate from "./generate";

--- a/packages/ogm/tests/integration/ogm.int.test.ts
+++ b/packages/ogm/tests/integration/ogm.int.test.ts
@@ -54,7 +54,7 @@ describe("OGM", () => {
 
     afterEach(async () => {
         const session = driver.session();
-        await cleanNodes(session, [typeMovie, typeActor, typeGenre, typeProduct, typeSize, typeColor, typePhoto]);
+        await cleanNodes(driver, [typeMovie, typeActor, typeGenre, typeProduct, typeSize, typeColor, typePhoto]);
         await session.close();
     });
 

--- a/packages/ogm/tests/utils/clean-nodes.ts
+++ b/packages/ogm/tests/utils/clean-nodes.ts
@@ -18,12 +18,11 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { Result, Session } from "neo4j-driver";
-import { runCypher } from "./run-cypher";
+import type { Driver, Result } from "neo4j-driver";
 import type { UniqueType } from "./utils";
 
 /** Removes all nodes with the given labels from the database */
-export async function cleanNodes(session: Session, labels: Array<string | UniqueType>): Promise<Result> {
+export async function cleanNodes(driver: Driver, labels: Array<string | UniqueType>): Promise<Result> {
     const nodeRef = new Cypher.Node({});
 
     const nodeHasLabelPredicates = labels.map((l) => {
@@ -34,5 +33,5 @@ export async function cleanNodes(session: Session, labels: Array<string | Unique
 
     const query = new Cypher.Match(nodeRef).where(nodeHasAnyLabelPredicate).detachDelete(nodeRef);
     const { cypher } = query.build();
-    return runCypher(session, cypher);
+    return driver.executeQuery(cypher);
 }


### PR DESCRIPTION
With this change, the tests now use pass the driver they set up instead of the session.