### PR TITLE
Change order of overrides in context

### DIFF
--- a/.changeset/lucky-dodos-build.md
+++ b/.changeset/lucky-dodos-build.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Change order of overrides in context to preserve internal values

--- a/packages/graphql/src/schema/resolvers/composition/wrap-query-and-mutation.ts
+++ b/packages/graphql/src/schema/resolvers/composition/wrap-query-and-mutation.ts
@@ -123,11 +123,15 @@ export const wrapQueryAndMutation =
             features,
             subscriptionsEnabled,
             executor,
-            neo4jDatabaseInfo,
             authorization: authorizationContext,
-            // Consider anything in here overrides
-            ...context,
         };
 
-        return next(root, args, { ...context, ...internalContext }, info);
+        const finalContext = {
+            // Some TCK tests override this value to generate version-specific Cypher
+            neo4jDatabaseInfo,
+            ...context,
+            ...internalContext,
+        };
+
+        return next(root, args, finalContext, info);
     };


### PR DESCRIPTION
# Description

Whilst the bug itself is extremely complex to reproduce, it could be seen that when the OGM was used inside a custom resolver and the context passed into it, the schema model of the library was overriding that of the OGM. This would cause features such as authorization to be injected in very specific scenarios.

## Complexity

Complexity: Low

# Issue

Closes #4572
