### PR TITLE
Fix flaky test delete-interface

### DIFF
--- a/packages/graphql/tests/integration/delete-interface.int.test.ts
+++ b/packages/graphql/tests/integration/delete-interface.int.test.ts
@@ -17,9 +17,7 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
-import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
 
 describe("delete interface relationships", () => {
@@ -85,46 +83,25 @@ describe("delete interface relationships", () => {
             typeDefs,
         });
 
-        actorName1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        actorName2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        actorName1 = "Keanu";
+        actorName2 = "Arthur";
 
-        movieTitle1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        movieTitle1 = "PotatoFilm";
 
-        movieTitle2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        movieTitle2 = "The attack of the carrtos";
 
-        movieRuntime1 = faker.number.int({ max: 100000 });
-        movieRuntime2 = faker.number.int({ max: 100000 });
-        movieScreenTime1 = faker.number.int({ max: 100000 });
-        movieScreenTime2 = faker.number.int({ max: 100000 });
+        movieRuntime1 = 1230;
+        movieRuntime2 = 405;
+        movieScreenTime1 = 500;
+        movieScreenTime2 = 501;
 
-        seriesTitle1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesTitle2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesTitle3 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesScreenTime1 = faker.number.int({ max: 100000 });
-        seriesScreenTime2 = faker.number.int({ max: 100000 });
-        seriesScreenTime3 = faker.number.int({ max: 100000 });
-        nestedMovieActorScreenTime = faker.number.int({ max: 100000 });
+        seriesTitle1 = "Series 1";
+        seriesTitle2 = "Series 2";
+        seriesTitle3 = "Boring series";
+        seriesScreenTime1 = 888;
+        seriesScreenTime2 = 999;
+        seriesScreenTime3 = 665;
+        nestedMovieActorScreenTime = 3232;
 
         await testHelper.executeCypher(
             `


### PR DESCRIPTION
# Description
The test delete-interface is flaky ([see example](https://github.com/neo4j/graphql/actions/runs/8454901188/job/23161122580?pr=4956)) This seem to be caused by random numbers.

If the randomly generated numbers are the same, the queries that rely on the count of elements being removed will fail. This PR change the random values by static values 
