### PR TITLE
Update test helper

### DIFF
--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
@@ -50,7 +50,7 @@ describe(`Field Level Authorization Where Requests`, () => {
             ${typeMovie.plural}: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
         }`;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name}
                 {name: "Terminator",year:1990,createdAt: datetime()})
                 <-[:ACTED_IN]-
@@ -84,7 +84,7 @@ describe(`Field Level Authorization Where Requests`, () => {
             }`;
 
         const token = createBearerToken(secret, { sub: "1234" });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
             count: 1,
@@ -100,7 +100,7 @@ describe(`Field Level Authorization Where Requests`, () => {
                 }
             }`;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect(gqlResult.data as any).toEqual({
@@ -118,7 +118,7 @@ describe(`Field Level Authorization Where Requests`, () => {
             }`;
 
         const invalidToken = createBearerToken(secret, { sub: "2222" });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, invalidToken);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, invalidToken);
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
             count: 0,

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe(`Field Level Authorization Where Requests`, () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
@@ -30,8 +30,6 @@ describe(`Field Level Authorization Where Requests`, () => {
     const secret = "secret";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
         typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
@@ -63,7 +63,7 @@ describe("Field Level Aggregations Auth", () => {
         extend type ${typeMovie.name} @authentication(operations: [AGGREGATE])
         `;
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name}
                 {name: "Terminator",testId: "1234",year:1990,createdAt: datetime()})
                 <-[:ACTED_IN]-
@@ -96,7 +96,7 @@ describe("Field Level Aggregations Auth", () => {
                     }
                 }`;
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
             expect(gqlResult.errors).toBeUndefined();
         });
 
@@ -109,7 +109,7 @@ describe("Field Level Aggregations Auth", () => {
                     }
                 }`;
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
             expect(gqlResult.errors).toBeUndefined();
         });
 
@@ -122,7 +122,7 @@ describe("Field Level Aggregations Auth", () => {
                     }
                 }`;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
             expect(gqlResult.errors).toBeUndefined();
         });
 
@@ -135,7 +135,7 @@ describe("Field Level Aggregations Auth", () => {
                     }
                 }`;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
             expect((gqlResult.errors as any[])[0].message).toBe("Unauthenticated");
         });
     });
@@ -173,7 +173,7 @@ describe("Field Level Aggregations Auth", () => {
                 @authorization(validate: [{ operations: [AGGREGATE], when: [BEFORE], where: { node: { testId: "$jwt.sub" } } }])
                 `;
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name}
                 {name: "Terminator",testId: "1234",year:1990,createdAt: datetime()})
                 <-[:ACTED_IN]-
@@ -205,7 +205,7 @@ describe("Field Level Aggregations Auth", () => {
                     }`;
 
             const token = createBearerToken(secret, { sub: "1234" });
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
             expect(gqlResult.errors).toBeUndefined();
         });
 
@@ -218,7 +218,7 @@ describe("Field Level Aggregations Auth", () => {
                         }
                     }`;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
             expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
         });
 
@@ -232,7 +232,7 @@ describe("Field Level Aggregations Auth", () => {
                     }`;
             const invalidToken = createBearerToken(secret, { sub: "2222" });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, invalidToken);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, invalidToken);
             expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
         });
     });

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
@@ -32,7 +32,7 @@ describe("Field Level Aggregations Auth", () => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     describe.each(testCases)(`isAuthenticated auth requests ~ $name`, ({ name, selection }) => {
         let token: string;
-        let testHelper: TestHelper;
+        const testHelper = new TestHelper();
 
         let typeMovie: UniqueType;
         let typeActor: UniqueType;
@@ -40,8 +40,6 @@ describe("Field Level Aggregations Auth", () => {
         const secret = "secret";
 
         beforeEach(async () => {
-            testHelper = new TestHelper();
-
             typeMovie = testHelper.createUniqueType("Movie");
             typeActor = testHelper.createUniqueType("Actor");
             typeDefs = `
@@ -141,7 +139,7 @@ describe("Field Level Aggregations Auth", () => {
     });
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     describe.each(testCases)(`allow requests ~ $name`, ({ name, selection }) => {
-        let testHelper: TestHelper;
+        const testHelper = new TestHelper();
 
         let typeMovie: UniqueType;
         let typeActor: UniqueType;
@@ -149,8 +147,6 @@ describe("Field Level Aggregations Auth", () => {
         const secret = "secret";
 
         beforeEach(async () => {
-            testHelper = new TestHelper();
-
             typeMovie = testHelper.createUniqueType("Movie");
             typeActor = testHelper.createUniqueType("Actor");
             typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
@@ -24,14 +24,12 @@ import { TestHelper } from "../../../utils/tests-helper";
 describe("Field Level Aggregations Field Authorization", () => {
     const secret = "the-secret";
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Series: UniqueType;
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Series = testHelper.createUniqueType("Series");
         Actor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
@@ -60,7 +60,7 @@ describe("Field Level Aggregations Field Authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (a:${Actor} {name: "Keanu"})-[:ACTED_ON  {screenTime: 10}]->(:${Series} {title: "Doctor Who", cost: 10.0, episodes: 5000})
         `);
     });
@@ -82,7 +82,7 @@ describe("Field Level Aggregations Field Authorization", () => {
 
         const token = createBearerToken(secret, { roles: ["movies-reader", "series-reader", "series-title-reader"] });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeDefined();
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
@@ -105,7 +105,7 @@ describe("Field Level Aggregations Field Authorization", () => {
 
         const token = createBearerToken(secret, { roles: ["movies-reader", "series-reader", "series-title-reader"] });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeDefined();
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
@@ -23,7 +23,7 @@ import { TestHelper } from "../../../utils/tests-helper";
 
 describe(`Field Level Authorization Where Requests`, () => {
     let token: string;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
@@ -32,8 +32,6 @@ describe(`Field Level Authorization Where Requests`, () => {
     const secret = "secret";
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
         typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
@@ -52,7 +52,7 @@ describe(`Field Level Authorization Where Requests`, () => {
             ${typeMovie.plural}: [${typeMovie.name}!]! @relationship(type: "ACTED_IN", direction: OUT)
         }`;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name}
                 {name: "Terminator",year:1990,createdAt: datetime()})
                 <-[:ACTED_IN]-
@@ -99,7 +99,7 @@ describe(`Field Level Authorization Where Requests`, () => {
                 }
             }`;
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
             count: 1,

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
@@ -54,7 +54,7 @@ describe("Field Level Aggregations Graphql alias", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
+        await testHelper.executeCypher(`CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
         CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})`);
     });
 
@@ -84,7 +84,7 @@ describe("Field Level Aggregations Graphql alias", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data.films[0].aggregation).toEqual({
@@ -118,7 +118,7 @@ describe("Field Level Aggregations Graphql alias", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data.films[0].aggregation).toEqual({

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("Field Level Aggregations Graphql alias", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -54,7 +54,7 @@ describe("Field Level Aggregations", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name} { title: "Terminator"})
             CREATE(m)<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
             CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})
@@ -76,7 +76,7 @@ describe("Field Level Aggregations", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
@@ -101,7 +101,7 @@ describe("Field Level Aggregations", () => {
             }
             `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
@@ -132,7 +132,7 @@ describe("Field Level Aggregations", () => {
             }
             `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
@@ -163,7 +163,7 @@ describe("Field Level Aggregations", () => {
             }
             `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
@@ -196,7 +196,7 @@ describe("Field Level Aggregations", () => {
             }
             `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({
@@ -227,7 +227,7 @@ describe("Field Level Aggregations", () => {
             }
             `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typeMovie.plural][0][`${typeActor.plural}Aggregate`]).toEqual({

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("Field Level Aggregations", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("Nested Field Level Aggregations", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
@@ -53,7 +53,7 @@ describe("Nested Field Level Aggregations", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(arnold:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
         CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})
         CREATE (:${typeMovie.name} {title: "Total Recall"})<-[:ACTED_IN { screentime: 180, character: "Quaid" }]-(arnold)
@@ -79,7 +79,7 @@ describe("Nested Field Level Aggregations", () => {
         }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
         expect(gqlResult.errors).toBeUndefined();
         const movies = (gqlResult.data as any)?.actors[0].movies;
         expect(movies).toHaveLength(2);

--- a/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Field Level Aggregations Where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
 
     let typeMovie: UniqueType;
     let typePerson: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typePerson = testHelper.createUniqueType("Person");
 

--- a/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
@@ -53,7 +53,7 @@ describe("Field Level Aggregations Where", () => {
         `;
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typePerson.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
             CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typePerson.name} {name: "Linda", age:37, born: datetime('2000-02-02')})`);
     });
@@ -73,7 +73,7 @@ describe("Field Level Aggregations Where", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
@@ -92,7 +92,7 @@ describe("Field Level Aggregations Where", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
@@ -109,7 +109,7 @@ describe("Field Level Aggregations Where", () => {
                 }
               }
           }`;
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
@@ -127,7 +127,7 @@ describe("Field Level Aggregations Where", () => {
                     }
                 }
             }`;
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typePerson.plural][0].moviesAggregate).toEqual({
@@ -144,7 +144,7 @@ describe("Field Level Aggregations Where", () => {
                     }
                 }
             }`;
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typePerson.plural][0].moviesAggregate).toEqual({
@@ -161,7 +161,7 @@ describe("Field Level Aggregations Where", () => {
                     }
                 }
             }`;
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult as any).data[typePerson.plural][0].moviesAggregate).toEqual({
@@ -181,7 +181,7 @@ describe("Field Level Aggregations Where", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
@@ -200,7 +200,7 @@ describe("Field Level Aggregations Where", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
@@ -219,7 +219,7 @@ describe("Field Level Aggregations Where", () => {
             }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({

--- a/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
@@ -22,11 +22,10 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-alias", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeMovie: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
@@ -57,7 +57,7 @@ describe("aggregations-top_level-alias", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${typeMovie} {testString: "${testString}", id: "1", title: "1", imdbRating: 1, createdAt: datetime("${minDate.toISOString()}")})
                     CREATE (:${typeMovie} {testString: "${testString}", id: "22", title: "22", imdbRating: 2, createdAt: datetime()})
@@ -91,7 +91,7 @@ describe("aggregations-top_level-alias", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
@@ -22,12 +22,10 @@ import { createBearerToken } from "../../../utils/create-bearer-token";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level authorization", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
@@ -65,13 +65,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${randomType.name} {id: "${userId}"})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -112,13 +112,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:User {id: "${userId}"})-[:POSTED]->(:Post {content: randomUUID()})
             `);
 
         const token = createBearerToken(secret, { sub: userId });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -170,13 +170,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", imdbRatingInt: rand()})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -222,13 +222,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", someId: "some-random-string"})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -274,13 +274,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", someString: "some-random-string"})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -326,13 +326,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", imdbRatingFloat: rand()})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -378,13 +378,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", imdbRatingBigInt: rand()})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -430,13 +430,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", createdAt: datetime()})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -482,13 +482,13 @@ describe("aggregations-top_level authorization", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:Person {id: "${userId}"})-[:DIRECTED]->(:Movie {id: "${movieId}", createdAt: datetime()})
             `);
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });

--- a/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
@@ -20,11 +20,9 @@
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-basic", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeAll(() => {
-        testHelper = new TestHelper();
-    });
+    beforeAll(() => {});
 
     afterAll(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
@@ -41,7 +41,7 @@ describe("aggregations-top_level-basic", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${randomType.name} {id: randomUUID()})
             CREATE (:${randomType.name} {id: randomUUID()})
         `);
@@ -54,7 +54,7 @@ describe("aggregations-top_level-basic", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
@@ -50,7 +50,7 @@ describe("aggregations-top_level-bigint", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
@@ -72,7 +72,7 @@ describe("aggregations-top_level-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -100,7 +100,7 @@ describe("aggregations-top_level-bigint", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
@@ -122,7 +122,7 @@ describe("aggregations-top_level-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -150,7 +150,7 @@ describe("aggregations-top_level-bigint", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
@@ -172,7 +172,7 @@ describe("aggregations-top_level-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -200,7 +200,7 @@ describe("aggregations-top_level-bigint", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
@@ -222,7 +222,7 @@ describe("aggregations-top_level-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -250,7 +250,7 @@ describe("aggregations-top_level-bigint", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}1})
                     CREATE (:${movieType.name} {testString: $testString, imdbRatingBigInt: ${bigInt}2})
@@ -275,7 +275,7 @@ describe("aggregations-top_level-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
@@ -21,13 +21,11 @@ import { generate } from "randomstring";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-bigint", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const bigInt = "2147483647";
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
@@ -42,7 +42,7 @@ describe("Aggregate -> count", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${randomType.name} {id: randomUUID()})
                     CREATE (:${randomType.name} {id: randomUUID()})
@@ -57,7 +57,7 @@ describe("Aggregate -> count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)[randomType.operations.aggregate].count).toBe(2);
@@ -82,7 +82,7 @@ describe("Aggregate -> count", () => {
             charset: "alphabetic",
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (:${randomType.name} {id: $id1})
                 CREATE (:${randomType.name} {id: $id2})
@@ -98,7 +98,7 @@ describe("Aggregate -> count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
@@ -21,11 +21,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("Aggregate -> count", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
@@ -22,12 +22,11 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-datetime", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let Movie: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         typeDefs = `
             type ${Movie} {

--- a/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
@@ -51,7 +51,7 @@ describe("aggregations-top_level-datetime", () => {
 
         const minDate = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, createdAt: datetime("${minDate.toISOString()}")})
                     CREATE (:${Movie} {testString: $testString, createdAt: datetime()})
@@ -73,7 +73,7 @@ describe("aggregations-top_level-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -95,7 +95,7 @@ describe("aggregations-top_level-datetime", () => {
         const maxDate = new Date();
         maxDate.setDate(maxDate.getDate() + 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, createdAt: datetime("${minDate.toISOString()}")})
                     CREATE (:${Movie} {testString: $testString, createdAt: datetime()})
@@ -117,7 +117,7 @@ describe("aggregations-top_level-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -139,7 +139,7 @@ describe("aggregations-top_level-datetime", () => {
         const maxDate = new Date();
         maxDate.setDate(maxDate.getDate() + 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, createdAt: datetime("${minDate.toISOString()}")})
                     CREATE (:${Movie} {testString: $testString, createdAt: datetime()})
@@ -162,7 +162,7 @@ describe("aggregations-top_level-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
@@ -23,13 +23,11 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-duration", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
     let typeDefs: string;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         typeDefs = `
             type ${Movie} {

--- a/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
@@ -56,7 +56,7 @@ describe("aggregations-top_level-duration", () => {
         const minDuration = new neo4jDriver.types.Duration(months, days, 0, 0);
         const maxDuration = new neo4jDriver.types.Duration(months + 1, days, 0, 0);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, runningTime: $minDuration})
                     CREATE (:${Movie} {testString: $testString, runningTime: $maxDuration})
@@ -78,7 +78,7 @@ describe("aggregations-top_level-duration", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -100,7 +100,7 @@ describe("aggregations-top_level-duration", () => {
         const minDuration = new neo4jDriver.types.Duration(months, days, 0, 0);
         const maxDuration = new neo4jDriver.types.Duration(months + 1, days, 0, 0);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, runningTime: $minDuration})
                     CREATE (:${Movie} {testString: $testString, runningTime: $maxDuration})
@@ -122,7 +122,7 @@ describe("aggregations-top_level-duration", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -144,7 +144,7 @@ describe("aggregations-top_level-duration", () => {
         const minDuration = new neo4jDriver.types.Duration(months, days, 0, 0);
         const maxDuration = new neo4jDriver.types.Duration(months + 1, days, 0, 0);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, runningTime: $minDuration})
                     CREATE (:${Movie} {testString: $testString, runningTime: $maxDuration})
@@ -167,7 +167,7 @@ describe("aggregations-top_level-duration", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
@@ -47,7 +47,7 @@ describe("aggregations-top_level-float", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1.1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2.1})
@@ -69,7 +69,7 @@ describe("aggregations-top_level-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -86,7 +86,7 @@ describe("aggregations-top_level-float", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1.1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2.1})
@@ -108,7 +108,7 @@ describe("aggregations-top_level-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -129,7 +129,7 @@ describe("aggregations-top_level-float", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1.1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2.1})
@@ -151,7 +151,7 @@ describe("aggregations-top_level-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -172,7 +172,7 @@ describe("aggregations-top_level-float", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1.1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2.1})
@@ -194,7 +194,7 @@ describe("aggregations-top_level-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -215,7 +215,7 @@ describe("aggregations-top_level-float", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1.1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2.1})
@@ -240,7 +240,7 @@ describe("aggregations-top_level-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
@@ -22,11 +22,10 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-float", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         const typeDefs = `
             type ${Movie} {

--- a/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
@@ -22,11 +22,10 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-id", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         const typeDefs = `
         type ${Movie} {

--- a/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
@@ -48,7 +48,7 @@ describe("aggregations-top_level-id", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testId: $id, id: "1"})
                     CREATE (:${Movie} {testId: $id, id: "22"})
@@ -70,7 +70,7 @@ describe("aggregations-top_level-id", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -91,7 +91,7 @@ describe("aggregations-top_level-id", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testId: $id, id: "1"})
                     CREATE (:${Movie} {testId: $id, id: "22"})
@@ -113,7 +113,7 @@ describe("aggregations-top_level-id", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -134,7 +134,7 @@ describe("aggregations-top_level-id", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testId: $id, id: "1"})
                     CREATE (:${Movie} {testId: $id, id: "22"})
@@ -157,7 +157,7 @@ describe("aggregations-top_level-id", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
@@ -48,7 +48,7 @@ describe("aggregations-top_level-int", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2})
@@ -70,7 +70,7 @@ describe("aggregations-top_level-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -91,7 +91,7 @@ describe("aggregations-top_level-int", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2})
@@ -113,7 +113,7 @@ describe("aggregations-top_level-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -134,7 +134,7 @@ describe("aggregations-top_level-int", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2})
@@ -156,7 +156,7 @@ describe("aggregations-top_level-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -177,7 +177,7 @@ describe("aggregations-top_level-int", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2})
@@ -199,7 +199,7 @@ describe("aggregations-top_level-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -220,7 +220,7 @@ describe("aggregations-top_level-int", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {testString: $testString, imdbRating: 1})
                     CREATE (:${Movie} {testString: $testString, imdbRating: 2})
@@ -245,7 +245,7 @@ describe("aggregations-top_level-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
@@ -22,11 +22,10 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-int", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         const typeDefs = `
         type ${Movie} {

--- a/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
@@ -57,7 +57,7 @@ describe("aggregations-top_level-many", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${typeMovie} {testId: "${testId}", id: "1", title: "1", imdbRating: 1, createdAt: datetime("${minDate.toISOString()}")})
                     CREATE (:${typeMovie} {testId: "${testId}", id: "22", title: "22", imdbRating: 2, createdAt: datetime()})
@@ -90,7 +90,7 @@ describe("aggregations-top_level-many", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
@@ -22,11 +22,10 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-many", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeMovie: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
     });
 

--- a/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
@@ -57,7 +57,7 @@ describe("aggregations-top_level-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${typeMovie} {testId: $id, title: "${titles[0]}"})
                     CREATE (:${typeMovie} {testId: $id, title: "${titles[1]}"})
@@ -79,7 +79,7 @@ describe("aggregations-top_level-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -109,7 +109,7 @@ describe("aggregations-top_level-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (:${typeMovie} {testId: $id, title: "${titles[0]}"})
                 CREATE (:${typeMovie} {testId: $id, title: "${titles[1]}"})
@@ -131,7 +131,7 @@ describe("aggregations-top_level-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -161,7 +161,7 @@ describe("aggregations-top_level-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${typeMovie} {testId: $id, title: "${titles[0]}"})
                     CREATE (:${typeMovie} {testId: $id, title: "${titles[1]}"})
@@ -184,7 +184,7 @@ describe("aggregations-top_level-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-top_level-string", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeMovie: UniqueType;
 
     const titles = [10, 11, 12, 13, 14].map((length) =>
@@ -34,7 +34,6 @@ describe("aggregations-top_level-string", () => {
     );
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
     });
 

--- a/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
@@ -53,7 +53,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (post1:${postType.name} { content: "${content1}" })<-[:LIKES]-(user1:${userType.name} { testString: "${testString1}" })
             CREATE (post2:${postType.name} { content: "${content2}" })<-[:LIKES]-(user2:${userType.name} { testString: "${testString2}" })
             CREATE (post3:${postType.name} { content: "${content3}" })<-[:LIKES]-(user3:${userType.name} { testString: "${testString3}" })
@@ -91,7 +91,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -123,7 +123,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -164,7 +164,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -205,7 +205,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -246,7 +246,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -287,7 +287,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -337,7 +337,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -381,7 +381,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -425,7 +425,7 @@ describe("Nested within AND/OR", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("Nested within AND/OR", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let userType: UniqueType;
     let postType: UniqueType;
@@ -38,7 +38,6 @@ describe("Nested within AND/OR", () => {
     const content5 = "Some more content";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
@@ -22,12 +22,11 @@ import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
 
 describe("aggregations-where-count", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
@@ -54,7 +54,7 @@ describe("aggregations-where-count", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -72,7 +72,7 @@ describe("aggregations-where-count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -94,7 +94,7 @@ describe("aggregations-where-count", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -112,7 +112,7 @@ describe("aggregations-where-count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -134,7 +134,7 @@ describe("aggregations-where-count", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -152,7 +152,7 @@ describe("aggregations-where-count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -178,7 +178,7 @@ describe("aggregations-where-count", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (p:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}"})
                     CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}"})
@@ -197,7 +197,7 @@ describe("aggregations-where-count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -219,7 +219,7 @@ describe("aggregations-where-count", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -237,7 +237,7 @@ describe("aggregations-where-count", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
@@ -22,13 +22,12 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-bigint", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let bigInt: string;
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         bigInt = "2147483647";
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");

--- a/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
@@ -61,7 +61,7 @@ describe("aggregations-where-edge-bigint", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someBigInt: toInteger(${bigInt})}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -79,7 +79,7 @@ describe("aggregations-where-edge-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -104,7 +104,7 @@ describe("aggregations-where-edge-bigint", () => {
         const someBigInt = `${bigInt}1`;
         const someBigIntGt = bigInt.substring(0, bigInt.length - 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someBigInt: ${someBigInt}}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -122,7 +122,7 @@ describe("aggregations-where-edge-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -144,7 +144,7 @@ describe("aggregations-where-edge-bigint", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someBigInt: toInteger(${bigInt})}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -162,7 +162,7 @@ describe("aggregations-where-edge-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -186,7 +186,7 @@ describe("aggregations-where-edge-bigint", () => {
 
         const someBigIntLT = `${bigInt}1`;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someBigInt: toInteger(${bigInt})}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -204,7 +204,7 @@ describe("aggregations-where-edge-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -226,7 +226,7 @@ describe("aggregations-where-edge-bigint", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someBigInt: toInteger(${bigInt})}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -244,7 +244,7 @@ describe("aggregations-where-edge-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
@@ -60,7 +60,7 @@ describe("aggregations-where-edge-datetime", () => {
 
         const someDateTime = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someDateTime: dateTime("${someDateTime.toISOString()}")}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -80,7 +80,7 @@ describe("aggregations-where-edge-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -106,7 +106,7 @@ describe("aggregations-where-edge-datetime", () => {
         const someDateTimeGT = new Date();
         someDateTimeGT.setDate(someDateTimeGT.getDate() - 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someDateTime: datetime("${someDateTime.toISOString()}")}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -126,7 +126,7 @@ describe("aggregations-where-edge-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -150,7 +150,7 @@ describe("aggregations-where-edge-datetime", () => {
 
         const someDateTime = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someDateTime: datetime("${someDateTime.toISOString()}")}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -170,7 +170,7 @@ describe("aggregations-where-edge-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -196,7 +196,7 @@ describe("aggregations-where-edge-datetime", () => {
         const someDateTimeLT = new Date();
         someDateTimeLT.setDate(someDateTimeLT.getDate() + 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someDateTime: datetime("${someDateTime.toISOString()}")}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -216,7 +216,7 @@ describe("aggregations-where-edge-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -240,7 +240,7 @@ describe("aggregations-where-edge-datetime", () => {
 
         const someDateTime = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someDateTime: datetime("${someDateTime.toISOString()}")}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -260,7 +260,7 @@ describe("aggregations-where-edge-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
@@ -22,13 +22,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-datetime", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
         const typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
@@ -57,7 +57,7 @@ describe("aggregations-where-edge-duration", () => {
     });
 
     test("should return posts where a edge like Int is EQUAL to", async () => {
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (p1:${Post} {content: "post1"})<-[:LIKES { someDuration: duration({months: 1}) }]-(:${User} {name: "user1"})
                     CREATE (p2:${Post} {content: "post2"})<-[:LIKES { someDuration: duration({months: 2}) }]-(:${User} {name: "user2"})
@@ -73,7 +73,7 @@ describe("aggregations-where-edge-duration", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)[Post.plural]).toIncludeSameMembers([{ content: "post2" }, { content: "post3" }]);

--- a/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
@@ -22,15 +22,13 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-duration", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let session: Session;
 
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
@@ -22,14 +22,12 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-float", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
@@ -63,7 +63,7 @@ describe("aggregations-where-edge-float", () => {
 
         const someFloat = Math.random() * Math.random() + 10.123;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someFloat: ${someFloat}}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -81,7 +81,7 @@ describe("aggregations-where-edge-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -106,7 +106,7 @@ describe("aggregations-where-edge-float", () => {
         const someFloat = Math.random() * Math.random() + 10.123;
         const someFloatGt = someFloat - 0.1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someFloat: ${someFloat}}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -124,7 +124,7 @@ describe("aggregations-where-edge-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -148,7 +148,7 @@ describe("aggregations-where-edge-float", () => {
 
         const someFloat = Math.random() * Math.random() + 10.123;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someFloat: ${someFloat}}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -166,7 +166,7 @@ describe("aggregations-where-edge-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -191,7 +191,7 @@ describe("aggregations-where-edge-float", () => {
         const someFloat = Math.random() * Math.random() + 10.123;
         const someFloatLT = someFloat + 0.1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someFloat: ${someFloat}}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -209,7 +209,7 @@ describe("aggregations-where-edge-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -233,7 +233,7 @@ describe("aggregations-where-edge-float", () => {
 
         const someFloat = Math.random() * Math.random() + 10.123;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES {someFloat: ${someFloat}}]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -251,7 +251,7 @@ describe("aggregations-where-edge-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
@@ -65,7 +65,7 @@ describe("aggregations-where-edge-id", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES { testId: "${testId}" }]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -83,7 +83,7 @@ describe("aggregations-where-edge-id", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
@@ -22,13 +22,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-id", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Post: UniqueType;
     let User: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Post = testHelper.createUniqueType("Post");
         User = testHelper.createUniqueType("User");
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
@@ -61,7 +61,7 @@ describe("aggregations-where-edge-int", () => {
 
         const someInt = Number(faker.number.int({ max: 100000 }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES { someInt: ${someInt} }]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -79,7 +79,7 @@ describe("aggregations-where-edge-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -100,7 +100,7 @@ describe("aggregations-where-edge-int", () => {
         const someInt = Number(faker.number.int({ max: 100000 }));
         const someIntGt = someInt - 1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES { someInt: ${someInt} }]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -118,7 +118,7 @@ describe("aggregations-where-edge-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -138,7 +138,7 @@ describe("aggregations-where-edge-int", () => {
 
         const someInt = Number(faker.number.int({ max: 100000 }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES { someInt: ${someInt} }]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -156,7 +156,7 @@ describe("aggregations-where-edge-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -177,7 +177,7 @@ describe("aggregations-where-edge-int", () => {
         const someInt = Number(faker.number.int({ max: 100000 }));
         const someIntLT = someInt + 1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES { someInt: ${someInt} }]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -195,7 +195,7 @@ describe("aggregations-where-edge-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -215,7 +215,7 @@ describe("aggregations-where-edge-int", () => {
 
         const someInt = Number(faker.number.int({ max: 100000 }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES { someInt: ${someInt} }]-(:${User} {testString: "${testString}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -233,7 +233,7 @@ describe("aggregations-where-edge-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -258,7 +258,7 @@ describe("aggregations-where-edge-int", () => {
 
             const avg = (someInt1 + someInt2 + someInt3) / 3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:${User} {testString: "${testString}"})
@@ -279,7 +279,7 @@ describe("aggregations-where-edge-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -297,7 +297,7 @@ describe("aggregations-where-edge-int", () => {
             const avg = (someInt1 + someInt2 + someInt3) / 3;
             const avgGT = avg - 1;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:${User} {testString: "${testString}"})
@@ -318,7 +318,7 @@ describe("aggregations-where-edge-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -335,7 +335,7 @@ describe("aggregations-where-edge-int", () => {
 
             const avg = (someInt1 + someInt2 + someInt3) / 3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:${User} {testString: "${testString}"})
@@ -356,7 +356,7 @@ describe("aggregations-where-edge-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             const [post] = (gqlResult.data as any)[Post.plural] as any[];
@@ -373,7 +373,7 @@ describe("aggregations-where-edge-int", () => {
             const avg = (someInt1 + someInt2 + someInt3) / 3;
             const avgLT = avg + 1;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:${User} {testString: "${testString}"})
@@ -394,7 +394,7 @@ describe("aggregations-where-edge-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -411,7 +411,7 @@ describe("aggregations-where-edge-int", () => {
 
             const avg = someInt1 + someInt2 + someInt3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:${User} {testString: "${testString}"})
@@ -432,7 +432,7 @@ describe("aggregations-where-edge-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -455,7 +455,7 @@ describe("aggregations-where-edge-int", () => {
 
             const sum = someInt1 + someInt2 + someInt3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES { someInt: ${someInt1} }]-(:${User} {testString: "${testString}"})
@@ -476,7 +476,7 @@ describe("aggregations-where-edge-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
@@ -23,12 +23,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-int", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
@@ -21,11 +21,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-edge-string", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
@@ -55,7 +55,7 @@ describe("aggregations-where-edge-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES { testString: "${testString}" }]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -73,7 +73,7 @@ describe("aggregations-where-edge-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -116,7 +116,7 @@ describe("aggregations-where-edge-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES {testString: "${testString}"}]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -134,7 +134,7 @@ describe("aggregations-where-edge-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -176,7 +176,7 @@ describe("aggregations-where-edge-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES {testString: "${testString}"}]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -194,7 +194,7 @@ describe("aggregations-where-edge-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -236,7 +236,7 @@ describe("aggregations-where-edge-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES {testString: "${testString}"}]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -254,7 +254,7 @@ describe("aggregations-where-edge-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -296,7 +296,7 @@ describe("aggregations-where-edge-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES {testString: "${testString}"}]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -314,7 +314,7 @@ describe("aggregations-where-edge-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -374,7 +374,7 @@ describe("aggregations-where-edge-string", () => {
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES { testString: "${shortestTestString}" }]-(:User {testString: "${shortestTestString}"})
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES { testString: "${testString2}" }]-(:User {testString: "${testString2}"})
@@ -393,7 +393,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 if (gqlResult.errors) {
                     console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -455,7 +455,7 @@ describe("aggregations-where-edge-string", () => {
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES { testString: "${shortestTestString}" }]-(:User {testString: "${shortestTestString}"})
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES { testString: "${testString2}" }]-(:User {testString: "${testString2}"})
@@ -474,7 +474,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 if (gqlResult.errors) {
                     console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -538,7 +538,7 @@ describe("aggregations-where-edge-string", () => {
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE(p)<-[:LIKES { testString: "${testString1}" }]-(:User {testString: "${testString}"})
@@ -559,7 +559,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 if (gqlResult.errors) {
                     console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -617,7 +617,7 @@ describe("aggregations-where-edge-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE(p)<-[:LIKES { testString: "${testString1}" }]-(:User {testString: "${testString}"})
@@ -638,7 +638,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -694,7 +694,7 @@ describe("aggregations-where-edge-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE(p)<-[:LIKES { testString: "${testString1}" }]-(:User {testString: "${testString}"})
@@ -715,7 +715,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -772,7 +772,7 @@ describe("aggregations-where-edge-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE(p)<-[:LIKES { testString: "${testString1}" }]-(:User {testString: "${testString}"})
@@ -793,7 +793,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -849,7 +849,7 @@ describe("aggregations-where-edge-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE(p)<-[:LIKES { testString: "${testString1}" }]-(:User {testString: "${testString}"})
@@ -870,7 +870,7 @@ describe("aggregations-where-edge-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -909,7 +909,7 @@ describe("aggregations-where-edge-string", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE(p:${Post} {content: "test"})<-[:LIKES {_someStringAlias:"10"}]-(:${User} {name: "a"})
             CREATE(p2:${Post} {content: "test2"})<-[:LIKES {_someStringAlias:"11"}]-(:${User} {name: "a"})
@@ -918,7 +918,7 @@ describe("aggregations-where-edge-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
@@ -53,7 +53,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (post1:${postType.name} { content: "${content1}" })<-[:LIKES]-(user1:${userType.name} { testString: "${testString1}" })
             CREATE (post2:${postType.name} { content: "${content2}" })<-[:LIKES]-(user2:${userType.name} { testString: "${testString2}" })
             CREATE (post3:${postType.name} { content: "${content3}" })<-[:LIKES]-(user3:${userType.name} { testString: "${testString3}" })
@@ -91,7 +91,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -121,7 +121,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -151,7 +151,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -190,7 +190,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -229,7 +229,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -268,7 +268,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -307,7 +307,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -346,7 +346,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../../../../utils/graphql-types";
 import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Delete using top level aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let userType: UniqueType;
     let postType: UniqueType;
@@ -38,7 +38,6 @@ describe("Delete using top level aggregate where", () => {
     const content5 = "Some more content";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../../../../utils/graphql-types";
 import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Connect using aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let userType: UniqueType;
     let postType: UniqueType;
     let likeInterface: UniqueType;
@@ -37,7 +37,6 @@ describe("Connect using aggregate where", () => {
     const date3 = new Date("2022-08-11T10:06:25.000Z");
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
         likeInterface = testHelper.createUniqueType("LikeEdge");
@@ -307,7 +306,7 @@ describe("Connect using aggregate where", () => {
 });
 
 describe("Connect UNIONs using aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let userType: UniqueType;
     let specialUserType: UniqueType;
     let postType: UniqueType;
@@ -329,7 +328,6 @@ describe("Connect UNIONs using aggregate where", () => {
     const content3 = "Post 3 has some long content";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         specialUserType = testHelper.createUniqueType("SpecialUser");
         postType = testHelper.createUniqueType("Post");

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
@@ -58,7 +58,7 @@ describe("Connect using aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (u:${userType.name} {name: "${userName}"})
             CREATE (u2:${userType.name} {name: "${userName2}"})
             CREATE (u3:${userType.name} {name: "${userName3}"})
@@ -107,14 +107,14 @@ describe("Connect using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
         expect(users).toEqual([
             { name: userName, likedPosts: expect.toIncludeSameMembers([{ id: postId1 }, { id: postId2 }]) },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
             WHERE u.name = "${userName}" 
@@ -160,7 +160,7 @@ describe("Connect using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
@@ -170,7 +170,7 @@ describe("Connect using aggregate where", () => {
                 likedPosts: expect.toIncludeSameMembers([{ id: postId1 }, { id: postId2 }, { id: postId3 }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
             WHERE u.name = "${userName}" 
@@ -222,7 +222,7 @@ describe("Connect using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
@@ -232,7 +232,7 @@ describe("Connect using aggregate where", () => {
                 likedPosts: expect.toIncludeSameMembers([{ id: postId1 }, { id: postId2 }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
             WHERE u.name = "${userName}" 
@@ -284,7 +284,7 @@ describe("Connect using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
@@ -294,7 +294,7 @@ describe("Connect using aggregate where", () => {
                 likedPosts: expect.toIncludeSameMembers([{ id: postId1 }, { id: postId2 }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
             WHERE u.name = "${userName}" 
@@ -359,7 +359,7 @@ describe("Connect UNIONs using aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (u:${specialUserType.name} {specialName: "${userName}"})
             CREATE (u2:${userType.name} {name: "${userName2}"})
             CREATE (u3:${userType.name} {name: "${userName3}"})
@@ -419,12 +419,12 @@ describe("Connect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
         expect(users).toEqual([{ id: postId3, likes: expect.toIncludeSameMembers([{ specialName: userName }]) }]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId3}"
@@ -484,7 +484,7 @@ describe("Connect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
@@ -498,7 +498,7 @@ describe("Connect UNIONs using aggregate where", () => {
                 ]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId1}"
@@ -569,7 +569,7 @@ describe("Connect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
@@ -579,7 +579,7 @@ describe("Connect UNIONs using aggregate where", () => {
                 likes: expect.toIncludeSameMembers([{ specialName: userName }, { specialName: userName4 }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId1}"

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../../../../utils/graphql-types";
 import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Disconnect using aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let userType: UniqueType;
     let postType: UniqueType;
     let likeInterface: UniqueType;
@@ -35,7 +35,6 @@ describe("Disconnect using aggregate where", () => {
     const date3 = new Date("2022-08-11T10:06:25.000Z");
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
         likeInterface = testHelper.createUniqueType("LikeEdge");
@@ -230,7 +229,7 @@ describe("Disconnect using aggregate where", () => {
 });
 
 describe("Disconnect UNIONs using aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let userType: UniqueType;
     let specialUserType: UniqueType;
     let postType: UniqueType;
@@ -252,7 +251,6 @@ describe("Disconnect UNIONs using aggregate where", () => {
     const content3 = "Post 3 has some long content";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         specialUserType = testHelper.createUniqueType("SpecialUser");
         postType = testHelper.createUniqueType("Post");

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
@@ -56,7 +56,7 @@ describe("Disconnect using aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (u:${userType.name} {name: "${userName}"})
             CREATE (u2:${userType.name} {name: "${userName2}"})
             CREATE (u)-[:LIKES { likedAt: dateTime("${date1.toISOString()}")}]->(p:${postType.name} {id: "${postId1}"})
@@ -101,12 +101,12 @@ describe("Disconnect using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
         expect(users).toEqual([{ name: userName, likedPosts: expect.toIncludeSameMembers([{ id: postId1 }]) }]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
             WHERE u.name = "${userName}" 
@@ -155,12 +155,12 @@ describe("Disconnect using aggregate where", () => {
              }
          `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
         expect(users).toEqual([{ name: userName, likedPosts: [] }]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
              MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
              WHERE u.name = "${userName}" 
@@ -212,12 +212,12 @@ describe("Disconnect using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
         expect(users).toEqual([{ name: userName, likedPosts: [{ id: postId1 }] }]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
              MATCH (u:${userType.name})-[r:LIKES]->(p:${postType.name}) 
              WHERE u.name = "${userName2}" 
@@ -282,7 +282,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (u:${specialUserType.name} {specialName: "${userName}"})
             CREATE (u2:${userType.name} {name: "${userName2}"})
             CREATE (u3:${userType.name} {name: "${userName3}"})
@@ -342,14 +342,14 @@ describe("Disconnect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
         expect(users).toEqual([
             { id: postId2, likes: expect.toIncludeSameMembers([{ name: userName2 }, { name: userName3 }]) },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId2}"
@@ -409,7 +409,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
@@ -419,7 +419,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                 likes: expect.toIncludeSameMembers([{ specialName: userName }, { name: userName2 }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId2}"
@@ -479,7 +479,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
@@ -489,7 +489,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                 likes: expect.toIncludeSameMembers([{ specialName: userName }, { name: userName2 }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId2}"
@@ -560,7 +560,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[postType.operations.update][postType.plural] as any[];
@@ -570,7 +570,7 @@ describe("Disconnect UNIONs using aggregate where", () => {
                 likes: expect.toIncludeSameMembers([{ specialName: userName }]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${specialUserType.name})-[r:LIKES]->(p:${postType.name})
             WHERE p.id = "${postId2}"

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../../../../utils/graphql-types";
 import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Delete using top level aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let userType: UniqueType;
     let postType: UniqueType;
@@ -39,7 +39,6 @@ describe("Delete using top level aggregate where", () => {
     const updatedContent = "This has been updated;";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
@@ -55,7 +55,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (post1:${postType.name} { id: randomUUID(), content: "${content1}" })<-[:LIKES]-(user1:${userType.name} { testString: "${testString1}" })
             CREATE (post2:${postType.name} { id: randomUUID(), content: "${content2}" })<-[:LIKES]-(user2:${userType.name} { testString: "${testString2}" })
             CREATE (post3:${postType.name} { id: randomUUID(), content: "${content3}" })<-[:LIKES]-(user3:${userType.name} { testString: "${testString3}" })
@@ -99,7 +99,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -132,7 +132,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -165,7 +165,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -207,7 +207,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -249,7 +249,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -291,7 +291,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -333,7 +333,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -375,7 +375,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -417,7 +417,7 @@ describe("Delete using top level aggregate where", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
@@ -58,7 +58,7 @@ describe("Update using aggregate where", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (u:${userType.name} {name: "${userName}"})
             CREATE (u2:${userType.name} {name: "${userName2}"})
             CREATE (u)-[:LIKES { likedAt: dateTime("${date1.toISOString()}")}]->(p:${
@@ -111,7 +111,7 @@ describe("Update using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
@@ -124,7 +124,7 @@ describe("Update using aggregate where", () => {
                 ]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
             MATCH (u:${userType.name})-[r:LIKES]->(post:${postType.name}) 
             WHERE u.name = "${userName}" 
@@ -192,7 +192,7 @@ describe("Update using aggregate where", () => {
              }
          `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
@@ -205,7 +205,7 @@ describe("Update using aggregate where", () => {
                 ]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
              MATCH (u:${userType.name})-[r:LIKES]->(post:${postType.name}) 
              WHERE u.name = "${userName}" 
@@ -270,7 +270,7 @@ describe("Update using aggregate where", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         const users = (gqlResult.data as any)[userType.operations.update][userType.plural] as any[];
@@ -283,7 +283,7 @@ describe("Update using aggregate where", () => {
                 ]),
             },
         ]);
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
              MATCH (u:${userType.name})-[r:LIKES]->(post:${postType.name}) 
              WHERE u.name = "${userName}" 

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../../../../utils/graphql-types";
 import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Update using aggregate where", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let userType: UniqueType;
     let postType: UniqueType;
     let likeInterface: UniqueType;
@@ -37,7 +37,6 @@ describe("Update using aggregate where", () => {
     const date3 = new Date("2022-08-11T10:06:25.000Z");
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
         likeInterface = testHelper.createUniqueType("LikeEdge");

--- a/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
@@ -57,7 +57,7 @@ describe("aggregations-where-node-bigint", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someBigInt: toInteger(${bigInt})})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -76,7 +76,7 @@ describe("aggregations-where-node-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -101,7 +101,7 @@ describe("aggregations-where-node-bigint", () => {
         const someBigInt = `${bigInt}1`;
         const someBigIntGt = bigInt.substring(0, bigInt.length - 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someBigInt: ${someBigInt}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -120,7 +120,7 @@ describe("aggregations-where-node-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -142,7 +142,7 @@ describe("aggregations-where-node-bigint", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someBigInt: toInteger(${bigInt})})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -161,7 +161,7 @@ describe("aggregations-where-node-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -185,7 +185,7 @@ describe("aggregations-where-node-bigint", () => {
 
         const someBigIntLT = `${bigInt}1`;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someBigInt: toInteger(${bigInt})})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -204,7 +204,7 @@ describe("aggregations-where-node-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -226,7 +226,7 @@ describe("aggregations-where-node-bigint", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someBigInt: toInteger(${bigInt})})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -245,7 +245,7 @@ describe("aggregations-where-node-bigint", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
@@ -22,13 +22,12 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-node-bigint", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let bigInt: string;
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         bigInt = "2147483647";
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");

--- a/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
@@ -22,12 +22,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-node-datetime", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
         const typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
@@ -56,7 +56,7 @@ describe("aggregations-where-node-datetime", () => {
 
         const someDateTime = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someDateTime: dateTime("${someDateTime.toISOString()}")})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -77,7 +77,7 @@ describe("aggregations-where-node-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -103,7 +103,7 @@ describe("aggregations-where-node-datetime", () => {
         const someDateTimeGT = new Date();
         someDateTimeGT.setDate(someDateTimeGT.getDate() - 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someDateTime: datetime("${someDateTime.toISOString()}")})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -124,7 +124,7 @@ describe("aggregations-where-node-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -148,7 +148,7 @@ describe("aggregations-where-node-datetime", () => {
 
         const someDateTime = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someDateTime: datetime("${someDateTime.toISOString()}")})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -169,7 +169,7 @@ describe("aggregations-where-node-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -195,7 +195,7 @@ describe("aggregations-where-node-datetime", () => {
         const someDateTimeLT = new Date();
         someDateTimeLT.setDate(someDateTimeLT.getDate() + 1);
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someDateTime: datetime("${someDateTime.toISOString()}")})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -216,7 +216,7 @@ describe("aggregations-where-node-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -240,7 +240,7 @@ describe("aggregations-where-node-datetime", () => {
 
         const someDateTime = new Date();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someDateTime: datetime("${someDateTime.toISOString()}")})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -261,7 +261,7 @@ describe("aggregations-where-node-datetime", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
@@ -22,12 +22,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-node-float", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
         const typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
@@ -56,7 +56,7 @@ describe("aggregations-where-node-float", () => {
 
         const someFloat = Math.random() * Math.random() + 10;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someFloat: ${someFloat}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -75,7 +75,7 @@ describe("aggregations-where-node-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -100,7 +100,7 @@ describe("aggregations-where-node-float", () => {
         const someFloat = Math.random() * Math.random() + 10;
         const someFloatGt = someFloat - 0.1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someFloat: ${someFloat}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -119,7 +119,7 @@ describe("aggregations-where-node-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -143,7 +143,7 @@ describe("aggregations-where-node-float", () => {
 
         const someFloat = Math.random() * Math.random() + 10;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someFloat: ${someFloat}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -162,7 +162,7 @@ describe("aggregations-where-node-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -187,7 +187,7 @@ describe("aggregations-where-node-float", () => {
         const someFloat = Math.random() * Math.random() + 10;
         const someFloatLT = someFloat + 0.1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someFloat: ${someFloat}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -206,7 +206,7 @@ describe("aggregations-where-node-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -230,7 +230,7 @@ describe("aggregations-where-node-float", () => {
 
         const someFloat = Math.random() * Math.random() + 10;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someFloat: ${someFloat}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -249,7 +249,7 @@ describe("aggregations-where-node-float", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
@@ -22,12 +22,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-node-id", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
 

--- a/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
@@ -60,7 +60,7 @@ describe("aggregations-where-node-id", () => {
             readable: true,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", id: "${testId}"})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -79,7 +79,7 @@ describe("aggregations-where-node-id", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
@@ -57,7 +57,7 @@ describe("aggregations-where-node-int", () => {
 
         const someInt = Number(faker.number.int({ max: 100000 }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -76,7 +76,7 @@ describe("aggregations-where-node-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -97,7 +97,7 @@ describe("aggregations-where-node-int", () => {
         const someInt = Number(faker.number.int({ max: 100000 }));
         const someIntGt = someInt - 1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -116,7 +116,7 @@ describe("aggregations-where-node-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -136,7 +136,7 @@ describe("aggregations-where-node-int", () => {
 
         const someInt = Number(faker.number.int({ max: 100000 }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -155,7 +155,7 @@ describe("aggregations-where-node-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -176,7 +176,7 @@ describe("aggregations-where-node-int", () => {
         const someInt = Number(faker.number.int({ max: 100000 }));
         const someIntLT = someInt + 1;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -195,7 +195,7 @@ describe("aggregations-where-node-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -215,7 +215,7 @@ describe("aggregations-where-node-int", () => {
 
         const someInt = Number(faker.number.int({ max: 100000 }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Post} {testString: "${testString}"})<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt}})
                     CREATE (:${Post} {testString: "${testString}"})
@@ -234,7 +234,7 @@ describe("aggregations-where-node-int", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -259,7 +259,7 @@ describe("aggregations-where-node-int", () => {
 
             const avg = (someInt1 + someInt2 + someInt3) / 3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt1}})
@@ -281,7 +281,7 @@ describe("aggregations-where-node-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -299,7 +299,7 @@ describe("aggregations-where-node-int", () => {
             const avg = (someInt1 + someInt2 + someInt3) / 3;
             const avgGT = avg - 1;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt1}})
@@ -321,7 +321,7 @@ describe("aggregations-where-node-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -338,7 +338,7 @@ describe("aggregations-where-node-int", () => {
 
             const avg = (someInt1 + someInt2 + someInt3) / 3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt1}})
@@ -360,7 +360,7 @@ describe("aggregations-where-node-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -378,7 +378,7 @@ describe("aggregations-where-node-int", () => {
             const avg = (someInt1 + someInt2 + someInt3) / 3;
             const avgLT = avg + 1;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt1}})
@@ -400,7 +400,7 @@ describe("aggregations-where-node-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -417,7 +417,7 @@ describe("aggregations-where-node-int", () => {
 
             const avg = (someInt1 + someInt2 + someInt3) / 3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt1}})
@@ -439,7 +439,7 @@ describe("aggregations-where-node-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -462,7 +462,7 @@ describe("aggregations-where-node-int", () => {
 
             const sum = someInt1 + someInt2 + someInt3;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:${Post} {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:${User} {testString: "${testString}", someInt: ${someInt1}})
@@ -484,7 +484,7 @@ describe("aggregations-where-node-int", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
@@ -23,12 +23,11 @@ import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-node-int", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
     let Post: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
         const typeDefs = `

--- a/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
@@ -21,11 +21,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-node-string", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
@@ -50,7 +50,7 @@ describe("aggregations-where-node-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -68,7 +68,7 @@ describe("aggregations-where-node-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -107,7 +107,7 @@ describe("aggregations-where-node-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -125,7 +125,7 @@ describe("aggregations-where-node-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -163,7 +163,7 @@ describe("aggregations-where-node-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -181,7 +181,7 @@ describe("aggregations-where-node-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -219,7 +219,7 @@ describe("aggregations-where-node-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -237,7 +237,7 @@ describe("aggregations-where-node-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -275,7 +275,7 @@ describe("aggregations-where-node-string", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString}"})
                     CREATE (:Post {testString: "${testString}"})
@@ -293,7 +293,7 @@ describe("aggregations-where-node-string", () => {
                 }
             `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -349,7 +349,7 @@ describe("aggregations-where-node-string", () => {
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${shortestTestString}"})
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString2}"})
@@ -368,7 +368,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 if (gqlResult.errors) {
                     console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -426,7 +426,7 @@ describe("aggregations-where-node-string", () => {
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${shortestTestString}"})
                         CREATE (:Post {testString: "${testString}"})<-[:LIKES]-(:User {testString: "${testString2}"})
@@ -445,7 +445,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 if (gqlResult.errors) {
                     console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -506,7 +506,7 @@ describe("aggregations-where-node-string", () => {
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:User {testString: "${testString1}"})
@@ -527,7 +527,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 if (gqlResult.errors) {
                     console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -582,7 +582,7 @@ describe("aggregations-where-node-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:User {testString: "${testString1}"})
@@ -603,7 +603,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -656,7 +656,7 @@ describe("aggregations-where-node-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:User {testString: "${testString1}"})
@@ -677,7 +677,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -731,7 +731,7 @@ describe("aggregations-where-node-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:User {testString: "${testString1}"})
@@ -752,7 +752,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -805,7 +805,7 @@ describe("aggregations-where-node-string", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (p:Post {testString: "${testString}"})
                         CREATE (p)<-[:LIKES]-(:User {testString: "${testString1}"})
@@ -826,7 +826,7 @@ describe("aggregations-where-node-string", () => {
                     }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -865,7 +865,7 @@ describe("aggregations-where-node-string", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE(p:${Post} {content: "test"})<-[:LIKES]-(:${User} {_name: "a"})
             CREATE(p2:${Post} {content: "test2"})<-[:LIKES]-(:${User} {_name: "b"})
@@ -873,7 +873,7 @@ describe("aggregations-where-node-string", () => {
         );
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
@@ -68,9 +68,9 @@ describe("array-pop-and-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc"] })
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -112,7 +112,7 @@ describe("array-pop-and-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ['a', 'b'], moreTags: []})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
         const token = "not valid token";
 
@@ -120,7 +120,7 @@ describe("array-pop-and-push", () => {
         const req = new IncomingMessage(socket);
         req.headers.authorization = `Bearer ${token}`;
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect((gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Unauthenticated"))).toBeTruthy();
@@ -160,9 +160,9 @@ describe("array-pop-and-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc"], moreTags: ["this", "that", "them"] })
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
@@ -25,11 +25,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-pop-and-push", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
@@ -22,11 +22,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-pop-and-push", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
@@ -65,9 +65,9 @@ describe("array-pop-and-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc"], moreTags: ["this", "that", "them"] })
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
@@ -25,11 +25,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-pop-errors", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
@@ -67,9 +67,9 @@ describe("array-pop-errors", () => {
             CREATE (m:${typeMovie} {title:$movieTitle})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -113,9 +113,9 @@ describe("array-pop-errors", () => {
             CREATE (m:${typeMovie} {title:$movieTitle})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -160,7 +160,7 @@ describe("array-pop-errors", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ['a', 'b']})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
         const token = "not valid token";
 
@@ -168,7 +168,7 @@ describe("array-pop-errors", () => {
         const req = new IncomingMessage(socket);
         req.headers.authorization = `Bearer ${token}`;
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect((gqlResult.errors as GraphQLError[]).some((el) => el.message.includes("Unauthenticated"))).toBeTruthy();
@@ -206,9 +206,9 @@ describe("array-pop-errors", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc", "xyz"]})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -251,9 +251,9 @@ describe("array-pop-errors", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags:["existing value"]})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -323,7 +323,7 @@ describe("array-pop-errors", () => {
         `;
 
         // Create new movie
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ pay: $initialPay }]-(b) RETURN a, actedIn, b
                 `,
@@ -333,7 +333,7 @@ describe("array-pop-errors", () => {
             }
         );
         // Update movie
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, numberToPop: 1 },
         });
 

--- a/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
@@ -23,11 +23,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-pop", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
@@ -124,9 +124,9 @@ describe("array-pop", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ${initialValue}})
         `;
 
-            await testHelper.runCypher(cypher, { movieTitle });
+            await testHelper.executeCypher(cypher, { movieTitle });
 
-            const gqlResult = await testHelper.runGraphQL(update);
+            const gqlResult = await testHelper.executeGraphQL(update);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -224,9 +224,9 @@ describe("array-pop", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ${initialValue}})
         `;
 
-            await testHelper.runCypher(cypher, { movieTitle });
+            await testHelper.executeCypher(cypher, { movieTitle });
 
-            const gqlResult = await testHelper.runGraphQL(update);
+            const gqlResult = await testHelper.executeGraphQL(update);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -324,9 +324,9 @@ describe("array-pop", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ${initialValue}})
         `;
 
-            await testHelper.runCypher(cypher, { movieTitle });
+            await testHelper.executeCypher(cypher, { movieTitle });
 
-            const gqlResult = await testHelper.runGraphQL(update);
+            const gqlResult = await testHelper.executeGraphQL(update);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -407,7 +407,7 @@ describe("array-pop", () => {
             }
         `;
 
-        const gqlCreateResult = await testHelper.runGraphQL(create, {
+        const gqlCreateResult = await testHelper.executeGraphQL(create, {
             variableValues: {
                 title: movieTitle,
                 longitude: point.longitude,
@@ -437,7 +437,7 @@ describe("array-pop", () => {
             }
         `;
 
-        const gqlUpdateResult = await testHelper.runGraphQL(update, {
+        const gqlUpdateResult = await testHelper.executeGraphQL(update, {
             variableValues: { elementsToPop },
         });
 
@@ -517,7 +517,7 @@ describe("array-pop", () => {
             }
         `;
 
-        const gqlCreateResult = await testHelper.runGraphQL(create, {
+        const gqlCreateResult = await testHelper.executeGraphQL(create, {
             variableValues: {
                 title: movieTitle,
                 x: cartesianPoint.x,
@@ -545,7 +545,7 @@ describe("array-pop", () => {
             }
         `;
 
-        const gqlUpdateResult = await testHelper.runGraphQL(update, {
+        const gqlUpdateResult = await testHelper.executeGraphQL(update, {
             variableValues: { elementsToPop },
         });
 
@@ -593,9 +593,9 @@ describe("array-pop", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: ["abc", "xyz"], moreTags: ["this", "that", "them"] })
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -660,13 +660,13 @@ describe("array-pop", () => {
             WITH a,b CREATE (a)<-[worksInMovies: WORKED_IN]-(b)
         `;
 
-        await testHelper.runCypher(cypher, {
+        await testHelper.executeCypher(cypher, {
             id,
             initialViewers: [1, 2],
             name: actorName,
         });
 
-        const gqlResult = await testHelper.runGraphQL(update, {
+        const gqlResult = await testHelper.executeGraphQL(update, {
             variableValues: { numberToPop: 1, id },
         });
 
@@ -734,7 +734,7 @@ describe("array-pop", () => {
         `;
 
         // Create new movie
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ pay: $initialPay }]-(b) RETURN a, actedIn, b
                 `,
@@ -744,12 +744,12 @@ describe("array-pop", () => {
             }
         );
         // Update movie
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, numberToPop: 1 },
         });
 
         expect(gqlResult.errors).toBeUndefined();
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
                 MATCH(b: ${actor.name}{id: $id}) -[c: ACTED_IN]-> (a: ${movie.name}) RETURN c.pay as pay
                 `,
@@ -821,7 +821,7 @@ describe("array-pop", () => {
         `;
 
         // Create new movie
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ locations: [point($initialLocation)] }]-(b) RETURN a, actedIn, b
                 `,
@@ -831,7 +831,7 @@ describe("array-pop", () => {
             }
         );
         // Update movie
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, numberToPop: 1 },
         });
 

--- a/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
@@ -67,9 +67,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -112,7 +112,7 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: []})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
         const token = "not valid token";
 
@@ -120,7 +120,7 @@ describe("array-push", () => {
         const req = new IncomingMessage(socket);
         req.headers.authorization = `Bearer ${token}`;
 
-        const gqlResult = await testHelper.runGraphQL(update, {
+        const gqlResult = await testHelper.executeGraphQL(update, {
             contextValue: { req },
         });
 
@@ -160,9 +160,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags:[]})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -204,9 +204,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags:["existing value"]})
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -277,7 +277,7 @@ describe("array-push", () => {
         `;
 
         // Create new movie
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ pay: $initialPay }]-(b) RETURN a, actedIn, b
                 `,
@@ -287,7 +287,7 @@ describe("array-push", () => {
             }
         );
         // Update movie
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, payIncrement },
         });
 

--- a/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
@@ -25,11 +25,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-push", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
@@ -23,11 +23,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-push", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
@@ -252,9 +252,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: []})
         `;
 
-            await testHelper.runCypher(cypher, { movieTitle });
+            await testHelper.executeCypher(cypher, { movieTitle });
 
-            const gqlResult = await testHelper.runGraphQL(update);
+            const gqlResult = await testHelper.executeGraphQL(update);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -330,9 +330,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: []})
         `;
 
-            await testHelper.runCypher(cypher, { movieTitle });
+            await testHelper.executeCypher(cypher, { movieTitle });
 
-            const gqlResult = await testHelper.runGraphQL(update, {
+            const gqlResult = await testHelper.executeGraphQL(update, {
                 variableValues: { inputValue },
             });
 
@@ -408,9 +408,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: []})
         `;
 
-            await testHelper.runCypher(cypher, { movieTitle });
+            await testHelper.executeCypher(cypher, { movieTitle });
 
-            const gqlResult = await testHelper.runGraphQL(update, {
+            const gqlResult = await testHelper.executeGraphQL(update, {
                 variableValues: { inputValue },
             });
 
@@ -459,9 +459,9 @@ describe("array-push", () => {
             CREATE (m:${typeMovie} {title:$movieTitle, tags: [], moreTags: [] })
         `;
 
-        await testHelper.runCypher(cypher, { movieTitle });
+        await testHelper.executeCypher(cypher, { movieTitle });
 
-        const gqlResult = await testHelper.runGraphQL(update);
+        const gqlResult = await testHelper.executeGraphQL(update);
 
         if (gqlResult.errors) {
             console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -526,13 +526,13 @@ describe("array-push", () => {
             WITH a,b CREATE (a)<-[worksInMovies: WORKED_IN]-(b)
         `;
 
-        await testHelper.runCypher(cypher, {
+        await testHelper.executeCypher(cypher, {
             id,
             initialViewers: [],
             name: actorName,
         });
 
-        const gqlResult = await testHelper.runGraphQL(update, {
+        const gqlResult = await testHelper.executeGraphQL(update, {
             variableValues: { value: [1, 2, 3, 4], id },
         });
 
@@ -601,7 +601,7 @@ describe("array-push", () => {
         `;
 
         // Create new movie
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ pay: $initialPay }]-(b) RETURN a, actedIn, b
                 `,
@@ -611,12 +611,12 @@ describe("array-push", () => {
             }
         );
         // Update movie
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, payIncrement },
         });
 
         expect(gqlResult.errors).toBeUndefined();
-        const storedValue = await testHelper.runCypher(
+        const storedValue = await testHelper.executeCypher(
             `
                 MATCH(b: ${actor.name}{id: $id}) -[c: ACTED_IN]-> (a: ${movie.name}) RETURN c.pay as pay
                 `,
@@ -688,7 +688,7 @@ describe("array-push", () => {
         `;
 
         // Create new movie
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${movie.name} {title: "The Matrix"}), (b:${actor.name} {id: $id, name: "Keanu"}) WITH a,b CREATE (a)<-[actedIn: ACTED_IN{ locations: [] }]-(b) RETURN a, actedIn, b
                 `,
@@ -697,7 +697,7 @@ describe("array-push", () => {
             }
         );
         // Update movie
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, location: [point] },
         });
 

--- a/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
@@ -76,12 +76,12 @@ describe("array-subscription", () => {
         }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${typeMovie.name} { id: "1", name: "Terminator", tags: [] })
             CREATE (:${typeMovie.name} { id: "2", name: "The Many Adventures of Winnie the Pooh" })
         `);
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -110,12 +110,12 @@ describe("array-subscription", () => {
         }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${typeMovie.name} { id: "1", name: "Terminator", tags: ["a tag"] })
             CREATE (:${typeMovie.name} { id: "2", name: "The Many Adventures of Winnie the Pooh" })
         `);
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -144,12 +144,12 @@ describe("array-subscription", () => {
         }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${typeMovie.name} { id: "1", name: "Terminator", tags: ["a tag"], moreTags: [] })
             CREATE (:${typeMovie.name} { id: "2", name: "The Many Adventures of Winnie the Pooh" })
         `);
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
@@ -23,15 +23,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("array-subscription", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let plugin: TestSubscriptionsEngine;
 
     let typeActor: UniqueType;
     let typeMovie: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         typeActor = testHelper.createUniqueType("Actor");
         typeMovie = testHelper.createUniqueType("Movie");
 

--- a/packages/graphql/tests/integration/config-options/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/query-options.int.test.ts
@@ -25,13 +25,12 @@ import { TestHelper } from "../utils/tests-helper";
 describe("query options", () => {
     let neoSchema: Neo4jGraphQL;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Actor: UniqueType;
     let Movie: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Actor = testHelper.createUniqueType("Actor");
         Movie = testHelper.createUniqueType("Movie");
 

--- a/packages/graphql/tests/integration/config-options/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/query-options.int.test.ts
@@ -72,14 +72,14 @@ describe("query options", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
               CREATE (:${Movie} {id: $id}), (:${Movie} {id: $id}), (:${Movie} {id: $id})
             `,
             { id }
         );
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             variableValues: { id },
             contextValue: { cypherQueryOptions: { runtime: "interpreted" } },
         });

--- a/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
@@ -61,7 +61,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                         `,
@@ -76,7 +76,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult.data as any)[randomType.plural]).toHaveLength(1);
@@ -108,7 +108,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                         `,
@@ -123,7 +123,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult.data as any)[randomType.plural]).toHaveLength(1);
@@ -151,7 +151,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $randomValue1})
@@ -167,7 +167,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -202,7 +202,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $randomValue1})
@@ -219,7 +219,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -246,7 +246,7 @@ describe("Advanced Filtering", () => {
 
             const superValue = `${value}${value}`;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $superValue})
                             CREATE (:${randomType.name} {property: $superValue})
@@ -263,7 +263,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -293,7 +293,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $notValue})
@@ -310,7 +310,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -337,7 +337,7 @@ describe("Advanced Filtering", () => {
 
             const superValue = `${value}${value}`;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $superValue})
                             CREATE (:${randomType.name} {property: $superValue})
@@ -354,7 +354,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -386,7 +386,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $notValue})
@@ -403,7 +403,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -433,7 +433,7 @@ describe("Advanced Filtering", () => {
 
             const superValue = `${value}${value}`;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $notValue})
@@ -450,7 +450,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -480,7 +480,7 @@ describe("Advanced Filtering", () => {
 
             const superValue = `${value}${value}`;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $notValue})
@@ -497,7 +497,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -535,7 +535,7 @@ describe("Advanced Filtering", () => {
             const matrixReloaded = "The Matrix Reloaded";
             const matrixRevolutions = "The Matrix Revolutions";
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${movieType.name} {title: $animatrix})
                             CREATE (:${movieType.name} {title: $matrix})
@@ -553,7 +553,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -595,7 +595,7 @@ describe("Advanced Filtering", () => {
             const matrixRevolutions = "The Matrix Revolutions";
             const matrixResurrections = "The Matrix Resurrections";
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${movieType.name} {title: $matrix})
                             CREATE (:${movieType.name} {title: $matrixReloaded})
@@ -613,7 +613,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -655,7 +655,7 @@ describe("Advanced Filtering", () => {
             const matrixReloaded = "The Matrix Reloaded";
             const matrixRevolutions = "The Matrix Revolutions";
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${movieType.name} {title: $animatrix})
                             CREATE (:${movieType.name} {title: $matrix})
@@ -673,7 +673,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -715,7 +715,7 @@ describe("Advanced Filtering", () => {
             const matrixRevolutions = "The Matrix Revolutions";
             const matrixResurrections = "The Matrix Resurrections";
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${movieType.name} {title: $matrix})
                             CREATE (:${movieType.name} {title: $matrixReloaded})
@@ -734,7 +734,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -782,7 +782,7 @@ describe("Advanced Filtering", () => {
                 notProperty = Math.floor(Math.random() * 9999) + 0.5;
             }
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $property})
                             CREATE (:${randomType.name} {property: $notProperty})
@@ -798,7 +798,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -841,7 +841,7 @@ describe("Advanced Filtering", () => {
                 randomValue2 = Math.floor(Math.random() * 9999) + 0.5;
             }
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                         `,
@@ -856,7 +856,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -899,7 +899,7 @@ describe("Advanced Filtering", () => {
                 randomValue2 = Math.floor(Math.random() * 99999) + 0.5;
             }
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $randomValue1})
@@ -916,7 +916,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -945,7 +945,7 @@ describe("Advanced Filtering", () => {
 
             const lessThanValue = value - (value + 1);
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $lessThanValue})
@@ -961,7 +961,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -990,7 +990,7 @@ describe("Advanced Filtering", () => {
 
             const lessThanValue = value - (value + 1);
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $lessThanValue})
@@ -1006,7 +1006,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -1034,7 +1034,7 @@ describe("Advanced Filtering", () => {
 
             const graterThanValue = value + 1;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $graterThanValue})
@@ -1050,7 +1050,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -1079,7 +1079,7 @@ describe("Advanced Filtering", () => {
 
             const greaterThan = value + 1;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                             CREATE (:${randomType.name} {property: $greaterThan})
@@ -1095,7 +1095,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -1117,7 +1117,7 @@ describe("Advanced Filtering", () => {
 
             const value = false;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                         `,
@@ -1132,7 +1132,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -1152,7 +1152,7 @@ describe("Advanced Filtering", () => {
 
             const value = false;
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (:${randomType.name} {property: $value})
                         `,
@@ -1167,7 +1167,7 @@ describe("Advanced Filtering", () => {
                             }
                         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -1206,7 +1206,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                                 CREATE (root:${randomType1.name} {id: $rootId})
                                 CREATE (:${randomType1.name} {id: $randomId})
@@ -1228,7 +1228,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
 
@@ -1261,7 +1261,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                             CREATE (movie:Movie {id: $movieId})-[:IN_GENRE]->(:Genre {id:$genreId})
                         `,
@@ -1279,7 +1279,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
 
@@ -1320,7 +1320,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                             CREATE (movie:Movie {id: $movieId})-[:IN_GENRE {id:$actedInId}]->(:Genre {id:$genreId})
                         `,
@@ -1338,7 +1338,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
                 expect((gqlResult.data as any).movies).toHaveLength(1);
@@ -1378,7 +1378,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                             CREATE (movie:Movie {id: $movieId})-[:IN_GENRE {id:$actedInId}]->(:Genre {id:$genreId})
                         `,
@@ -1396,7 +1396,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
 
@@ -1440,7 +1440,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                                 CREATE (root1:${randomType1.name} {id: $rootId1})
                                 CREATE (root2:${randomType1.name} {id: $rootId2})
@@ -1463,7 +1463,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
 
@@ -1505,7 +1505,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                             CREATE (root1:${randomType1.name} {id: $rootId1})-[:IN_GENRE]->(relation1:${randomType2.name} {id: $relationId1})
                             CREATE (root2:${randomType1.name} {id: $rootId2})-[:IN_GENRE]->(relation2:${randomType2.name} {id: $relationId2})
@@ -1524,7 +1524,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
 
@@ -1573,7 +1573,7 @@ describe("Advanced Filtering", () => {
                     charset: "alphabetic",
                 });
 
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                             CREATE (:${randomType1.name} {id: $rootId1})-[:IN_GENRE {id: $actedInId}]->(:${randomType2.name} {id: $relationId1})
                             CREATE (:${randomType1.name} {id: $rootId2})-[:IN_GENRE {id: randomUUID()}]->(:${randomType2.name} {id: $relationId2})
@@ -1592,7 +1592,7 @@ describe("Advanced Filtering", () => {
                         }
                     `;
 
-                const gqlResult = await testHelper.runGraphQL(query);
+                const gqlResult = await testHelper.executeGraphQL(query);
 
                 expect(gqlResult.errors).toBeUndefined();
 
@@ -1638,7 +1638,7 @@ describe("Advanced Filtering", () => {
             `;
 
                 await testHelper.initNeo4jGraphQL({ typeDefs });
-                await testHelper.runCypher(
+                await testHelper.executeCypher(
                     `
                     CREATE (m1:${Movie}) SET m1 = $movies[0]
                     CREATE (m2:${Movie}) SET m2 = $movies[1]
@@ -1674,7 +1674,7 @@ describe("Advanced Filtering", () => {
                 }
 
                 test("ALL", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("ALL"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("ALL"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1690,7 +1690,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("NONE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("NONE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("NONE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1706,7 +1706,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SINGLE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SINGLE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SINGLE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1722,7 +1722,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SOME", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SOME"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SOME"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1760,7 +1760,7 @@ describe("Advanced Filtering", () => {
                 `;
 
                 test("ALL", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("ALL"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("ALL"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1776,7 +1776,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("NONE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("NONE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("NONE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1792,7 +1792,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SINGLE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SINGLE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SINGLE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1808,7 +1808,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SOME", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SOME"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SOME"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1846,7 +1846,7 @@ describe("Advanced Filtering", () => {
                 `;
 
                 test("ALL", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("ALL"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("ALL"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1862,7 +1862,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("NONE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("NONE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("NONE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1878,7 +1878,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SINGLE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SINGLE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SINGLE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1894,7 +1894,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SOME", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SOME"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SOME"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1932,7 +1932,7 @@ describe("Advanced Filtering", () => {
                 `;
 
                 test("ALL", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("ALL"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("ALL"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1948,7 +1948,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("NONE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("NONE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("NONE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1964,7 +1964,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SINGLE", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SINGLE"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SINGLE"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -1980,7 +1980,7 @@ describe("Advanced Filtering", () => {
                 });
 
                 test("SOME", async () => {
-                    const gqlResult = await testHelper.runGraphQL(generateQuery("SOME"), {
+                    const gqlResult = await testHelper.executeGraphQL(generateQuery("SOME"), {
                         variableValues: { movieIds: movies.map(({ id }) => id) },
                     });
 
@@ -2034,7 +2034,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                             CREATE (root:${randomType1.name} {id: $rootId})
                             CREATE (:${randomType1.name} {id: $randomId})
@@ -2055,7 +2055,7 @@ describe("Advanced Filtering", () => {
 
             // Test null checking (nodes without any related nodes on the specified field)
 
-            const nullResult = await testHelper.runGraphQL(nullQuery);
+            const nullResult = await testHelper.executeGraphQL(nullQuery);
 
             expect(nullResult.errors).toBeUndefined();
 
@@ -2074,7 +2074,7 @@ describe("Advanced Filtering", () => {
                     }
                 `;
 
-            const notNullResult = await testHelper.runGraphQL(notNullQuery);
+            const notNullResult = await testHelper.executeGraphQL(notNullQuery);
 
             expect(notNullResult.errors).toBeUndefined();
 
@@ -2114,7 +2114,7 @@ describe("Advanced Filtering", () => {
                 charset: "alphabetic",
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (:${randomType.name} {id: $id1})
                         CREATE (:${randomType.name} {id: $id2, optional: $optionalValue})
@@ -2132,7 +2132,7 @@ describe("Advanced Filtering", () => {
                     }
                 `;
 
-            const nullResult = await testHelper.runGraphQL(nullQuery);
+            const nullResult = await testHelper.executeGraphQL(nullQuery);
 
             expect(nullResult.errors).toBeUndefined();
 
@@ -2150,7 +2150,7 @@ describe("Advanced Filtering", () => {
                     }
                 `;
 
-            const notNullResult = await testHelper.runGraphQL(notNullQuery);
+            const notNullResult = await testHelper.executeGraphQL(notNullQuery);
 
             expect(notNullResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
@@ -22,10 +22,9 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Advanced Filtering", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         process.env.NEO4J_GRAPHQL_ENABLE_REGEX = "true"; // this may cause race condition
     });
 

--- a/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
@@ -115,7 +115,7 @@ describe("interface relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (a)-[:ACTED_IN { screenTime: $movieScreenTime }]->(:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -136,7 +136,7 @@ describe("interface relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle2 },
         });
 
@@ -198,7 +198,7 @@ describe("interface relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -220,7 +220,7 @@ describe("interface relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle },
         });
 
@@ -286,7 +286,7 @@ describe("interface relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -307,7 +307,7 @@ describe("interface relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle },
         });
 
@@ -363,7 +363,7 @@ describe("interface relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -386,7 +386,7 @@ describe("interface relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle2 },
         });
 
@@ -456,7 +456,7 @@ describe("interface relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -479,7 +479,7 @@ describe("interface relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle2 },
         });
 

--- a/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
@@ -23,14 +23,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("interface relationships", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeSeries: UniqueType;
     let typeActor: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typeSeries = testHelper.createUniqueType("Series");
         typeActor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
@@ -114,7 +114,7 @@ describe("union relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (a)-[:ACTED_IN { screenTime: $movieScreenTime }]->(:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -135,7 +135,7 @@ describe("union relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle2 },
         });
 
@@ -198,7 +198,7 @@ describe("union relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -219,7 +219,7 @@ describe("union relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle },
         });
 
@@ -295,7 +295,7 @@ describe("union relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -317,7 +317,7 @@ describe("union relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle },
         });
 
@@ -384,7 +384,7 @@ describe("union relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -405,7 +405,7 @@ describe("union relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle },
         });
 
@@ -462,7 +462,7 @@ describe("union relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -485,7 +485,7 @@ describe("union relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle2 },
         });
 
@@ -556,7 +556,7 @@ describe("union relationships", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${typeActor} { name: $actorName })
                 CREATE (m:${typeMovie} { title: $movieTitle, runtime:$movieRuntime })
@@ -579,7 +579,7 @@ describe("union relationships", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { title: movieTitle2 },
         });
 

--- a/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
@@ -23,14 +23,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("union relationships", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeSeries: UniqueType;
     let typeActor: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typeSeries = testHelper.createUniqueType("Series");
         typeActor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/filtering/operations.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/operations.int.test.ts
@@ -44,7 +44,7 @@ describe("Filtering Operations", () => {
         }
     `;
 
-        await testHelper.runCypher(`CREATE (:${movieType} {title: "The Matrix", released: 1999})
+        await testHelper.executeCypher(`CREATE (:${movieType} {title: "The Matrix", released: 1999})
                 CREATE (:${movieType} {title: "The Italian Job", released: 1969})
                 CREATE (:${movieType} {title: "The Italian Job", released: 2003})
                 CREATE (:${movieType} {title: "The Lion King", released: 1994})
@@ -67,7 +67,7 @@ describe("Filtering Operations", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/filtering/operations.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/operations.int.test.ts
@@ -21,12 +21,11 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Filtering Operations", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let personType: UniqueType;
     let movieType: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         personType = testHelper.createUniqueType("Person");
         movieType = testHelper.createUniqueType("Movie");
 

--- a/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
@@ -47,7 +47,7 @@ describe("Single relationship (1-*) filtering", () => {
         }
     `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${Movie} {title: "The Matrix", released: 1999})
                 CREATE (:${Movie} {title: "The Italian Job", released: 1969})
                 CREATE (:${Movie} {title: "The Italian Job", released: 2003})
@@ -69,7 +69,7 @@ describe("Single relationship (1-*) filtering", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE(jw:${Person} {name: "Jon Wu"})
             CREATE(:${Movie} {title: "Hard Target"})<-[:DIRECTED]-(jw)
             CREATE(cb:${Movie} {title: "Chi bi"})<-[:DIRECTED]-(jw)
@@ -77,7 +77,7 @@ describe("Single relationship (1-*) filtering", () => {
             CREATE(m:${Movie} {title: "Avatar"})<-[:DIRECTED]-(:${Person} {name: "Richie McFamous"})
         `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
 
@@ -100,7 +100,7 @@ describe("Single relationship (1-*) filtering", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE(a:${Person} {name: "That actor that you are not so sure what the name is but have seen before"})
             CREATE(a2:${Person} {name: "not so famous one"})
             CREATE(a3:${Person} {name: "don't know this one"})
@@ -120,7 +120,7 @@ describe("Single relationship (1-*) filtering", () => {
             CREATE(a3)-[:ACTED_IN]->(m)
         `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
         expect((result.data as any)[Person.plural]).toIncludeSameMembers([
@@ -142,7 +142,7 @@ describe("Single relationship (1-*) filtering", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE(jw:${Person} {name: "Jon Wu"})
             CREATE(:${Movie} {title: "Hard Target"})<-[:DIRECTED]-(jw)
             CREATE(cb:${Movie} {title: "Chi bi"})<-[:DIRECTED]-(jw)
@@ -150,7 +150,7 @@ describe("Single relationship (1-*) filtering", () => {
             CREATE(m:${Movie} {title: "Avatar"})<-[:DIRECTED]-(:${Person} {name: "Richie McFamous"})
         `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
@@ -24,10 +24,9 @@ describe("Single relationship (1-*) filtering", () => {
     let Person: UniqueType;
     let Movie: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Person = testHelper.createUniqueType("Person");
         Movie = testHelper.createUniqueType("Movie");
 

--- a/packages/graphql/tests/integration/issues/1049.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1049.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1049", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Book: UniqueType;
     let Film: UniqueType;
@@ -29,8 +29,6 @@ describe("https://github.com/neo4j/graphql/issues/1049", () => {
     let Media: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Book = testHelper.createUniqueType("Book");
         Film = testHelper.createUniqueType("Film");
         Person = testHelper.createUniqueType("Person");

--- a/packages/graphql/tests/integration/issues/1049.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1049.int.test.ts
@@ -111,7 +111,7 @@ describe("https://github.com/neo4j/graphql/issues/1049", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
         expect(mutationResult.errors).toBeUndefined();
 
         const query = `
@@ -122,7 +122,7 @@ describe("https://github.com/neo4j/graphql/issues/1049", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({ [Person.plural]: [{ name: "Bob" }] });
     });

--- a/packages/graphql/tests/integration/issues/1050.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1050.int.test.ts
@@ -108,7 +108,7 @@ describe("https://github.com/neo4j/graphql/issues/1050", () => {
     });
 
     test("should handle auth appropriately for nested connection", async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
           CREATE (c:${testUser.name} {id: 'abc'})
             -[:OWNS]->(i:${testInbox.name} {ownerId: 'abc'})
             -[:CONTAINS]->(m:${testMessage.name} {ownerId: 'abc', subject: 'Hello', body: 'World'})
@@ -133,7 +133,7 @@ describe("https://github.com/neo4j/graphql/issues/1050", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             contextValue: {
                 token: testHelper.createBearerToken("secret"),
                 user: {

--- a/packages/graphql/tests/integration/issues/1050.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1050.int.test.ts
@@ -27,10 +27,9 @@ describe("https://github.com/neo4j/graphql/issues/1050", () => {
     let testMessage: UniqueType;
     let testAttachment: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         testUser = testHelper.createUniqueType("User");
         testInbox = testHelper.createUniqueType("Inbox");
         testMessage = testHelper.createUniqueType("Message");

--- a/packages/graphql/tests/integration/issues/1115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1115.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
     let parentType: UniqueType;
     let childType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         parentType = testHelper.createUniqueType("Parent");
         childType = testHelper.createUniqueType("Child");
 

--- a/packages/graphql/tests/integration/issues/1115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1115.int.test.ts
@@ -67,7 +67,7 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
     });
 
     test("should not throw on multiple connectOrCreate with auth", async () => {
-        await testHelper.runCypher(`CREATE (:${parentType})<-[:HAS]-(:${childType} {tcId: "123"})`);
+        await testHelper.executeCypher(`CREATE (:${parentType})<-[:HAS]-(:${childType} {tcId: "123"})`);
 
         const token = testHelper.createBearerToken("secret", { roles: ["upstream"] });
         const query = `
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/1115", () => {
         }
         `;
 
-        const res = await testHelper.runGraphQLWithToken(query, token);
+        const res = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(res.errors).toBeUndefined();
         expect(res.data).toEqual({

--- a/packages/graphql/tests/integration/issues/1121.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1121.int.test.ts
@@ -110,7 +110,7 @@ describe("https://github.com/neo4j/graphql/issues/1121", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
         expect(mutationResult.errors).toBeUndefined();
 
         const query = `
@@ -129,7 +129,7 @@ describe("https://github.com/neo4j/graphql/issues/1121", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({
             [Food.plural]: [

--- a/packages/graphql/tests/integration/issues/1121.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1121.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1121", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Food: UniqueType;
     let Banana: UniqueType;
@@ -29,8 +29,6 @@ describe("https://github.com/neo4j/graphql/issues/1121", () => {
     let Syrup: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Food = testHelper.createUniqueType("Food");
         Banana = testHelper.createUniqueType("Banana");
         Sugar = testHelper.createUniqueType("Sugar");

--- a/packages/graphql/tests/integration/issues/1127.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1127.int.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/1127", () => {
             }
         `;
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues: {
                 input: [
                     {

--- a/packages/graphql/tests/integration/issues/1127.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1127.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1127", () => {
     let addressType: UniqueType;
     let postalCodeType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         customerType = testHelper.createUniqueType("Customer");
         addressType = testHelper.createUniqueType("Address");
         postalCodeType = testHelper.createUniqueType("PostalCode");

--- a/packages/graphql/tests/integration/issues/1132.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1132.int.test.ts
@@ -79,14 +79,14 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
                 }
             `;
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${testSource.name} { id: "${sourceId}" })
                 CREATE (:${testTarget.name} { id: "${targetId}" })
             `);
 
             const token = createBearerToken(secret, { sub: sourceId });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeUndefined();
             expect(result.data as any).toEqual({
                 [testSource.operations.update]: {
@@ -145,13 +145,13 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
                 }
             `;
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${testSource.name} { id: "${sourceId}" })-[:HAS_TARGET]->(:${testTarget.name} { id: "${targetId}" })
             `);
 
             const token = createBearerToken(secret, { sub });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect((result.errors as any[])[0].message).toBe("Forbidden");
         });
 
@@ -198,13 +198,13 @@ describe("https://github.com/neo4j/graphql/issues/1132", () => {
                 }
             `;
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${testSource.name} { id: "${sourceId}" })-[:HAS_TARGET]->(:${testTarget.name} { id: "${targetId}" })
             `);
 
             const token = createBearerToken(secret, { sub: targetId });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeUndefined();
             expect(result.data as any).toEqual({
                 [testSource.operations.update]: {

--- a/packages/graphql/tests/integration/issues/1132.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1132.int.test.ts
@@ -25,11 +25,9 @@ import { TestHelper } from "../utils/tests-helper";
 describe("https://github.com/neo4j/graphql/issues/1132", () => {
     const secret = "secret";
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/1150.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1150.int.test.ts
@@ -24,7 +24,7 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1150", () => {
     const secret = "secret";
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Battery: UniqueType;
     let CombustionEngine: UniqueType;
@@ -32,8 +32,6 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
     let DriveComposition: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Battery = testHelper.createUniqueType("Battery");
         CombustionEngine = testHelper.createUniqueType("CombustionEngine");
         Drive = testHelper.createUniqueType("Drive");

--- a/packages/graphql/tests/integration/issues/1150.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1150.int.test.ts
@@ -127,7 +127,7 @@ describe("https://github.com/neo4j/graphql/issues/1150", () => {
         `;
 
         const token = createBearerToken(secret, { roles: "admin" });
-        const res = await testHelper.runGraphQLWithToken(query, token);
+        const res = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(res.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/1221.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1221.int.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })
                 CREATE (m:${testMasterData} { current: true, id: "323" })
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(m)<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "421" })
@@ -134,7 +134,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 
@@ -171,7 +171,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "323" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "621" })
 
@@ -221,7 +221,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 
@@ -278,7 +278,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(m:${testMasterData} { current: true, id: "123" })
                 CREATE (m)<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })
                 CREATE (m)<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "921" })
@@ -329,7 +329,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 
@@ -386,7 +386,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             typeDefs: extendedTypeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })<-[:MAIN { current: true }]-(:${testMain} { current: true, id: "1321" })
                 CREATE (s:${testSeries} { current: true, id: "421" })
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(s)<-[:MAIN { current: true }]-(:${testMain} { current: true, id: "1321" })
@@ -448,7 +448,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 
@@ -493,7 +493,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             typeDefs: extendedTypeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(m:${testMasterData} { current: true, id: "123" })
                 CREATE (m)<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })
                 CREATE (m)<-[:ARCHITECTURE { current: true }]-(s:${testSeries} { current: true, id: "921" })
@@ -556,7 +556,7 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 

--- a/packages/graphql/tests/integration/issues/1221.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1221.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1221", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let testMain: UniqueType;
     let testSeries: UniqueType;
@@ -33,7 +33,6 @@ describe("https://github.com/neo4j/graphql/issues/1221", () => {
     let extendedTypeDefs: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         testMain = testHelper.createUniqueType("Main");
         testSeries = testHelper.createUniqueType("Series");
         testNameDetails = testHelper.createUniqueType("NameDetails");

--- a/packages/graphql/tests/integration/issues/1249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1249.int.test.ts
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
             }
         `;
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             contextValue: { cypherParams: { tenant: "BULK" } },
         });
 

--- a/packages/graphql/tests/integration/issues/1249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1249.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1249", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Bulk: UniqueType;
     let Material: UniqueType;
@@ -29,7 +29,6 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
     let typeDefs: string;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Bulk = testHelper.createUniqueType("Bulk");
         Material = testHelper.createUniqueType("Material");
         Supplier = testHelper.createUniqueType("Supplier");

--- a/packages/graphql/tests/integration/issues/1287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1287.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1287", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let screeningsType: UniqueType;
     let norwegianScreenable: UniqueType;
@@ -29,8 +29,6 @@ describe("https://github.com/neo4j/graphql/issues/1287", () => {
     let typeDefs: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
-
         screeningsType = testHelper.createUniqueType("Screening");
         norwegianScreenable = testHelper.createUniqueType("NorwegianScreenableMeta");
 

--- a/packages/graphql/tests/integration/issues/1287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1287.int.test.ts
@@ -81,7 +81,7 @@ describe("https://github.com/neo4j/graphql/issues/1287", () => {
             }
         `;
 
-        const res = await testHelper.runGraphQL(query);
+        const res = await testHelper.executeGraphQL(query);
 
         expect(res.errors).toBeUndefined();
         expect(res.data).toEqual({

--- a/packages/graphql/tests/integration/issues/1320.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1320.int.test.ts
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
             (risk1: ${riskType.name} {code: 'risk-1', mitigationState: 'Accepted'}),
             (team1)-[:OWNS_RISK]->(risk1)
         `;
-        await testHelper.runCypher(cypherInsert);
+        await testHelper.executeCypher(cypherInsert);
 
         const query = `
             query getAggreationOnTeams {
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
                 }
             }
         `;
-        const res = await testHelper.runGraphQL(query);
+        const res = await testHelper.executeGraphQL(query);
 
         expect(res.errors).toBeUndefined();
         const expectedReturn = {

--- a/packages/graphql/tests/integration/issues/1320.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1320.int.test.ts
@@ -26,10 +26,9 @@ describe("https://github.com/neo4j/graphql/issues/1320", () => {
     let teamType: UniqueType;
     let mitigationStateType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         riskType = testHelper.createUniqueType("Risk");
         teamType = testHelper.createUniqueType("Team");
         mitigationStateType = testHelper.createUniqueType("MitigationState");

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -116,10 +116,10 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
             }
         `;
 
-        const createProgrammeItemsResults = await testHelper.runGraphQL(createProgrammeItems);
+        const createProgrammeItemsResults = await testHelper.executeGraphQL(createProgrammeItems);
         expect(createProgrammeItemsResults.errors).toBeUndefined();
 
-        const updateProgrammeItemsResults = await testHelper.runGraphQL(updateProgrammeItems);
+        const updateProgrammeItemsResults = await testHelper.executeGraphQL(updateProgrammeItems);
         expect(updateProgrammeItemsResults.errors).toBeUndefined();
 
         const query = /* GraphQL */ `
@@ -134,7 +134,7 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
                 }
             }
         `;
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             [ProgrammeItem.plural]: expect.toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1348", () => {
     let Season: UniqueType;
     let ProgrammeItem: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Series = testHelper.createUniqueType("Series");
         Season = testHelper.createUniqueType("Season");
         ProgrammeItem = testHelper.createUniqueType("ProgrammeItem");

--- a/packages/graphql/tests/integration/issues/1364.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1364.int.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m1:${testMovie} { title: "A Movie" })-[:HAS_GENRE]->(:${testGenre} { name: "Genre 1" })
             CREATE (m1)-[:HAS_GENRE]->(:${testGenre} { name: "Genre 2" })
             CREATE (m2:${testMovie} { title: "B Movie" })-[:HAS_GENRE]->(:${testGenre} { name: "Genre 3" })
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
 
         expect(queryResult.data as any).toEqual({
@@ -136,7 +136,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
 
         expect(queryResult.data as any).toEqual({
@@ -180,7 +180,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
 
         expect(queryResult.data as any).toEqual({
@@ -226,7 +226,7 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
 
         expect(queryResult.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/1364.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1364.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1364", () => {
     let testMovie: UniqueType;
     let testGenre: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testActor = testHelper.createUniqueType("Actor");
         testMovie = testHelper.createUniqueType("Movie");
         testGenre = testHelper.createUniqueType("Genre");

--- a/packages/graphql/tests/integration/issues/1414.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1414.int.test.ts
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/1414", () => {
             }
         `;
 
-        const createProgrammeItemsResults = await testHelper.runGraphQL(createProgrammeItems);
+        const createProgrammeItemsResults = await testHelper.executeGraphQL(createProgrammeItems);
         expect(createProgrammeItemsResults.errors).toBeUndefined();
         expect(createProgrammeItemsResults.data as any).toEqual({
             [testProgrammeItem.operations.create]: {
@@ -100,7 +100,7 @@ describe("https://github.com/neo4j/graphql/issues/1414", () => {
             },
         });
 
-        const updateProgrammeItemsResults = await testHelper.runGraphQL(updateProgrammeItems);
+        const updateProgrammeItemsResults = await testHelper.executeGraphQL(updateProgrammeItems);
         expect(updateProgrammeItemsResults.errors).toBeUndefined();
         expect(updateProgrammeItemsResults.data as any).toEqual({
             [testProgrammeItem.operations.update]: {

--- a/packages/graphql/tests/integration/issues/1414.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1414.int.test.ts
@@ -26,10 +26,9 @@ describe("https://github.com/neo4j/graphql/issues/1414", () => {
 
     let counter = 0;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testProduct = testHelper.createUniqueType("Product");
         testProgrammeItem = testHelper.createUniqueType("ProgrammeItem");
 

--- a/packages/graphql/tests/integration/issues/1430.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1430.int.test.ts
@@ -27,11 +27,9 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
     let testChildTwo: UniqueType;
 
     let schema: GraphQLSchema;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         testAbce = testHelper.createUniqueType("ABCE");
         testChildOne = testHelper.createUniqueType("ChildOne");
         testChildTwo = testHelper.createUniqueType("ChildTwo");

--- a/packages/graphql/tests/integration/issues/1430.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1430.int.test.ts
@@ -100,7 +100,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const createMutationResults = await testHelper.runGraphQL(createMutation);
+        const createMutationResults = await testHelper.executeGraphQL(createMutation);
 
         expect(createMutationResults.errors).toHaveLength(1);
         expect(createMutationResults.errors?.[0]?.message).toBe(
@@ -138,7 +138,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const createMutationResults = await testHelper.runGraphQL(createMutation);
+        const createMutationResults = await testHelper.executeGraphQL(createMutation);
 
         expect(createMutationResults.errors).toBeUndefined();
         expect(createMutationResults.data as any).toEqual({
@@ -176,7 +176,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const updateMutationResults = await testHelper.runGraphQL(updateMutation);
+        const updateMutationResults = await testHelper.executeGraphQL(updateMutation);
 
         expect(updateMutationResults.errors).toHaveLength(1);
         expect(updateMutationResults.errors?.[0]?.message).toContain(
@@ -214,7 +214,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const createMutationResults = await testHelper.runGraphQL(createMutation);
+        const createMutationResults = await testHelper.executeGraphQL(createMutation);
 
         expect(createMutationResults.errors).toBeUndefined();
         expect(createMutationResults.data as any).toEqual({
@@ -253,7 +253,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const updateMutationResults = await testHelper.runGraphQL(updateMutation);
+        const updateMutationResults = await testHelper.executeGraphQL(updateMutation);
 
         expect(updateMutationResults.errors).toHaveLength(1);
         expect(updateMutationResults.errors?.[0]?.message).toContain(
@@ -291,7 +291,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const createMutationResults = await testHelper.runGraphQL(createMutation);
+        const createMutationResults = await testHelper.executeGraphQL(createMutation);
 
         expect(createMutationResults.errors).toBeUndefined();
         expect(createMutationResults.data as any).toEqual({
@@ -330,7 +330,7 @@ describe("https://github.com/neo4j/graphql/issues/1430", () => {
             }
         `;
 
-        const updateMutationResults = await testHelper.runGraphQL(updateMutation);
+        const updateMutationResults = await testHelper.executeGraphQL(updateMutation);
 
         expect(updateMutationResults.errors).toHaveLength(1);
         expect(updateMutationResults.errors?.[0]?.message).toContain(

--- a/packages/graphql/tests/integration/issues/1528.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1528.int.test.ts
@@ -26,10 +26,9 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
     let testMovie: UniqueType;
     let testGenre: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testPerson = testHelper.createUniqueType("Person");
         testMovie = testHelper.createUniqueType("Movie");
         testGenre = testHelper.createUniqueType("Genre");

--- a/packages/graphql/tests/integration/issues/1528.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1528.int.test.ts
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (g:${testGenre} {name: "Western"})
             CREATE (m1:${testMovie} { title: "A Movie" })-[:IS_GENRE]->(g)
             CREATE (m2:${testMovie} { title: "B Movie" })-[:IS_GENRE]->(g)
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/issues/1528", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
 
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/1535.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1535.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
     let testBooking: UniqueType;
     let FooBar: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testTenant = testHelper.createUniqueType("Tenant");
         testBooking = testHelper.createUniqueType("Booking");
         FooBar = testHelper.createUniqueType("FooBar");

--- a/packages/graphql/tests/integration/issues/1535.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1535.int.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${testTenant} { id: "12", name: "Tenant1" })<-[:HOSTED_BY]-(:${testBooking} { id: "212" })
         `);
 
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/1535", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
 
         expect(queryResult.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/1536.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1536.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1536", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let SomeNodeType: UniqueType;
     let OtherNodeType: UniqueType;
     let MyImplementationType: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         SomeNodeType = testHelper.createUniqueType("SomeNode");
         OtherNodeType = testHelper.createUniqueType("OtherNode");
         MyImplementationType = testHelper.createUniqueType("MyImplementation");

--- a/packages/graphql/tests/integration/issues/1536.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1536.int.test.ts
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/1536", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE(:${SomeNodeType} {id: "1"})-[:HAS_OTHER_NODES]->(other:${OtherNodeType} {id: "2"})
             CREATE(other)-[:HAS_INTERFACE_NODES]->(:${MyImplementationType} {id: "3"})
         `);
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/1536", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
         expect(queryResult.data).toEqual({
             [SomeNodeType.plural]: [

--- a/packages/graphql/tests/integration/issues/1551.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1551.int.test.ts
@@ -67,7 +67,7 @@ describe("https://github.com/neo4j/graphql/issues/1551", () => {
             }
         `;
 
-        await testHelper.runGraphQL(createMutation);
+        await testHelper.executeGraphQL(createMutation);
 
         const updateMutation = `
             mutation {
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/1551", () => {
             }
         `;
 
-        const updateResult = await testHelper.runGraphQL(updateMutation);
+        const updateResult = await testHelper.executeGraphQL(updateMutation);
         expect(updateResult.errors).toEqual([
             new GraphQLError(`Cannot set non-nullable field ${testType.name}.level to null`),
         ]);

--- a/packages/graphql/tests/integration/issues/1551.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1551.int.test.ts
@@ -24,10 +24,9 @@ import { TestHelper } from "../utils/tests-helper";
 describe("https://github.com/neo4j/graphql/issues/1551", () => {
     let testType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testType = testHelper.createUniqueType("AttribValue");
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1566.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1566.int.test.ts
@@ -95,9 +95,9 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
             CREATE (c:${testCommunity.name} { id: 111111 })-[:COMMUNITY_CONTENTPIECE_HASCONTENTPIECES]->(:${testContent.name} { name: "content1" })
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
         expect((result.data as any)?.[testCommunity.plural]?.[0]).toEqual({
@@ -133,9 +133,9 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
             CREATE (c)-[:COMMUNITY_PROJECT_HASASSOCIATEDPROJECTS]->(:${testProject.name} { name: "project2" })
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
         expect(result.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/1566.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1566.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1566", () => {
     let testProject: UniqueType;
     let testCommunity: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         testContent = testHelper.createUniqueType("Content");
         testProject = testHelper.createUniqueType("Project");
         testCommunity = testHelper.createUniqueType("Community");

--- a/packages/graphql/tests/integration/issues/1640.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1640.int.test.ts
@@ -81,9 +81,9 @@ describe("https://github.com/neo4j/graphql/issues/1640", () => {
             CREATE(org2)-[:HAS_ADMINISTRATOR]->(admin2)
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
         expect(result.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/1640.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1640.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1640", () => {
     let testAdmin: UniqueType;
     let testOrganization: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testAdmin = testHelper.createUniqueType("Admin");
         testOrganization = testHelper.createUniqueType("Organization");
 

--- a/packages/graphql/tests/integration/issues/1683.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1683.int.test.ts
@@ -70,9 +70,9 @@ describe("https://github.com/neo4j/graphql/issues/1683", () => {
             CREATE (s:${systemType} { code: "arthur" });
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeUndefined();
         expect(result.data as any).toEqual({
             [systemType.plural]: [{ code: "arthur", updatesDataConnection: { edges: [] } }],

--- a/packages/graphql/tests/integration/issues/1683.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1683.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1683", () => {
     let systemType: UniqueType;
     let governedDataTest: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         systemType = testHelper.createUniqueType("System");
         governedDataTest = testHelper.createUniqueType("GovernedData");
 

--- a/packages/graphql/tests/integration/issues/1686.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1686.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1686", () => {
     let movieType: UniqueType;
     let genreType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         productionType = testHelper.createUniqueType("Production");
         movieType = testHelper.createUniqueType("Movie");
         genreType = testHelper.createUniqueType("Genre");

--- a/packages/graphql/tests/integration/issues/1686.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1686.int.test.ts
@@ -75,9 +75,9 @@ describe("https://github.com/neo4j/graphql/issues/1686", () => {
             CREATE (h:${movieType.name} { id: "2", title: "The Hobbit" })-[:HAS_GENRE]->(g3:${genreType.name} { id: "12", name: "Fantasy" })
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeUndefined();
         expect(result.data as any).toEqual({
             [movieType.operations.connection]: {

--- a/packages/graphql/tests/integration/issues/1687.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1687.int.test.ts
@@ -82,9 +82,9 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
             CREATE (h:${movieType.name} { id: "2", title: "The Hobbit" })-[:HAS_GENRE]->(g3:${genreType.name} { id: "12", name: "Fantasy" })
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeUndefined();
         expect(result.data as any).toEqual({
             [genreType.plural]: expect.toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/1687.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1687.int.test.ts
@@ -25,11 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/1687", () => {
     let movieType: UniqueType;
     let genreType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         productionType = testHelper.createUniqueType("Production");
         movieType = testHelper.createUniqueType("Movie");
         genreType = testHelper.createUniqueType("Genre");

--- a/packages/graphql/tests/integration/issues/1735.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1735.int.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
                 },
             },
         ];
-        await testHelper.runGraphQL(source, {
+        await testHelper.executeGraphQL(source, {
             variableValues: { input },
         });
     });
@@ -100,7 +100,7 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
         }
       `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[movieType.operations.connection]).toEqual({

--- a/packages/graphql/tests/integration/issues/1735.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1735.int.test.ts
@@ -24,11 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
     let actorType: UniqueType;
     let movieType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         actorType = testHelper.createUniqueType("Actor");
         movieType = testHelper.createUniqueType("Movie");
 

--- a/packages/graphql/tests/integration/issues/1751.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1751.int.test.ts
@@ -45,7 +45,7 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
   `;
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE (a:${adminType} {adminId: "my-admin-to-delete"})<-[:HAS_ADMINISTRATOR]-(o:${organizationType} {title: "Google"})
         CREATE (a2:${adminType} {adminId: "my-admin2"})<-[:HAS_ADMINISTRATOR]-(o2:${organizationType} { title: "Yahoo"})
         CREATE (a3:${adminType} {adminId: "my-admin3"})<-[:HAS_ADMINISTRATOR]-(o3:${organizationType} { title: "Altavista"})
@@ -70,7 +70,7 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data?.[organizationType.operations.delete]).toEqual({
@@ -78,12 +78,12 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
             relationshipsDeleted: 2,
         });
 
-        const remainingOrgs = await testHelper.runCypher(`
+        const remainingOrgs = await testHelper.executeCypher(`
             MATCH(org:${organizationType})
             RETURN org.title as title
             `);
 
-        const remainingAdmins = await testHelper.runCypher(`
+        const remainingAdmins = await testHelper.executeCypher(`
             MATCH(admin:${adminType})
             RETURN admin.adminId as adminId
             `);

--- a/packages/graphql/tests/integration/issues/1751.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1751.int.test.ts
@@ -24,11 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1735", () => {
     let organizationType: UniqueType;
     let adminType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         organizationType = testHelper.createUniqueType("Organization");
         adminType = testHelper.createUniqueType("Admin");
 

--- a/packages/graphql/tests/integration/issues/1756.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1756.int.test.ts
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
           }
       `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[productType.operations.create]).toEqual({
@@ -132,7 +132,7 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
         }
     `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[productType.operations.create]).toEqual({

--- a/packages/graphql/tests/integration/issues/1756.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1756.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1756", () => {
     let productType: UniqueType;
     let genreType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         productType = testHelper.createUniqueType("Product");
         genreType = testHelper.createUniqueType("Genre");
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1760.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1760.int.test.ts
@@ -24,7 +24,7 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1760", () => {
     let schema: GraphQLSchema;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let ApplicationVariant: UniqueType;
@@ -34,7 +34,6 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
     let typeDefs: string;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         ApplicationVariant = testHelper.createUniqueType("ApplicationVariant");
         NameDetails = testHelper.createUniqueType("NameDetails");
         Market = testHelper.createUniqueType("Market");

--- a/packages/graphql/tests/integration/issues/1760.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1760.int.test.ts
@@ -135,7 +135,7 @@ describe("https://github.com/neo4j/graphql/issues/1760", () => {
         `;
 
         const token = createBearerToken(secret, { roles: ["ALL"] });
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeFalsy();
     });

--- a/packages/graphql/tests/integration/issues/1761.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1761.int.test.ts
@@ -23,14 +23,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1761", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let neoSchema: Neo4jGraphQL;
     let session: Session;
 
     let myType: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         myType = testHelper.createUniqueType("MyType");
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/1761.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1761.int.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/1761", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(mutation);
+        const result = await testHelper.executeGraphQL(mutation);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/1779.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1779.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
     let personType: UniqueType;
     let schoolType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         personType = testHelper.createUniqueType("Person");
         schoolType = testHelper.createUniqueType("School");
 

--- a/packages/graphql/tests/integration/issues/1779.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1779.int.test.ts
@@ -58,7 +58,7 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
         CREATE (personD:${personType.name} { name: "D", age: 25 })-[:ATTENDS]->(schoolYoung)
     `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
 
         const query = `
             {
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/1779", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[personType.plural]).toEqual(

--- a/packages/graphql/tests/integration/issues/1782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1782.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1782", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let testMain: UniqueType;
     let testSeries: UniqueType;
@@ -29,7 +29,6 @@ describe("https://github.com/neo4j/graphql/issues/1782", () => {
     let testMasterData: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testMain = testHelper.createUniqueType("Main");
         testSeries = testHelper.createUniqueType("Series");
         testNameDetails = testHelper.createUniqueType("NameDetails");

--- a/packages/graphql/tests/integration/issues/1782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1782.int.test.ts
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/1782", () => {
     });
 
     test("should only return the single 'chain' and the multiple nested 'chains', three relations deep, using SOME", async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })<-[:MAIN { current: true }]-(:${testMain} { current: true, id: "1321" })
                 CREATE (s:${testSeries} { current: true, id: "421" })
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(s)<-[:MAIN { current: true }]-(:${testMain} { current: true, id: "1322" })
@@ -140,7 +140,7 @@ describe("https://github.com/neo4j/graphql/issues/1782", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 

--- a/packages/graphql/tests/integration/issues/1783.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1783.int.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
     });
 
     test("missing parameter with implicit AND", async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "321" })
                 CREATE (:${testNameDetails} { fullName: "MHA" })<-[:HAS_NAME { current: true }]-(:${testMasterData} { current: true, id: "123" })<-[:ARCHITECTURE { current: true }]-(:${testSeries} { current: true, id: "3213" })-[:HAS_NAME { current: true }]->(:${testNameDetails} { fullName: "MHA1" })
                 CREATE (m:${testMasterData} { current: true, id: "323" })
@@ -140,7 +140,7 @@ describe("https://github.com/neo4j/graphql/issues/1783", () => {
             },
         };
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 

--- a/packages/graphql/tests/integration/issues/1783.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1783.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1783", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let testSeries: UniqueType;
     let testNameDetails: UniqueType;
     let testMasterData: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         testSeries = testHelper.createUniqueType("Series");
         testNameDetails = testHelper.createUniqueType("NameDetails");
         testMasterData = testHelper.createUniqueType("MasterData");

--- a/packages/graphql/tests/integration/issues/1817.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1817.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1817", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let TypeContainerType: UniqueType;
     let TypeContainer: UniqueType;
     let TypeMaterial: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         TypeContainerType = testHelper.createUniqueType("ContainerType");
         TypeContainer = testHelper.createUniqueType("Container");
         TypeMaterial = testHelper.createUniqueType("Material");

--- a/packages/graphql/tests/integration/issues/1817.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1817.int.test.ts
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/1817", () => {
               }
             `;
 
-        const res = await testHelper.runGraphQL(query);
+        const res = await testHelper.executeGraphQL(query);
 
         expect(res.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/1848.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1848.int.test.ts
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/1848", () => {
             }
         `;
 
-        const res = await testHelper.runGraphQL(query);
+        const res = await testHelper.executeGraphQL(query);
 
         expect(res.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/1848.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1848.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1848", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let ContentPiece: UniqueType;
     let Project: UniqueType;
     let Community: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         ContentPiece = testHelper.createUniqueType("ContentPiece");
         Project = testHelper.createUniqueType("Project");
         Community = testHelper.createUniqueType("Community");

--- a/packages/graphql/tests/integration/issues/190.int.test.ts
+++ b/packages/graphql/tests/integration/issues/190.int.test.ts
@@ -49,7 +49,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
         }
     `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                     CREATE (user1:${User} {uid: 'user1'}),(user2:${User} {uid: 'user2'}),(female:${UserDemographics}{type:'Gender',value:'Female'}),(male:${UserDemographics}{type:'Gender',value:'Male'}),(age:${UserDemographics}{type:'Age',value:'50+'}),(state:${UserDemographics}{type:'State',value:'VIC'})
                     CREATE (user1)-[:HAS_DEMOGRAPHIC]->(female)
                     CREATE (user2)-[:HAS_DEMOGRAPHIC]->(male)
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect((result?.data as any)?.[User.plural][0].uid).toBe("user1");
@@ -114,7 +114,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/190.int.test.ts
+++ b/packages/graphql/tests/integration/issues/190.int.test.ts
@@ -27,10 +27,9 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
     let UserDemographics: UniqueType;
     let typeDefs: DocumentNode;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         UserDemographics = testHelper.createUniqueType("UserDemographics");
 

--- a/packages/graphql/tests/integration/issues/1933.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1933.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
     let employeeType: UniqueType;
     let projectType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         employeeType = testHelper.createUniqueType("Employee");
         projectType = testHelper.createUniqueType("Project");
 

--- a/packages/graphql/tests/integration/issues/1933.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1933.int.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             CREATE (e2)-[:PARTICIPATES { allocation: 20.0 }]->(p2)
         `;
 
-        await testHelper.runCypher(cypher);
+        await testHelper.executeCypher(cypher);
     });
 
     afterAll(async () => {
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[employeeType.plural]).toEqual([]);
@@ -122,7 +122,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[employeeType.plural]).toEqual([
@@ -158,7 +158,7 @@ describe("https://github.com/neo4j/graphql/issues/1933", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result?.data?.[employeeType.plural]).toEqual([

--- a/packages/graphql/tests/integration/issues/200.int.test.ts
+++ b/packages/graphql/tests/integration/issues/200.int.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/200", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { catOne, catTwo, exampleImageLocations: [] },
         });
 

--- a/packages/graphql/tests/integration/issues/200.int.test.ts
+++ b/packages/graphql/tests/integration/issues/200.int.test.ts
@@ -23,10 +23,9 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/200", () => {
     let Category: UniqueType;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Category = testHelper.createUniqueType("Category");
     });
 

--- a/packages/graphql/tests/integration/issues/2022.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2022.int.test.ts
@@ -97,7 +97,7 @@ describe("https://github.com/neo4j/graphql/issues/2022", () => {
             }
         `;
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
         expect(queryResult.errors).toBeUndefined();
     });
 });

--- a/packages/graphql/tests/integration/issues/2022.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2022.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2022", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let ArtPiece: UniqueType;
     let AuctionItem: UniqueType;
     let Organization: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         ArtPiece = testHelper.createUniqueType("ArtItem");
         AuctionItem = testHelper.createUniqueType("Auction");
         Organization = testHelper.createUniqueType("Organization");

--- a/packages/graphql/tests/integration/issues/2068.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2068.int.test.ts
@@ -22,11 +22,9 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/pull/2068", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/2068.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2068.int.test.ts
@@ -146,13 +146,13 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
         `;
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${actorType.name} { name: "${actorName}", age: ${actorAge} })
                 CREATE (:${tvShowType.name} { title: "${sharedTitle}", numSeasons: ${numberOfSeasons} })
                 CREATE (:${movieType.name} { title: "${sharedTitle}" })
             `);
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)?.[actorType.plural]?.[0].movieOrTVShow).toIncludeSameMembers([
@@ -232,14 +232,14 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs, features: { authorization: { key: secret } } });
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${userType.name} {id: "${userID}"})
                 CREATE (:${contentType.name} {id: "${contentID}"})
             `);
 
             const token = createBearerToken(secret, { sub: userID });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -267,7 +267,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs, features: { authorization: { key: secret } } });
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${userType.name} {id: "${userID1}"})
                 CREATE (:${userType.name} {id: "${userID2}"})
                 CREATE (:${contentType.name} {id: "${contentID}"})
@@ -275,7 +275,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             const token = createBearerToken(secret, { sub: userID1 });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -302,13 +302,13 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs, features: { authorization: { key: secret } } });
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${userType.name} {id: "${userID}"})-[:HAS_CONTENT]->(:${contentType.name} {id: "${contentID}"})
             `);
 
             const token = createBearerToken(secret, { sub: userID });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -334,13 +334,13 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs, features: { authorization: { key: secret } } });
 
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
                 CREATE (:${userType.name} {id: "${userID}"})-[:HAS_CONTENT]->(:${contentType.name} {id: "${contentID}"})
             `);
 
             const token = createBearerToken(secret, { sub: userID });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
             expect(gqlResult.errors).toBeUndefined();
 
@@ -425,7 +425,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 validToken
             );
@@ -450,7 +450,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 invalidToken
             );
@@ -466,7 +466,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 validToken
             );
@@ -491,7 +491,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 invalidToken
             );
@@ -507,7 +507,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 validToken
             );
@@ -532,7 +532,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 invalidToken
             );
@@ -548,7 +548,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(createOperation, movieType.plural),
                 validToken
             );
@@ -573,9 +573,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 validToken
             );
@@ -600,9 +600,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 invalidToken
             );
@@ -618,9 +618,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 validToken
             );
@@ -646,9 +646,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 invalidToken
             );
@@ -664,9 +664,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 validToken
             );
@@ -691,9 +691,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 invalidToken
             );
@@ -709,9 +709,9 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
                 features: { authorization: { key: secret } },
             });
 
-            await testHelper.runCypher(`CREATE (:${movieType.name})`);
+            await testHelper.executeCypher(`CREATE (:${movieType.name})`);
 
-            const gqlResult = await testHelper.runGraphQLWithToken(
+            const gqlResult = await testHelper.executeGraphQLWithToken(
                 getQuery(updateOperation, movieType.plural),
                 validToken
             );
@@ -782,7 +782,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect(gqlResult.data).toEqual({
@@ -830,7 +830,7 @@ describe("https://github.com/neo4j/graphql/pull/2068", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeUndefined();
             expect(gqlResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/207.int.test.ts
+++ b/packages/graphql/tests/integration/issues/207.int.test.ts
@@ -86,7 +86,7 @@ describe("https://github.com/neo4j/graphql/issues/207", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const result = await testHelper.runGraphQL(mutation);
+        const result = await testHelper.executeGraphQL(mutation);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/207.int.test.ts
+++ b/packages/graphql/tests/integration/issues/207.int.test.ts
@@ -23,10 +23,9 @@ describe("https://github.com/neo4j/graphql/issues/207", () => {
     let Book: UniqueType;
     let Author: UniqueType;
     let typeDefs: string;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Book = testHelper.createUniqueType("Book");
         Author = testHelper.createUniqueType("Author");
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/2100.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2100.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2100", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let token: string;
 
     let BacentaType: UniqueType;
@@ -34,8 +34,6 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
     let typeDefs: string;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         BacentaType = testHelper.createUniqueType("Bacenta");
         ServiceLogType = testHelper.createUniqueType("ServiceLog");
         BussingRecordType = testHelper.createUniqueType("BussingRecord");

--- a/packages/graphql/tests/integration/issues/2100.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2100.int.test.ts
@@ -95,7 +95,7 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
             }
             `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (b:${BacentaType} {id: "1"})
                 SET b.name =  "test"
@@ -138,7 +138,7 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeFalsy();
         expect((result?.data as any)[BussingRecordType.plural][0].id).toBe("3");
@@ -178,7 +178,7 @@ describe("https://github.com/neo4j/graphql/issues/2100", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const result = await testHelper.runGraphQLWithToken(query, token, {
+        const result = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: {
                 id: 1,
             },

--- a/packages/graphql/tests/integration/issues/2189.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2189.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2189", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Test_Item: UniqueType;
     let Test_Feedback: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Test_Item = testHelper.createUniqueType("Test_Item");
         Test_Feedback = testHelper.createUniqueType("Test_Feedback");
 

--- a/packages/graphql/tests/integration/issues/2189.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2189.int.test.ts
@@ -108,7 +108,7 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
 
         expect(mutationResult.errors).toBeFalsy();
         expect((mutationResult?.data as any)[Test_Item.operations.create].info).toEqual({
@@ -116,7 +116,7 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             nodesCreated: 3,
         });
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
 
         expect(queryResult.errors).toBeFalsy();
         expect((queryResult?.data as any)[Test_Item.plural]).toHaveLength(2);
@@ -160,7 +160,7 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
 
         expect(mutationResult.errors).toBeFalsy();
         expect((mutationResult?.data as any)[Test_Item.operations.create].info).toEqual({
@@ -168,7 +168,7 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             nodesCreated: 3,
         });
 
-        const queryResult = await testHelper.runGraphQL(query);
+        const queryResult = await testHelper.executeGraphQL(query);
 
         expect(queryResult.errors).toBeFalsy();
         expect((queryResult?.data as any)[Test_Item.plural]).toHaveLength(2);
@@ -213,7 +213,7 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect((result?.data as any)[Test_Item.operations.create].info).toEqual({
@@ -260,7 +260,7 @@ describe("https://github.com/neo4j/graphql/issues/2189", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect((result?.data as any)[Test_Item.operations.create].info).toEqual({

--- a/packages/graphql/tests/integration/issues/2249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2249.int.test.ts
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
     });
 
     test("Update with create on an interface type should return valid Cypher", async () => {
-        await testHelper.runCypher(`CREATE (:${Movie} { title: "John Wick" })`);
+        await testHelper.executeCypher(`CREATE (:${Movie} { title: "John Wick" })`);
 
         const mutation = `
             mutation {
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/2249", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
 
         expect(mutationResult.errors).toBeFalsy();
         expect(mutationResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2249.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2249", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Person: UniqueType;
     let Influencer: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
         Influencer = testHelper.createUniqueType("Influencer");

--- a/packages/graphql/tests/integration/issues/2250.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2250.int.test.ts
@@ -107,7 +107,7 @@ describe("https://github.com/neo4j/graphql/issues/2250", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
 
         expect(mutationResult.errors).toBeFalsy();
     });

--- a/packages/graphql/tests/integration/issues/2250.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2250.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2250", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Person: UniqueType;
     let Actor: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/2261.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2261.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2261", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let ProgrammeItem: UniqueType;
     let Edition: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         ProgrammeItem = testHelper.createUniqueType("ProgrammeItem");
         Edition = testHelper.createUniqueType("Edition");
 

--- a/packages/graphql/tests/integration/issues/2261.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2261.int.test.ts
@@ -63,7 +63,7 @@ describe("https://github.com/neo4j/graphql/issues/2261", () => {
     });
 
     test("nested query with top level @cypher directive with subscriptions should return valid Cypher", async () => {
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (e:${Edition} {id: "ed-id"})<-[:HAS_EDITION]-(p:${ProgrammeItem} {id: "p-id"})`
         );
 
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/2261", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2262.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2262.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2262", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Component: UniqueType;
     let Process: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Component = testHelper.createUniqueType("Component");
         Process = testHelper.createUniqueType("Process");
 

--- a/packages/graphql/tests/integration/issues/2262.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2262.int.test.ts
@@ -55,7 +55,7 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
     });
 
     test("nested update with create while using subscriptions should generate valid Cypher", async () => {
-        await testHelper.runCypher(`CREATE(:${Component} {uuid: "c1"})<-[:OUTPUT]-(:${Process} {uuid: "p1"})`);
+        await testHelper.executeCypher(`CREATE(:${Component} {uuid: "c1"})<-[:OUTPUT]-(:${Process} {uuid: "p1"})`);
         const query = `
             query ComponentsProcesses {
                 ${Component.plural}(where: { uuid: "c1" }) {
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/2262", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2267.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2267.int.test.ts
@@ -55,7 +55,7 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE(:${Place} {displayName: "786 aa"})<-[:ACTIVITY]-(:${Post} {name: "A post"})
         CREATE(:${Place} {displayName: "8 à Huita"})
         CREATE(:${Place} {displayName: "9ème Sauvagea"})<-[:ACTIVITY]-(:${Story} {name: "A story"})
@@ -81,7 +81,7 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
           }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -117,7 +117,7 @@ describe("https://github.com/neo4j/graphql/issues/2267", () => {
           }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2267.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2267.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2267", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Place: UniqueType;
     let Post: UniqueType;
     let Story: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Place = testHelper.createUniqueType("Place");
         Post = testHelper.createUniqueType("Post");
         Story = testHelper.createUniqueType("Story");

--- a/packages/graphql/tests/integration/issues/227.int.test.ts
+++ b/packages/graphql/tests/integration/issues/227.int.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/227", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE (t:${Town} {id: $townId})
             MERGE (t)<-[:BELONGS_TO]-(m:${Member} {id: $memberId})
@@ -95,7 +95,7 @@ describe("https://github.com/neo4j/graphql/issues/227", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(source, {
+        const gqlResult = await testHelper.executeGraphQL(source, {
             variableValues: { id: townId },
         });
 

--- a/packages/graphql/tests/integration/issues/227.int.test.ts
+++ b/packages/graphql/tests/integration/issues/227.int.test.ts
@@ -25,10 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/227", () => {
     let Member: UniqueType;
     let Gender: UniqueType;
     let Town: UniqueType;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Member = testHelper.createUniqueType("Member");
         Gender = testHelper.createUniqueType("Gender");
         Town = testHelper.createUniqueType("Town");

--- a/packages/graphql/tests/integration/issues/235.int.test.ts
+++ b/packages/graphql/tests/integration/issues/235.int.test.ts
@@ -22,14 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/235", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let A: UniqueType;
     let B: UniqueType;
     let C: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
-
         A = testHelper.createUniqueType("A");
         B = testHelper.createUniqueType("B");
         C = testHelper.createUniqueType("C");

--- a/packages/graphql/tests/integration/issues/235.int.test.ts
+++ b/packages/graphql/tests/integration/issues/235.int.test.ts
@@ -117,14 +117,14 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
             }
         `;
 
-        const createBsResult = await testHelper.runGraphQL(createBs, {
+        const createBsResult = await testHelper.executeGraphQL(createBs, {
             variableValues: { b1, b2 },
         });
 
         expect(createBsResult.errors).toBeFalsy();
         expect((createBsResult.data as any)[B.operations.create][B.plural]).toEqual([{ name: b1 }, { name: b2 }]);
 
-        const createAsResult = await testHelper.runGraphQL(createAs, {
+        const createAsResult = await testHelper.executeGraphQL(createAs, {
             variableValues: { a, b1, b2, c },
         });
 
@@ -136,7 +136,7 @@ describe("https://github.com/neo4j/graphql/issues/235", () => {
         expect((createAsResult.data as any)?.[A.operations.create][A.plural][0].rel_b).toContainEqual({ name: b2 });
         expect((createAsResult.data as any)?.[A.operations.create][A.plural][0].rel_c).toEqual([{ name: c }]);
 
-        const asResult = await testHelper.runGraphQL(as, {
+        const asResult = await testHelper.executeGraphQL(as, {
             variableValues: { a },
         });
 

--- a/packages/graphql/tests/integration/issues/2388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2388.int.test.ts
@@ -22,14 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2388", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let PartAddress: UniqueType;
     let PartUsage: UniqueType;
     let Part: UniqueType;
     const secret = "secret";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         PartAddress = testHelper.createUniqueType("PartAddress");
         PartUsage = testHelper.createUniqueType("PartUsage");
         Part = testHelper.createUniqueType("Part");

--- a/packages/graphql/tests/integration/issues/2388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2388.int.test.ts
@@ -70,7 +70,7 @@ describe("https://github.com/neo4j/graphql/issues/2388", () => {
         `;
 
         // Initialise data
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (p:${Part})<-[uo:USAGE_OF]-(pu:${PartUsage})-[bt:BELONGS_TO]->(pa:${PartAddress})
             SET pa.id = "123"
         `);
@@ -102,7 +102,7 @@ describe("https://github.com/neo4j/graphql/issues/2388", () => {
 
         const token = createBearerToken(secret, { roles: ["upstream", "downstream"] });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Part.plural]: [

--- a/packages/graphql/tests/integration/issues/2396.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2396.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2396", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let PostalCode: UniqueType;
     let Address: UniqueType;
@@ -31,7 +31,6 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
     let Estate: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         PostalCode = testHelper.createUniqueType("PostalCode");
         Address = testHelper.createUniqueType("Address");
         Mandate = testHelper.createUniqueType("Mandate");

--- a/packages/graphql/tests/integration/issues/2396.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2396.int.test.ts
@@ -699,7 +699,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             }
         `;
 
-        await testHelper.runGraphQLWithToken(query, createBearerToken("secret"), {
+        await testHelper.executeGraphQLWithToken(query, createBearerToken("secret"), {
             variableValues: { input },
         });
     });
@@ -740,7 +740,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             },
         };
 
-        const result = await testHelper.runGraphQLWithToken(query, createBearerToken("secret"), {
+        const result = await testHelper.executeGraphQLWithToken(query, createBearerToken("secret"), {
             variableValues,
         });
 
@@ -780,7 +780,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             },
         };
 
-        const result = await testHelper.runGraphQLWithToken(query, createBearerToken("secret"), {
+        const result = await testHelper.executeGraphQLWithToken(query, createBearerToken("secret"), {
             variableValues,
         });
 
@@ -823,7 +823,7 @@ describe("https://github.com/neo4j/graphql/issues/2396", () => {
             },
         };
 
-        const result = await testHelper.runGraphQLWithToken(query, createBearerToken("secret"), {
+        const result = await testHelper.executeGraphQLWithToken(query, createBearerToken("secret"), {
             variableValues,
         });
 

--- a/packages/graphql/tests/integration/issues/2437.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2437.int.test.ts
@@ -57,7 +57,7 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
             extend type ${Valuation} @authorization(filter: [{ where: { node: { archivedAt: null } } }])
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE(a:${Agent} {uuid: "a1"})
         CREATE(:${Valuation} {uuid: "v1"})<-[:IS_VALUATION_AGENT]-(a)
         CREATE(:${Valuation} {uuid: "v2"})<-[:IS_VALUATION_AGENT]-(a)
@@ -101,7 +101,7 @@ describe("https://github.com/neo4j/graphql/issues/2437", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQLWithToken(query, createBearerToken("secret"));
+        const result = await testHelper.executeGraphQLWithToken(query, createBearerToken("secret"));
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2437.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2437.int.test.ts
@@ -22,13 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2437", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Agent: UniqueType;
     let Valuation: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Agent = testHelper.createUniqueType("Agent");
         Valuation = testHelper.createUniqueType("Valuation");
 

--- a/packages/graphql/tests/integration/issues/247.int.test.ts
+++ b/packages/graphql/tests/integration/issues/247.int.test.ts
@@ -23,12 +23,11 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/247", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
     let User: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         User = testHelper.createUniqueType("User");
     });

--- a/packages/graphql/tests/integration/issues/247.int.test.ts
+++ b/packages/graphql/tests/integration/issues/247.int.test.ts
@@ -94,14 +94,14 @@ describe("https://github.com/neo4j/graphql/issues/247", () => {
             }
         `;
 
-        const createUsersResult = await testHelper.runGraphQL(createUsers, {
+        const createUsersResult = await testHelper.executeGraphQL(createUsers, {
             variableValues: { name },
         });
 
         expect(createUsersResult.errors).toBeFalsy();
         expect((createUsersResult.data as any)[User.operations.create][User.plural]).toEqual([{ name }]);
 
-        const createMoviesResult = await testHelper.runGraphQL(createMovies, {
+        const createMoviesResult = await testHelper.executeGraphQL(createMovies, {
             variableValues: { title1, title2, title3 },
         });
 
@@ -112,7 +112,7 @@ describe("https://github.com/neo4j/graphql/issues/247", () => {
             { title: title3 },
         ]);
 
-        const connectResult = await testHelper.runGraphQL(connect, {
+        const connectResult = await testHelper.executeGraphQL(connect, {
             variableValues: { name, title2, title3 },
         });
 

--- a/packages/graphql/tests/integration/issues/2474.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2474.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let PostalCode: UniqueType;
     let Address: UniqueType;
@@ -31,7 +31,6 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
     let Valuation: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         PostalCode = testHelper.createUniqueType("PostalCode");
         Address = testHelper.createUniqueType("Address");
         Estate = testHelper.createUniqueType("Estate");

--- a/packages/graphql/tests/integration/issues/2474.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2474.int.test.ts
@@ -166,7 +166,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
           }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Mandate.operations.create]: {
@@ -196,7 +196,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
             },
         });
 
-        const dbResult: any = await testHelper.runCypher(`
+        const dbResult: any = await testHelper.executeCypher(`
             MATCH (mandate:${Mandate.name})-[:HAS_VALUATION]->(valuation:${Valuation.name})-[:VALUATION_FOR]->(estate:${Estate.name})-[:HAS_ADDRESS]->(address:${Address.name})-[:HAS_POSTAL_CODE]->(postalCode:${PostalCode.name})
             RETURN mandate, valuation, estate, address, postalCode
         `);
@@ -285,7 +285,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
           }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Mandate.operations.create]: {
@@ -320,7 +320,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
             },
         });
 
-        const dbResult: any = await testHelper.runCypher(`
+        const dbResult: any = await testHelper.executeCypher(`
             MATCH (mandate:${Mandate.name})-[:HAS_VALUATION]->(valuation:${Valuation.name})-[:VALUATION_FOR]->(estate:${Estate.name})-[:HAS_ADDRESS]->(address:${Address.name})<-[:HAS_ADDRESS]-(estate2:${Estate.name})
             RETURN mandate, valuation, estate, address, estate2
         `);

--- a/packages/graphql/tests/integration/issues/2548.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2548.int.test.ts
@@ -23,14 +23,13 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2548", () => {
     const secret = "secret";
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
 
     let query: string;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/2548.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2548.int.test.ts
@@ -63,7 +63,7 @@ describe("https://github.com/neo4j/graphql/issues/2548", () => {
             features: { authorization: { key: secret } },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${User} { userId: "1", isPublic: true })
             CREATE (:${User} { userId: "2", isPublic: false })
         `);
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/2548", () => {
     });
 
     test("should return public information for unauthenticated request", async () => {
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -89,7 +89,7 @@ describe("https://github.com/neo4j/graphql/issues/2548", () => {
     test("should return all records for admin request", async () => {
         const token = createBearerToken(secret, { roles: ["ADMIN"] });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeFalsy();
         expect((result.data as any)[User.plural]).toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2560", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Person: UniqueType;
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(mutation);
+        const result = await testHelper.executeGraphQL(mutation);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -140,7 +140,7 @@ describe("https://github.com/neo4j/graphql/issues/2560", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(mutation);
+        const result = await testHelper.executeGraphQL(mutation);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2574.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2574.int.test.ts
@@ -75,7 +75,7 @@ describe("https://github.com/neo4j/graphql/issues/2574", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             variableValues: {
                 input: {
                     child: {

--- a/packages/graphql/tests/integration/issues/2574.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2574.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2574", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let A: UniqueType;
     let B: UniqueType;
     let D: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         A = testHelper.createUniqueType("A");
         B = testHelper.createUniqueType("B");
         D = testHelper.createUniqueType("D");

--- a/packages/graphql/tests/integration/issues/2581.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2581.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2581", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Author: UniqueType;
     let Book: UniqueType;
     let Sales: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Author = testHelper.createUniqueType("Author");
         Book = testHelper.createUniqueType("Book");
         Sales = testHelper.createUniqueType("Sales");

--- a/packages/graphql/tests/integration/issues/2581.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2581.int.test.ts
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE(a:${Author} {name: "Douglas Adams"})-[:AUTHORED_BOOK]->(:${Book} {name: "The Hitchhiker's Guide to the Galaxy", year:1979, refID:1})
         CREATE(a)-[:AUTHORED_BOOK]->(:${Book} {name: "The Restaurant at the End of the Universe", year:1980, refID:2})
 
@@ -105,7 +105,7 @@ describe("https://github.com/neo4j/graphql/issues/2581", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/2630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2630.int.test.ts
@@ -84,7 +84,7 @@ describe("https://github.com/neo4j/graphql/issues/2630", () => {
         const postId = generate({ charset: "alphabetic" });
         const userName = generate({ charset: "alphabetic" });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (post:${Post} { id: $postId })
                 CREATE (user:${User} { id: $userId, name: $userName })
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/2630", () => {
             { userId, postId, userName }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2630.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2630", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let HasName: UniqueType;
     let Post: UniqueType;
@@ -31,8 +31,6 @@ describe("https://github.com/neo4j/graphql/issues/2630", () => {
     let PostSubject: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         HasName = testHelper.createUniqueType("HasName");
         Post = testHelper.createUniqueType("Post");
         User = testHelper.createUniqueType("User");

--- a/packages/graphql/tests/integration/issues/2652.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2652.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2652", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let locationType: UniqueType;
     let reviewType: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         locationType = testHelper.createUniqueType("Location");
         reviewType = testHelper.createUniqueType("Review");
 

--- a/packages/graphql/tests/integration/issues/2652.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2652.int.test.ts
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/2652", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
     });

--- a/packages/graphql/tests/integration/issues/2662.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2662.int.test.ts
@@ -58,7 +58,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }    
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (p:${postType} { content: "${content1}" })<-[:LIKES { someString: "${someString1}" }]-(:${userType} { name: "${name1}" })
             CREATE (p)<-[:LIKES { someString: "${someString2}" }]-(:${userType} { name: "${name2}" })
             CREATE (:${postType} { content: "${content2}" })<-[:LIKES { someString: "${someString3}" }]-(:${userType} { name: "${name3}" })
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -114,7 +114,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -142,7 +142,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -182,7 +182,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -214,7 +214,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -254,7 +254,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -286,7 +286,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -318,7 +318,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -350,7 +350,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -379,7 +379,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -419,7 +419,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -451,7 +451,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -483,7 +483,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -523,7 +523,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -552,7 +552,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -581,7 +581,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -613,7 +613,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -645,7 +645,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -677,7 +677,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -706,7 +706,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -768,7 +768,7 @@ describe("https://github.com/neo4j/graphql/issues/2662 - alternative typedefs", 
             }    
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (p:${postType} { someProperty: 1 })<-[:LIKES { someProperty: "${someString1}" }]-(:${userType} { someProperty: 1 })
             CREATE (p)<-[:LIKES { someProperty: "${someString2}" }]-(:${userType} { someProperty: 2 })
             CREATE (:${postType} { someProperty: 2 })<-[:LIKES { someProperty: "${someString3}" }]-(:${userType} { someProperty: 3 })
@@ -795,7 +795,7 @@ describe("https://github.com/neo4j/graphql/issues/2662 - alternative typedefs", 
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/2662.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2662.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2662", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let userType: UniqueType;
     let postType: UniqueType;
@@ -39,8 +39,6 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
     const post1Average = (someString1.length + someString2.length) / 2;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
         likesInterface = testHelper.createUniqueType("Likes");
@@ -736,7 +734,7 @@ describe("https://github.com/neo4j/graphql/issues/2662", () => {
 });
 
 describe("https://github.com/neo4j/graphql/issues/2662 - alternative typedefs", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let userType: UniqueType;
     let postType: UniqueType;
@@ -749,8 +747,6 @@ describe("https://github.com/neo4j/graphql/issues/2662 - alternative typedefs", 
     const post1Average = (someString1.length + someString2.length) / 2;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         userType = testHelper.createUniqueType("User");
         postType = testHelper.createUniqueType("Post");
         likesInterface = testHelper.createUniqueType("Likes");

--- a/packages/graphql/tests/integration/issues/2669.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2669.int.test.ts
@@ -54,7 +54,7 @@ describe("https://github.com/neo4j/graphql/issues/2669", () => {
 
         neoSchema = await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
+        await testHelper.executeCypher(`CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
         CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})`);
     });
 
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/2669", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/2669", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeMovie.plural][0].actorsAggregate).toEqual({

--- a/packages/graphql/tests/integration/issues/2669.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2669.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2669", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/2669", () => {
     let neoSchema: Neo4jGraphQL;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/2670.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2670.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2670", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let movieType: UniqueType;
     let genreType: UniqueType;
@@ -47,8 +47,6 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
     beforeAll(async () => {});
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         movieType = testHelper.createUniqueType("Movie");
         genreType = testHelper.createUniqueType("Genre");
         seriesType = testHelper.createUniqueType("Series");

--- a/packages/graphql/tests/integration/issues/2670.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2670.int.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m1:${movieType.name} { title: "${movieTitle1}" })-[:IN_GENRE { intValue: ${intValue1} }]->(g1:${genreType.name} { name: "${genreName1}" })
             CREATE (m2:${movieType.name} { title: "${movieTitle2}" })-[:IN_GENRE { intValue: ${intValue2} }]->(g1)
             CREATE (m3:${movieType.name} { title: "${movieTitle3}" })-[:IN_GENRE { intValue: ${intValue3} }]->(g1)
@@ -105,7 +105,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -129,7 +129,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -153,7 +153,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -180,7 +180,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -207,7 +207,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -231,7 +231,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -255,7 +255,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -282,7 +282,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -306,7 +306,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -333,7 +333,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -354,7 +354,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -378,7 +378,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -405,7 +405,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -429,7 +429,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -459,7 +459,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -483,7 +483,7 @@ describe("https://github.com/neo4j/graphql/issues/2670", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2697.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2697.int.test.ts
@@ -49,7 +49,7 @@ describe("https://github.com/neo4j/graphql/issues/2697", () => {
         `;
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (t1:${typeMovie.name} { title: "Terminator 1", duration: duration("PT1H47M") }),
             (t2:${typeMovie.name} { title: "Terminator 2", duration: duration("PT2H15M") }),
             (arnold:${typeActor.name} { name: "Arnold"}),
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/2697", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeActor.plural]).toEqual(
@@ -98,7 +98,7 @@ describe("https://github.com/neo4j/graphql/issues/2697", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult as any).data[typeActor.plural]).toEqual([

--- a/packages/graphql/tests/integration/issues/2697.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2697.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2697", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/2708.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2708.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2708", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let movieType: UniqueType;
     let genreType: UniqueType;
@@ -45,8 +45,6 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
     const genre2AverageTitleLength = (movieTitle4.length + movieTitle2.length) / 2;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         movieType = testHelper.createUniqueType("Movie");
         genreType = testHelper.createUniqueType("Genre");
         seriesType = testHelper.createUniqueType("Series");

--- a/packages/graphql/tests/integration/issues/2708.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2708.int.test.ts
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m1:${movieType.name} { title: "${movieTitle1}" })-[:IN_GENRE { intValue: ${intValue1} }]->(g1:${genreType.name} { name: "${genreName1}" })
             CREATE (m2:${movieType.name} { title: "${movieTitle2}" })-[:IN_GENRE { intValue: ${intValue2} }]->(g1)
             CREATE (m3:${movieType.name} { title: "${movieTitle3}" })-[:IN_GENRE { intValue: ${intValue3} }]->(g1)
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -127,7 +127,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -151,7 +151,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -178,7 +178,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -205,7 +205,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -229,7 +229,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -253,7 +253,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -280,7 +280,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -304,7 +304,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -331,7 +331,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -352,7 +352,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -376,7 +376,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -403,7 +403,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -420,7 +420,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -444,7 +444,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -474,7 +474,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -498,7 +498,7 @@ describe("https://github.com/neo4j/graphql/issues/2708", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2709.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2709.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2709", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Dishney: UniqueType;
     let Netflix: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Dishney = testHelper.createUniqueType("Dishney");
         Netflix = testHelper.createUniqueType("Netflix");
@@ -157,7 +155,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
 });
 
 describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Dishney: UniqueType;
@@ -165,8 +163,6 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
     let Publisher: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Dishney = testHelper.createUniqueType("Dishney");
         Netflix = testHelper.createUniqueType("Netflix");

--- a/packages/graphql/tests/integration/issues/2709.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2709.int.test.ts
@@ -95,7 +95,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:Film { title: "A Netflix movie" })<-[:DISTRIBUTED_BY]-(:${Netflix} { name: "Netflix" })
             CREATE (:Film { title: "A Dishney movie" })<-[:DISTRIBUTED_BY]-(:${Dishney} { name: "Dishney" })
         `);
@@ -120,7 +120,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -143,7 +143,7 @@ describe("https://github.com/neo4j/graphql/issues/2709", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({
@@ -240,7 +240,7 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
             ################
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:Film { title: "A Netflix movie" })<-[:DISTRIBUTED_BY]-(:${Netflix} { name: "Netflix" })
             CREATE (:Film { title: "A Dishney movie" })<-[:DISTRIBUTED_BY]-(:${Dishney} { name: "Dishney" })
             CREATE (:Film { title: "A Publisher movie" })<-[:DISTRIBUTED_BY]-(:${Publisher} { name: "The Publisher" })
@@ -266,7 +266,7 @@ describe("https://github.com/neo4j/graphql/issues/2709 - extended", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data as any).toEqual({

--- a/packages/graphql/tests/integration/issues/2713.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2713.int.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (m1:${movieType.name} { title: "${movieTitle1}" })-[:IN_GENRE { intValue: ${intValue1} }]->(g1:${genreType.name} { name: "${genreName1}" })
             CREATE (m2:${movieType.name} { title: "${movieTitle2}" })-[:IN_GENRE { intValue: ${intValue2} }]->(g1)
             CREATE (m3:${movieType.name} { title: "${movieTitle3}" })-[:IN_GENRE { intValue: ${intValue3} }]->(g1)
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2713.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2713.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2713", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let movieType: UniqueType;
     let genreType: UniqueType;
@@ -40,8 +40,6 @@ describe("https://github.com/neo4j/graphql/issues/2713", () => {
     const intValue5 = 42;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         movieType = testHelper.createUniqueType("Movie");
         genreType = testHelper.createUniqueType("Genre");
         inGenreInterface = testHelper.createUniqueType("InGenre");

--- a/packages/graphql/tests/integration/issues/2766.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2766.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2766", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Actor: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/2766.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2766.int.test.ts
@@ -55,7 +55,7 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (a:${Actor} {name: "arthur"})-[:ACTED_IN]->(:${Movie} { title: "some title"})
                 CREATE (a)-[:ACTED_IN]->(:${Movie} { title: "another title"})
         `);
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2766", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Actor.plural]: [

--- a/packages/graphql/tests/integration/issues/2782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2782.int.test.ts
@@ -58,7 +58,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE(p:${Product} {id: "1", name: "NormalConnect"})
             CREATE(p)-[:HAS_COLOR]->(red:${Color} {id: "1", name: "Red"})
             CREATE(red)<-[:OF_COLOR]-(photo:${Photo} {id: "123"})
@@ -121,7 +121,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Product.operations.update]: {
@@ -159,7 +159,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
         `;
 
-        const result2 = await testHelper.runGraphQL(query2);
+        const result2 = await testHelper.executeGraphQL(query2);
 
         expect(result2.errors).toBeFalsy();
         expect(result2.data).toEqual({
@@ -185,7 +185,7 @@ describe("https://github.com/neo4j/graphql/issues/2782", () => {
             }
         `;
 
-        const result3 = await testHelper.runGraphQL(query3);
+        const result3 = await testHelper.executeGraphQL(query3);
 
         expect(result3.errors).toBeFalsy();
         expect(result3.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2782.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2782", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Product: UniqueType;
     let Color: UniqueType;
     let Photo: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Product = testHelper.createUniqueType("Product");
         Color = testHelper.createUniqueType("Color");
         Photo = testHelper.createUniqueType("Photo");

--- a/packages/graphql/tests/integration/issues/2803.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2803.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2803", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Actor: UniqueType;
@@ -95,8 +95,6 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
     const updatedName = "a new name!";
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/2803.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2803.int.test.ts
@@ -121,7 +121,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE (a1:${Actor})-[rel1:ACTED_IN]->(m1:${Movie})
             CREATE (a1)-[rel2:ACTED_IN]->(m2:${Movie})
@@ -174,7 +174,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -200,7 +200,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -227,7 +227,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -257,7 +257,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -284,7 +284,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -312,7 +312,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -345,7 +345,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -383,7 +383,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -410,7 +410,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -437,7 +437,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -468,7 +468,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -494,7 +494,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -527,7 +527,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -560,7 +560,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -586,7 +586,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -615,7 +615,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -644,7 +644,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -681,7 +681,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
@@ -717,7 +717,7 @@ describe("https://github.com/neo4j/graphql/issues/2803", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2812.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2812.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2812", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const secret = "secret";
 
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
     let Actor: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/2812.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2812.int.test.ts
@@ -89,7 +89,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         `;
             const token = createBearerToken(secret, { roles: ["role-A", "role-B", "admin"], sub: "User" });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeFalsy();
         });
 
@@ -113,7 +113,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         `;
             const token = createBearerToken(secret, { roles: ["role-A", "role-B", "admin"], sub: "User" });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeFalsy();
         });
 
@@ -137,7 +137,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         `;
             const token = createBearerToken(secret, { roles: ["role-A", "role-B", "admin"], sub: "User" });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeFalsy();
         });
     });
@@ -163,7 +163,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         `;
             const token = createBearerToken(secret, { roles: ["admin"], sub: "User" });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeTruthy();
         });
 
@@ -187,7 +187,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         `;
             const token = createBearerToken(secret, { roles: ["admin"], sub: "User" });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeTruthy();
         });
 
@@ -211,7 +211,7 @@ describe("https://github.com/neo4j/graphql/issues/2812", () => {
         `;
             const token = createBearerToken(secret, { roles: ["admin"], sub: "User" });
 
-            const result = await testHelper.runGraphQLWithToken(query, token);
+            const result = await testHelper.executeGraphQLWithToken(query, token);
             expect(result.errors).toBeFalsy();
         });
     });

--- a/packages/graphql/tests/integration/issues/2820.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2820.int.test.ts
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (a:${Actor} { name: "Actor" })
             CREATE (a)-[:ACTED_IN]->(:${Movie} { title: "House" })
             CREATE (a)-[:ACTED_IN]->(:${Series} { title: "House" })
@@ -85,7 +85,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -160,7 +160,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -203,7 +203,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -238,7 +238,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -271,7 +271,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -300,7 +300,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -351,7 +351,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -399,7 +399,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 
@@ -434,7 +434,7 @@ describe("https://github.com/neo4j/graphql/issues/2820", () => {
             }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/2820.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2820.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2820", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Series: UniqueType;
     let Actor: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Series = testHelper.createUniqueType("Series");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/283.int.test.ts
+++ b/packages/graphql/tests/integration/issues/283.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/283", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Post: UniqueType;
     let typeDefs: string;
 
@@ -36,7 +36,6 @@ describe("https://github.com/neo4j/graphql/issues/283", () => {
     };
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         typeDefs = `
         type Mutation {
             login: String

--- a/packages/graphql/tests/integration/issues/283.int.test.ts
+++ b/packages/graphql/tests/integration/issues/283.int.test.ts
@@ -83,12 +83,12 @@ describe("https://github.com/neo4j/graphql/issues/283", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const result = await testHelper.runGraphQL(mutation);
+        const result = await testHelper.executeGraphQL(mutation);
 
         expect(result.errors).toBeFalsy();
 
         expect(typeof (result?.data as any)?.createPost?.datetime).toBe("string");
 
-        await testHelper.runCypher(`MATCH (p:${Post}) WHERE p.title = "${title}" DELETE p`);
+        await testHelper.executeCypher(`MATCH (p:${Post}) WHERE p.title = "${title}" DELETE p`);
     });
 });

--- a/packages/graphql/tests/integration/issues/2847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2847.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2847", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Actor: UniqueType;
     let Product: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");
         Product = testHelper.createUniqueType("Product");

--- a/packages/graphql/tests/integration/issues/2847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2847.int.test.ts
@@ -49,7 +49,7 @@ describe("https://github.com/neo4j/graphql/issues/2847", () => {
           }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE (c:${Actor})
             SET c.name = $name
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/2847", () => {
               }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [Actor.plural]: expect.toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/2871.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2871.int.test.ts
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
         SecondLevel = testHelper.createUniqueType("SecondLevel");
         ThirdLevel = testHelper.createUniqueType("ThirdLevel");
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE (f1:${FirstLevel})-[:HAS_SECOND_LEVEL]->(s1:${SecondLevel})-[:HAS_THIRD_LEVEL]->(t1:${ThirdLevel})
             CREATE (f2:${FirstLevel})-[:HAS_SECOND_LEVEL]->(s2:${SecondLevel})-[:HAS_THIRD_LEVEL]->(t2:${ThirdLevel})
@@ -134,7 +134,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({
             [FirstLevel.plural]: expect.toIncludeSameMembers([firstLevelInput2]),
@@ -160,8 +160,8 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             }
         `;
 
-        const resultExpectingEmptyList = await testHelper.runGraphQL(queryExpectingEmptyList);
-        const resultExpectingData = await testHelper.runGraphQL(queryExpectingData);
+        const resultExpectingEmptyList = await testHelper.executeGraphQL(queryExpectingEmptyList);
+        const resultExpectingData = await testHelper.executeGraphQL(queryExpectingData);
 
         expect(resultExpectingEmptyList.errors).toBeFalsy();
         expect(resultExpectingData.errors).toBeFalsy();
@@ -174,7 +174,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
     });
 
     test("should not match if SOME second level relationships meet nested predicates", async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (f4:${FirstLevel} {id: "22", createdAt: "1970-01-02T01:00:00.000Z"})-[:HAS_SECOND_LEVEL]->(s4:${SecondLevel} {id: "24", createdAt: "1970-01-02T01:00:00.000Z"})-[:HAS_THIRD_LEVEL]->(:${ThirdLevel} {id: "25", createdAt: "1970-01-02T01:00:00.000Z"})
             `);
 
@@ -187,7 +187,7 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/2871.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2871.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2871", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let FirstLevel: UniqueType;
     let SecondLevel: UniqueType;
@@ -65,8 +65,6 @@ describe("https://github.com/neo4j/graphql/issues/2871", () => {
     };
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         FirstLevel = testHelper.createUniqueType("FirstLevel");
         SecondLevel = testHelper.createUniqueType("SecondLevel");
         ThirdLevel = testHelper.createUniqueType("ThirdLevel");

--- a/packages/graphql/tests/integration/issues/288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/288.int.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const createResult = await testHelper.runGraphQL(createMutation);
+        const createResult = await testHelper.executeGraphQL(createMutation);
 
         expect(createResult.errors).toBeFalsy();
 
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
             { USERID: userid, COMPANYID: companyid1 },
         ]);
 
-        const updateResult = await testHelper.runGraphQL(updateMutation);
+        const updateResult = await testHelper.executeGraphQL(updateMutation);
 
         expect(updateResult.errors).toBeFalsy();
 
@@ -98,6 +98,6 @@ describe("https://github.com/neo4j/graphql/issues/288", () => {
             { USERID: userid, COMPANYID: companyid2 },
         ]);
 
-        await testHelper.runCypher(`MATCH (u:${USER}) WHERE u.USERID = "${userid}" DELETE u`);
+        await testHelper.executeCypher(`MATCH (u:${USER}) WHERE u.USERID = "${userid}" DELETE u`);
     });
 });

--- a/packages/graphql/tests/integration/issues/288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/288.int.test.ts
@@ -22,15 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/288", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let USER: UniqueType;
     let COMPANY: UniqueType;
 
     let typeDefs: string;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
-
         USER = testHelper.createUniqueType("USER");
         COMPANY = testHelper.createUniqueType("COMPANY");
 

--- a/packages/graphql/tests/integration/issues/2889.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2889.int.test.ts
@@ -61,7 +61,7 @@ describe("https://github.com/neo4j/graphql/issues/2889", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect((result.data?.[MyEnumHolder.operations.create] as any)[MyEnumHolder.plural]).toEqual([

--- a/packages/graphql/tests/integration/issues/2889.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2889.int.test.ts
@@ -21,13 +21,11 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2889", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let MyEnumHolder: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         MyEnumHolder = testHelper.createUniqueType("MyEnumHolder");
 
         const typeDefs = `

--- a/packages/graphql/tests/integration/issues/2981.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2981.int.test.ts
@@ -64,7 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
     });
 
     test("should be able to create a nested translated title", async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
            CREATE(book:${Book} {isbn: "123", originalTitle: "Original title"})
         `);
         const query = `
@@ -89,7 +89,7 @@ describe("https://github.com/neo4j/graphql/issues/2981", () => {
           }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data?.[Book.operations.update]).toEqual({

--- a/packages/graphql/tests/integration/issues/2981.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2981.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2981", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Book: UniqueType;
     let BookTitle_SV: UniqueType;
     let BookTitle_EN: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Book = testHelper.createUniqueType("Book");
         BookTitle_SV = testHelper.createUniqueType("BookTitle_SV");
         BookTitle_EN = testHelper.createUniqueType("BookTitle_EN");

--- a/packages/graphql/tests/integration/issues/2982.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2982.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2982", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Post: UniqueType;
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/2982", () => {
     let BlogArticle: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
         Comment = testHelper.createUniqueType("Comment");

--- a/packages/graphql/tests/integration/issues/2982.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2982.int.test.ts
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/2982", () => {
         const articleId = generate({ charset: "alphabetic" });
         const userName = generate({ charset: "alphabetic" });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (user:${User} { id: $userId })
                 CREATE (article:${BlogArticle} { id: $articleId })
@@ -92,7 +92,7 @@ describe("https://github.com/neo4j/graphql/issues/2982", () => {
             { userId, articleId, userName }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/3009.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3009.int.test.ts
@@ -50,7 +50,7 @@ describe("https://github.com/neo4j/graphql/issues/3009", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({ [User.plural]: [{ joinedAt: "2020-01-01" }] });
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3009", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({ [User.plural]: [{ joinedAt: "2020-01-01T00:00:00.000Z" }] });

--- a/packages/graphql/tests/integration/issues/3009.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3009.int.test.ts
@@ -21,10 +21,9 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3009", () => {
     let User: UniqueType;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
     });
 

--- a/packages/graphql/tests/integration/issues/3015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3015.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3015", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let NodeA: UniqueType;
     let NodeB: UniqueType;
     let Connected: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         NodeA = testHelper.createUniqueType("NodeA");
         NodeB = testHelper.createUniqueType("NodeB");
         Connected = testHelper.createUniqueType("Connected");

--- a/packages/graphql/tests/integration/issues/3015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3015.int.test.ts
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/3015", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (a:${NodeA} {name: "testA"})
             CREATE (b:${NodeB} {name: "testB"})
             CREATE (c:${Connected} {name: "connectedB"})
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/issues/3015", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/3027.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3027.int.test.ts
@@ -22,15 +22,13 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3027", () => {
     describe("union", () => {
-        let testHelper: TestHelper;
+        const testHelper = new TestHelper();
 
         let Book: UniqueType;
         let BookTitle_SV: UniqueType;
         let BookTitle_EN: UniqueType;
 
         beforeEach(async () => {
-            testHelper = new TestHelper();
-
             Book = testHelper.createUniqueType("Book");
             BookTitle_SV = testHelper.createUniqueType("BookTitle_SV");
             BookTitle_EN = testHelper.createUniqueType("BookTitle_EN");
@@ -107,15 +105,13 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
     });
 
     describe("interface", () => {
-        let testHelper: TestHelper;
+        const testHelper = new TestHelper();
 
         let Book: UniqueType;
         let BookTitle_SV: UniqueType;
         let BookTitle_EN: UniqueType;
 
         beforeEach(async () => {
-            testHelper = new TestHelper();
-
             Book = testHelper.createUniqueType("Book");
             BookTitle_SV = testHelper.createUniqueType("BookTitle_SV");
             BookTitle_EN = testHelper.createUniqueType("BookTitle_EN");

--- a/packages/graphql/tests/integration/issues/3027.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3027.int.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         });
 
         test("should validate cardinality against all the implementations", async () => {
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
            CREATE(:${Book} {isbn: "123", originalTitle: "Original title"})<-[:TRANSLATED_BOOK_TITLE]-(:${BookTitle_SV} { value: "Exempel på svensk titel"})
         `);
             const query = `
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
           }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeTruthy();
             expect(result.errors).toEqual(
@@ -152,7 +152,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
         });
 
         test("should validate cardinality against all the implementations", async () => {
-            await testHelper.runCypher(`
+            await testHelper.executeCypher(`
            CREATE(book:${Book} {isbn: "123", originalTitle: "Original title"})<-[:TRANSLATED_BOOK_TITLE]-(:${BookTitle_SV} { value: "Exempel på svensk titel"})
         `);
             const query = `
@@ -178,7 +178,7 @@ describe("https://github.com/neo4j/graphql/issues/3027", () => {
           }
         `;
 
-            const result = await testHelper.runGraphQL(query);
+            const result = await testHelper.executeGraphQL(query);
 
             expect(result.errors).toBeTruthy();
             expect(result.errors).toEqual(

--- a/packages/graphql/tests/integration/issues/315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/315.int.test.ts
@@ -22,14 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/315", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
 
     let Post: UniqueType;
     let User: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Post = testHelper.createUniqueType("Post");
         User = testHelper.createUniqueType("User");
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/315.int.test.ts
@@ -211,7 +211,7 @@ describe("https://github.com/neo4j/graphql/issues/315", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const mutationResult = await testHelper.runGraphQL(mutation, {
+        const mutationResult = await testHelper.executeGraphQL(mutation, {
             variableValues: { input },
         });
 
@@ -225,7 +225,7 @@ describe("https://github.com/neo4j/graphql/issues/315", () => {
             expect(friend.posts).toHaveLength(3);
         });
 
-        const queryResult = await testHelper.runGraphQL(query, {
+        const queryResult = await testHelper.executeGraphQL(query, {
             variableValues: {
                 userID,
             },

--- a/packages/graphql/tests/integration/issues/3165.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3165.int.test.ts
@@ -109,11 +109,11 @@ describe("https://github.com/neo4j/graphql/issues/3165", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
 
         expect(mutationResult.errors).toBeFalsy();
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/3165.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3165.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3165", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let A: UniqueType;
     let B: UniqueType;
     let Related: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         A = testHelper.createUniqueType("A");
         B = testHelper.createUniqueType("B");
         Related = testHelper.createUniqueType("Related");

--- a/packages/graphql/tests/integration/issues/3251.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3251.int.test.ts
@@ -44,7 +44,7 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (a:${Genre} { name: "Action" })
             CREATE (:${Genre} { name: "Thriller" })
             CREATE (:${Movie} { name: "TestMovie1" })-[:HAS_GENRE]->(a)
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/3251", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
 
         expect(mutationResult.errors).toHaveLength(1);
         expect((mutationResult.errors as any)[0]?.message).toBe(`${Movie}.genre required exactly once`);

--- a/packages/graphql/tests/integration/issues/3251.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3251.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3251", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Genre: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Genre = testHelper.createUniqueType("Genre");
 

--- a/packages/graphql/tests/integration/issues/326.int.test.ts
+++ b/packages/graphql/tests/integration/issues/326.int.test.ts
@@ -23,13 +23,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/326", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
     let User: UniqueType;
     let id: string;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         id = generate({
             charset: "alphabetic",

--- a/packages/graphql/tests/integration/issues/326.int.test.ts
+++ b/packages/graphql/tests/integration/issues/326.int.test.ts
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/326", () => {
         id = generate({
             charset: "alphabetic",
         });
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${User.name} {id: $id, email: randomUUID()})
                 `,
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/326", () => {
 
         const token = testHelper.createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -127,7 +127,7 @@ describe("https://github.com/neo4j/graphql/issues/326", () => {
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });

--- a/packages/graphql/tests/integration/issues/330.int.test.ts
+++ b/packages/graphql/tests/integration/issues/330.int.test.ts
@@ -25,11 +25,10 @@ import { TestHelper } from "../utils/tests-helper";
 // Reference: https://github.com/neo4j/graphql/pull/303#discussion_r671148932
 describe("unauthenticated-requests", () => {
     const secret = "secret";
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let User: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
     });
 

--- a/packages/graphql/tests/integration/issues/330.int.test.ts
+++ b/packages/graphql/tests/integration/issues/330.int.test.ts
@@ -54,7 +54,7 @@ describe("unauthenticated-requests", () => {
             }
         `;
 
-        await testHelper.runCypher(`CREATE (:${User} { id: "ID" })`);
+        await testHelper.executeCypher(`CREATE (:${User} { id: "ID" })`);
 
         await testHelper.initNeo4jGraphQL({
             typeDefs,
@@ -67,7 +67,7 @@ describe("unauthenticated-requests", () => {
 
         const token = createBearerToken(secret);
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -89,7 +89,7 @@ describe("unauthenticated-requests", () => {
             }
         `;
 
-        await testHelper.runCypher(`CREATE (:${User} { id: "ID" })`);
+        await testHelper.executeCypher(`CREATE (:${User} { id: "ID" })`);
 
         await testHelper.initNeo4jGraphQL({
             typeDefs,
@@ -102,7 +102,7 @@ describe("unauthenticated-requests", () => {
 
         const token = testHelper.createBearerToken(secret);
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeUndefined();
         expect(gqlResult.data).toEqual({
@@ -140,7 +140,7 @@ describe("unauthenticated-requests", () => {
 
         const token = testHelper.createBearerToken(secret);
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect((gqlResult.errors as any[])[0].message).toBe("Forbidden");
     });
@@ -158,7 +158,7 @@ describe("unauthenticated-requests", () => {
             typeDefs,
         });
 
-        await expect(() => testHelper.runCypher(`CREATE (:${User} { shouldFail: {} })`)).rejects.toThrow(
+        await expect(() => testHelper.executeCypher(`CREATE (:${User} { shouldFail: {} })`)).rejects.toThrow(
             "Property values can only be of primitive types or arrays thereof. Encountered: Map{}."
         );
     });

--- a/packages/graphql/tests/integration/issues/3355.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3355.int.test.ts
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/3355", () => {
           }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (:${Movie} {id: $id, name: $initialName})
             `,
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/3355", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, name: updatedName },
         });
 

--- a/packages/graphql/tests/integration/issues/3355.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3355.int.test.ts
@@ -23,11 +23,10 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3355", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
     });
 

--- a/packages/graphql/tests/integration/issues/3394.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3394.int.test.ts
@@ -47,7 +47,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (e:${Employee} {fg_item_id: "p1", description: "a p1", fg_item: "part1"})
                     CREATE (p1:${Product} {fg_item_id: "p1", description: "a p1", fg_item: "part1"})
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data?.[Product.plural]).toEqual([
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data?.[Employee.plural]).toEqual([
@@ -141,7 +141,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             }
         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeFalsy();
             expect(gqlResult.data?.[Product.operations.connection]).toEqual({
@@ -181,7 +181,7 @@ describe("https://github.com/neo4j/graphql/issues/3394", () => {
             }
         `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             expect(gqlResult.errors).toBeFalsy();
             expect(gqlResult.data?.[Employee.plural]).toEqual([

--- a/packages/graphql/tests/integration/issues/3394.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3394.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3394", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Product: UniqueType;
     let Employee: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Product = testHelper.createUniqueType("Product");
         Employee = testHelper.createUniqueType("Employee");
 

--- a/packages/graphql/tests/integration/issues/3428.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3428.int.test.ts
@@ -185,20 +185,22 @@ describe("https://github.com/neo4j/graphql/issues/3428", () => {
             `;
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            const createWithNestedCreateResult = await testHelper.runGraphQL(createMutationWithNestedCreate);
-            const createWithNestedConnectResult = await testHelper.runGraphQL(createMutationWithNestedConnect);
-            const createWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const createWithNestedCreateResult = await testHelper.executeGraphQL(createMutationWithNestedCreate);
+            const createWithNestedConnectResult = await testHelper.executeGraphQL(createMutationWithNestedConnect);
+            const createWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 createMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedCreateResult = await testHelper.runGraphQL(updateMutationWithNestedCreate);
-            const updateWithNestedConnectResult = await testHelper.runGraphQL(updateMutationWithNestedConnect);
-            const updateWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const updateWithNestedCreateResult = await testHelper.executeGraphQL(updateMutationWithNestedCreate);
+            const updateWithNestedConnectResult = await testHelper.executeGraphQL(updateMutationWithNestedConnect);
+            const updateWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 updateMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedUpdateResult = await testHelper.runGraphQL(updateMutationWithNestedUpdate);
-            const updateWithNestedDisconnectResult = await testHelper.runGraphQL(updateMutationWithNestedDisconnect);
-            const updateWithNestedDeleteResult = await testHelper.runGraphQL(updateMutationWithNestedDelete);
-            const deleteWithNestedDeleteResult = await testHelper.runGraphQL(deleteMutationWithNestedDelete);
+            const updateWithNestedUpdateResult = await testHelper.executeGraphQL(updateMutationWithNestedUpdate);
+            const updateWithNestedDisconnectResult = await testHelper.executeGraphQL(
+                updateMutationWithNestedDisconnect
+            );
+            const updateWithNestedDeleteResult = await testHelper.executeGraphQL(updateMutationWithNestedDelete);
+            const deleteWithNestedDeleteResult = await testHelper.executeGraphQL(deleteMutationWithNestedDelete);
 
             expect(createWithNestedCreateResult.errors).toBeDefined();
             expect((createWithNestedCreateResult.errors as any)[0].message).toInclude(
@@ -253,20 +255,22 @@ describe("https://github.com/neo4j/graphql/issues/3428", () => {
             `;
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            const createWithNestedCreateResult = await testHelper.runGraphQL(createMutationWithNestedCreate);
-            const createWithNestedConnectResult = await testHelper.runGraphQL(createMutationWithNestedConnect);
-            const createWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const createWithNestedCreateResult = await testHelper.executeGraphQL(createMutationWithNestedCreate);
+            const createWithNestedConnectResult = await testHelper.executeGraphQL(createMutationWithNestedConnect);
+            const createWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 createMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedCreateResult = await testHelper.runGraphQL(updateMutationWithNestedCreate);
-            const updateWithNestedConnectResult = await testHelper.runGraphQL(updateMutationWithNestedConnect);
-            const updateWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const updateWithNestedCreateResult = await testHelper.executeGraphQL(updateMutationWithNestedCreate);
+            const updateWithNestedConnectResult = await testHelper.executeGraphQL(updateMutationWithNestedConnect);
+            const updateWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 updateMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedUpdateResult = await testHelper.runGraphQL(updateMutationWithNestedUpdate);
-            const updateWithNestedDisconnectResult = await testHelper.runGraphQL(updateMutationWithNestedDisconnect);
-            const updateWithNestedDeleteResult = await testHelper.runGraphQL(updateMutationWithNestedDelete);
-            const deleteWithNestedDeleteResult = await testHelper.runGraphQL(deleteMutationWithNestedDelete);
+            const updateWithNestedUpdateResult = await testHelper.executeGraphQL(updateMutationWithNestedUpdate);
+            const updateWithNestedDisconnectResult = await testHelper.executeGraphQL(
+                updateMutationWithNestedDisconnect
+            );
+            const updateWithNestedDeleteResult = await testHelper.executeGraphQL(updateMutationWithNestedDelete);
+            const deleteWithNestedDeleteResult = await testHelper.executeGraphQL(deleteMutationWithNestedDelete);
 
             expect(createWithNestedCreateResult.errors).toBeDefined();
             expect((createWithNestedCreateResult.errors as any)[0].message).toInclude(
@@ -465,20 +469,22 @@ describe("https://github.com/neo4j/graphql/issues/3428", () => {
             `;
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            const createWithNestedCreateResult = await testHelper.runGraphQL(createMutationWithNestedCreate);
-            const createWithNestedConnectResult = await testHelper.runGraphQL(createMutationWithNestedConnect);
-            const createWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const createWithNestedCreateResult = await testHelper.executeGraphQL(createMutationWithNestedCreate);
+            const createWithNestedConnectResult = await testHelper.executeGraphQL(createMutationWithNestedConnect);
+            const createWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 createMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedCreateResult = await testHelper.runGraphQL(updateMutationWithNestedCreate);
-            const updateWithNestedConnectResult = await testHelper.runGraphQL(updateMutationWithNestedConnect);
-            const updateWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const updateWithNestedCreateResult = await testHelper.executeGraphQL(updateMutationWithNestedCreate);
+            const updateWithNestedConnectResult = await testHelper.executeGraphQL(updateMutationWithNestedConnect);
+            const updateWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 updateMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedUpdateResult = await testHelper.runGraphQL(updateMutationWithNestedUpdate);
-            const updateWithNestedDisconnectResult = await testHelper.runGraphQL(updateMutationWithNestedDisconnect);
-            const updateWithNestedDeleteResult = await testHelper.runGraphQL(updateMutationWithNestedDelete);
-            const deleteWithNestedDeleteResult = await testHelper.runGraphQL(deleteMutationWithNestedDelete);
+            const updateWithNestedUpdateResult = await testHelper.executeGraphQL(updateMutationWithNestedUpdate);
+            const updateWithNestedDisconnectResult = await testHelper.executeGraphQL(
+                updateMutationWithNestedDisconnect
+            );
+            const updateWithNestedDeleteResult = await testHelper.executeGraphQL(updateMutationWithNestedDelete);
+            const deleteWithNestedDeleteResult = await testHelper.executeGraphQL(deleteMutationWithNestedDelete);
 
             expect(createWithNestedCreateResult.errors).toBeDefined();
             expect((createWithNestedCreateResult.errors as any)[0].message).toInclude(
@@ -538,20 +544,22 @@ describe("https://github.com/neo4j/graphql/issues/3428", () => {
             `;
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            const createWithNestedCreateResult = await testHelper.runGraphQL(createMutationWithNestedCreate);
-            const createWithNestedConnectResult = await testHelper.runGraphQL(createMutationWithNestedConnect);
-            const createWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const createWithNestedCreateResult = await testHelper.executeGraphQL(createMutationWithNestedCreate);
+            const createWithNestedConnectResult = await testHelper.executeGraphQL(createMutationWithNestedConnect);
+            const createWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 createMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedCreateResult = await testHelper.runGraphQL(updateMutationWithNestedCreate);
-            const updateWithNestedConnectResult = await testHelper.runGraphQL(updateMutationWithNestedConnect);
-            const updateWithNestedConnectOrCreateResult = await testHelper.runGraphQL(
+            const updateWithNestedCreateResult = await testHelper.executeGraphQL(updateMutationWithNestedCreate);
+            const updateWithNestedConnectResult = await testHelper.executeGraphQL(updateMutationWithNestedConnect);
+            const updateWithNestedConnectOrCreateResult = await testHelper.executeGraphQL(
                 updateMutationWithNestedConnectOrCreate
             );
-            const updateWithNestedUpdateResult = await testHelper.runGraphQL(updateMutationWithNestedUpdate);
-            const updateWithNestedDisconnectResult = await testHelper.runGraphQL(updateMutationWithNestedDisconnect);
-            const updateWithNestedDeleteResult = await testHelper.runGraphQL(updateMutationWithNestedDelete);
-            const deleteWithNestedDeleteResult = await testHelper.runGraphQL(deleteMutationWithNestedDelete);
+            const updateWithNestedUpdateResult = await testHelper.executeGraphQL(updateMutationWithNestedUpdate);
+            const updateWithNestedDisconnectResult = await testHelper.executeGraphQL(
+                updateMutationWithNestedDisconnect
+            );
+            const updateWithNestedDeleteResult = await testHelper.executeGraphQL(updateMutationWithNestedDelete);
+            const deleteWithNestedDeleteResult = await testHelper.executeGraphQL(deleteMutationWithNestedDelete);
 
             expect(createWithNestedCreateResult.errors).toBeDefined();
             expect((createWithNestedCreateResult.errors as any)[0].message).toInclude(

--- a/packages/graphql/tests/integration/issues/3428.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3428.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3428", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Person: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
     });

--- a/packages/graphql/tests/integration/issues/349.int.test.ts
+++ b/packages/graphql/tests/integration/issues/349.int.test.ts
@@ -24,11 +24,9 @@ import { gql } from "graphql-tag";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/349", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (post:${Post} {id: $postId, title: $postTitle, content: $postContent})
                     CREATE (comment1:${Comment} {id: $comment1Id, content: $comment1Content, flagged: true})
@@ -114,7 +114,7 @@ describe("https://github.com/neo4j/graphql/issues/350", () => {
             }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
         expect(result.errors).toBeFalsy();
         expect((result?.data as any)[Post.plural][0].flaggedComments).toContainEqual({
             content: comment1Content,

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -22,14 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/350", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Post: UniqueType;
     let Comment: UniqueType;
     let typeDefs: string;
 
-    beforeAll(() => {
-        testHelper = new TestHelper();
-    });
+    beforeAll(() => {});
 
     afterAll(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/354.int.test.ts
+++ b/packages/graphql/tests/integration/issues/354.int.test.ts
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/354", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeTruthy();
         expect((result.errors as any[])[0].message).toBe(`${testComment.name}.post required exactly once`);

--- a/packages/graphql/tests/integration/issues/354.int.test.ts
+++ b/packages/graphql/tests/integration/issues/354.int.test.ts
@@ -22,11 +22,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/354", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeAll(() => {
-        testHelper = new TestHelper();
-    });
+    beforeAll(() => {});
 
     afterAll(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/360.int.test.ts
+++ b/packages/graphql/tests/integration/issues/360.int.test.ts
@@ -20,11 +20,9 @@
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/360", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/360.int.test.ts
+++ b/packages/graphql/tests/integration/issues/360.int.test.ts
@@ -55,7 +55,7 @@ describe("https://github.com/neo4j/graphql/issues/360", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${type.name} {id: randomUUID(), name: randomUUID(), start: datetime(), end: datetime()})
                     CREATE (:${type.name} {id: randomUUID(), name: randomUUID(), start: datetime(), end: datetime()})
@@ -63,7 +63,7 @@ describe("https://github.com/neo4j/graphql/issues/360", () => {
                 `
         );
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)[type.plural]).toHaveLength(3);
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/360", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${type.name} {id: randomUUID(), name: randomUUID(), start: datetime(), end: datetime()})
                     CREATE (:${type.name} {id: randomUUID(), name: randomUUID(), start: datetime(), end: datetime()})
@@ -102,7 +102,7 @@ describe("https://github.com/neo4j/graphql/issues/360", () => {
                 `
         );
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)[type.plural]).toHaveLength(3);
@@ -136,7 +136,7 @@ describe("https://github.com/neo4j/graphql/issues/360", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${type.name} {id: randomUUID(), name: randomUUID(), start: datetime($rangeStart), end: datetime($rangeEnd)})
                     CREATE (:${type.name} {id: randomUUID(), name: randomUUID(), start: datetime($rangeStart), end: datetime($rangeEnd)})
@@ -145,7 +145,7 @@ describe("https://github.com/neo4j/graphql/issues/360", () => {
             { rangeStart, rangeEnd }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { rangeStart, rangeEnd },
         });
 

--- a/packages/graphql/tests/integration/issues/369.int.test.ts
+++ b/packages/graphql/tests/integration/issues/369.int.test.ts
@@ -87,7 +87,7 @@ describe("https://github.com/neo4j/graphql/issues/369", () => {
                 }
             }
         `;
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Dato} {uuid: $datoUUID})-[:DEPENDE {uuid: $relUUID}]->(:${Dato} {uuid: $datoToUUID})
                 `,
@@ -98,7 +98,7 @@ describe("https://github.com/neo4j/graphql/issues/369", () => {
             }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 
@@ -162,7 +162,7 @@ describe("https://github.com/neo4j/graphql/issues/369", () => {
                 }
             }
         `;
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (d:${Dato} {uuid: $datoUUID})-[:DEPENDE {uuid: $relUUID}]->(:${Dato} {uuid: $datoToUUID})
                     CREATE (d)-[:DEPENDE {uuid: randomUUID()}]->(:Dato {uuid: randomUUID()})
@@ -175,7 +175,7 @@ describe("https://github.com/neo4j/graphql/issues/369", () => {
             }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/369.int.test.ts
+++ b/packages/graphql/tests/integration/issues/369.int.test.ts
@@ -23,11 +23,10 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/369", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Dato: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         Dato = testHelper.createUniqueType("Dato");
     });
 

--- a/packages/graphql/tests/integration/issues/3765.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3765.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3765", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Post: UniqueType;
     let User: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Post = testHelper.createUniqueType("Post");
         User = testHelper.createUniqueType("User");
 

--- a/packages/graphql/tests/integration/issues/3765.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3765.int.test.ts
@@ -45,7 +45,7 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE(p1:${Post} {content: "p1"})
                ${`CREATE(p1)<-[:LIKES]-(:${User}) `.repeat(2)}
@@ -74,7 +74,7 @@ describe("https://github.com/neo4j/graphql/issues/3765", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data?.[Post.plural]).toIncludeSameMembers([{ content: "p1" }, { content: "p3" }]);

--- a/packages/graphql/tests/integration/issues/387.int.test.ts
+++ b/packages/graphql/tests/integration/issues/387.int.test.ts
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
             }
     `;
 
-        await testHelper.runCypher(`CREATE (:${Place.name} { name: "${name}" })`);
+        await testHelper.executeCypher(`CREATE (:${Place.name} { name: "${name}" })`);
     });
 
     afterEach(async () => {
@@ -100,7 +100,7 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 
@@ -125,7 +125,7 @@ describe("https://github.com/neo4j/graphql/issues/387", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/387.int.test.ts
+++ b/packages/graphql/tests/integration/issues/387.int.test.ts
@@ -24,14 +24,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/387", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let name: string;
     let url: string;
     let typeDefs: DocumentNode;
     let Place: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Place = testHelper.createUniqueType("Place");
 
         name = generate({

--- a/packages/graphql/tests/integration/issues/388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/388.int.test.ts
@@ -22,14 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/388", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Post: UniqueType;
     let User: UniqueType;
     let typeDefs: string;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         Post = testHelper.createUniqueType("Post");
         User = testHelper.createUniqueType("User");
 

--- a/packages/graphql/tests/integration/issues/388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/388.int.test.ts
@@ -212,7 +212,7 @@ describe("https://github.com/neo4j/graphql/issues/388", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const mutationResult = await testHelper.runGraphQL(mutation, {
+        const mutationResult = await testHelper.executeGraphQL(mutation, {
             variableValues: { input },
         });
 
@@ -226,7 +226,7 @@ describe("https://github.com/neo4j/graphql/issues/388", () => {
             expect(friend.posts).toHaveLength(3);
         });
 
-        const queryResult = await testHelper.runGraphQL(query, {
+        const queryResult = await testHelper.executeGraphQL(query, {
             variableValues: {
                 userID,
             },

--- a/packages/graphql/tests/integration/issues/3888.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3888.int.test.ts
@@ -91,11 +91,11 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
 
         const token = createBearerToken(secret, { sub: "michel" });
 
-        const createUserResult = await testHelper.runGraphQLWithToken(createUser, token);
+        const createUserResult = await testHelper.executeGraphQLWithToken(createUser, token);
 
         expect(createUserResult.errors).toBeFalsy();
 
-        const createPostResult = await testHelper.runGraphQLWithToken(createPost, token);
+        const createPostResult = await testHelper.executeGraphQLWithToken(createPost, token);
 
         expect(createPostResult.errors).toBeFalsy();
         expect(createPostResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/3888.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3888.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3888", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const secret = "secret";
 
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/3888", () => {
     let User: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Post = testHelper.createUniqueType("Post");
         User = testHelper.createUniqueType("User");
 

--- a/packages/graphql/tests/integration/issues/3901.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3901.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3901", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const secret = "secret";
 
@@ -31,8 +31,6 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
     let User: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Serie = testHelper.createUniqueType("Serie");
         Season = testHelper.createUniqueType("Season");
         User = testHelper.createUniqueType("User");

--- a/packages/graphql/tests/integration/issues/3901.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3901.int.test.ts
@@ -137,11 +137,11 @@ describe("https://github.com/neo4j/graphql/issues/3901", () => {
 
         const token = createBearerToken(secret, { sub: "michel", roles: ["verified", "creator"] });
 
-        const createUserResult = await testHelper.runGraphQLWithToken(createUser, token);
+        const createUserResult = await testHelper.executeGraphQLWithToken(createUser, token);
 
         expect(createUserResult.errors).toBeFalsy();
 
-        const createPostResult = await testHelper.runGraphQLWithToken(createPost, token);
+        const createPostResult = await testHelper.executeGraphQLWithToken(createPost, token);
 
         expect(createPostResult.errors).toBeFalsy();
         expect(createPostResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/3912.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3912.int.test.ts
@@ -21,12 +21,11 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3912", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Event: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Event = testHelper.createUniqueType("Event");
 
         const typeDefs = /* GraphQL */ `

--- a/packages/graphql/tests/integration/issues/3912.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3912.int.test.ts
@@ -65,7 +65,7 @@ describe("https://github.com/neo4j/graphql/issues/3912", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/3929.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3929.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3929", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const secret = "secret";
 
@@ -31,8 +31,6 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
     let Person: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Group = testHelper.createUniqueType("Group");
         Person = testHelper.createUniqueType("Person");

--- a/packages/graphql/tests/integration/issues/3929.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3929.int.test.ts
@@ -118,11 +118,11 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
 
         const token = createBearerToken(secret, { uid: "user1_id" });
 
-        const createUsersResult = await testHelper.runGraphQLWithToken(createUsers, token);
+        const createUsersResult = await testHelper.executeGraphQLWithToken(createUsers, token);
 
         expect(createUsersResult.errors).toBeFalsy();
 
-        const createGroupsResult = await testHelper.runGraphQLWithToken(createGroups, token, {
+        const createGroupsResult = await testHelper.executeGraphQLWithToken(createGroups, token, {
             variableValues: {
                 input: [
                     {
@@ -162,7 +162,7 @@ describe("https://github.com/neo4j/graphql/issues/3929", () => {
 
         expect(createGroupsResult.errors).toBeFalsy();
 
-        const updateGroupsResult = await testHelper.runGraphQLWithToken(updateGroups, token, {
+        const updateGroupsResult = await testHelper.executeGraphQLWithToken(updateGroups, token, {
             variableValues: {
                 where: {
                     name: "Group 1",

--- a/packages/graphql/tests/integration/issues/3932.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3932.int.test.ts
@@ -72,7 +72,7 @@ describe("https://github.com/neo4j/graphql/issues/3932", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/3932.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3932.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3932", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Image: UniqueType;
     let Invite: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Image = testHelper.createUniqueType("Image");
         Invite = testHelper.createUniqueType("Invite");
 

--- a/packages/graphql/tests/integration/issues/3938.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3938.int.test.ts
@@ -22,15 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3938", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let Group: UniqueType;
     let Invitee: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Group = testHelper.createUniqueType("Group");
         Invitee = testHelper.createUniqueType("Invitee");
 

--- a/packages/graphql/tests/integration/issues/3938.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3938.int.test.ts
@@ -100,13 +100,13 @@ describe("https://github.com/neo4j/graphql/issues/3938", () => {
 
         const token = createBearerToken(secret, {});
 
-        const createGroupsResult = await testHelper.runGraphQLWithToken(createGroups, token, {
+        const createGroupsResult = await testHelper.executeGraphQLWithToken(createGroups, token, {
             variableValues: { input: [{ name: "test" }] },
         });
 
         expect(createGroupsResult.errors).toBeFalsy();
 
-        const updateGroupsResult = await testHelper.runGraphQLWithToken(updateGroups, token, {
+        const updateGroupsResult = await testHelper.executeGraphQLWithToken(updateGroups, token, {
             variableValues: {
                 where: {
                     name: "test",

--- a/packages/graphql/tests/integration/issues/4004.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4004.int.test.ts
@@ -22,13 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4004", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeEpisode: UniqueType;
     let typeSeries: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         typeEpisode = testHelper.createUniqueType("Episode");
         typeSeries = testHelper.createUniqueType("Series");
     });

--- a/packages/graphql/tests/integration/issues/4004.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4004.int.test.ts
@@ -68,7 +68,7 @@ describe("https://github.com/neo4j/graphql/issues/4004", () => {
         }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (m:${typeSeries.name} { id: randomUUID() })
                     CREATE (m)<-[:IN_SERIES]-(:${typeEpisode.name} { id: randomUUID() })
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/4004", () => {
                 `
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
         expect(result.data?.[typeSeries.plural]).toEqual(

--- a/packages/graphql/tests/integration/issues/4007.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4007.int.test.ts
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (m:${typeMovie.name} {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:${typeActor.name} {name: randomUUID()})
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
             }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/4007.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4007.int.test.ts
@@ -23,13 +23,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4007", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
     });

--- a/packages/graphql/tests/integration/issues/4015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4015.int.test.ts
@@ -76,7 +76,7 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (m:${typeMovie.name} {title: $movieTitle})
                     CREATE (m)<-[:ACTED_IN]-(:${typeActor.name} {name: randomUUID(), surname: randomUUID()})
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/4007", () => {
             }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/4015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4015.int.test.ts
@@ -23,14 +23,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4007", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
-
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
     });

--- a/packages/graphql/tests/integration/issues/402.int.test.ts
+++ b/packages/graphql/tests/integration/issues/402.int.test.ts
@@ -80,14 +80,14 @@ describe("https://github.com/neo4j/graphql/issues/402", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Event} {id: $eventId})-[:HAPPENS_IN]->(:${Area} {id: $areaId})
                 `,
             { eventId, areaId }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/402.int.test.ts
+++ b/packages/graphql/tests/integration/issues/402.int.test.ts
@@ -22,14 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/402", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Event: UniqueType;
     let Area: UniqueType;
     let typeDefs: string;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
-
         Event = testHelper.createUniqueType("Event");
         Area = testHelper.createUniqueType("Area");
     });

--- a/packages/graphql/tests/integration/issues/4056.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4056.int.test.ts
@@ -23,7 +23,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4056", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Tenant: UniqueType;
@@ -41,8 +41,6 @@ describe("https://github.com/neo4j/graphql/issues/4056", () => {
     let myUserId: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Tenant = testHelper.createUniqueType("Tenant");
         Settings = testHelper.createUniqueType("Settings");

--- a/packages/graphql/tests/integration/issues/4077.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4077.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4077", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let User: UniqueType;
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
     let PreviewClip: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Video = testHelper.createUniqueType("Video");
         PreviewClip = testHelper.createUniqueType("PreviewClip");

--- a/packages/graphql/tests/integration/issues/4077.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4077.int.test.ts
@@ -113,7 +113,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${PreviewClip} { id: "clip1", markedAsDone: false})<-[:VIDEO_HAS_PREVIEW_CLIP]-(v:${Video} {id:"1234", processing: "published"})
             CREATE (v)<-[:PUBLISHER]-(:${User} {id:"user1_id"})
 
@@ -122,7 +122,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
 
         const token = createBearerToken(secret, { sub: "user1_id" });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
 
@@ -144,7 +144,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${PreviewClip} { id: "clip1", markedAsDone: false})<-[:VIDEO_HAS_PREVIEW_CLIP]-(v:${Video} {id:"1234", processing: "published"})
             CREATE (v)<-[:PUBLISHER]-(:${User} {id:"user1_id"})
 
@@ -153,7 +153,7 @@ describe("https://github.com/neo4j/graphql/issues/4077", () => {
 
         const token = createBearerToken(secret, { sub: "user1_id" });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/4099.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4099.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4099", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let User: UniqueType;
     let Person: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Person = testHelper.createUniqueType("Person");
 

--- a/packages/graphql/tests/integration/issues/4099.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4099.int.test.ts
@@ -58,7 +58,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
     });
 
     beforeEach(async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${User} { id: 1 })
             CREATE (:${Person} { id: 1 })
         `);
@@ -79,7 +79,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
 
         const token = testHelper.createBearerToken(secret, { isAdmin: true });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
 
@@ -101,7 +101,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
 
         const token = testHelper.createBearerToken(secret, { isAdmin: false });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
 
@@ -119,7 +119,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
 
         const token = testHelper.createBearerToken(secret, { isAdmin: false });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
 
@@ -141,7 +141,7 @@ describe("https://github.com/neo4j/graphql/issues/4099", () => {
 
         const token = testHelper.createBearerToken(secret, { isAdmin: true });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/4110.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4110.int.test.ts
@@ -61,7 +61,7 @@ describe("https://github.com/neo4j/graphql/issues/4110", () => {
     });
 
     beforeEach(async () => {
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (c1:${Company} { id: "example" })
             CREATE (c2:${Company} { id: "another" })
 
@@ -93,7 +93,7 @@ describe("https://github.com/neo4j/graphql/issues/4110", () => {
 
         const token = createBearerToken(secret);
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
         expect((result.data as any)[Company.plural]).toEqual([

--- a/packages/graphql/tests/integration/issues/4110.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4110.int.test.ts
@@ -22,15 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4110", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let Company: UniqueType;
     let InBetween: UniqueType;
 
-    beforeAll(() => {
-        testHelper = new TestHelper();
-    });
+    beforeAll(() => {});
 
     beforeEach(async () => {
         Company = testHelper.createUniqueType("User");

--- a/packages/graphql/tests/integration/issues/4112.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4112.int.test.ts
@@ -30,7 +30,7 @@ describe("https://github.com/neo4j/graphql/issues/4112", () => {
         testHelper = new TestHelper();
         Category = testHelper.createUniqueType("Category");
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Category} {name: "test"});
                 `
@@ -67,14 +67,14 @@ describe("https://github.com/neo4j/graphql/issues/4112", () => {
             groups: ["user"],
         });
 
-        const gqlResultUser = await testHelper.runGraphQLWithToken(query, nonAdminToken);
+        const gqlResultUser = await testHelper.executeGraphQLWithToken(query, nonAdminToken);
 
         expect((gqlResultUser.errors as any[])[0].message).toBe("Unauthenticated");
 
         const adminToken = createBearerToken(secret, {
             groups: ["user", "admin"],
         });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, adminToken);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, adminToken);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -113,14 +113,14 @@ describe("https://github.com/neo4j/graphql/issues/4112", () => {
             myApplication: { roles: ["user"] },
         });
 
-        const gqlResultUser = await testHelper.runGraphQLWithToken(query, nonAdminToken);
+        const gqlResultUser = await testHelper.executeGraphQLWithToken(query, nonAdminToken);
 
         expect((gqlResultUser.errors as any[])[0].message).toBe("Unauthenticated");
 
         const adminToken = createBearerToken(secret, {
             myApplication: { roles: ["user", "admin"] },
         });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, adminToken);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, adminToken);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -159,14 +159,14 @@ describe("https://github.com/neo4j/graphql/issues/4112", () => {
             "https://github.com/claims": { "https://github.com/claims/roles": ["user"] },
         });
 
-        const gqlResultUser = await testHelper.runGraphQLWithToken(query, nonAdminToken);
+        const gqlResultUser = await testHelper.executeGraphQLWithToken(query, nonAdminToken);
 
         expect((gqlResultUser.errors as any[])[0].message).toBe("Unauthenticated");
 
         const adminToken = createBearerToken(secret, {
             "https://github.com/claims": { "https://github.com/claims/roles": ["admin"] },
         });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, adminToken);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, adminToken);
 
         expect(gqlResult.errors).toBeUndefined();
 
@@ -213,14 +213,14 @@ describe("https://github.com/neo4j/graphql/issues/4112", () => {
             myApplication: { roles: ["user"] },
         });
 
-        const gqlResultUser = await testHelper.runGraphQLWithToken(query, nonAdminToken);
+        const gqlResultUser = await testHelper.executeGraphQLWithToken(query, nonAdminToken);
 
         expect((gqlResultUser.errors as any[])[0].message).toBe("Unauthenticated");
 
         const adminToken = createBearerToken(secret, {
             myApplication: { roles: ["user", "admin"] },
         });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, adminToken);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, adminToken);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/4112.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4112.int.test.ts
@@ -23,11 +23,10 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4112", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Category: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Category = testHelper.createUniqueType("Category");
 
         await testHelper.executeCypher(

--- a/packages/graphql/tests/integration/issues/4113.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4113.int.test.ts
@@ -128,7 +128,7 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
                 }
             }
       `;
-        const gqlResult1 = await testHelper.runGraphQL(setupCreateUsers);
+        const gqlResult1 = await testHelper.executeGraphQL(setupCreateUsers);
         expect(gqlResult1.errors).toBeFalsy();
 
         const setupCreateStores = `#graphql
@@ -156,7 +156,7 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
                 }
                 }
             }`;
-        const gqlResult2 = await testHelper.runGraphQL(setupCreateStores);
+        const gqlResult2 = await testHelper.executeGraphQL(setupCreateStores);
         expect(gqlResult2.errors).toBeFalsy();
         const storeId = (gqlResult2.data?.[Store.operations.create] as Record<string, any>)[Store.plural][0].id;
 
@@ -194,7 +194,7 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
         `;
 
         const token = createBearerToken("secret", { roles: ["employee"], store: storeId });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
@@ -357,7 +357,7 @@ describe("replicates the test for relationship to interface so that multiple ref
                 }
             }
       `;
-        const gqlResult1 = await testHelper.runGraphQL(setupCreateUsers);
+        const gqlResult1 = await testHelper.executeGraphQL(setupCreateUsers);
         expect(gqlResult1.errors).toBeFalsy();
 
         const setupCreateStores = `#graphql
@@ -385,7 +385,7 @@ describe("replicates the test for relationship to interface so that multiple ref
                 }
                 }
             }`;
-        const gqlResult2 = await testHelper.runGraphQL(setupCreateStores);
+        const gqlResult2 = await testHelper.executeGraphQL(setupCreateStores);
         expect(gqlResult2.errors).toBeFalsy();
         const storeId = (gqlResult2.data?.[Store.operations.create] as Record<string, any>)[Store.plural][0].id;
 
@@ -428,7 +428,7 @@ describe("replicates the test for relationship to interface so that multiple ref
         `;
 
         const token = createBearerToken("secret", { roles: ["employee"], store: storeId });
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/4113.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4113.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4113", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Store: UniqueType;
@@ -30,7 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
     let TransactionItem: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Store = testHelper.createUniqueType("Store");
         Transaction = testHelper.createUniqueType("Transaction");
@@ -220,7 +219,7 @@ describe("https://github.com/neo4j/graphql/issues/4113", () => {
 });
 
 describe("replicates the test for relationship to interface so that multiple refNodes are target", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Store: UniqueType;
@@ -229,8 +228,6 @@ describe("replicates the test for relationship to interface so that multiple ref
     let TransactionItem2: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Store = testHelper.createUniqueType("Store");
         Transaction = testHelper.createUniqueType("Transaction");

--- a/packages/graphql/tests/integration/issues/4115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4115.int.test.ts
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (u:${User} { id:"user1"})
             CREATE (paid:${User} { id:"paid-user", roles: ["plan:paid"]})
             CREATE (f1:${Family} { id: "family1" })<-[:CREATOR_OF]-(u)
@@ -117,7 +117,7 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
 
         const token = createBearerToken(secret, { uid: "user1" });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
         expect((result.data as any)[Family.plural]).toIncludeSameMembers([
@@ -150,7 +150,7 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
 
         const token = createBearerToken(secret, { uid: "paid-user" });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
         expect((result.data as any)[Family.plural]).toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/4115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4115.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4115", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let User: UniqueType;
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/4115", () => {
     let Person: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Family = testHelper.createUniqueType("Family");
         Person = testHelper.createUniqueType("Person");

--- a/packages/graphql/tests/integration/issues/4118.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4118.int.test.ts
@@ -168,7 +168,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
             typeDefs,
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId, roles: ["overlord"] } },
         });
@@ -181,7 +181,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
         });
 
         const settingsId = (addTenantResponse.data as any)[Tenant.operations.create][Tenant.plural][0].settings.id;
-        const addOpeningDaysResponse = await testHelper.runGraphQL(ADD_OPENING_DAYS, {
+        const addOpeningDaysResponse = await testHelper.executeGraphQL(ADD_OPENING_DAYS, {
             variableValues: openingDayInput(settingsId),
             contextValue: { jwt: { id: myUserId, roles: ["overlord"] } },
         });
@@ -202,7 +202,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
                 }
             }`;
 
-        const addLolResponse = await testHelper.runGraphQL(addLolsQuery, {
+        const addLolResponse = await testHelper.executeGraphQL(addLolsQuery, {
             variableValues: {
                 input: {
                     host: {
@@ -239,7 +239,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId, roles: ["overlord"] } },
         });
@@ -252,7 +252,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
         });
 
         const settingsId = (addTenantResponse.data as any)[Tenant.operations.create][Tenant.plural][0].settings.id;
-        const addOpeningDaysResponse = await testHelper.runGraphQL(ADD_OPENING_DAYS, {
+        const addOpeningDaysResponse = await testHelper.executeGraphQL(ADD_OPENING_DAYS, {
             variableValues: openingDayInput(settingsId),
             contextValue: { jwt: { id: myUserId, roles: ["overlord"] } },
         });
@@ -274,7 +274,7 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
             }
         `;
 
-        const addLolResponse = await testHelper.runGraphQL(addLolsSource, {
+        const addLolResponse = await testHelper.executeGraphQL(addLolsSource, {
             variableValues: {
                 input: {
                     host: {

--- a/packages/graphql/tests/integration/issues/4118.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4118.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4118", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Tenant: UniqueType;
@@ -38,8 +38,6 @@ describe("https://github.com/neo4j/graphql/issues/4118", () => {
     let myUserId: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Tenant = testHelper.createUniqueType("Tenant");
         Settings = testHelper.createUniqueType("Settings");

--- a/packages/graphql/tests/integration/issues/413.int.test.ts
+++ b/packages/graphql/tests/integration/issues/413.int.test.ts
@@ -24,11 +24,10 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/413", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let JobPlan: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
         JobPlan = testHelper.createUniqueType("JobPlan");
     });
 

--- a/packages/graphql/tests/integration/issues/413.int.test.ts
+++ b/packages/graphql/tests/integration/issues/413.int.test.ts
@@ -78,7 +78,7 @@ describe("https://github.com/neo4j/graphql/issues/413", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${JobPlan} {tenantID: $tenantID})
                     CREATE (:${JobPlan} {tenantID: $tenantID})
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/issues/413", () => {
             tenant_id: tenantID,
         });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/4170.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4170.int.test.ts
@@ -155,7 +155,7 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId } },
         });
@@ -176,7 +176,7 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId } },
         });

--- a/packages/graphql/tests/integration/issues/4170.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4170.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4170", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Tenant: UniqueType;
@@ -36,7 +36,6 @@ describe("https://github.com/neo4j/graphql/issues/4170", () => {
     let ADD_TENANT: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         myUserId = Math.random().toString(36).slice(2, 7);
 
         User = testHelper.createUniqueType("User");

--- a/packages/graphql/tests/integration/issues/4196.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4196.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4196", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Foo: UniqueType;
     let Bar: UniqueType;
     let FooBar: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Foo = testHelper.createUniqueType("Foo");
         Bar = testHelper.createUniqueType("Bar");
         FooBar = testHelper.createUniqueType("FooBar");

--- a/packages/graphql/tests/integration/issues/4196.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4196.int.test.ts
@@ -51,7 +51,7 @@ describe("https://github.com/neo4j/graphql/issues/4196", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             MERGE (:${Foo} {name: "A"})-[:relatesTo]->(b1:${Bar} {name: "bar1"})
             MERGE (:${Foo} {name: "B"})
             MERGE (:${Foo} {name: "C"})-[:relatesTo]->(b3:${Bar} {name: "bar3"})
@@ -83,7 +83,7 @@ describe("https://github.com/neo4j/graphql/issues/4196", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/4214.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4214.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4214", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
     let User: UniqueType;
@@ -30,8 +30,6 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
     let TransactionItem: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Store = testHelper.createUniqueType("Store");
         Transaction = testHelper.createUniqueType("Transaction");

--- a/packages/graphql/tests/integration/issues/4214.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4214.int.test.ts
@@ -150,7 +150,7 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE(u1:${User} {roles: ["store-owner"], id: "15cbd399-daaf-4579-ad2e-264bc956094c", email: "a@a.com"})
         CREATE(u2:${User} {roles: ["store-owner"], id: "2856f385-46b4-4136-a608-2d5ad627133c", email: "b@b.com"})
         CREATE(s1:${Store} {name: "Store", id: "8c8bb4bc-07dc-4808-bb20-f69d447a03b0"})
@@ -198,7 +198,7 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             store: "8c8bb4bc-07dc-4808-bb20-f69d447a03b0",
         });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeUndefined();
     });
@@ -234,7 +234,7 @@ describe("https://github.com/neo4j/graphql/issues/4214", () => {
             store: "8c8bb4bc-07dc-4808-bb20-f69d447a03b0",
         });
 
-        const result = await testHelper.runGraphQLWithToken(query, token);
+        const result = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(result.errors).toBeDefined();
         expect(result.errors?.[0]?.message).toBe("Forbidden");

--- a/packages/graphql/tests/integration/issues/4223.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4223.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4223", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Tenant: UniqueType;
@@ -37,7 +37,6 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
     let ADD_TENANT: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Tenant = testHelper.createUniqueType("Tenant");
         Settings = testHelper.createUniqueType("Settings");

--- a/packages/graphql/tests/integration/issues/4223.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4223.int.test.ts
@@ -189,7 +189,7 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId } },
         });
@@ -210,7 +210,7 @@ describe("https://github.com/neo4j/graphql/issues/4223", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId } },
         });

--- a/packages/graphql/tests/integration/issues/4239.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4239.int.test.ts
@@ -55,7 +55,7 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
             },
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (m:${Movie.name} {title: "Matrix"})<-[:DIRECTED]-(p:${Person.name} {id: "SOME_ID"})`
         );
     });
@@ -73,7 +73,7 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: { jwt: { sub: "SOME_ID" } },
         });
         expect(response.errors).toBeFalsy();
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/issues/4239", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: { jwt: { sub: "SOME_WRONG_ID" } },
         });
         expect((response.errors as any[])[0].message).toBe("Forbidden");

--- a/packages/graphql/tests/integration/issues/4239.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4239.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4239", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Person: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
 

--- a/packages/graphql/tests/integration/issues/4268.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4268.int.test.ts
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             },
         });
 
-        await testHelper.runCypher(`CREATE (m:${Movie.name} {title: "SomeTitle"})`, {});
+        await testHelper.executeCypher(`CREATE (m:${Movie.name} {title: "SomeTitle"})`, {});
     });
 
     afterAll(async () => {
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: {
                 jwt: { id: "some-id", email: "some-email", roles: ["admin"] },
             },
@@ -89,7 +89,7 @@ describe("https://github.com/neo4j/graphql/issues/4268", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: {
                 jwt: { id: "some-id", email: "some-email", roles: ["not-an-admin"] },
             },

--- a/packages/graphql/tests/integration/issues/4268.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4268.int.test.ts
@@ -21,12 +21,11 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4268", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         const typeDefs = /* GraphQL */ `
         type JWT @jwt {

--- a/packages/graphql/tests/integration/issues/4287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4287.int.test.ts
@@ -57,7 +57,7 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (a:${Actor} { name: "Someone" })
             CREATE (a)-[:ACTED_IN]->(:${Movie} {title: "something"})
             CREATE (a)-[:ACTED_IN]->(:${Series} {title: "whatever"})
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/4287", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query);
+        const response = await testHelper.executeGraphQL(query);
         expect(response.errors).toBeFalsy();
         expect(response.data?.[Actor.plural]).toIncludeSameMembers([
             {

--- a/packages/graphql/tests/integration/issues/4287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4287.int.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4287", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Actor: UniqueType;
     let Movie: UniqueType;
     let Series: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Actor = testHelper.createUniqueType("Actor");
         Movie = testHelper.createUniqueType("Movie");
         Series = testHelper.createUniqueType("Series");

--- a/packages/graphql/tests/integration/issues/4292.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4292.int.test.ts
@@ -181,7 +181,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
             },
         });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (m:${Person.name} {title: "SomeTitle", id: "person-1", name: "SomePerson"})<-[:CREATOR_OF]-(u:${User.name} { id: "user-1", email: "email-1", roles: ["admin"]})
                 CREATE (g:${Group.name} { id: "family_id_1", name: "group-1" })<-[:MEMBER_OF]-(m)
                 `);
@@ -214,7 +214,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: {
                 jwt: { uid: "user-1", email: "some-email", roles: ["admin"] },
             },
@@ -255,7 +255,7 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: { jwt: { uid: "not-user-1", email: "some-email", roles: ["admin"] } },
         });
         expect(response.errors?.[0]?.message).toContain("Forbidden");

--- a/packages/graphql/tests/integration/issues/4292.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4292.int.test.ts
@@ -27,11 +27,9 @@ describe("https://github.com/neo4j/graphql/issues/4292", () => {
     let Admin: UniqueType;
     let Contributor: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Group = testHelper.createUniqueType("Group");
         Person = testHelper.createUniqueType("Person");

--- a/packages/graphql/tests/integration/issues/433.int.test.ts
+++ b/packages/graphql/tests/integration/issues/433.int.test.ts
@@ -22,14 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/433", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
     let Person: UniqueType;
     let typeDefs: string;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Person = testHelper.createUniqueType("Person");
     });

--- a/packages/graphql/tests/integration/issues/433.int.test.ts
+++ b/packages/graphql/tests/integration/issues/433.int.test.ts
@@ -76,14 +76,14 @@ describe("https://github.com/neo4j/graphql/issues/433", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${Movie} {title: $movieTitle})<-[:ACTED_IN]-(:${Person} {name: $personName})
                 `,
             { movieTitle, personName }
         );
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/440.int.test.ts
+++ b/packages/graphql/tests/integration/issues/440.int.test.ts
@@ -57,7 +57,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
             .fill(0)
             .map(() => generate({ charset: "alphabetic" }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (v:${Video} {id: $videoID}),
                 (v)-[:IS_CATEGORIZED_AS]->(:${Category} {id: $c0}),
                 (v)-[:IS_CATEGORIZED_AS]->(:${Category} {id: $c1})`,
@@ -97,7 +97,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const mutationResult = await testHelper.runGraphQL(mutation, {
+        const mutationResult = await testHelper.executeGraphQL(mutation, {
             variableValues,
         });
 
@@ -118,7 +118,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
             .fill(0)
             .map(() => generate({ charset: "alphabetic" }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (v:${Video} {id: $videoID}),
                 (v)-[:IS_CATEGORIZED_AS]->(:${Category} {id: $c0}),
                 (v)-[:IS_CATEGORIZED_AS]->(:${Category} {id: $c1})`,
@@ -158,7 +158,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const mutationResult = await testHelper.runGraphQL(mutation, {
+        const mutationResult = await testHelper.executeGraphQL(mutation, {
             variableValues,
         });
 
@@ -184,7 +184,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
             .fill(0)
             .map(() => generate({ charset: "alphabetic" }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (v:${Video} {id: $videoID}),
                 (v)-[:IS_CATEGORIZED_AS]->(:${Category} {id: $c0}),
                 (v)-[:IS_CATEGORIZED_AS]->(:${Category} {id: $c1})`,
@@ -224,7 +224,7 @@ describe("https://github.com/neo4j/graphql/issues/440", () => {
 
         await neoSchema.checkNeo4jCompat();
 
-        const mutationResult = await testHelper.runGraphQL(mutation, {
+        const mutationResult = await testHelper.executeGraphQL(mutation, {
             variableValues,
         });
 

--- a/packages/graphql/tests/integration/issues/440.int.test.ts
+++ b/packages/graphql/tests/integration/issues/440.int.test.ts
@@ -23,13 +23,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/440", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let Video: UniqueType;
     let Category: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         Video = testHelper.createUniqueType("Video");
         Category = testHelper.createUniqueType("Category");
 

--- a/packages/graphql/tests/integration/issues/4405.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4405.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4405", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/4405.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4405.int.test.ts
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
             },
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (m:${Movie.name} {title: "Matrix" })<-[:ACTED_IN]-(a:${Actor.name} { name: "Keanu"})
                 CREATE (a)-[:ACTED_IN]->(:${Movie.name} {title: "John Wick" })
@@ -82,7 +82,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: { jwt: { uid: "user-1" } },
         });
         expect(response.errors).toBeFalsy();
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/4405", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query, {
+        const response = await testHelper.executeGraphQL(query, {
             contextValue: { jwt: { uid: "user-1" } },
         });
         expect(response.errors?.[0]?.message).toContain("Forbidden");

--- a/packages/graphql/tests/integration/issues/4429.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4429.int.test.ts
@@ -184,7 +184,7 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId } },
         });
@@ -205,7 +205,7 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
             },
         });
 
-        const addTenantResponse = await testHelper.runGraphQL(ADD_TENANT, {
+        const addTenantResponse = await testHelper.executeGraphQL(ADD_TENANT, {
             variableValues: tenantVariables,
             contextValue: { jwt: { id: myUserId } },
         });

--- a/packages/graphql/tests/integration/issues/4429.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4429.int.test.ts
@@ -21,7 +21,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4429", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Tenant: UniqueType;
@@ -36,8 +36,6 @@ describe("https://github.com/neo4j/graphql/issues/4429", () => {
     let myUserId: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Tenant = testHelper.createUniqueType("Tenant");
         Settings = testHelper.createUniqueType("Settings");

--- a/packages/graphql/tests/integration/issues/4450.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4450.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4450", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Actor: UniqueType;
     let Scene: UniqueType;
     let Location: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Actor = testHelper.createUniqueType("Actor");
         Scene = testHelper.createUniqueType("Scene");
         Location = testHelper.createUniqueType("Location");

--- a/packages/graphql/tests/integration/issues/4450.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4450.int.test.ts
@@ -60,7 +60,7 @@ describe("https://github.com/neo4j/graphql/issues/4450", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (:${Actor} {name: "actor-1"})-[:IN_SCENE {cut: true}]->(:${Scene} {number: 1})-[:AT_LOCATION]->(:${Location} {city: "test"})
                 `
@@ -80,7 +80,7 @@ describe("https://github.com/neo4j/graphql/issues/4450", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query);
+        const response = await testHelper.executeGraphQL(query);
 
         expect(response.errors).toBeFalsy();
         expect(response.data).toEqual({

--- a/packages/graphql/tests/integration/issues/4477.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4477.int.test.ts
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE
                         (brand1:${Brand} {name: 'brand1'}),
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/4477", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query);
+        const response = await testHelper.executeGraphQL(query);
 
         expect(response.errors).toBeFalsy();
         expect(response.data).toEqual({

--- a/packages/graphql/tests/integration/issues/4477.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4477.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4477", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Brand: UniqueType;
     let Service: UniqueType;
     let Collection: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Brand = testHelper.createUniqueType("Brand");
         Service = testHelper.createUniqueType("Service");
         Collection = testHelper.createUniqueType("Collection");

--- a/packages/graphql/tests/integration/issues/4520.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4520.int.test.ts
@@ -24,7 +24,7 @@ import { TestHelper } from "../utils/tests-helper";
 const testLabel = generate({ charset: "alphabetic" });
 
 describe("https://github.com/neo4j/graphql/issues/4520", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Serie: UniqueType;
@@ -32,8 +32,6 @@ describe("https://github.com/neo4j/graphql/issues/4520", () => {
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Serie = testHelper.createUniqueType("Serie");
         FxEngineer = testHelper.createUniqueType("FxEngineer");

--- a/packages/graphql/tests/integration/issues/4520.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4520.int.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/4520", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE
                         (m:${Movie}:${testLabel} {title: 'Test Movie'}),
@@ -118,7 +118,7 @@ describe("https://github.com/neo4j/graphql/issues/4520", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query);
+        const response = await testHelper.executeGraphQL(query);
 
         expect(response.errors).toBeFalsy();
         expect(response.data).toEqual({

--- a/packages/graphql/tests/integration/issues/4532.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4532.int.test.ts
@@ -52,7 +52,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
                 typeDefs,
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                 CREATE(i:${Inventory} {id: "i1"})
                 CREATE(i)-[:HasChildren { order: 3 }]->(c1:${Scenario} { id: "c3"})
@@ -88,7 +88,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
                 }
             `;
 
-            const response = await testHelper.runGraphQL(query);
+            const response = await testHelper.executeGraphQL(query);
             expect(response.errors).toBeFalsy();
             expect(response.data).toEqual({
                 [Inventory.plural]: expect.toIncludeSameMembers([
@@ -161,7 +161,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
                 typeDefs,
             });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                 CREATE(i:${Inventory} {id: "i1"})
                 CREATE(i)-[:HasChildren { order: 3 }]->(c1:${Image} { id: "c3"})
@@ -196,7 +196,7 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
                 }
             `;
 
-            const response = await testHelper.runGraphQL(query);
+            const response = await testHelper.executeGraphQL(query);
             expect(response.errors).toBeFalsy();
             expect(response.data).toEqual({
                 [Inventory.plural]: expect.toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/4532.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4532.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4532", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     describe("order-by relationship property", () => {
         let Inventory: UniqueType;
         let Scenario: UniqueType;
 
         beforeAll(async () => {
-            testHelper = new TestHelper();
-
             Inventory = testHelper.createUniqueType("Inventory");
             Scenario = testHelper.createUniqueType("Scenario");
 
@@ -128,8 +126,6 @@ describe("https://github.com/neo4j/graphql/issues/4532", () => {
         let Video: UniqueType;
 
         beforeAll(async () => {
-            testHelper = new TestHelper();
-
             Inventory = testHelper.createUniqueType("Inventory");
             Image = testHelper.createUniqueType("Image");
             Video = testHelper.createUniqueType("Video");

--- a/packages/graphql/tests/integration/issues/4583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4583.int.test.ts
@@ -23,7 +23,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4583", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Series: UniqueType;
@@ -45,7 +45,6 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
     let sameTitle;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Series = testHelper.createUniqueType("Series");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/4583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4583.int.test.ts
@@ -107,7 +107,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
         episodeNr = faker.number.int({ max: 100000 });
         sameTitle = "sameTitle";
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${Actor} { name: $actorName })
                 CREATE (a2:${Actor} { name: $actorName2 })
@@ -166,7 +166,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
 
@@ -222,7 +222,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
 
@@ -285,7 +285,7 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4615", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Series: UniqueType;
     let Actor: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Series = testHelper.createUniqueType("Series");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -68,7 +68,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 // Create Movies
                 CREATE (m1:${Movie} { title: "The Movie One", cost: 10000000, runtime: 120, release: dateTime('2007-08-31T16:47+00:00') })
@@ -117,7 +117,7 @@ describe("https://github.com/neo4j/graphql/issues/4615", () => {
             }
         `;
 
-        const response = await testHelper.runGraphQL(query);
+        const response = await testHelper.executeGraphQL(query);
         expect(response.errors).toBeFalsy();
         expect(response.data).toEqual({
             showsAggregate: {

--- a/packages/graphql/tests/integration/issues/4617.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4617.int.test.ts
@@ -45,7 +45,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
             charset: "alphabetic",
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `   CREATE (:${Post.name} {title: "Post 1"})
                     CREATE (:${User.name} {id: $id, email: randomUUID()})
                     CREATE (:${Actor.name} {id: $id, email: randomUUID(), name: $actorName })
@@ -97,7 +97,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: id });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -143,7 +143,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -190,7 +190,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: id });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -236,7 +236,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -294,7 +294,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: id });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -352,7 +352,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -415,7 +415,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: id });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 
@@ -477,7 +477,7 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
 
         const token = createBearerToken(secret, { sub: "invalid" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
             variableValues: { id },
         });
 

--- a/packages/graphql/tests/integration/issues/4617.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4617.int.test.ts
@@ -24,7 +24,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4617", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
     let User: UniqueType;
     let Post: UniqueType;
@@ -33,7 +33,6 @@ describe("https://github.com/neo4j/graphql/issues/4617", () => {
     let actorName: string;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Post = testHelper.createUniqueType("Post");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/464.int.test.ts
+++ b/packages/graphql/tests/integration/issues/464.int.test.ts
@@ -33,7 +33,7 @@ describe("https://github.com/neo4j/graphql/issues/464", () => {
 
     let neoSchema: Neo4jGraphQL;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const bookId = generate({
         charset: "alphabetic",
@@ -58,7 +58,6 @@ describe("https://github.com/neo4j/graphql/issues/464", () => {
     let queryBooks: string;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         typeAuthor = testHelper.createUniqueType("Author");
         typeBook = testHelper.createUniqueType("Book");
 

--- a/packages/graphql/tests/integration/issues/4667.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4667.int.test.ts
@@ -31,7 +31,7 @@ describe("https://github.com/neo4j/graphql/issues/4667", () => {
         MyThing = testHelper.createUniqueType("MyThing");
         MyStuff = testHelper.createUniqueType("MyStuff");
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${MyThing} {id: "A"})-[:THE_STUFF]->(b1:${MyStuff} {id: "C"})
             CREATE (:${MyThing} {id: "B"})
         `);
@@ -68,7 +68,7 @@ describe("https://github.com/neo4j/graphql/issues/4667", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeUndefined();
         expect(result.data).toEqual({

--- a/packages/graphql/tests/integration/issues/4667.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4667.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4667", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let MyThing: UniqueType;
     let MyStuff: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         MyThing = testHelper.createUniqueType("MyThing");
         MyStuff = testHelper.createUniqueType("MyStuff");
 

--- a/packages/graphql/tests/integration/issues/4704.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4704.int.test.ts
@@ -23,7 +23,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4704", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Movie: UniqueType;
     let Series: UniqueType;
@@ -46,7 +46,6 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
     let episodeNr;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
         Series = testHelper.createUniqueType("Series");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/4704.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4704.int.test.ts
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
         seriesScreenTime = faker.number.int({ max: 100000 });
         episodeNr = faker.number.int({ max: 100000 });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE (a:${Actor} { name: $actorName })
                 CREATE (a2:${Actor} { name: $actorName2 })
@@ -161,7 +161,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data?.[Actor.plural]).toEqual(
@@ -186,7 +186,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data?.[Actor.plural]).toEqual([
@@ -211,7 +211,7 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data?.[Actor.plural]).toEqual(

--- a/packages/graphql/tests/integration/issues/4741.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4741.int.test.ts
@@ -43,7 +43,7 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
         `;
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${Opportunity} {country: "UK"})
             CREATE (o:${Opportunity} {country: "ES"})-[:HAS_LIST]->(:${ListOli} {name: "l1"})
             CREATE (o)-[:HAS_LIST]->(:${ListOli} {name: "l2"})
@@ -70,7 +70,7 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
             }
         `;
 
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             [Opportunity.operations.connection]: {
@@ -104,7 +104,7 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
             }
         `;
 
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             [Opportunity.operations.connection]: {

--- a/packages/graphql/tests/integration/issues/4741.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4741.int.test.ts
@@ -24,10 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/4741", () => {
     let Opportunity: UniqueType;
     let ListOli: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         Opportunity = testHelper.createUniqueType("Opportunity");
         ListOli = testHelper.createUniqueType("ListOli");
 

--- a/packages/graphql/tests/integration/issues/4759.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4759.int.test.ts
@@ -24,11 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/4759", () => {
     let Node1: UniqueType;
     let Node2: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Node1 = testHelper.createUniqueType("Node1");
         Node2 = testHelper.createUniqueType("Node2");
 

--- a/packages/graphql/tests/integration/issues/4759.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4759.int.test.ts
@@ -47,7 +47,7 @@ describe("https://github.com/neo4j/graphql/issues/4759", () => {
         `;
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE (:${Node1} { uuid: "id0", name: "name0"})
         CREATE (n1:${Node1} { uuid: "id1", name: "name1"})<-[:HAS_NODE]-(:${Node2} { uuid: "id2", name: "name2" , active: true })
         CREATE (n1)<-[:HAS_NODE]-(:${Node2} { uuid: "id3", name: "name3" , active: true })
@@ -72,7 +72,7 @@ describe("https://github.com/neo4j/graphql/issues/4759", () => {
             }
         `;
 
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             [Node1.plural]: expect.toIncludeSameMembers([
@@ -107,7 +107,7 @@ describe("https://github.com/neo4j/graphql/issues/4759", () => {
             }
         `;
 
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             [Node1.plural]: expect.toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/4814.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4814.int.test.ts
@@ -24,11 +24,9 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
     let AStep: UniqueType;
     let BStep: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         AStep = new UniqueType("AStep");
         BStep = new UniqueType("BStep");
 

--- a/packages/graphql/tests/integration/issues/4814.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4814.int.test.ts
@@ -53,7 +53,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
         `;
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (step0:${AStep} { id: "0"})
             CREATE (step1:${AStep} { id: "1"})
             CREATE (step2:${BStep} { id: "2"})
@@ -95,7 +95,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
             }
         `;
 
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             steps: expect.toIncludeSameMembers([
@@ -204,7 +204,7 @@ describe("https://github.com/neo4j/graphql/issues/4814", () => {
             }
         `;
 
-        const queryResults = await testHelper.runGraphQL(query);
+        const queryResults = await testHelper.executeGraphQL(query);
         expect(queryResults.errors).toBeUndefined();
         expect(queryResults.data).toEqual({
             steps: expect.toIncludeSameMembers([

--- a/packages/graphql/tests/integration/issues/487.int.test.ts
+++ b/packages/graphql/tests/integration/issues/487.int.test.ts
@@ -114,12 +114,12 @@ describe("https://github.com/neo4j/graphql/issues/487", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${typeMovie.name} { id: "${movieId}" })<-[:DIRECTED]-(:${typeDirector.name} {id: "${directorId}"})
                 CREATE (:${typeBook.name} { id: "${bookId}" })<-[:WROTE]-(:${typeAuthor.name} {id: "${authorId}"})
             `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         if (result.errors) {
             console.log(JSON.stringify(result.errors, null, 2));
@@ -231,12 +231,12 @@ describe("https://github.com/neo4j/graphql/issues/487", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${typeMovie.name} { id: "${movieId}" })<-[:DIRECTED]-(:${typeDirector.name} {id: "${directorId}"})
                 CREATE (:${typeBook.name} { id: "${bookId}" })<-[:WROTE]-(:${typeAuthor.name} {id: "${authorId}"})
             `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         if (result.errors) {
             console.log(JSON.stringify(result.errors, null, 2));

--- a/packages/graphql/tests/integration/issues/487.int.test.ts
+++ b/packages/graphql/tests/integration/issues/487.int.test.ts
@@ -22,11 +22,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/487", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/488.int.test.ts
+++ b/packages/graphql/tests/integration/issues/488.int.test.ts
@@ -22,11 +22,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/488", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeAll(() => {
-        testHelper = new TestHelper();
-    });
+    beforeAll(() => {});
 
     afterAll(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/488.int.test.ts
+++ b/packages/graphql/tests/integration/issues/488.int.test.ts
@@ -101,11 +101,11 @@ describe("https://github.com/neo4j/graphql/issues/488", () => {
             },
         };
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (j:${testJournalist.name} { id: "${journalistId}" })-[:HAS_KEYWORD]->(:${testEmoji.name} { id: "${emojiId}", type: "${emojiType}" })
             `);
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             variableValues,
         });
 

--- a/packages/graphql/tests/integration/issues/505.int.test.ts
+++ b/packages/graphql/tests/integration/issues/505.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/505", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let userType: UniqueType;
     let workspaceType: UniqueType;
@@ -31,7 +31,6 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
     let typeDefs: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         userType = testHelper.createUniqueType("User");
         workspaceType = testHelper.createUniqueType("Workspace");
         pageType = testHelper.createUniqueType("User");

--- a/packages/graphql/tests/integration/issues/505.int.test.ts
+++ b/packages/graphql/tests/integration/issues/505.int.test.ts
@@ -107,7 +107,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
 
     async function queryTest(variableValues: any, userId: string) {
         async function graphqlQuery(query: string) {
-            return testHelper.runGraphQL(query, {
+            return testHelper.executeGraphQL(query, {
                 contextValue: {
                     jwt: {
                         sub: userId,
@@ -171,7 +171,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
             .fill(0)
             .map(() => generate({ charset: "alphabetic" }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u:${userType} {id: $userId, authId: $userId}),
                 (w:${workspaceType} {id: $workspaceId}),
                 (w)-[:HAS_ADMIN]->(u),
@@ -228,7 +228,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
             .fill(0)
             .map(() => generate({ charset: "alphabetic" }));
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u:${userType} {id: $userId, authId: $userId}),
                 (w1:${workspaceType} {id: $w0id}),
                 (w2:${workspaceType} {id: $w1id}),
@@ -301,7 +301,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         // current relationship on where checks *all* nodes hold true
         // so all members/admins of workspace must have matching jwt sub
         // for now, don't add u0 as member of workspaces so constraint holds
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u0:${userType} {id: $u0id, authId: $u0id}),
                 (u1:${userType} {id: $u1id, authId: $u1id}),
                 (w1:${workspaceType} {id: $w0id}),
@@ -380,7 +380,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         // current relationship on where checks *all* nodes hold true
         // so all members/admins of workspace must have matching jwt sub
         // for now, don't add u0 as member of workspaces so constraint holds
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u0:${userType} {id: $u0id, authId: $u0id}),
                 (u1:${userType} {id: $u1id, authId: $u1id}),
                 (w1:${workspaceType} {id: $w0id}),
@@ -459,7 +459,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         // current relationship on where checks *all* nodes hold true
         // so all members/admins of workspace must have matching jwt sub
         // for now, don't add u0 as member of workspaces so constraint holds
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u0:${userType} {id: $u0id, authId: $u0id}),
                 (u1:${userType} {id: $u1id, authId: $u1id}),
                 (w1:${workspaceType} {id: $w0id}),
@@ -538,7 +538,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         // current relationship on where checks *all* nodes hold true
         // so all members/admins of workspace must have matching jwt sub
         // for now, don't add u0 as member of workspaces so constraint holds
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u0:${userType} {id: $u0id, authId: $u0id}),
                 (u1:${userType} {id: $u1id, authId: $u1id}),
                 (w1:${workspaceType} {id: $w0id}),
@@ -616,7 +616,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         // current relationship on where checks *all* nodes hold true
         // so all members/admins of workspace must have matching jwt sub
         // for now, don't add u0 as member of workspaces so constraint holds
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u0:${userType} {id: $u0id, authId: $u0id}),
                 (u1:${userType} {id: $u1id, authId: $u1id}),
                 (w1:${workspaceType} {id: $w0id}),
@@ -695,7 +695,7 @@ describe("https://github.com/neo4j/graphql/issues/505", () => {
         // current relationship on where checks *all* nodes hold true
         // so all members/admins of workspace must have matching jwt sub
         // for now, don't add u0 as member of workspaces so constraint holds
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (u0:${userType} {id: $u0id, authId: $u0id}),
                 (u1:${userType} {id: $u1id, authId: $u1id}),
                 (w1:${workspaceType} {id: $w0id}),

--- a/packages/graphql/tests/integration/issues/526.int.test.ts
+++ b/packages/graphql/tests/integration/issues/526.int.test.ts
@@ -57,7 +57,7 @@ describe("https://github.com/neo4j/graphql/issues/526 - Int Argument on Custom Q
         }
     `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (m1:${Movie} {title: "M1"}), (m2:${Movie} {title: "M2"}), (t1:${Tag} {name: "T1"}), (t2:${Tag} {name: "T2"})
                     CREATE (m1)-[:HAS]->(t1)<-[:HAS]-(m2)
@@ -86,7 +86,7 @@ describe("https://github.com/neo4j/graphql/issues/526 - Int Argument on Custom Q
 
         await neoSchema.checkNeo4jCompat();
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/526.int.test.ts
+++ b/packages/graphql/tests/integration/issues/526.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/526 - Int Argument on Custom Query Converted to Float", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Movie: UniqueType;
     let Tag: UniqueType;
     let typeDefs: string;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Movie = testHelper.createUniqueType("Movie");
         Tag = testHelper.createUniqueType("Tag");
 

--- a/packages/graphql/tests/integration/issues/549.int.test.ts
+++ b/packages/graphql/tests/integration/issues/549.int.test.ts
@@ -67,7 +67,7 @@ describe("https://github.com/neo4j/graphql/issues/549", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeTruthy();
         expect((result.errors as any[])[0].message).toBe(`${testMovie.name}.director required exactly once`);

--- a/packages/graphql/tests/integration/issues/549.int.test.ts
+++ b/packages/graphql/tests/integration/issues/549.int.test.ts
@@ -21,11 +21,9 @@ import { gql } from "graphql-tag";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/549", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeAll(() => {
-        testHelper = new TestHelper();
-    });
+    beforeAll(() => {});
 
     afterAll(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/556.int.test.ts
+++ b/packages/graphql/tests/integration/issues/556.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/556 - Input Object type ArticleCreateInput must define one or more fields", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let User: UniqueType;
     let Thing: UniqueType;
 
     beforeAll(() => {
-        testHelper = new TestHelper();
-
         User = testHelper.createUniqueType("User");
         Thing = testHelper.createUniqueType("Thing");
 

--- a/packages/graphql/tests/integration/issues/556.int.test.ts
+++ b/packages/graphql/tests/integration/issues/556.int.test.ts
@@ -66,7 +66,7 @@ describe("https://github.com/neo4j/graphql/issues/556 - Input Object type Articl
 
         await neoSchema.checkNeo4jCompat();
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/issues/560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/560.int.test.ts
@@ -22,11 +22,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/560", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/560.int.test.ts
@@ -63,11 +63,11 @@ describe("https://github.com/neo4j/graphql/issues/560", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (j:${testLog.name} { id: "${logId}" })
             `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         if (result.errors) {
             console.log(JSON.stringify(result.errors, null, 2));
@@ -116,11 +116,11 @@ describe("https://github.com/neo4j/graphql/issues/560", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (j:${testLog.name} { id: "${logId}" })
             `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         if (result.errors) {
             console.log(JSON.stringify(result.errors, null, 2));

--- a/packages/graphql/tests/integration/issues/572.int.test.ts
+++ b/packages/graphql/tests/integration/issues/572.int.test.ts
@@ -21,11 +21,9 @@ import { gql } from "graphql-tag";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Revert https://github.com/neo4j/graphql/pull/572", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/572.int.test.ts
+++ b/packages/graphql/tests/integration/issues/572.int.test.ts
@@ -53,7 +53,7 @@ describe("Revert https://github.com/neo4j/graphql/pull/572", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({

--- a/packages/graphql/tests/integration/issues/579.int.test.ts
+++ b/packages/graphql/tests/integration/issues/579.int.test.ts
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/pull/579", () => {
               }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (product:${Product} {name: "Pringles", id: $productId})
                     CREATE (color:${Color} {name: "Yellow", id: $colorId})
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/pull/579", () => {
             }
         );
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: {},
         });
 

--- a/packages/graphql/tests/integration/issues/579.int.test.ts
+++ b/packages/graphql/tests/integration/issues/579.int.test.ts
@@ -22,14 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/pull/579", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let Product: UniqueType;
     let Color: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Product = testHelper.createUniqueType("Product");
         Color = testHelper.createUniqueType("Color");
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/582.int.test.ts
+++ b/packages/graphql/tests/integration/issues/582.int.test.ts
@@ -51,7 +51,7 @@ describe("https://github.com/neo4j/graphql/issues/582", () => {
             }
         `;
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                     CREATE (:${type.name} { type: "Cat" })-[:EDGE]->(:${type.name} { type: "Dog" })<-[:EDGE]-(:${type.name} { type: "Bird" })-[:EDGE]->(:${type.name} { type: "Fish" })
             `
@@ -64,7 +64,7 @@ describe("https://github.com/neo4j/graphql/issues/582", () => {
     });
 
     test("should get all Cats where there exists at least one child Dog that has a Bird parent", async () => {
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: {
                 where: {
                     type: "Cat",
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/582", () => {
     });
 
     test("should get all Cats where there exists at least one child Dog that has a Bird parent which has a Fish child", async () => {
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: {
                 where: {
                     type: "Cat",

--- a/packages/graphql/tests/integration/issues/582.int.test.ts
+++ b/packages/graphql/tests/integration/issues/582.int.test.ts
@@ -21,14 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/582", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let type: UniqueType;
     let typeDefs: string;
     let query: string;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         type = testHelper.createUniqueType("Entity");
 
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/583.int.test.ts
@@ -22,7 +22,7 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/583", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let Series: UniqueType;
     let Actor: UniqueType;
@@ -35,8 +35,6 @@ describe("https://github.com/neo4j/graphql/issues/583", () => {
     let shortFilm: { title: string };
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         Actor = testHelper.createUniqueType("Actor");
         Series = testHelper.createUniqueType("Series");
         Movie = testHelper.createUniqueType("Movie");

--- a/packages/graphql/tests/integration/issues/583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/583.int.test.ts
@@ -95,7 +95,7 @@ describe("https://github.com/neo4j/graphql/issues/583", () => {
 
         const testLabel = testHelper.createUniqueType("Test");
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE (actor:${Actor}:${testLabel})
             SET actor = $actor
@@ -135,7 +135,7 @@ describe("https://github.com/neo4j/graphql/issues/583", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { actorId: actor.id },
         });
 

--- a/packages/graphql/tests/integration/issues/594.int.test.ts
+++ b/packages/graphql/tests/integration/issues/594.int.test.ts
@@ -46,7 +46,7 @@ describe("https://github.com/neo4j/graphql/issues/594", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`CREATE (:${typeMovie.name} {title: "Cool Movie"})<-[:ACTED_IN]-(:${typePerson.name} {name: "Some Name", nickname: "SName"})
+        await testHelper.executeCypher(`CREATE (:${typeMovie.name} {title: "Cool Movie"})<-[:ACTED_IN]-(:${typePerson.name} {name: "Some Name", nickname: "SName"})
                 CREATE (:${typeMovie.name} {title: "Super Cool Movie"})<-[:ACTED_IN]-(:${typePerson.name} {name: "Super Cool Some Name"})`);
     });
 
@@ -69,7 +69,7 @@ describe("https://github.com/neo4j/graphql/issues/594", () => {
             }
         `;
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect(gqlResult.data[typeMovie.plural]).toEqual(
@@ -91,7 +91,7 @@ describe("https://github.com/neo4j/graphql/issues/594", () => {
             }
         `;
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
         expect(gqlResult.data[`${typePerson.plural}Aggregate`]).toEqual({ surname: { shortest: null } });

--- a/packages/graphql/tests/integration/issues/594.int.test.ts
+++ b/packages/graphql/tests/integration/issues/594.int.test.ts
@@ -22,13 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/594", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeMovie: UniqueType;
     let typePerson: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typePerson = testHelper.createUniqueType("Person");
         const typeDefs = gql`

--- a/packages/graphql/tests/integration/issues/619.int.test.ts
+++ b/packages/graphql/tests/integration/issues/619.int.test.ts
@@ -72,7 +72,7 @@ describe("https://github.com/neo4j/graphql/issues/619", () => {
             }
         `;
 
-        const gqlResult: any = await testHelper.runGraphQL(mutation);
+        const gqlResult: any = await testHelper.executeGraphQL(mutation);
 
         expect(gqlResult.errors).toBeUndefined();
     });

--- a/packages/graphql/tests/integration/issues/619.int.test.ts
+++ b/packages/graphql/tests/integration/issues/619.int.test.ts
@@ -21,13 +21,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/619", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let FooIsARandomName: UniqueType;
     let BarIsACoolName: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         FooIsARandomName = testHelper.createUniqueType("FooIsARandomName");
         BarIsACoolName = testHelper.createUniqueType("BarIsACoolName");
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/620.int.test.ts
+++ b/packages/graphql/tests/integration/issues/620.int.test.ts
@@ -22,13 +22,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/620", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeUser: UniqueType;
     let typeBusiness: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         typeUser = testHelper.createUniqueType("User");
         typeBusiness = testHelper.createUniqueType("Business");
 

--- a/packages/graphql/tests/integration/issues/620.int.test.ts
+++ b/packages/graphql/tests/integration/issues/620.int.test.ts
@@ -44,7 +44,7 @@ describe("https://github.com/neo4j/graphql/issues/620", () => {
         `;
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
               CREATE (u:${typeUser.name} {id: "1234", name: "arthur"})
               CREATE (b:${typeBusiness.name} {id: "1234", name: "ford"})
             `);
@@ -68,7 +68,7 @@ describe("https://github.com/neo4j/graphql/issues/620", () => {
             }
         `;
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/630.int.test.ts
@@ -24,10 +24,9 @@ import { TestHelper } from "../utils/tests-helper";
 describe("https://github.com/neo4j/graphql/issues/630", () => {
     let typeMovie: UniqueType;
     let typeActor: UniqueType;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         typeMovie = testHelper.createUniqueType("Movie");
         typeActor = testHelper.createUniqueType("Actor");
 

--- a/packages/graphql/tests/integration/issues/630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/630.int.test.ts
@@ -71,7 +71,7 @@ describe("https://github.com/neo4j/graphql/issues/630", () => {
             title: "The Matrix",
         };
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
             CREATE (movie:${typeMovie}:${testLabel}) SET movie = $movie
             CREATE (actor1:${typeActor}:${testLabel}) SET actor1 = $actors[0]
@@ -103,7 +103,7 @@ describe("https://github.com/neo4j/graphql/issues/630", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(source, {
+        const gqlResult = await testHelper.executeGraphQL(source, {
             variableValues: { actorId: actors[0]?.id },
         });
 

--- a/packages/graphql/tests/integration/issues/832.int.test.ts
+++ b/packages/graphql/tests/integration/issues/832.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/832", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Person: UniqueType;
     let Place: UniqueType;
     let Interaction: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Person = testHelper.createUniqueType("Person");
         Place = testHelper.createUniqueType("Place");
         Interaction = testHelper.createUniqueType("Interaction");

--- a/packages/graphql/tests/integration/issues/832.int.test.ts
+++ b/packages/graphql/tests/integration/issues/832.int.test.ts
@@ -59,7 +59,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${Person.name} { id: "adam", name: "Adam" })
             CREATE (:${Person.name} { id: "eve", name: "Eve" })
             CREATE (:${Person.name} { id: "cain", name: "Cain" })
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             }
         `;
 
-        const mutation0Result = await testHelper.runGraphQL(mutation0);
+        const mutation0Result = await testHelper.executeGraphQL(mutation0);
         expect((mutation0Result.data as any)?.[Interaction.operations.create].info.nodesCreated).toBe(1);
         expect((mutation0Result.data as any)?.[Interaction.operations.create].info.relationshipsCreated).toBe(3);
 
@@ -120,7 +120,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             }
         `;
 
-        const mutation1Result = await testHelper.runGraphQL(mutation1);
+        const mutation1Result = await testHelper.executeGraphQL(mutation1);
         expect((mutation1Result.data as any)?.[Interaction.operations.create].info.nodesCreated).toBe(1);
         expect((mutation1Result.data as any)?.[Interaction.operations.create].info.relationshipsCreated).toBe(3);
     });
@@ -153,7 +153,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
         expect((mutationResult.data as any)?.[Interaction.operations.create].info.nodesCreated).toBe(2);
         expect((mutationResult.data as any)?.[Interaction.operations.create].info.relationshipsCreated).toBe(6);
     });
@@ -183,7 +183,7 @@ describe("https://github.com/neo4j/graphql/issues/832", () => {
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
         expect((mutationResult.data as any)?.[Interaction.operations.create].info.nodesCreated).toBe(2);
         expect((mutationResult.data as any)?.[Interaction.operations.create].info.relationshipsCreated).toBe(2);
     });

--- a/packages/graphql/tests/integration/issues/847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/847.int.test.ts
@@ -25,11 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
     let placeType: UniqueType;
     let interactionType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         personType = testHelper.createUniqueType("Person");
         placeType = testHelper.createUniqueType("Place");
         interactionType = testHelper.createUniqueType("Interaction");

--- a/packages/graphql/tests/integration/issues/847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/847.int.test.ts
@@ -90,7 +90,7 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
             }
         `;
 
-        const mutationRes = await testHelper.runGraphQL(mutation);
+        const mutationRes = await testHelper.executeGraphQL(mutation);
 
         expect(mutationRes.errors).toBeUndefined();
 
@@ -124,7 +124,7 @@ describe("https://github.com/neo4j/graphql/issues/847", () => {
             }
         `;
 
-        const queryRes = await testHelper.runGraphQL(query);
+        const queryRes = await testHelper.executeGraphQL(query);
 
         expect(queryRes.errors).toBeUndefined();
 

--- a/packages/graphql/tests/integration/issues/894.int.test.ts
+++ b/packages/graphql/tests/integration/issues/894.int.test.ts
@@ -75,10 +75,10 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
                 }
             }
         `;
-        const createUserResult = await testHelper.runGraphQL(createUserQuery);
+        const createUserResult = await testHelper.executeGraphQL(createUserQuery);
         expect(createUserResult.errors).toBeUndefined();
 
-        const createOrgResult = (await testHelper.runGraphQL(createOrgQuery)) as any;
+        const createOrgResult = (await testHelper.executeGraphQL(createOrgQuery)) as any;
         expect(createOrgResult.errors).toBeUndefined();
         const orgId = createOrgResult?.data[testOrganization.operations.create][testOrganization.plural][0]
             .id as string;
@@ -97,10 +97,10 @@ describe("https://github.com/neo4j/graphql/issues/894", () => {
                 }
             `;
 
-        const swapSidesResult = await testHelper.runGraphQL(swapSidesQuery);
+        const swapSidesResult = await testHelper.executeGraphQL(swapSidesQuery);
         expect(swapSidesResult.errors).toBeUndefined();
 
-        const userOrgs = await testHelper.runCypher(`
+        const userOrgs = await testHelper.executeCypher(`
                 MATCH (user:${testUser.name} { name: "Luke Skywalker" })-[r:ACTIVELY_MANAGING]->(org:${testOrganization.name}) return org.name as orgName
             `);
 

--- a/packages/graphql/tests/integration/issues/894.int.test.ts
+++ b/packages/graphql/tests/integration/issues/894.int.test.ts
@@ -24,11 +24,10 @@ import { TestHelper } from "../utils/tests-helper";
 describe("https://github.com/neo4j/graphql/issues/894", () => {
     let testUser: UniqueType;
     let testOrganization: UniqueType;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let session: Session;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         testUser = testHelper.createUniqueType("User");
         testOrganization = testHelper.createUniqueType("Organization");
 

--- a/packages/graphql/tests/integration/issues/915.int.test.ts
+++ b/packages/graphql/tests/integration/issues/915.int.test.ts
@@ -83,10 +83,9 @@ describe("https://github.com/neo4j/graphql/issues/915", () => {
     let MULTIDB_SUPPORT = true;
     let Order: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         driver = await testHelper.getDriver();
         Order = testHelper.createUniqueType("Order");
 

--- a/packages/graphql/tests/integration/issues/915.int.test.ts
+++ b/packages/graphql/tests/integration/issues/915.int.test.ts
@@ -94,7 +94,7 @@ describe("https://github.com/neo4j/graphql/issues/915", () => {
 
         const cypher = `CREATE DATABASE ${databaseName} WAIT`;
         try {
-            await testHelper.runCypher(cypher);
+            await testHelper.executeCypher(cypher);
         } catch (e) {
             if (e instanceof Error) {
                 if (isMultiDbUnsupportedError(e)) {
@@ -113,7 +113,7 @@ describe("https://github.com/neo4j/graphql/issues/915", () => {
         if (MULTIDB_SUPPORT) {
             const cypher = `DROP DATABASE ${databaseName}`;
 
-            await testHelper.runCypher(cypher);
+            await testHelper.executeCypher(cypher);
         }
         await testHelper.close();
     });

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -77,7 +77,7 @@ describe("https://github.com/neo4j/graphql/issues/923", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             contextValue: {
                 jwt: {
                     sub: "test",
@@ -86,7 +86,7 @@ describe("https://github.com/neo4j/graphql/issues/923", () => {
         });
         expect(result.errors).toBeUndefined();
 
-        const blogPostCount = await testHelper.runCypher(`
+        const blogPostCount = await testHelper.executeCypher(`
           MATCH (m:${testBlogpost.name} { slug: "myslug" })
           RETURN COUNT(m) as count
         `);

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -23,14 +23,12 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/923", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let testBlogpost: UniqueType;
     let testCategory: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         testBlogpost = testHelper.createUniqueType("BlogPost");
         testCategory = testHelper.createUniqueType("Category");
         // driver = await neo4j.getDriver();

--- a/packages/graphql/tests/integration/issues/976.int.test.ts
+++ b/packages/graphql/tests/integration/issues/976.int.test.ts
@@ -111,10 +111,10 @@ describe("https://github.com/neo4j/graphql/issues/976", () => {
                 }
             }
         `;
-        const createBibRefResult = await testHelper.runGraphQL(createBibRefQuery);
+        const createBibRefResult = await testHelper.executeGraphQL(createBibRefQuery);
         expect(createBibRefResult.errors).toBeUndefined();
 
-        const bibRefRes = await testHelper.runCypher(`
+        const bibRefRes = await testHelper.executeCypher(`
             MATCH (bibRef:${testBibliographicReference.name})-[r:isInPublication]->(concept:${testConcept.name}) RETURN bibRef.uri as bibRefUri, concept.uri as conceptUri
         `);
 
@@ -122,7 +122,7 @@ describe("https://github.com/neo4j/graphql/issues/976", () => {
         expect(bibRefRes.records[0]?.toObject().bibRefUri as string).toBe("urn:myiri2");
         expect(bibRefRes.records[0]?.toObject().conceptUri as string).toBe("new-e");
 
-        const updateBibRefResult = await testHelper.runGraphQL(updateBibRefQuery);
+        const updateBibRefResult = await testHelper.executeGraphQL(updateBibRefQuery);
         expect(updateBibRefResult.errors).toBeUndefined();
         expect(updateBibRefResult?.data).toEqual({
             [testConcept.operations.delete]: {
@@ -144,7 +144,7 @@ describe("https://github.com/neo4j/graphql/issues/976", () => {
             },
         });
 
-        const conceptCount = await testHelper.runCypher(`
+        const conceptCount = await testHelper.executeCypher(`
             MATCH (bibRef:${testBibliographicReference.name})-[r:isInPublication]->(concept:${testConcept.name}) RETURN bibRef.uri as bibRefUri, COUNT(concept) as conceptCount
         `);
 

--- a/packages/graphql/tests/integration/issues/976.int.test.ts
+++ b/packages/graphql/tests/integration/issues/976.int.test.ts
@@ -24,11 +24,9 @@ import { TestHelper } from "../utils/tests-helper";
 describe("https://github.com/neo4j/graphql/issues/976", () => {
     let testBibliographicReference: UniqueType;
     let testConcept: UniqueType;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         testBibliographicReference = testHelper.createUniqueType("BibliographicReference");
         testConcept = testHelper.createUniqueType("Concept");
 

--- a/packages/graphql/tests/integration/issues/988.int.test.ts
+++ b/packages/graphql/tests/integration/issues/988.int.test.ts
@@ -58,7 +58,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
             }
         `;
         await testHelper.initNeo4jGraphQL({ typeDefs });
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `CREATE (:${manufacturerType.name} {name: "C", id: "a"})<-[:MANUFACTURER {current: true}]-(:${seriesType.name} {name: "123", current: true})-[:BRAND {current: true}]->(:${brandType.name} {name: "smart"})<-[:BRAND {current: true}]-(:${seriesType.name} {name: "456", current: true})-[:MANUFACTURER {current: false}]->(:${manufacturerType.name} {name: "AM"})`
         );
     });
@@ -97,7 +97,7 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
             }
         `;
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             variableValues: {
                 where: {
                     current: true,

--- a/packages/graphql/tests/integration/issues/988.int.test.ts
+++ b/packages/graphql/tests/integration/issues/988.int.test.ts
@@ -25,11 +25,9 @@ describe("https://github.com/neo4j/graphql/issues/988", () => {
     let brandType: UniqueType;
     let manufacturerType: UniqueType;
 
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         seriesType = testHelper.createUniqueType("Series");
         brandType = testHelper.createUniqueType("Brand");
         manufacturerType = testHelper.createUniqueType("Manufacturer");

--- a/packages/graphql/tests/integration/issues/bind-any.int.test.ts
+++ b/packages/graphql/tests/integration/issues/bind-any.int.test.ts
@@ -34,7 +34,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
         Organization = testHelper.createUniqueType("Organization");
         Group = testHelper.createUniqueType("Group");
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
         CREATE(o:${Organization} { id: "org_1" })
         CREATE(:${User} { id: "user1" })-[:IS_MEMBER_OF]->(o)
         CREATE(:${User} { id: "user2" })-[:IS_MEMBER_OF]->(o)
@@ -84,7 +84,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             contextValue: {
                 jwt: {
                     sub: "user1",
@@ -143,7 +143,7 @@ describe("https://github.com/neo4j/graphql/issues/2474", () => {
           }
       `;
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             contextValue: {
                 jwt: {
                     sub: "user1",

--- a/packages/graphql/tests/integration/issues/bind-any.int.test.ts
+++ b/packages/graphql/tests/integration/issues/bind-any.int.test.ts
@@ -22,14 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let User: UniqueType;
     let Organization: UniqueType;
     let Group: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         User = testHelper.createUniqueType("User");
         Organization = testHelper.createUniqueType("Organization");
         Group = testHelper.createUniqueType("Group");

--- a/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -21,14 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("context-variable-not-always-resolved-on-cypher-queries", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let expr: UniqueType;
     let work: UniqueType;
     let resourceType: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
         expr = testHelper.createUniqueType("Expr");
         work = testHelper.createUniqueType("Work");
         resourceType = testHelper.createUniqueType("ResourceType");

--- a/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -64,7 +64,7 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
             typeDefs,
         });
 
-        await testHelper.runCypher(
+        await testHelper.executeCypher(
             `
                 CREATE(p1:Exprlabel:context:tenant:Resource:test {uri: "stuff"})
                 CREATE (work:WorkLabel:test:Resource {uri: "another-stuff"})
@@ -102,7 +102,7 @@ describe("context-variable-not-always-resolved-on-cypher-queries", () => {
             }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             contextValue: {
                 cypherParams: {
                     tenant: "test",

--- a/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
+++ b/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
@@ -88,7 +88,7 @@ describe("587: Dates in edges can cause wrongly generated cypher", () => {
         }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (genre:${Genre} { id: "${genreId}" })
                 CREATE (movie:${Movie} { title: "${title}" })
                 CREATE (actor:${Actor} { name: "${name}", birthday: datetime("2021-11-16T10:53:20.200000000Z")})
@@ -96,7 +96,7 @@ describe("587: Dates in edges can cause wrongly generated cypher", () => {
                 RETURN actor
             `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
     });

--- a/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
+++ b/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
@@ -22,14 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("587: Dates in edges can cause wrongly generated cypher", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let Genre: UniqueType;
     let Actor: UniqueType;
     let Movie: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         Genre = testHelper.createUniqueType("Genre");
         Movie = testHelper.createUniqueType("Movie");
         Actor = testHelper.createUniqueType("Actor");

--- a/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
+++ b/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
@@ -54,7 +54,7 @@ describe("Empty fields on unions due to escaped labels", () => {
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`CREATE (u:${typeUser.name} {name: "dan"})
+        await testHelper.executeCypher(`CREATE (u:${typeUser.name} {name: "dan"})
               CREATE (b:${typeBlog.name} {title:"my cool blog"})
               CREATE (p:${typePost.name} {content: "my cool post"})
 
@@ -81,7 +81,7 @@ describe("Empty fields on unions due to escaped labels", () => {
             }
         `;
 
-        const gqlResult: any = await testHelper.runGraphQL(query);
+        const gqlResult: any = await testHelper.executeGraphQL(query);
         expect(gqlResult.errors).toBeUndefined();
         expect(gqlResult.data).toEqual({
             users: [{ name: "dan", content: [{ title: "my cool blog" }] }],

--- a/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
+++ b/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Empty fields on unions due to escaped labels", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let typeBlog: UniqueType;
     let typePost: UniqueType;
     let typeUser: UniqueType;
 
     beforeAll(async () => {
-        testHelper = new TestHelper();
-
         typeBlog = testHelper.createUniqueType("Blog");
         typePost = testHelper.createUniqueType("Post");
         typeUser = testHelper.createUniqueType("User");

--- a/packages/graphql/tests/integration/issues/interface-post-multi-create.int.test.ts
+++ b/packages/graphql/tests/integration/issues/interface-post-multi-create.int.test.ts
@@ -59,7 +59,7 @@ describe("Projecting interface relationships following create of multiple nodes"
 
         await testHelper.initNeo4jGraphQL({ typeDefs });
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
             CREATE (:${Person.name} { id: "adam", name: "Adam" })
             CREATE (:${Person.name} { id: "eve", name: "Eve" })
             CREATE (:${Person.name} { id: "cain", name: "Cain" })
@@ -104,7 +104,7 @@ describe("Projecting interface relationships following create of multiple nodes"
             }
         `;
 
-        const mutationResult = await testHelper.runGraphQL(mutation);
+        const mutationResult = await testHelper.executeGraphQL(mutation);
         expect(mutationResult.errors).toBeUndefined();
     });
 });

--- a/packages/graphql/tests/integration/issues/interface-post-multi-create.int.test.ts
+++ b/packages/graphql/tests/integration/issues/interface-post-multi-create.int.test.ts
@@ -21,15 +21,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Projecting interface relationships following create of multiple nodes", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     let Person: UniqueType;
     let Place: UniqueType;
     let Interaction: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
-
         Person = testHelper.createUniqueType("Person");
         Place = testHelper.createUniqueType("Place");
         Interaction = testHelper.createUniqueType("Interaction");

--- a/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
+++ b/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
@@ -21,11 +21,9 @@ import { createBearerToken } from "../../utils/create-bearer-token";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Label cypher injection", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
+++ b/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
@@ -52,7 +52,7 @@ describe("Label cypher injection", () => {
         }
         `;
 
-        const res = await testHelper.runGraphQL(query, {
+        const res = await testHelper.executeGraphQL(query, {
             contextValue: {
                 label: "Movie\\u0060) MATCH",
             },
@@ -89,7 +89,7 @@ describe("Label cypher injection", () => {
 
         const token = createBearerToken("1234", { label: "Movie\\u0060) MATCH" });
 
-        const res = await testHelper.runGraphQLWithToken(query, token);
+        const res = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(res.errors).toBeUndefined();
     });

--- a/packages/graphql/tests/integration/issues/only-info.int.test.ts
+++ b/packages/graphql/tests/integration/issues/only-info.int.test.ts
@@ -22,12 +22,11 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/567", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let typeDefs: string;
     let Movie: UniqueType;
 
     beforeEach(async () => {
-        testHelper = new TestHelper();
         Movie = testHelper.createUniqueType("Movie");
 
         typeDefs = `

--- a/packages/graphql/tests/integration/issues/only-info.int.test.ts
+++ b/packages/graphql/tests/integration/issues/only-info.int.test.ts
@@ -68,11 +68,11 @@ describe("https://github.com/neo4j/graphql/issues/567", () => {
             }
         `;
 
-        await testHelper.runCypher(`
+        await testHelper.executeCypher(`
                 CREATE (:${Movie} { id: "${movieId}", title: "${existingTitle}" })
             `);
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         if (result.errors) {
             console.log(JSON.stringify(result.errors, null, 2));
@@ -109,7 +109,7 @@ describe("https://github.com/neo4j/graphql/issues/567", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query);
+        const result = await testHelper.executeGraphQL(query);
 
         expect(result.errors).toBeFalsy();
 

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
@@ -25,7 +25,7 @@ import { TestHelper } from "../utils/tests-helper";
 
 describe("Global authentication - Authorization JWKS plugin", () => {
     let jwksMock: JWKSMock;
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let testMovie: UniqueType;
 
     let typeDefs: string;
@@ -33,8 +33,6 @@ describe("Global authentication - Authorization JWKS plugin", () => {
     let query: string;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
-
         testMovie = testHelper.createUniqueType("Movie");
 
         typeDefs = `

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
@@ -73,7 +73,7 @@ describe("Global authentication - Authorization JWKS plugin", () => {
             },
         });
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -96,7 +96,7 @@ describe("Global authentication - Authorization JWKS plugin", () => {
             },
         });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, `Bearer xxx.invalidtoken.xxxx`);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, `Bearer xxx.invalidtoken.xxxx`);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -125,7 +125,7 @@ describe("Global authentication - Authorization JWKS plugin", () => {
             iat: 1600000000,
         });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)[testMovie.plural]).toHaveLength(0);

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
@@ -23,7 +23,7 @@ import { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("Global authentication - Authorization JWT plugin", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
     const secret = "secret";
     const testMovie = new UniqueType("Movie");
@@ -43,9 +43,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
         }
     `;
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
@@ -61,7 +61,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
             },
         });
 
-        const gqlResult = await testHelper.runGraphQL(query);
+        const gqlResult = await testHelper.executeGraphQL(query);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -82,7 +82,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
             },
         });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, "Bearer xxx.invalidtoken.xxx");
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, "Bearer xxx.invalidtoken.xxx");
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -105,7 +105,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
 
         const token = createBearerToken("wrong-secret", { sub: "test" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeDefined();
         expect(
@@ -129,7 +129,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
                 },
             });
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
             expect(gqlResult.errors).toBeUndefined();
         } catch (error) {
             initError = error;
@@ -153,7 +153,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
 
             const token = createBearerToken(secret, { sub: "test" });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
             expect(gqlResult.errors).toBeUndefined();
             expect((gqlResult.data as any)[testMovie.plural]).toHaveLength(0);
         } catch (error) {
@@ -175,7 +175,7 @@ describe("Global authentication - Authorization JWT plugin", () => {
 
         const token = createBearerToken(secret, { sub: "test" });
 
-        const gqlResult = await testHelper.runGraphQLWithToken(query, token);
+        const gqlResult = await testHelper.executeGraphQLWithToken(query, token);
 
         expect(gqlResult.errors).toBeUndefined();
         expect((gqlResult.data as any)[testMovie.plural]).toHaveLength(0);

--- a/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
@@ -43,7 +43,7 @@ describe("integration/rfcs/query-limits", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         WITH [1,2,3,4,5] AS iterate
                         UNWIND iterate AS i
@@ -60,7 +60,7 @@ describe("integration/rfcs/query-limits", () => {
                         }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -92,7 +92,7 @@ describe("integration/rfcs/query-limits", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (movie:${randomType1.name} {id: "${movieId}"})
                         WITH movie, [1,2,3,4,5] AS iterate
@@ -113,7 +113,7 @@ describe("integration/rfcs/query-limits", () => {
                         }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));
@@ -143,7 +143,7 @@ describe("integration/rfcs/query-limits", () => {
 
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
-            await testHelper.runCypher(
+            await testHelper.executeCypher(
                 `
                         CREATE (movie:${randomType1.name} {id: "${movieId}"})
                         WITH movie, [1,2,3,4,5] AS iterate
@@ -168,7 +168,7 @@ describe("integration/rfcs/query-limits", () => {
                         }
                 `;
 
-            const gqlResult = await testHelper.runGraphQL(query);
+            const gqlResult = await testHelper.executeGraphQL(query);
 
             if (gqlResult.errors) {
                 console.log(JSON.stringify(gqlResult.errors, null, 2));

--- a/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
@@ -21,11 +21,9 @@ import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("integration/rfcs/query-limits", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
@@ -22,14 +22,13 @@ import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("integration/rfc/003", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     let Director: UniqueType;
     let Movie: UniqueType;
     let CoDirector: UniqueType;
     let Address: UniqueType;
 
     beforeEach(() => {
-        testHelper = new TestHelper();
         Director = testHelper.createUniqueType("Director");
         Movie = testHelper.createUniqueType("Movie");
         CoDirector = testHelper.createUniqueType("CoDirector");

--- a/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
@@ -70,7 +70,7 @@ describe("integration/rfc/003", () => {
                     }
                 `;
 
-                const result = await testHelper.runGraphQL(mutation);
+                const result = await testHelper.executeGraphQL(mutation);
 
                 expect(result.errors).toBeTruthy();
                 expect((result.errors as any[])[0].message).toBe(`${Movie}.director required exactly once`);
@@ -114,7 +114,7 @@ describe("integration/rfc/003", () => {
                         }
                     `;
 
-                    const result = await testHelper.runGraphQL(mutation);
+                    const result = await testHelper.executeGraphQL(mutation);
 
                     expect(result.errors).toBeTruthy();
                     expect((result.errors as any[])[0].message).toBe(`${Director}.address required exactly once`);
@@ -151,11 +151,11 @@ describe("integration/rfc/003", () => {
                     }
                 `;
 
-                await testHelper.runCypher(`
+                await testHelper.executeCypher(`
                         CREATE (:${Movie} {id: "${movieId}"})
                     `);
 
-                const result = await testHelper.runGraphQL(mutation);
+                const result = await testHelper.executeGraphQL(mutation);
 
                 expect(result.errors).toBeTruthy();
                 expect((result.errors as any[])[0].message).toBe(`${Movie}.director required exactly once`);
@@ -202,11 +202,11 @@ describe("integration/rfc/003", () => {
                         }
                     `;
 
-                    await testHelper.runCypher(`
+                    await testHelper.executeCypher(`
                             CREATE (:${Movie} {id: "${movieId}"})<-[:DIRECTED]-(:${Director} { id: "${directorId}" })
                         `);
 
-                    const result = await testHelper.runGraphQL(mutation);
+                    const result = await testHelper.executeGraphQL(mutation);
 
                     expect(result.errors).toBeTruthy();
                     expect((result.errors as any[])[0].message).toBe(`${Director}.address required exactly once`);
@@ -252,11 +252,11 @@ describe("integration/rfc/003", () => {
                         }
                     `;
 
-                    await testHelper.runCypher(`
+                    await testHelper.executeCypher(`
                             CREATE (:${Movie} {id: "${movieId}"})
                         `);
 
-                    const result = await testHelper.runGraphQL(mutation);
+                    const result = await testHelper.executeGraphQL(mutation);
 
                     expect(result.errors).toBeTruthy();
                     expect((result.errors as any[])[0].message).toBe(`${Director}.address required exactly once`);
@@ -306,11 +306,11 @@ describe("integration/rfc/003", () => {
                         }
                     `;
 
-                    await testHelper.runCypher(`
+                    await testHelper.executeCypher(`
                             CREATE (:${Movie} {id: "${movieId}"})<-[:DIRECTED]-(:${Director} {id: "${directorId}"})
                         `);
 
-                    const result = await testHelper.runGraphQL(mutation);
+                    const result = await testHelper.executeGraphQL(mutation);
 
                     expect(result.errors).toBeTruthy();
                     expect((result.errors as any[])[0].message).toBe(`${Movie}.director required exactly once`);
@@ -351,7 +351,7 @@ describe("integration/rfc/003", () => {
                     }
                 `;
 
-                const result = await testHelper.runGraphQL(mutation);
+                const result = await testHelper.executeGraphQL(mutation);
 
                 expect(result.errors).toBeTruthy();
                 expect((result.errors as any[])[0].message).toBe(`${Movie}.director required exactly once`);
@@ -407,11 +407,11 @@ describe("integration/rfc/003", () => {
                         }
                     `;
 
-                    await testHelper.runCypher(`
+                    await testHelper.executeCypher(`
                             CREATE (:${Director} {id: "${directorId}"})
                         `);
 
-                    const result = await testHelper.runGraphQL(mutation);
+                    const result = await testHelper.executeGraphQL(mutation);
 
                     expect(result.errors).toBeTruthy();
                     expect((result.errors as any[])[0].message).toBe(`${Director}.address required exactly once`);
@@ -453,11 +453,11 @@ describe("integration/rfc/003", () => {
                         }
                     `;
 
-                    await testHelper.runCypher(`
+                    await testHelper.executeCypher(`
                             CREATE (:${Movie} {id: "${movieId}"})<-[:DIRECTED]-(:${Director} {id: "${directorId}"})
                         `);
 
-                    const result = await testHelper.runGraphQL(mutation);
+                    const result = await testHelper.executeGraphQL(mutation);
 
                     expect(result.errors).toBeTruthy();
                     expect((result.errors as any[])[0].message).toBe(`${Movie}.director required exactly once`);
@@ -513,12 +513,12 @@ describe("integration/rfc/003", () => {
                     }
                 `;
 
-                await testHelper.runCypher(`
+                await testHelper.executeCypher(`
                         CREATE (:${Movie} {id: "${movieId}"})<-[:DIRECTED]-(:${Director} {id: "${directorId1}"})
                         CREATE (:${Director} {id: "${directorId2}"})
                     `);
 
-                const result = await testHelper.runGraphQL(mutation);
+                const result = await testHelper.executeGraphQL(mutation);
 
                 expect(result.errors).toBeUndefined();
 
@@ -579,12 +579,12 @@ describe("integration/rfc/003", () => {
                     }
                 `;
 
-                await testHelper.runCypher(`
+                await testHelper.executeCypher(`
                         CREATE (:${Movie} {id: "${movieId}"})<-[:DIRECTED]-(:${Director} {id: "${directorId1}"})
                         CREATE (:${Director} {id: "${directorId2}"})
                     `);
 
-                const result = await testHelper.runGraphQL(mutation);
+                const result = await testHelper.executeGraphQL(mutation);
 
                 expect(result.errors).toBeUndefined();
 
@@ -644,13 +644,13 @@ describe("integration/rfc/003", () => {
                     }
                 `;
 
-                await testHelper.runCypher(`
+                await testHelper.executeCypher(`
                         CREATE (:${Movie} {id: "${movieId}"})
                         CREATE (:${Director} {id: "${directorId1}"})
                         CREATE (:${Director} {id: "${directorId2}"})
                     `);
 
-                const result = await testHelper.runGraphQL(mutation);
+                const result = await testHelper.executeGraphQL(mutation);
 
                 expect(result.errors).toBeTruthy();
                 expect((result.errors as any[])[0].message).toBe(`${Movie}.director must be less than or equal to one`);

--- a/packages/graphql/tests/integration/root-connections.int.test.ts
+++ b/packages/graphql/tests/integration/root-connections.int.test.ts
@@ -17,12 +17,12 @@
  * limitations under the License.
  */
 
-import type { Driver } from "neo4j-driver";
 import { graphql } from "graphql";
+import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
-import Neo4jHelper from "./neo4j";
 import { Neo4jGraphQL } from "../../src/classes";
 import { UniqueType } from "../utils/graphql-types";
+import Neo4jHelper from "./neo4j";
 
 describe("root-connections", () => {
     let driver: Driver;

--- a/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
@@ -80,7 +80,7 @@ describe("unwind-create field-level auth rules", () => {
 
             const token = createBearerToken("secret", { sub: id });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
                 variableValues: { id, id2 },
             });
 
@@ -129,7 +129,7 @@ describe("unwind-create field-level auth rules", () => {
 
             const token = createBearerToken("secret", { sub: id });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
                 variableValues: { id, name },
             });
 
@@ -192,7 +192,7 @@ describe("unwind-create field-level auth rules", () => {
 
             const token = createBearerToken("secret", { sub: id });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
                 variableValues: { id, name },
             });
 
@@ -247,7 +247,7 @@ describe("unwind-create field-level auth rules", () => {
 
             const token = createBearerToken("secret", { roles: ["user"] });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
                 variableValues: { id, id2 },
             });
 
@@ -296,7 +296,7 @@ describe("unwind-create field-level auth rules", () => {
 
             const token = createBearerToken("secret", { roles: ["invalid-role"] });
 
-            const gqlResult = await testHelper.runGraphQLWithToken(query, token, {
+            const gqlResult = await testHelper.executeGraphQLWithToken(query, token, {
                 variableValues: { name },
             });
 

--- a/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
@@ -27,12 +27,10 @@ import { TestHelper } from "../utils/tests-helper";
  */
 
 describe("unwind-create field-level auth rules", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
     const secret = "secret";
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
@@ -23,11 +23,9 @@ import { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("unwind-create", () => {
-    let testHelper: TestHelper;
+    const testHelper = new TestHelper();
 
-    beforeEach(() => {
-        testHelper = new TestHelper();
-    });
+    beforeEach(() => {});
 
     afterEach(async () => {
         await testHelper.close();

--- a/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
@@ -62,7 +62,7 @@ describe("unwind-create", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, id2 },
         });
 
@@ -72,7 +72,7 @@ describe("unwind-create", () => {
             expect.arrayContaining([{ id }, { id: id2 }])
         );
 
-        const reFind = await testHelper.runCypher(
+        const reFind = await testHelper.executeCypher(
             `
               MATCH (m:${Movie})
               RETURN m
@@ -136,7 +136,7 @@ describe("unwind-create", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, id2, actor1Name, actor2Name },
         });
 
@@ -149,7 +149,7 @@ describe("unwind-create", () => {
             ])
         );
 
-        const reFind = await testHelper.runCypher(
+        const reFind = await testHelper.executeCypher(
             `
               MATCH (m:${Movie})<-[:ACTED_IN]-(a:${Actor})
               RETURN m,a
@@ -253,7 +253,7 @@ describe("unwind-create", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, id2, id3, id4, actor1Name, actor2Name },
         });
 
@@ -266,7 +266,7 @@ describe("unwind-create", () => {
             ])
         );
 
-        const reFind = await testHelper.runCypher(
+        const reFind = await testHelper.executeCypher(
             `
               MATCH (m:${Movie})<-[:ACTED_IN]-(a:${Actor})
               RETURN m,a
@@ -349,7 +349,7 @@ describe("unwind-create", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, id2, actor1Name, actor2Name },
         });
 
@@ -362,7 +362,7 @@ describe("unwind-create", () => {
             ])
         );
 
-        const reFind = await testHelper.runCypher(
+        const reFind = await testHelper.executeCypher(
             `
               MATCH (m:${Movie})<-[r:ACTED_IN]-(a:${Actor})
               RETURN m,r,a
@@ -454,7 +454,7 @@ describe("unwind-create", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: { id, id2, actorName, modelerName },
         });
 
@@ -467,7 +467,7 @@ describe("unwind-create", () => {
             ])
         );
 
-        const reFind = await testHelper.runCypher(
+        const reFind = await testHelper.executeCypher(
             `
               MATCH (m:${Movie})<-[r:${workedIn}]-(a)
               RETURN m,r,a
@@ -593,7 +593,7 @@ describe("unwind-create", () => {
           }
         `;
 
-        const gqlResult = await testHelper.runGraphQL(query, {
+        const gqlResult = await testHelper.executeGraphQL(query, {
             variableValues: {
                 id,
                 movieName,
@@ -617,7 +617,7 @@ describe("unwind-create", () => {
             ])
         );
 
-        const reFind = await testHelper.runCypher(
+        const reFind = await testHelper.executeCypher(
             `
               MATCH (m:${Movie})<-[r:${actedIn}]-(a)
               RETURN m,r,a
@@ -700,7 +700,7 @@ describe("unwind-create", () => {
             }
         `;
 
-        const result = await testHelper.runGraphQL(query, {
+        const result = await testHelper.executeGraphQL(query, {
             variableValues: { movieTitle, actorName, movie2Title, actor2Name },
         });
 

--- a/packages/graphql/tests/integration/utils/tests-helper.ts
+++ b/packages/graphql/tests/integration/utils/tests-helper.ts
@@ -63,12 +63,12 @@ export class TestHelper {
         return uniqueType;
     }
 
-    public async runCypher(query: string, params: Record<string, unknown> = {}): Promise<neo4j.QueryResult> {
+    public async executeCypher(query: string, params: Record<string, unknown> = {}): Promise<neo4j.QueryResult> {
         const driver = await this.getDriver();
         return driver.executeQuery(query, params, { database: this.database });
     }
 
-    public async runGraphQL(
+    public async executeGraphQL(
         query: string,
         args: Pick<GraphQLArgs, "variableValues" | "contextValue"> = {}
     ): Promise<ExecutionResult> {
@@ -88,12 +88,12 @@ export class TestHelper {
         });
     }
 
-    public async runGraphQLWithToken(
+    public async executeGraphQLWithToken(
         query: string,
         token: string,
         args: Partial<Pick<GraphQLArgs, "variableValues">> = {}
     ): Promise<ExecutionResult> {
-        return this.runGraphQL(query, {
+        return this.executeGraphQL(query, {
             ...args,
             contextValue: await this.getContextValue({ token }),
         });


### PR DESCRIPTION
# Description
This PR adds the following changes to TestHelper:

* TestHelper state is reset on `.close` this means that there is no need to create a new instance and can be used with `const`
* Rename `run*` to `execute*`

Unique types could also be made stateful with a reset to allow for const, but that means the typedefs should be in sync with the `close` and that may be unintuitive for devs