### PR TITLE
Use is int instead of instanceof integer

### DIFF
--- a/.changeset/mean-jokes-double.md
+++ b/.changeset/mean-jokes-double.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Use isInt for checking if type is of type neo4j-driver.Integer. This is the recommended way of performing this check and can remove some flakiness

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -19,7 +19,7 @@
 
 import { mergeDeep } from "@graphql-tools/utils";
 import type { FieldsByTypeName, ResolveTree } from "graphql-parse-resolve-info";
-import { Integer } from "neo4j-driver";
+import { isInt, type Integer } from "neo4j-driver";
 import type { AttributeAdapter } from "../../../schema-model/attribute/model-adapters/AttributeAdapter";
 import type { EntityAdapter } from "../../../schema-model/entity/EntityAdapter";
 import type { ConcreteEntityAdapter } from "../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
@@ -332,7 +332,7 @@ export class OperationsFactory {
         const limitDirective = isUnionEntity(entity) ? undefined : entity.annotations.limit;
 
         let limit: Integer | number | undefined = options?.limit ?? limitDirective?.default ?? limitDirective?.max;
-        if (limit instanceof Integer) {
+        if (isInt(limit)) {
             limit = limit.toNumber();
         }
         const maxLimit = limitDirective?.max;

--- a/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/ConnectionFactory.ts
@@ -21,7 +21,7 @@ import { mergeDeep } from "@graphql-tools/utils";
 import { isObject, isString } from "graphql-compose";
 import type { ResolveTree } from "graphql-parse-resolve-info";
 import { cursorToOffset } from "graphql-relay";
-import { Integer } from "neo4j-driver";
+import { isInt, type Integer } from "neo4j-driver";
 import type { EntityAdapter } from "../../../../schema-model/entity/EntityAdapter";
 import { InterfaceEntity } from "../../../../schema-model/entity/InterfaceEntity";
 import { ConcreteEntityAdapter } from "../../../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
@@ -271,7 +271,7 @@ export class ConnectionFactory {
         const limitDirective = entity.annotations.limit;
 
         let limit: Integer | number | undefined = options?.first ?? limitDirective?.default ?? limitDirective?.max;
-        if (limit instanceof Integer) {
+        if (isInt(limit)) {
             limit = limit.toNumber();
         }
         const maxLimit = limitDirective?.max;


### PR DESCRIPTION
# Description

Use `isInt` for checking if type is of type `neo4j-driver.Integer`. This is the recommended way of performing this check and can remove some flakiness

## Complexity

Complexity: Low
