### PR TITLE
Skip instrospector tests from aura

### DIFF
--- a/.github/workflows/reusable-aura-tests.yml
+++ b/.github/workflows/reusable-aura-tests.yml
@@ -56,7 +56,7 @@ jobs:
       matrix:
         package:
           - graphql
-          - introspector
+          # - introspector  # Skipped as all tests require CREATE DATABASE at the moment
           - ogm
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
Currently, all tests in the introspector require multiDB, so it is pointless to try and run them in aura, plus due to error messages being manually parsed, make these tests brittle (they fail only in some versions)

This PR remove these tests from running in Aura until we can improve them
