### PR TITLE
Update cypher builder to latest version

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -90,7 +90,7 @@
         "@graphql-tools/resolvers-composition": "^7.0.0",
         "@graphql-tools/schema": "10.0.3",
         "@graphql-tools/utils": "^10.0.0",
-        "@neo4j/cypher-builder": "^1.7.1",
+        "@neo4j/cypher-builder": "^1.13.0",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dot-prop": "^6.0.1",

--- a/packages/graphql/src/translate/batch-create/unwind-create-visitors/UnwindCreateVisitor.ts
+++ b/packages/graphql/src/translate/batch-create/unwind-create-visitors/UnwindCreateVisitor.ts
@@ -17,22 +17,22 @@
  * limitations under the License.
  */
 
-import type { PredicateReturn } from "../../../types";
-import type { CallbackBucket } from "../../../classes/CallbackBucket";
-import type { Visitor, CreateAST, NestedCreateAST, UnwindASTNode } from "../GraphQLInputAST/GraphQLInputAST";
-import type { Node, Relationship } from "../../../classes";
-import createRelationshipValidationString from "../../create-relationship-validation-string";
-import { filterTruthy } from "../../../utils/utils";
 import type { Expr, Map, MapProjection } from "@neo4j/cypher-builder";
 import Cypher from "@neo4j/cypher-builder";
-import mapToDbProperty from "../../../utils/map-to-db-property";
-import { getCypherRelationshipDirection } from "../../../utils/get-relationship-direction";
-import {
-    createAuthorizationAfterPredicateField,
-    createAuthorizationAfterPredicate,
-} from "../../authorization/create-authorization-after-predicate";
-import { checkAuthentication } from "../../authorization/check-authentication";
+import type { Node, Relationship } from "../../../classes";
+import type { CallbackBucket } from "../../../classes/CallbackBucket";
+import type { PredicateReturn } from "../../../types";
 import type { Neo4jGraphQLTranslationContext } from "../../../types/neo4j-graphql-translation-context";
+import { getCypherRelationshipDirection } from "../../../utils/get-relationship-direction";
+import mapToDbProperty from "../../../utils/map-to-db-property";
+import { filterTruthy } from "../../../utils/utils";
+import { checkAuthentication } from "../../authorization/check-authentication";
+import {
+    createAuthorizationAfterPredicate,
+    createAuthorizationAfterPredicateField,
+} from "../../authorization/create-authorization-after-predicate";
+import createRelationshipValidationString from "../../create-relationship-validation-string";
+import type { CreateAST, NestedCreateAST, UnwindASTNode, Visitor } from "../GraphQLInputAST/GraphQLInputAST";
 
 type UnwindCreateScopeDefinition = {
     unwindVar: Cypher.Variable;
@@ -139,7 +139,7 @@ export class UnwindCreateVisitor implements Visitor<Cypher.Clause> {
             ])
         );
         this.rootNode = currentNode;
-        this.clause = new Cypher.Call(clause).innerWith(this.unwindVar);
+        this.clause = new Cypher.Call(clause).importWith(this.unwindVar);
         return this.clause;
     }
 

--- a/packages/graphql/src/translate/create-connect-or-create-and-params.ts
+++ b/packages/graphql/src/translate/create-connect-or-create-and-params.ts
@@ -108,7 +108,7 @@ export function createConnectOrCreateAndParams({
 
         const withStatement = new Cypher.With(...withVarsVariables);
 
-        const callStatement = new Cypher.Call(Cypher.concat(statement, returnStatement)).innerWith(
+        const callStatement = new Cypher.Call(Cypher.concat(statement, returnStatement)).importWith(
             ...withVarsVariables
         );
         const subqueryClause = Cypher.concat(withStatement, callStatement);

--- a/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherUnionAttributeField.ts
+++ b/packages/graphql/src/translate/queryAST/ast/fields/attribute-fields/CypherUnionAttributeField.ts
@@ -19,12 +19,12 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { AttributeAdapter } from "../../../../../schema-model/attribute/model-adapters/AttributeAdapter";
+import { filterTruthy } from "../../../../../utils/utils";
 import { CypherAnnotationSubqueryGenerator } from "../../../cypher-generators/CypherAnnotationSubqueryGenerator";
 import type { QueryASTContext } from "../../QueryASTContext";
 import type { QueryASTNode } from "../../QueryASTNode";
 import { CypherAttributeField } from "./CypherAttributeField";
 import type { CypherUnionAttributePartial } from "./CypherUnionAttributePartial";
-import { filterTruthy } from "../../../../../utils/utils";
 
 // Should Cypher be an operation?
 export class CypherUnionAttributeField extends CypherAttributeField {
@@ -68,7 +68,7 @@ export class CypherUnionAttributeField extends CypherAttributeField {
             });
 
             const callSubqueries = p.getSubqueries(nestedContext).map((sq) => {
-                return new Cypher.Call(sq).innerWith(innerNode);
+                return new Cypher.Call(sq).importWith(innerNode);
             });
             if (callSubqueries.length === 0) return undefined;
             const withClause = new Cypher.With("*", [this.customCypherVar, innerNode]);

--- a/packages/graphql/src/translate/queryAST/ast/filters/ConnectionFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/ConnectionFilter.ts
@@ -18,17 +18,17 @@
  */
 
 import Cypher from "@neo4j/cypher-builder";
-import type { RelationshipWhereOperator } from "../../../where/types";
-import { Filter } from "./Filter";
-import type { QueryASTContext } from "../QueryASTContext";
-import type { RelationshipAdapter } from "../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
-import type { QueryASTNode } from "../QueryASTNode";
 import type { ConcreteEntityAdapter } from "../../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
 import type { InterfaceEntityAdapter } from "../../../../schema-model/entity/model-adapters/InterfaceEntityAdapter";
-import { isConcreteEntity } from "../../utils/is-concrete-entity";
-import { isInterfaceEntity } from "../../utils/is-interface-entity";
+import type { RelationshipAdapter } from "../../../../schema-model/relationship/model-adapters/RelationshipAdapter";
+import type { RelationshipWhereOperator } from "../../../where/types";
 import { hasTarget } from "../../utils/context-has-target";
 import { createNodeFromEntity } from "../../utils/create-node-from-entity";
+import { isConcreteEntity } from "../../utils/is-concrete-entity";
+import { isInterfaceEntity } from "../../utils/is-interface-entity";
+import type { QueryASTContext } from "../QueryASTContext";
+import type { QueryASTNode } from "../QueryASTNode";
+import { Filter } from "./Filter";
 
 export class ConnectionFilter extends Filter {
     protected innerFilters: Filter[] = [];
@@ -203,7 +203,7 @@ export class ConnectionFilter extends Filter {
         const subqueries = this.innerFilters.flatMap((f) => {
             const nestedSubqueries = f
                 .getSubqueries(queryASTContext)
-                .map((sq) => new Cypher.Call(sq).innerWith(queryASTContext.target));
+                .map((sq) => new Cypher.Call(sq).importWith(queryASTContext.target));
             const selection = f.getSelection(queryASTContext);
             const predicate = f.getPredicate(queryASTContext);
             const clauses = [...selection, ...nestedSubqueries];
@@ -249,7 +249,7 @@ export class ConnectionFilter extends Filter {
                     const returnVar = new Cypher.Variable();
                     truthyFilters.push(returnVar);
                     return new Cypher.Call(sq)
-                        .innerWith(queryASTContext.target)
+                        .importWith(queryASTContext.target)
                         .with("*")
                         .where(predicate)
                         .return([Cypher.gt(Cypher.count(queryASTContext.target), new Cypher.Literal(0)), returnVar]);
@@ -268,7 +268,7 @@ export class ConnectionFilter extends Filter {
                     const returnVar = new Cypher.Variable();
                     falsyFilters.push(returnVar);
                     return new Cypher.Call(sq)
-                        .innerWith(queryASTContext.target)
+                        .importWith(queryASTContext.target)
                         .with("*")
                         .where(Cypher.not(predicate))
                         .return([Cypher.gt(Cypher.count(queryASTContext.target), new Cypher.Literal(0)), returnVar]);

--- a/packages/graphql/src/translate/queryAST/ast/filters/RelationshipFilter.ts
+++ b/packages/graphql/src/translate/queryAST/ast/filters/RelationshipFilter.ts
@@ -246,7 +246,7 @@ export class RelationshipFilter extends Filter {
             const returnVar = new Cypher.Variable();
             returnVariables.push(returnVar);
             const nestedSubqueries = f.getSubqueries(context).map((sq) => {
-                return new Cypher.Call(sq).innerWith(context.target);
+                return new Cypher.Call(sq).importWith(context.target);
             });
 
             let predicate = f.getPredicate(context);

--- a/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ConnectionReadOperation.ts
@@ -124,7 +124,7 @@ export class ConnectionReadOperation extends Operation {
         }
 
         const authFilterSubqueries = this.getAuthFilterSubqueries(nestedContext).map((sq) =>
-            new Cypher.Call(sq).innerWith(nestedContext.target)
+            new Cypher.Call(sq).importWith(nestedContext.target)
         );
         const edgesVar = new Cypher.NamedVariable("edges");
         const totalCount = new Cypher.NamedVariable("totalCount");
@@ -220,7 +220,7 @@ export class ConnectionReadOperation extends Operation {
                 ...postPaginationSubqueries,
                 new Cypher.Return([Cypher.collect(edgeProjectionMap), returnVar])
             )
-        ).innerWith(edgesVar);
+        ).importWith(edgesVar);
     }
 
     private createProjectionMapForEdge(context: QueryASTContext<Cypher.Node>): Cypher.Map {
@@ -344,9 +344,9 @@ export class ConnectionReadOperation extends Operation {
         if (!hasTarget(context)) throw new Error("No parent node found!");
         const sortNodeFields = this.sortFields.flatMap((sf) => sf.node);
         /**
-         * cypherSortFieldsFlagMap is a Record<string, boolean> that holds the name of the sort field as key 
+         * cypherSortFieldsFlagMap is a Record<string, boolean> that holds the name of the sort field as key
          * and a boolean flag defined as true when the field is a `@cypher` field.
-         **/ 
+         **/
         const cypherSortFieldsFlagMap = sortNodeFields.reduce<Record<string, boolean>>(
             (sortFieldsFlagMap, sortField) => {
                 if (sortField instanceof CypherPropertySort) {

--- a/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/ReadOperation.ts
@@ -148,7 +148,7 @@ export class ReadOperation extends Operation {
         const sortSubqueries = wrapSubqueriesInCypherCalls(nestedContext, this.sortFields, [nestedContext.target]);
 
         const authFilterSubqueries = this.getAuthFilterSubqueries(nestedContext).map((sq) =>
-            new Cypher.Call(sq).innerWith(nestedContext.target)
+            new Cypher.Call(sq).importWith(nestedContext.target)
         );
 
         const authFiltersPredicate = this.getAuthFilterPredicate(nestedContext);

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeConnectionReadOperation.ts
@@ -89,7 +89,7 @@ export class CompositeConnectionReadOperation extends Operation {
 
             extraWithOrder.return([Cypher.collect(edgeVar), edgesVar2]);
             returnEdgesVar = edgesVar2;
-            orderSubquery = new Cypher.Call(extraWithOrder).innerWith(edgesVar);
+            orderSubquery = new Cypher.Call(extraWithOrder).importWith(edgesVar);
         }
 
         nestedSubquery.with([Cypher.collect(edgeVar), edgesVar]).with(edgesVar, [Cypher.size(edgesVar), totalCount]);

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeCypherOperation.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeCypherOperation.ts
@@ -19,9 +19,9 @@
 
 import Cypher from "@neo4j/cypher-builder";
 import type { QueryASTContext } from "../../QueryASTContext";
+import type { QueryASTNode } from "../../QueryASTNode";
 import type { EntitySelection } from "../../selection/EntitySelection";
 import { Operation, type OperationTranspileResult } from "../operations";
-import type { QueryASTNode } from "../../QueryASTNode";
 import type { CompositeReadPartial } from "./CompositeReadPartial";
 
 export class CompositeCypherOperation extends Operation {
@@ -52,7 +52,7 @@ export class CompositeCypherOperation extends Operation {
         );
 
         const subquery = new Cypher.Call(partialsSubquery)
-            .innerWith(nestedContext.target)
+            .importWith(nestedContext.target)
             .return([partialContext.returnVariable, nestedContext.returnVariable]);
         return {
             clauses: [matchClause, subquery],

--- a/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadPartial.ts
+++ b/packages/graphql/src/translate/queryAST/ast/operations/composite/CompositeReadPartial.ts
@@ -68,7 +68,7 @@ export class CompositeReadPartial extends ReadOperation {
         const subqueries = Cypher.concat(...this.getFieldsSubqueries(nestedContext), ...cypherFieldSubqueries);
         const sortSubqueries = this.sortFields
             .flatMap((sq) => sq.getSubqueries(nestedContext))
-            .map((sq) => new Cypher.Call(sq).innerWith(nestedContext.target));
+            .map((sq) => new Cypher.Call(sq).importWith(nestedContext.target));
 
         const ret = this.getProjectionClause(nestedContext, context.returnVariable);
 

--- a/packages/graphql/src/translate/queryAST/ast/selection/CustomCypherSelection.ts
+++ b/packages/graphql/src/translate/queryAST/ast/selection/CustomCypherSelection.ts
@@ -83,7 +83,7 @@ export class CustomCypherSelection extends EntitySelection {
         if (this.isNested && context.target) {
             const aliasTargetToPublicTarget = new Cypher.With([context.target, CYPHER_TARGET_VARIABLE]);
             statementSubquery = new Cypher.Call(Cypher.concat(aliasTargetToPublicTarget, statementCypherQuery));
-            statementSubquery.innerWith(context.target);
+            statementSubquery.importWith(context.target);
         } else {
             statementSubquery = new Cypher.Call(statementCypherQuery);
         }

--- a/packages/graphql/src/translate/queryAST/cypher-generators/CypherAnnotationSubqueryGenerator.ts
+++ b/packages/graphql/src/translate/queryAST/cypher-generators/CypherAnnotationSubqueryGenerator.ts
@@ -24,8 +24,8 @@ import { QueryASTContext } from "../ast/QueryASTContext";
 import type { Field } from "../ast/fields/Field";
 import type { CypherUnionAttributePartial } from "../ast/fields/attribute-fields/CypherUnionAttributePartial";
 import { assertIsCypherNode } from "../utils/assert-is-cypher-node";
-import { wrapSubqueryInCall } from "../utils/wrap-subquery-in-call";
 import { replaceArgumentsInStatement } from "../utils/replace-arguments-in-statement";
+import { wrapSubqueryInCall } from "../utils/wrap-subquery-in-call";
 
 /** Variable exposed to the user in their custom cypher */
 const CYPHER_TARGET_VARIABLE = new Cypher.NamedVariable("this");
@@ -140,7 +140,7 @@ export class CypherAnnotationSubqueryGenerator {
 
         const statementSubquery = Cypher.concat(aliasTargetToPublicTarget, statementCypherQuery);
 
-        const callStatement = new Cypher.Call(statementSubquery).innerWith(target);
+        const callStatement = new Cypher.Call(statementSubquery).importWith(target);
 
         if (this.attribute.typeHelper.isScalar() || this.attribute.typeHelper.isEnum()) {
             callStatement.unwind([this.columnName, this.returnVariable]);

--- a/packages/graphql/src/translate/queryAST/utils/wrap-subquery-in-call.ts
+++ b/packages/graphql/src/translate/queryAST/utils/wrap-subquery-in-call.ts
@@ -21,5 +21,5 @@ import Cypher from "@neo4j/cypher-builder";
 
 /** Wraps provided queries in Call statements with inner target */
 export function wrapSubqueryInCall(subquery: Cypher.Clause, target: Cypher.Variable): Cypher.Call {
-    return new Cypher.Call(subquery).innerWith(target);
+    return new Cypher.Call(subquery).importWith(target);
 }

--- a/packages/graphql/src/translate/queryAST/utils/wrap-subquery-in-calls.ts
+++ b/packages/graphql/src/translate/queryAST/utils/wrap-subquery-in-calls.ts
@@ -35,7 +35,7 @@ export function wrapSubqueriesInCypherCalls(
     ).map((sq) => {
         const call = new Cypher.Call(sq);
         if (withArgs) {
-            call.innerWith(...withArgs);
+            call.importWith(...withArgs);
         }
         return call;
     });

--- a/packages/graphql/src/translate/translate-create.ts
+++ b/packages/graphql/src/translate/translate-create.ts
@@ -143,7 +143,7 @@ export default async function translateCreate({
                 if (queryASTResult.clauses.length) {
                     projectedVariables.push(queryASTResult.projectionExpr as Cypher.Node);
                     const clause = Cypher.concat(...queryASTResult.clauses);
-                    return new Cypher.Call(clause).innerWith(varName);
+                    return new Cypher.Call(clause).importWith(varName);
                 }
             })
         )

--- a/yarn.lock
+++ b/yarn.lock
@@ -3624,10 +3624,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@neo4j/cypher-builder@npm:^1.7.1":
-  version: 1.7.1
-  resolution: "@neo4j/cypher-builder@npm:1.7.1"
-  checksum: 10c0/1984fc284a4eb0439d67667e4a99f0b8733c64a284545fa982952b94a4eee07331d03106673fd3580ae96f21c68542a0723f075bb3ef61068a08023fed4052e1
+"@neo4j/cypher-builder@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "@neo4j/cypher-builder@npm:1.13.0"
+  checksum: 10c0/50e67618d4c1dab37ac8f2de25cde844c17447bc53fae8d723c84a397fb28c53f8f3ccb47536a09313eedbdbad81e093b228786fac4a10a95c0274f99278fa70
   languageName: node
   linkType: hard
 
@@ -3775,7 +3775,7 @@ __metadata:
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:10.0.3"
     "@graphql-tools/utils": "npm:^10.0.0"
-    "@neo4j/cypher-builder": "npm:^1.7.1"
+    "@neo4j/cypher-builder": "npm:^1.13.0"
     "@types/deep-equal": "npm:1.0.4"
     "@types/is-uuid": "npm:1.0.2"
     "@types/jest": "npm:29.5.12"


### PR DESCRIPTION
# Description

Updates cypher builder to 1.13.0 and changes all deprecated `innerWith` methods to `importWith`
