### PR TITLE
Disable sonacloud run on push to dev

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,7 +1,7 @@
 name: "SonarCloud"
 
 on:
-  push:
+ # push:
     # branches:
     #   - dev
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -2,8 +2,8 @@ name: "SonarCloud"
 
 on:
   push:
-    branches:
-      - dev
+    # branches:
+    #   - dev
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -37,4 +37,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.NEO4J_TEAM_GRAPHQL_PERSONAL_ACCESS_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets[env.SONAR_TOKEN_SECRET] }}
- 


### PR DESCRIPTION
# Description

As sonarcloud is not working until more setup is done, there is no reason to keep it running on dev only to fail until fixed
