### PR TITLE
Bug-fix 4831

### DIFF
--- a/.changeset/six-snails-sell.md
+++ b/.changeset/six-snails-sell.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fixed bug that caused an empty string and false boolean argument being evaluated as `NULL` when passed as an argument of a `@cypher` field.

--- a/packages/graphql/src/translate/queryAST/utils/replace-arguments-in-statement.ts
+++ b/packages/graphql/src/translate/queryAST/utils/replace-arguments-in-statement.ts
@@ -33,11 +33,11 @@ export function replaceArgumentsInStatement({
     let cypherStatement = statement;
     definedArguments.forEach((arg) => {
         const value = rawArguments[arg.name];
-        if (value) {
+        if (value === undefined || value === null) {
+            cypherStatement = cypherStatement.replaceAll(`$${arg.name}`, "NULL");
+        } else {
             const paramName = new Cypher.Param(value).getCypher(env);
             cypherStatement = cypherStatement.replaceAll(`$${arg.name}`, paramName);
-        } else {
-            cypherStatement = cypherStatement.replaceAll(`$${arg.name}`, "NULL");
         }
     });
 

--- a/packages/graphql/tests/integration/issues/4831.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4831.int.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { GraphQLSchema } from "graphql";
+import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
+import { Neo4jGraphQL } from "../../../src";
+import { cleanNodesUsingSession } from "../../utils/clean-nodes";
+import { UniqueType } from "../../utils/graphql-types";
+import Neo4jHelper from "../neo4j";
+
+describe("https://github.com/neo4j/graphql/issues/4831", () => {
+    let schema: GraphQLSchema;
+    let driver: Driver;
+    let neo4j: Neo4jHelper;
+    let Test: UniqueType;
+
+    async function graphqlQuery(query: string) {
+        return graphql({
+            schema,
+            source: query,
+            contextValue: neo4j.getContextValues(),
+        });
+    }
+
+    beforeAll(async () => {
+        neo4j = new Neo4jHelper();
+        driver = await neo4j.getDriver();
+
+        Test = new UniqueType("Test");
+        const typeDefs = /* GraphQL */ `
+            type ${Test} {
+                testBoolean(value: Boolean): Boolean @cypher(statement: "RETURN $value as value", columnName: "value")
+                testString(value: String): String @cypher(statement: "RETURN $value as value", columnName: "value")
+            }
+        `;
+
+        const neo4jGraphQL = new Neo4jGraphQL({
+            typeDefs,
+            features: {},
+        });
+        schema = await neo4jGraphQL.getSchema();
+        await neo4j.run(`CREATE (:${Test.name})`);
+    });
+
+    afterAll(async () => {
+        const session = await neo4j.getSession();
+        await cleanNodesUsingSession(session, [Test]);
+        await driver.close();
+    });
+
+    describe("Boolean", () => {
+        test("the parameter should be false when the cypher argument is false", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testBoolean(value: false)
+                    }
+                }
+            `;
+
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testBoolean: false }],
+            });
+        });
+
+        test("the parameter should be true when the cypher argument is true", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testBoolean(value: true)
+                    }
+                }
+            `;
+
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testBoolean: true }],
+            });
+        });
+
+        test("the parameter should be NULL when the cypher argument is not passed", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testBoolean
+                    }
+                }
+            `;
+
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testBoolean: null }],
+            });
+        });
+
+        test("the parameter should be NULL when the cypher argument passed is NULL", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testBoolean(value: null)
+                    }
+                }
+            `;
+
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testBoolean: null }],
+            });
+        });
+    });
+
+    describe("String", () => {
+        test("the parameter should be an empty string when the cypher argument is an empty string", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testString(value: "")
+                    }
+                }
+            `;
+
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testString: "" }],
+            });
+        });
+
+        test("the parameter should be 'some-string' when the cypher argument is 'some-string'", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testString(value: "some-string")
+                    }
+                }
+            `;
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testString: "some-string" }],
+            });
+        });
+
+        test("the parameter should be NULL when the cypher argument is not passed", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testString
+                    }
+                }
+            `;
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testString: null }],
+            });
+        });
+
+        test("the parameter should be NULL when the cypher argument passed is NULL", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    ${Test.plural} {
+                        testString(value: null)
+                    }
+                }
+            `;
+            const queryResults = await graphqlQuery(query);
+            expect(queryResults.errors).toBeUndefined();
+            expect(queryResults.data).toEqual({
+                [Test.plural]: [{ testString: null }],
+            });
+        });
+    });
+});

--- a/packages/graphql/tests/tck/issues/4831.test.ts
+++ b/packages/graphql/tests/tck/issues/4831.test.ts
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/4831", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            type Test {
+                testBoolean(value: Boolean): Boolean @cypher(statement: "RETURN $value as value", columnName: "value")
+                testString(value: String): String @cypher(statement: "RETURN $value as value", columnName: "value")
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+            features: {},
+        });
+    });
+
+    describe("Boolean", () => {
+        test("the parameter should be false when the cypher argument is false", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testBoolean(value: false)
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN $param0 as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testBoolean: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`
+                "{
+                    \\"param0\\": false
+                }"
+            `);
+        });
+
+        test("the parameter should be true when the cypher argument is true", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testBoolean(value: true)
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN $param0 as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testBoolean: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`
+                "{
+                    \\"param0\\": true
+                }"
+            `);
+        });
+
+        test("the parameter should be NULL when the cypher argument is not passed", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testBoolean
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN NULL as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testBoolean: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+        });
+
+        test("the parameter should be NULL when the cypher argument passed is NULL", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testBoolean(value: null)
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN NULL as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testBoolean: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+        });
+    });
+
+    describe("String", () => {
+        test("the parameter should be an empty string when the cypher argument is an empty string", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testString(value: "")
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN $param0 as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testString: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`
+                "{
+                    \\"param0\\": \\"\\"
+                }"
+            `);
+        });
+
+        test("the parameter should be 'some-string' when the cypher argument is 'some-string'", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testString(value: "some-string")
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN $param0 as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testString: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`
+                "{
+                    \\"param0\\": \\"some-string\\"
+                }"
+            `);
+        });
+
+        test("the parameter should be NULL when the cypher argument is not passed", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testString
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN NULL as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testString: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+        });
+
+        test("the parameter should be NULL when the cypher argument passed is NULL", async () => {
+            const query = /* GraphQL */ `
+                query ExampleQuery {
+                    tests {
+                        testString(value: null)
+                    }
+                }
+            `;
+
+            const result = await translateQuery(neoSchema, query);
+
+            expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+                "MATCH (this:Test)
+                CALL {
+                    WITH this
+                    CALL {
+                        WITH this
+                        WITH this AS this
+                        RETURN NULL as value
+                    }
+                    WITH value AS this0
+                    RETURN this0 AS var1
+                }
+                RETURN this { testString: var1 } AS this"
+            `);
+
+            expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+        });
+    });
+});


### PR DESCRIPTION
# Description

This PR fix bug report #4831 was caused by an empty string and false boolean argument being evaluated as `NULL` when passed as an argument of a `@cypher` field.

## Complexity


Complexity: Low

# Issue

Closes #4831 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [x] Documentation has been updated
- [x] TCK tests have been updated
- [x] Integration tests have been updated
- [x] Example applications have been updated
- [x] New files have copyright header
- [x] CLA (https://neo4j.com/developer/cla/) has been signed
