### PR TITLE
Link to Aura and changed EAP period

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ___
 
 **GraphQL API for Aura**  
-We’ve been working to make GraphQL natively available in Aura and we are now ready to let people try it in an Early Access Program that will run from 1st April to end of May.  There will be at least one more iteration with additional features before a full release later this year.
+We’ve been working to make GraphQL natively available in [Aura](https://neo4j.com/cloud/platform/aura-graph-database/), Neo4j's Cloud based Graph Database service,  and we are now ready to let people try it in an Early Access Program that will run from April to the end of May.  There will be at least one more iteration with additional features before a full release later this year.
 
 This will offer
 


### PR DESCRIPTION
Added link to Aura and some words to explain what that is

Removed 1st April and period now reads between April and May

# Description

> **Note**
> 
> Please provide a description of the work completed in this PR below

## Complexity

> **Note**
>
> Please provide an estimated complexity of this PR of either Low, Medium or High

Complexity:

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
