### PR TITLE
remove faker from tests

### DIFF
--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -51,7 +51,6 @@
     "devDependencies": {
         "@apollo/gateway": "2.7.2",
         "@apollo/server": "4.10.2",
-        "@faker-js/faker": "8.4.1",
         "@types/deep-equal": "1.0.4",
         "@types/is-uuid": "1.0.2",
         "@types/jest": "29.5.12",

--- a/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -58,7 +57,7 @@ describe("aggregations-where-edge-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(234);
 
         await testHelper.executeCypher(
             `
@@ -96,7 +95,7 @@ describe("aggregations-where-edge-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(5454);
         const someIntGt = someInt - 1;
 
         await testHelper.executeCypher(
@@ -135,7 +134,7 @@ describe("aggregations-where-edge-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(100000);
 
         await testHelper.executeCypher(
             `
@@ -173,7 +172,7 @@ describe("aggregations-where-edge-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(2);
         const someIntLT = someInt + 1;
 
         await testHelper.executeCypher(
@@ -212,7 +211,7 @@ describe("aggregations-where-edge-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(572);
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/aggregations/where/node/int-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int-connections.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -55,7 +54,7 @@ describe("aggregations-where-node-int - connections", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(3214);
 
         await testHelper.executeCypher(
             `
@@ -102,7 +101,7 @@ describe("aggregations-where-node-int - connections", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(1222);
         const someIntGt = someInt - 1;
 
         await testHelper.executeCypher(
@@ -150,7 +149,7 @@ describe("aggregations-where-node-int - connections", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(0);
 
         await testHelper.executeCypher(
             `
@@ -197,7 +196,7 @@ describe("aggregations-where-node-int - connections", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(1);
         const someIntLT = someInt + 1;
 
         await testHelper.executeCypher(
@@ -245,7 +244,7 @@ describe("aggregations-where-node-int - connections", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(43);
 
         await testHelper.executeCypher(
             `
@@ -604,7 +603,7 @@ describe("aggregations-where-node-int - connections - interface relationships of
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(9999);
 
         await testHelper.executeCypher(
             `
@@ -651,7 +650,7 @@ describe("aggregations-where-node-int - connections - interface relationships of
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(9090);
         const someIntGt = someInt - 1;
 
         await testHelper.executeCypher(
@@ -699,7 +698,7 @@ describe("aggregations-where-node-int - connections - interface relationships of
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(78);
 
         await testHelper.executeCypher(
             `
@@ -746,7 +745,7 @@ describe("aggregations-where-node-int - connections - interface relationships of
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(3219);
         const someIntLT = someInt + 1;
 
         await testHelper.executeCypher(
@@ -794,7 +793,7 @@ describe("aggregations-where-node-int - connections - interface relationships of
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(77);
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -67,7 +66,7 @@ describe("aggregations-where-node-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(67883);
 
         await testHelper.executeCypher(
             `
@@ -106,7 +105,7 @@ describe("aggregations-where-node-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(38531);
         const someIntGt = someInt - 1;
 
         await testHelper.executeCypher(
@@ -146,7 +145,7 @@ describe("aggregations-where-node-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(33494);
 
         await testHelper.executeCypher(
             `
@@ -185,7 +184,7 @@ describe("aggregations-where-node-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(64621);
         const someIntLT = someInt + 1;
 
         await testHelper.executeCypher(
@@ -225,7 +224,7 @@ describe("aggregations-where-node-int", () => {
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(84082);
 
         await testHelper.executeCypher(
             `
@@ -549,7 +548,7 @@ describe("aggregations-where-node-int interface relationships of concrete types"
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(10628);
 
         await testHelper.executeCypher(
             `
@@ -588,7 +587,7 @@ describe("aggregations-where-node-int interface relationships of concrete types"
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(28724);
         const someIntGt = someInt - 1;
 
         await testHelper.executeCypher(
@@ -628,7 +627,7 @@ describe("aggregations-where-node-int interface relationships of concrete types"
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(86262);
 
         await testHelper.executeCypher(
             `
@@ -667,7 +666,7 @@ describe("aggregations-where-node-int interface relationships of concrete types"
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(89902);
         const someIntLT = someInt + 1;
 
         await testHelper.executeCypher(
@@ -707,7 +706,7 @@ describe("aggregations-where-node-int interface relationships of concrete types"
             readable: true,
         });
 
-        const someInt = Number(faker.number.int({ max: 100000 }));
+        const someInt = Number(78777);
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import { TestHelper } from "../utils/tests-helper";
@@ -33,10 +32,10 @@ describe("array-pop", () => {
 
     const dateTime = new Date().toISOString();
     const date = dateTime.split("T")[0];
-    const time = faker.date.past().toISOString().split("T")[1] as string;
+    const time = "2023-08-16T22:27:38.587Z".split("T")[1] as string;
     const initialTimeValue = `${time.slice(0, -1)}000000Z`;
-    const initialLocalTimeValue = `${faker.date.past().toISOString().split("T")[1]?.split("Z")[0]}000000`;
-    const initialLocalDateTimeValue = `${faker.date.past().toISOString().split("Z")[0]}000000`;
+    const initialLocalTimeValue = `${"2023-11-08T20:39:21.174Z".split("T")[1]?.split("Z")[0]}000000`;
+    const initialLocalDateTimeValue = `${"2024-02-13T11:48:01.107Z".split("Z")[0]}000000`;
 
     test.each([
         {
@@ -339,9 +338,9 @@ describe("array-pop", () => {
     );
 
     const point = {
-        longitude: parseFloat(faker.location.longitude().toString()),
-        latitude: parseFloat(faker.location.latitude().toString()),
-        height: faker.number.float(),
+        longitude: parseFloat("-141.9601"),
+        latitude: parseFloat("57.4183"),
+        height: 0.50958710629493,
     };
 
     test.each([
@@ -451,8 +450,8 @@ describe("array-pop", () => {
     });
 
     const cartesianPoint = {
-        x: faker.number.float(),
-        y: faker.number.float(),
+        x: 0.8333638033363968,
+        y: 0.19128136802464724,
     };
 
     test.each([

--- a/packages/graphql/tests/integration/delete-interface.int.test.ts
+++ b/packages/graphql/tests/integration/delete-interface.int.test.ts
@@ -17,9 +17,7 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
-import { generate } from "randomstring";
 import { TestHelper } from "./utils/tests-helper";
 
 describe("delete interface relationships", () => {
@@ -85,46 +83,25 @@ describe("delete interface relationships", () => {
             typeDefs,
         });
 
-        actorName1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        actorName2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        actorName1 = "Arthur Dent";
+        actorName2 = "Ford Prefect";
 
-        movieTitle1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        movieTitle1 = "The Hitchhiker's Guide to the Galaxy";
 
-        movieTitle2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        movieTitle2 = "The Restaurant at the End of the Universe";
 
-        movieRuntime1 = faker.number.int({ max: 100000 });
-        movieRuntime2 = faker.number.int({ max: 100000 });
-        movieScreenTime1 = faker.number.int({ max: 100000 });
-        movieScreenTime2 = faker.number.int({ max: 100000 });
+        movieRuntime1 = 121;
+        movieRuntime2 = 321;
+        movieScreenTime1 = 455;
+        movieScreenTime2 = 4325;
 
-        seriesTitle1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesTitle2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesTitle3 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesScreenTime1 = faker.number.int({ max: 100000 });
-        seriesScreenTime2 = faker.number.int({ max: 100000 });
-        seriesScreenTime3 = faker.number.int({ max: 100000 });
-        nestedMovieActorScreenTime = faker.number.int({ max: 100000 });
+        seriesTitle1 = "Life, the Universe and Everything";
+        seriesTitle2 = "So Long, and Thanks for All the Fish";
+        seriesTitle3 = "Mostly Harmless";
+        seriesScreenTime1 = 111;
+        seriesScreenTime2 = 3232;
+        seriesScreenTime3 = 5556;
+        nestedMovieActorScreenTime = 2496;
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/delete-union.int.test.ts
+++ b/packages/graphql/tests/integration/delete-union.int.test.ts
@@ -17,9 +17,7 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
-import { generate } from "randomstring";
 import { TestHelper } from "./utils/tests-helper";
 
 describe("delete union relationships", () => {
@@ -81,46 +79,24 @@ describe("delete union relationships", () => {
         await testHelper.initNeo4jGraphQL({
             typeDefs,
         });
-        actorName1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        actorName2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        actorName1 = "Arthur Dent";
+        actorName2 = "Ford Prefect";
+        movieTitle1 = "The Hitchhiker's Guide to the Galaxy";
+        movieTitle2 = "The Restaurant at the End of the Universe";
 
-        movieTitle1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        movieRuntime1 = 1234;
+        movieRuntime2 = 3333;
+        movieScreenTime1 = 4444;
+        movieScreenTime2 = 8080;
 
-        movieTitle2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
+        seriesTitle1 = "So Long, and Thanks for All the Fish";
+        seriesTitle2 = "Mostly Harmless";
+        seriesTitle3 = "And another thing";
 
-        movieRuntime1 = faker.number.int({ max: 100000 });
-        movieRuntime2 = faker.number.int({ max: 100000 });
-        movieScreenTime1 = faker.number.int({ max: 100000 });
-        movieScreenTime2 = faker.number.int({ max: 100000 });
-
-        seriesTitle1 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesTitle2 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesTitle3 = generate({
-            readable: true,
-            charset: "alphabetic",
-        });
-        seriesScreenTime1 = faker.number.int({ max: 100000 });
-        seriesScreenTime2 = faker.number.int({ max: 100000 });
-        seriesScreenTime3 = faker.number.int({ max: 100000 });
-        nestedMovieActorScreenTime = faker.number.int({ max: 100000 });
+        seriesScreenTime1 = 9;
+        seriesScreenTime2 = 121;
+        seriesScreenTime3 = 111;
+        nestedMovieActorScreenTime = 32;
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -87,15 +86,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 96406;
+        const movieScreenTime = 9448;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 56834;
+        const seriesScreenTime = 3167;
 
         const query = `
             query Actors($title: String) {
@@ -170,15 +169,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 47026;
+        const movieScreenTime = 85740;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 3093;
+        const seriesScreenTime = 96705;
 
         const query = `
             query Actors($title: String) {
@@ -258,15 +257,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 46474;
+        const movieScreenTime = 95753;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 8658;
+        const seriesScreenTime = 76273;
 
         const query = `
             query Actors($title: String) {
@@ -335,15 +334,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 51686;
+        const movieScreenTime = 60481;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 18888;
+        const seriesScreenTime = 75798;
 
         const query = `
             query Actors($title: String) {
@@ -428,15 +427,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 13985;
+        const movieScreenTime = 20492;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 4471;
+        const seriesScreenTime = 70112;
 
         const query = `
             query Actors($title: String) {

--- a/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -85,15 +84,15 @@ describe("union relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 18723;
+        const movieScreenTime = 83582;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 50148;
+        const seriesScreenTime = 8697;
 
         const query = /* GraphQL */ `
             query Actors($title: String) {
@@ -169,15 +168,15 @@ describe("union relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 61632;
+        const movieScreenTime = 69036;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 61753;
+        const seriesScreenTime = 51960;
 
         const query = /* GraphQL */ `
             query Actors($title: String) {
@@ -266,15 +265,15 @@ describe("union relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 25423;
+        const movieScreenTime = 26354;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 36248;
+        const seriesScreenTime = 74985;
 
         const query = /* GraphQL */ `
             query Actors($title: String) {
@@ -355,15 +354,15 @@ describe("union relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 24426;
+        const movieScreenTime = 65872;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 84714;
+        const seriesScreenTime = 26046;
 
         const query = /* GraphQL */ `
             query Actors($title: String) {
@@ -433,15 +432,15 @@ describe("union relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 55815;
+        const movieScreenTime = 86611;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 61405;
+        const seriesScreenTime = 64097;
 
         const query = /* GraphQL */ `
             query Actors($title: String) {
@@ -527,15 +526,15 @@ describe("union relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 9931;
+        const movieScreenTime = 29383;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 15912;
+        const seriesScreenTime = 72093;
 
         const query = /* GraphQL */ `
             query Actors($title: String) {

--- a/packages/graphql/tests/integration/fragments.int.test.ts
+++ b/packages/graphql/tests/integration/fragments.int.test.ts
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
-import { generate } from "randomstring";
 import { TestHelper } from "./utils/tests-helper";
 
 describe("fragments", () => {
@@ -58,25 +56,16 @@ describe("fragments", () => {
         }
     `;
 
-    const actorName = generate({
-        readable: true,
-        charset: "alphabetic",
-    });
+    const actorName = "Marvin";
 
-    const movieTitle = generate({
-        readable: true,
-        charset: "alphabetic",
-    });
-    const movieRuntime = faker.number.int({ max: 100000 });
-    const movieScreenTime = faker.number.int({ max: 100000 });
+    const movieTitle = "The Hitchhiker's Guide to the Galaxy";
+    const movieRuntime = 1230;
+    const movieScreenTime = 3210;
 
-    const seriesTitle = generate({
-        readable: true,
-        charset: "alphabetic",
-    });
-    const seriesRuntime = faker.number.int({ max: 100000 });
-    const seriesEpisodes = faker.number.int({ max: 100000 });
-    const seriesScreenTime = faker.number.int({ max: 100000 });
+    const seriesTitle = "So Long, and Thanks for All the Fish";
+    const seriesRuntime = 112;
+    const seriesEpisodes = 113;
+    const seriesScreenTime = 114;
 
     beforeAll(async () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });

--- a/packages/graphql/tests/integration/interfaces/relationships/create/connect.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/create/connect.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -91,8 +90,8 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 20340;
+        const movieScreenTime = 87163;
 
         const query = `
             mutation CreateActorConnectMovie($name1: String!, $title: String, $screenTime: Int!, $name2: String) {

--- a/packages/graphql/tests/integration/interfaces/relationships/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/create/create.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,8 +86,8 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 73876;
+        const movieScreenTime = 15855;
 
         const query = `
             mutation CreateActorConnectMovie($name: String!, $title: String!, $runtime: Int!, $screenTime: Int!) {
@@ -160,15 +159,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const screenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 81094;
+        const screenTime = 79933;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
 
-        const episodeRuntime = faker.number.int({ max: 100000 });
+        const episodeRuntime = 13437;
 
         const query = `
             mutation CreateActorConnectMovie(

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-filters.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-filters.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -96,13 +95,13 @@ describe("interface filters of declared relationships", () => {
 
         movieTitle = "movie1";
         movieTitle2 = "movie2";
-        movieRuntime = faker.number.int({ max: 100000 });
-        movieScreenTime = faker.number.int({ max: 100000 });
+        movieRuntime = 74223;
+        movieScreenTime = 19124;
 
         seriesTitle = "series1";
-        seriesEpisodes = faker.number.int({ max: 100000 });
-        seriesScreenTime = faker.number.int({ max: 100000 });
-        episodeNr = faker.number.int({ max: 100000 });
+        seriesEpisodes = 32695;
+        seriesScreenTime = 70317;
+        episodeNr = 89129;
 
         await testHelper.executeCypher(
             `
@@ -404,13 +403,13 @@ describe("interface filters of declared interface relationships", () => {
 
         movieTitle = "movie1";
         movieTitle2 = "movie2";
-        movieRuntime = faker.number.int({ max: 100000 });
-        movieScreenTime = faker.number.int({ max: 100000 });
+        movieRuntime = 38566;
+        movieScreenTime = 35472;
 
         seriesTitle = "series1";
-        seriesEpisodes = faker.number.int({ max: 100000 });
-        seriesScreenTime = faker.number.int({ max: 100000 });
-        episodeNr = faker.number.int({ max: 100000 });
+        seriesEpisodes = 89908;
+        seriesScreenTime = 56668;
+        episodeNr = 33194;
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-one-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-one-level-chain.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -95,12 +94,12 @@ describe("interface implementing interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 90446;
+        const movieScreenTime = 94090;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 59857;
+        const seriesScreenTime = 16711;
 
         const query = `
             query Productions {
@@ -280,13 +279,13 @@ describe("interface implementing interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 33068;
+        const movieScreenTime = 5810;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 49193;
+        const seriesScreenTime = 86451;
+        const episodeNr = 96228;
 
         const query = /* GraphQL */ `
             query Shows {
@@ -522,13 +521,13 @@ describe("interface implementing interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 39467;
+        const movieScreenTime = 81390;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 3154;
+        const seriesScreenTime = 44814;
+        const episodeNr = 60460;
 
         const query = /* GraphQL */ `
             query Shows {
@@ -857,13 +856,13 @@ describe("interface implementing interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 19548;
+        const movieScreenTime = 77112;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 92772;
+        const seriesScreenTime = 97200;
+        const episodeNr = 24425;
 
         const query = /* GraphQL */ `
             query Shows {
@@ -948,12 +947,12 @@ describe("interface implementing interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 83562;
+        const movieScreenTime = 62906;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 90176;
+        const seriesScreenTime = 44779;
 
         // const query = `
         //     query Actors {

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-simple.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-simple.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -90,12 +89,12 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 73595;
+        const movieScreenTime = 41211;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 36220;
+        const seriesScreenTime = 15272;
 
         const query = `
             query Productions {
@@ -230,13 +229,13 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 97371;
+        const movieScreenTime = 75427;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 78598;
+        const seriesScreenTime = 17239;
+        const episodeNr = 50222;
 
         const query = /* GraphQL */ `
             query Productions {
@@ -473,14 +472,14 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
+        const movieRuntime = 12532;
         const movieScreenTime = 1;
         const movieScreenTime2 = 2;
         const movieScreenTime3 = 3;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 23359;
+        const seriesScreenTime = 33984;
         const episodeNr = 10;
         const episodeNr2 = 11;
 
@@ -614,14 +613,14 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
+        const movieRuntime = 97692;
         const movieScreenTime = 1;
         const movieScreenTime2 = 2;
         const movieScreenTime3 = 3;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 54091;
+        const seriesScreenTime = 52819;
         const episodeNr = 10;
         const episodeNr2 = 11;
 
@@ -754,13 +753,13 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 99338;
+        const movieScreenTime = 59670;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 95731;
+        const seriesScreenTime = 75877;
+        const episodeNr = 49452;
 
         const query = /* GraphQL */ `
             mutation {
@@ -1030,13 +1029,13 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 9152;
+        const movieScreenTime = 85537;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 5492;
+        const seriesScreenTime = 37374;
+        const episodeNr = 86743;
 
         const query = /* GraphQL */ `
             mutation {
@@ -1338,13 +1337,13 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 3730;
+        const movieScreenTime = 94414;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 3616;
+        const seriesScreenTime = 66797;
+        const episodeNr = 57531;
 
         const query = /* GraphQL */ `
             mutation {
@@ -1697,7 +1696,7 @@ describe("interface with declared relationships", () => {
         const actorName2 = "actor2";
 
         const movieTitle = "movie1";
-        const movieRuntime = faker.number.int({ max: 100000 });
+        const movieRuntime = 57523;
 
         const query = /* GraphQL */ `
             mutation {
@@ -1833,13 +1832,13 @@ describe("interface with declared relationships", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 26229;
+        const movieScreenTime = 47701;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 10004;
+        const seriesScreenTime = 94676;
+        const episodeNr = 2552;
 
         const query = /* GraphQL */ `
         mutation CreateActors {

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-three-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-three-level-chain.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -105,13 +104,13 @@ describe("interface implementing interface with declared relationships - three l
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 1621;
+        const movieScreenTime = 16828;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 65410;
+        const seriesScreenTime = 45786;
+        const episodeNr = 56314;
 
         const query = /* GraphQL */ `
             query WatchableThings {
@@ -347,13 +346,13 @@ describe("interface implementing interface with declared relationships - three l
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 81383;
+        const movieScreenTime = 81144;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 35606;
+        const seriesScreenTime = 87912;
+        const episodeNr = 98213;
 
         const query = /* GraphQL */ `
             query WatchableThings {
@@ -682,13 +681,13 @@ describe("interface implementing interface with declared relationships - three l
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 18685;
+        const movieScreenTime = 12230;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 86077;
+        const seriesScreenTime = 79022;
+        const episodeNr = 53842;
 
         const query = /* GraphQL */ `
             query Things {
@@ -924,13 +923,13 @@ describe("interface implementing interface with declared relationships - three l
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 28411;
+        const movieScreenTime = 29405;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 7525;
+        const seriesScreenTime = 66294;
+        const episodeNr = 75985;
 
         const query = /* GraphQL */ `
             query Things {
@@ -1259,13 +1258,13 @@ describe("interface implementing interface with declared relationships - three l
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 17645;
+        const movieScreenTime = 55577;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 70906;
+        const seriesScreenTime = 73766;
+        const episodeNr = 88063;
 
         const query = /* GraphQL */ `
             query Shows {
@@ -1501,13 +1500,13 @@ describe("interface implementing interface with declared relationships - three l
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 12657;
+        const movieScreenTime = 66515;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 50455;
+        const seriesScreenTime = 92056;
+        const episodeNr = 50724;
 
         const query = /* GraphQL */ `
             query Shows {

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-two-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-two-level-chain.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -100,13 +99,13 @@ describe("interface implementing interface with declared relationships - two lev
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 89247;
+        const movieScreenTime = 54804;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 43471;
+        const seriesScreenTime = 67186;
+        const episodeNr = 82467;
 
         const query = /* GraphQL */ `
             query Things {
@@ -342,13 +341,13 @@ describe("interface implementing interface with declared relationships - two lev
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 67159;
+        const movieScreenTime = 99602;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 28043;
+        const seriesScreenTime = 45240;
+        const episodeNr = 18199;
 
         const query = /* GraphQL */ `
             query Things {
@@ -677,13 +676,13 @@ describe("interface implementing interface with declared relationships - two lev
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 21789;
+        const movieScreenTime = 27695;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 13078;
+        const seriesScreenTime = 80574;
+        const episodeNr = 69185;
 
         const query = /* GraphQL */ `
             query Shows {
@@ -919,13 +918,13 @@ describe("interface implementing interface with declared relationships - two lev
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 98454;
+        const movieScreenTime = 67373;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const episodeNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 28950;
+        const seriesScreenTime = 32643;
+        const episodeNr = 55960;
 
         const query = /* GraphQL */ `
             query Shows {

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-mutations.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-mutations.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -100,13 +99,13 @@ describe("type narrowing - mutations setup", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 69423;
+        const movieScreenTime = 1227;
 
         const seriesTitle = "series1";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 65752;
+        const seriesScreenTime = 64112;
+        const sceneNr = 2291;
 
         const query = /* GraphQL */ `
         mutation {

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-nested.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-nested.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -47,12 +46,12 @@ describe("type narrowing nested connections", () => {
         untrainedPersonName = "anyone";
         movieTitle = "movie1";
         movieTitle2 = "movie2";
-        movieRuntime = faker.number.int({ max: 100000 });
-        movieScreenTime = faker.number.int({ max: 100000 });
+        movieRuntime = 99105;
+        movieScreenTime = 87653;
         amatureProductionTitle = "amature";
-        seriesEpisodes = faker.number.int({ max: 100000 });
-        seriesScreenTime = faker.number.int({ max: 100000 });
-        sceneNr = faker.number.int({ max: 100000 });
+        seriesEpisodes = 607;
+        seriesScreenTime = 73385;
+        sceneNr = 16220;
 
         Movie = testHelper.createUniqueType("Movie");
         AmatureProduction = testHelper.createUniqueType("AmatureProduction");

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -95,13 +94,13 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 63563;
+        const movieScreenTime = 42699;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 88310;
+        const seriesScreenTime = 40968;
+        const sceneNr = 92937;
 
         const query = /* GraphQL */ `
             query Productions {
@@ -219,13 +218,13 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 41886;
+        const movieScreenTime = 72079;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 34992;
+        const seriesScreenTime = 43724;
+        const sceneNr = 96768;
 
         const query = /* GraphQL */ `
             query Productions {
@@ -402,13 +401,13 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 12527;
+        const movieScreenTime = 41858;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 65818;
+        const seriesScreenTime = 67600;
+        const sceneNr = 88992;
 
         const query = /* GraphQL */ `
             query Productions {
@@ -560,13 +559,13 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 17297;
+        const movieScreenTime = 33241;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 1345;
+        const seriesScreenTime = 17269;
+        const sceneNr = 9176;
 
         const query = /* GraphQL */ `
             query People {
@@ -679,13 +678,13 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 69186;
+        const movieScreenTime = 33869;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 88178;
+        const seriesScreenTime = 41685;
+        const sceneNr = 20583;
 
         const query = /* GraphQL */ `
             query People {
@@ -795,14 +794,14 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
-        const movieScreenTime2 = faker.number.int({ max: 100000 });
+        const movieRuntime = 80494;
+        const movieScreenTime = 34409;
+        const movieScreenTime2 = 12485;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 79217;
+        const seriesScreenTime = 60447;
+        const sceneNr = 85423;
 
         const query = /* GraphQL */ `
             query People {
@@ -955,14 +954,14 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
-        const movieScreenTime2 = faker.number.int({ max: 100000 });
+        const movieRuntime = 49337;
+        const movieScreenTime = 80113;
+        const movieScreenTime2 = 5407;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 189;
+        const seriesScreenTime = 22550;
+        const sceneNr = 40154;
 
         const query = /* GraphQL */ `
             query People {
@@ -1115,14 +1114,14 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
-        const movieScreenTime2 = faker.number.int({ max: 100000 });
+        const movieRuntime = 12169;
+        const movieScreenTime = 33584;
+        const movieScreenTime2 = 98332;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 80053;
+        const seriesScreenTime = 98561;
+        const sceneNr = 21219;
 
         const query = /* GraphQL */ `
             query People {
@@ -1265,14 +1264,14 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
-        const movieScreenTime2 = faker.number.int({ max: 100000 });
+        const movieRuntime = 39883;
+        const movieScreenTime = 64889;
+        const movieScreenTime2 = 82496;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 42968;
+        const seriesScreenTime = 64469;
+        const sceneNr = 2621;
 
         const query = /* GraphQL */ `
             query Actors {
@@ -1359,14 +1358,14 @@ describe("type narrowing - simple case", () => {
 
         const movieTitle = "movie1";
         const movieTitle2 = "movie2";
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
-        const movieScreenTime2 = faker.number.int({ max: 100000 });
+        const movieRuntime = 67705;
+        const movieScreenTime = 88223;
+        const movieScreenTime2 = 91931;
 
         const amatureProductionTitle = "amature";
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
-        const sceneNr = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 16632;
+        const seriesScreenTime = 39594;
+        const sceneNr = 76405;
 
         const query = /* GraphQL */ `
         query Actors {

--- a/packages/graphql/tests/integration/interfaces/relationships/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/delete/delete.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,14 +86,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 5642;
+        const movieScreenTime = 20268;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 28707;
 
         const query = `
             mutation DeleteActorAndMovie($name: String, $title: String) {
@@ -149,14 +148,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 54902;
+        const movieScreenTime = 89424;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 7797;
 
         const query = `
             mutation DeleteActorAndMovie($name1: String, $name2: String, $title: String) {

--- a/packages/graphql/tests/integration/interfaces/relationships/read.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/read.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
 import { TestHelper } from "../../utils/tests-helper";
@@ -79,15 +78,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 88052;
+        const movieScreenTime = 47337;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 45953;
+        const seriesScreenTime = 99847;
 
         const query = `
             query Actors($name: String) {
@@ -150,26 +149,26 @@ describe("interface relationships", () => {
 
         const movie1 = {
             title: "A",
-            runtime: faker.number.int({ max: 100000 }),
-            screenTime: faker.number.int({ max: 100000 }),
+            runtime: 23408,
+            screenTime: 40446,
         };
 
         const movie2 = {
             title: "B",
-            runtime: faker.number.int({ max: 100000 }),
-            screenTime: faker.number.int({ max: 100000 }),
+            runtime: 76130,
+            screenTime: 89440,
         };
 
         const series1 = {
             title: "C",
-            episodes: faker.number.int({ max: 100000 }),
-            screenTime: faker.number.int({ max: 100000 }),
+            episodes: 64675,
+            screenTime: 83928,
         };
 
         const series2 = {
             title: "D",
-            episodes: faker.number.int({ max: 100000 }),
-            screenTime: faker.number.int({ max: 100000 }),
+            episodes: 8135,
+            screenTime: 83728,
         };
 
         const query = /* GraphQL */ `
@@ -224,21 +223,21 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 85953;
+        const movieScreenTime = 50667;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 85490;
+        const seriesScreenTime = 1726;
 
         const newMovieTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const newMovieRuntime = faker.number.int({ max: 100000 });
+        const newMovieRuntime = 6106;
 
         const query = `
             query Actors($name: String) {
@@ -306,11 +305,11 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 76300;
+        const movieScreenTime = 28270;
 
-        const seriesEpisodes = faker.number.int({ max: 100000 });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesEpisodes = 52388;
+        const seriesScreenTime = 70458;
 
         const query = `
             query Actors($name: String, $title: String) {

--- a/packages/graphql/tests/integration/interfaces/relationships/update/connect.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/connect.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,14 +86,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 68296;
+        const movieScreenTime = 45708;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 69129;
 
         const query = `
             mutation ConnectMovie($name: String, $title: String, $screenTime: Int!) {
@@ -164,14 +163,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 67082;
+        const movieScreenTime = 39674;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 86317;
 
         const query = `
             mutation ConnectMovie($name1: String, $name2: String, $title: String, $screenTime: Int!) {

--- a/packages/graphql/tests/integration/interfaces/relationships/update/create.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/create.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,14 +86,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 86474;
+        const movieScreenTime = 34999;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 20350;
 
         const query = `
             mutation UpdateCreate(
@@ -187,14 +186,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 48235;
+        const movieScreenTime = 43438;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 45235;
 
         const query = `
             mutation UpdateCreate(

--- a/packages/graphql/tests/integration/interfaces/relationships/update/delete.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/delete.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,14 +86,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 57622;
+        const movieScreenTime = 922;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 14299;
 
         const query = `
             mutation DeleteMovie($name: String, $title: String) {
@@ -164,14 +163,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 43669;
+        const movieScreenTime = 28870;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 90401;
 
         const query = `
             mutation DeleteMovie($name1: String, $name2: String, $title: String) {

--- a/packages/graphql/tests/integration/interfaces/relationships/update/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/disconnect.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,14 +86,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 59348;
+        const movieScreenTime = 7079;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 5423;
 
         const query = `
             mutation DisconnectMovie($name: String, $title: String) {
@@ -164,14 +163,14 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 77473;
+        const movieScreenTime = 72796;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 61111;
 
         const query = `
             mutation DisconnectMovie($name1: String, $name2: String, $title: String) {

--- a/packages/graphql/tests/integration/interfaces/relationships/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/update.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
 import { TestHelper } from "../../../utils/tests-helper";
@@ -87,8 +86,8 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 76907;
+        const movieScreenTime = 82739;
 
         const movieNewTitle = generate({
             readable: true,
@@ -99,7 +98,7 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 53301;
 
         const query = `
             mutation UpdateUpdate($name: String, $oldTitle: String, $newTitle: String) {
@@ -182,8 +181,8 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const movieScreenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 44372;
+        const movieScreenTime = 92046;
 
         const movieNewTitle = generate({
             readable: true,
@@ -194,7 +193,7 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const seriesScreenTime = faker.number.int({ max: 100000 });
+        const seriesScreenTime = 38286;
 
         const query = `
             mutation UpdateUpdate($name: String, $newName: String, $oldTitle: String, $newTitle: String) {

--- a/packages/graphql/tests/integration/issues/4583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4583.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import gql from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -97,13 +96,13 @@ describe("https://github.com/neo4j/graphql/issues/4583", () => {
 
         movieTitle = "movie1";
         movieTitle2 = "movie2";
-        movieRuntime = faker.number.int({ max: 100000 });
-        movieScreenTime = faker.number.int({ max: 100000 });
+        movieRuntime = 992;
+        movieScreenTime = 45827;
 
         seriesTitle = "series1";
-        seriesEpisodes = faker.number.int({ max: 100000 });
-        seriesScreenTime = faker.number.int({ max: 100000 });
-        episodeNr = faker.number.int({ max: 100000 });
+        seriesEpisodes = 10440;
+        seriesScreenTime = 61849;
+        episodeNr = 16099;
         sameTitle = "sameTitle";
 
         await testHelper.executeCypher(

--- a/packages/graphql/tests/integration/issues/4704.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4704.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -100,13 +99,13 @@ describe("https://github.com/neo4j/graphql/issues/4704", () => {
 
         movieTitle = "movie1";
         movieTitle2 = "movie2";
-        movieRuntime = faker.number.int({ max: 100000 });
-        movieScreenTime = faker.number.int({ max: 100000 });
+        movieRuntime = 32607;
+        movieScreenTime = 16903;
 
         seriesTitle = "series1";
-        seriesEpisodes = faker.number.int({ max: 100000 });
-        seriesScreenTime = faker.number.int({ max: 100000 });
-        episodeNr = faker.number.int({ max: 100000 });
+        seriesEpisodes = 42394;
+        seriesScreenTime = 2922;
+        episodeNr = 47931;
 
         await testHelper.executeCypher(
             `

--- a/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
@@ -101,15 +100,15 @@ describe("interface relationships", () => {
             readable: true,
             charset: "alphabetic",
         });
-        const movieRuntime = faker.number.int({ max: 100000 });
-        const screenTime = faker.number.int({ max: 100000 });
+        const movieRuntime = 44706;
+        const screenTime = 70531;
 
         const seriesTitle = generate({
             readable: true,
             charset: "alphabetic",
         });
 
-        const episodeRuntime = faker.number.int({ max: 100000 });
+        const episodeRuntime = 27151;
 
         const query = `
             mutation CreateActorConnectMovie(

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import { int } from "neo4j-driver";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
@@ -55,12 +54,12 @@ describe("Subscriptions to spatial types", () => {
     });
 
     test("create type with Point field", async () => {
-        const longitude1 = parseFloat(faker.location.longitude().toString());
-        const longitude2 = parseFloat(faker.location.longitude().toString());
-        const latitude1 = parseFloat(faker.location.latitude().toString());
-        const latitude2 = parseFloat(faker.location.latitude().toString());
-        const height1 = faker.number.float();
-        const height2 = faker.number.float();
+        const longitude1 = parseFloat("-71.0007");
+        const longitude2 = parseFloat("139.1539");
+        const latitude1 = parseFloat("48.1706");
+        const latitude2 = parseFloat("-50.9324");
+        const height1 = 0.34409760613925755;
+        const height2 = 0.19406892964616418;
 
         const query = `
         mutation CreateMovie($longitude1: Float!, $latitude1: Float!, $height1: Float!, $longitude2: Float!, $latitude2: Float!, $height2: Float!)  {
@@ -180,10 +179,10 @@ describe("Subscriptions to spatial types", () => {
         );
     });
     test("update type with Point field", async () => {
-        const longitude1 = parseFloat(faker.location.longitude().toString());
-        const latitude1 = parseFloat(faker.location.latitude().toString());
-        const height1 = faker.number.float();
-        const newLatitude = parseFloat(faker.location.latitude().toString());
+        const longitude1 = parseFloat("-38.9491");
+        const latitude1 = parseFloat("-75.8207");
+        const height1 = 0.8940616026520729;
+        const newLatitude = parseFloat("-42.7308");
 
         await testHelper.executeCypher(`
             CALL {
@@ -272,8 +271,8 @@ describe("Subscriptions to spatial types", () => {
         );
     });
     test("query type with Point field and filters", async () => {
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude().toString());
+        const longitude = parseFloat("154.8561");
+        const latitude = parseFloat("73.8678");
 
         await testHelper.executeCypher(`
             CALL {
@@ -336,8 +335,8 @@ describe("Subscriptions to spatial types", () => {
                 locations: [
                     { longitude, latitude },
                     {
-                        longitude: parseFloat(faker.location.longitude().toString()),
-                        latitude: parseFloat(faker.location.latitude().toString()),
+                        longitude: parseFloat("51.8962"),
+                        latitude: parseFloat("-9.6844"),
                     },
                 ],
             },
@@ -373,12 +372,12 @@ describe("Subscriptions to spatial types", () => {
             variableValues: {
                 locations: [
                     {
-                        longitude: parseFloat(faker.location.longitude().toString()),
-                        latitude: parseFloat(faker.location.latitude().toString()),
+                        longitude: parseFloat("12.4692"),
+                        latitude: parseFloat("55.2318"),
                     },
                     {
-                        longitude: parseFloat(faker.location.longitude().toString()),
-                        latitude: parseFloat(faker.location.latitude().toString()),
+                        longitude: parseFloat("162.6476"),
+                        latitude: parseFloat("-10.2548"),
                     },
                 ],
             },
@@ -397,10 +396,10 @@ describe("Subscriptions to spatial types", () => {
     });
 
     test("create type with CartesianPoint field", async () => {
-        const x1 = faker.number.float();
-        const y1 = faker.number.float();
-        const x2 = faker.number.float();
-        const y2 = faker.number.float();
+        const x1 = 0.8607480155769736;
+        const y1 = 0.6322691068053246;
+        const x2 = 0.21531713823787868;
+        const y2 = 0.8199794858228415;
 
         const query = `
         mutation CreateMovie($x1: Float!, $x2: Float!, $y1: Float!, $y2: Float!)  {
@@ -518,9 +517,9 @@ describe("Subscriptions to spatial types", () => {
         ]);
     });
     test("update type with CartesianPoint field", async () => {
-        const x = faker.number.float();
-        const y = faker.number.float();
-        const newY = faker.number.float();
+        const x = 0.8504534482490271;
+        const y = 0.8674011980183423;
+        const newY = 0.142022400861606;
 
         await testHelper.executeCypher(`
             CALL {
@@ -610,8 +609,8 @@ describe("Subscriptions to spatial types", () => {
     });
 
     test("query type with CartesianPoint field and filters", async () => {
-        const x = faker.number.float();
-        const y = faker.number.float();
+        const x = 0.8776046128477901;
+        const y = 0.01593078044243157;
 
         await testHelper.executeCypher(`
             CALL {
@@ -674,8 +673,8 @@ describe("Subscriptions to spatial types", () => {
                 locations: [
                     { x, y },
                     {
-                        x: faker.number.float(),
-                        y: faker.number.float(),
+                        x: 0.425140418112278,
+                        y: 0.5120728241745383,
                     },
                 ],
             },
@@ -711,12 +710,12 @@ describe("Subscriptions to spatial types", () => {
             variableValues: {
                 locations: [
                     {
-                        x: faker.number.float(),
-                        y: faker.number.float(),
+                        x: 0.13677962007932365,
+                        y: 0.05952018848620355,
                     },
                     {
-                        x: faker.number.float(),
-                        y: faker.number.float(),
+                        x: 0.993210831657052,
+                        y: 0.3956587021239102,
                     },
                 ],
             },

--- a/packages/graphql/tests/integration/types/localdatetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localdatetime.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseLocalDateTime } from "../../../src/graphql/scalars/LocalDateTime";
@@ -49,7 +48,7 @@ describe("LocalDateTime", () => {
     describe("create", () => {
         test("should create a movie (with a LocalDateTime)", async () => {
             const id = generate({ readable: false });
-            const localDT = faker.date.past().toISOString().split("Z")[0];
+            const localDT = "2023-04-04T09:19:20.620Z".split("Z")[0];
             const parsedLocalDateTime = parseLocalDateTime(localDT);
 
             const mutation = /* GraphQL */ `
@@ -93,9 +92,7 @@ describe("LocalDateTime", () => {
 
         test("should create a movie (with many Times)", async () => {
             const id = generate({ readable: false });
-            const localDTs = [...new Array(faker.number.int({ min: 2, max: 4 }))].map(
-                () => faker.date.past().toISOString().split("Z")[0]
-            );
+            const localDTs = [...new Array(3)].map(() => "2023-07-14T01:17:41.537Z".split("Z")[0]);
             const parsedLocalDateTimes = localDTs.map((localDT) => parseLocalDateTime(localDT));
 
             const mutation = /* GraphQL */ `
@@ -158,7 +155,7 @@ describe("LocalDateTime", () => {
     describe("update", () => {
         test("should update a movie (with a LocalDateTime)", async () => {
             const id = generate({ readable: false });
-            const localDT = faker.date.past().toISOString().split("Z")[0];
+            const localDT = "2023-12-28T09:03:31.293Z".split("Z")[0];
             const parsedLocalDateTime = parseLocalDateTime(localDT);
 
             await testHelper.executeCypher(
@@ -212,7 +209,7 @@ describe("LocalDateTime", () => {
     describe("filter", () => {
         test("should filter based on localDT equality", async () => {
             const id = generate({ readable: false });
-            const date = faker.date.future();
+            const date = new Date("2024-09-17T11:49:48.322Z");
             const localDT = date.toISOString().split("Z")[0];
             const neo4jLocalDateTime = neo4jDriver.types.LocalDateTime.fromStandardDate(date);
             const parsedLocalDateTime = parseLocalDateTime(localDT);
@@ -249,7 +246,7 @@ describe("LocalDateTime", () => {
             "should filter based on localDT comparison, for filter %s",
             async (filter) => {
                 const futureId = generate({ readable: false });
-                const future = faker.date.future({ years: 2 }).toISOString().split("Z")[0];
+                const future = "2025-02-18T18:10:55.462Z".split("Z")[0];
                 const parsedFuture = parseLocalDateTime(future);
                 const neo4jFuture = new neo4jDriver.types.LocalDateTime(
                     parsedFuture.year,
@@ -275,7 +272,7 @@ describe("LocalDateTime", () => {
                 );
 
                 const pastId = generate({ readable: false });
-                const past = faker.date.past({ years: 2 }).toISOString().split("Z")[0];
+                const past = "2022-08-29T10:21:43.108Z".split("Z")[0];
                 const parsedPast = parseLocalDateTime(past);
                 const neo4jPast = new neo4jDriver.types.LocalDateTime(
                     parsedPast.year,
@@ -361,7 +358,7 @@ describe("LocalDateTime", () => {
     describe("sorting", () => {
         test.each(["ASC", "DESC"])("should sort based on localDT, sorting by %s", async (sort) => {
             const futureId = generate({ readable: false });
-            const future = faker.date.future({ years: 2 }).toISOString().split("Z")[0];
+            const future = "2025-08-10T05:25:26.654Z".split("Z")[0];
             const parsedFuture = parseLocalDateTime(future);
             const neo4jFuture = new neo4jDriver.types.LocalDateTime(
                 parsedFuture.year,
@@ -387,7 +384,7 @@ describe("LocalDateTime", () => {
             );
 
             const pastId = generate({ readable: false });
-            const past = faker.date.past({ years: 2 }).toISOString().split("Z")[0];
+            const past = "2023-10-05T14:58:45.170Z".split("Z")[0];
             const parsedPast = parseLocalDateTime(past);
             const neo4jPast = new neo4jDriver.types.LocalDateTime(
                 parsedPast.year,

--- a/packages/graphql/tests/integration/types/localtime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localtime.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseLocalTime } from "../../../src/graphql/scalars/LocalTime";
@@ -49,7 +48,7 @@ describe("LocalTime", () => {
     describe("create", () => {
         test("should create a movie (with a LocalTime)", async () => {
             const id = generate({ readable: false });
-            const time = faker.date.past().toISOString().split("T")[1]?.split("Z")[0];
+            const time = "2023-10-16T16:33:05.024Z".split("T")[1]?.split("Z")[0];
             const parsedTime = parseLocalTime(time);
 
             const mutation = /* GraphQL */ `
@@ -93,9 +92,7 @@ describe("LocalTime", () => {
 
         test("should create a movie (with many Times)", async () => {
             const id = generate({ readable: false });
-            const times = [...new Array(faker.number.int({ min: 2, max: 4 }))].map(
-                () => faker.date.past().toISOString().split("T")[1]?.split("Z")[0]
-            );
+            const times = [...new Array(3)].map(() => "2023-11-03T00:02:28.229Z".split("T")[1]?.split("Z")[0]);
             const parsedTimes = times.map((time) => parseLocalTime(time));
 
             const mutation = /* GraphQL */ `
@@ -156,7 +153,7 @@ describe("LocalTime", () => {
     describe("update", () => {
         test("should update a movie (with a LocalTime)", async () => {
             const id = generate({ readable: false });
-            const time = faker.date.past().toISOString().split("T")[1]?.split("Z")[0];
+            const time = "2024-01-18T11:15:48.144Z".split("T")[1]?.split("Z")[0];
             const parsedTime = parseLocalTime(time);
 
             await testHelper.executeCypher(
@@ -210,7 +207,7 @@ describe("LocalTime", () => {
     describe("filter", () => {
         test("should filter based on time equality", async () => {
             const id = generate({ readable: false });
-            const date = faker.date.future();
+            const date = new Date("2024-09-17T11:49:48.322Z");
             const time = date.toISOString().split("T")[1]?.split("Z")[0];
             const neo4jTime = neo4jDriver.types.LocalTime.fromStandardDate(date);
             const parsedTime = parseLocalTime(time);

--- a/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -43,9 +42,9 @@ describe("CartesianPoint", () => {
     });
 
     test("enables creation of a node with a cartesian point", async () => {
-        const serial = faker.string.uuid();
-        const x = faker.number.float();
-        const y = faker.number.float();
+        const serial = "81dfaca5-0365-4bf7-b1fe-6cab702966d0";
+        const x = 0.7811776334419847;
+        const y = 0.7400629911571741;
 
         const create = /* GraphQL */ `
             mutation CreateParts($serial: String!, $x: Float!, $y: Float!) {
@@ -88,10 +87,10 @@ describe("CartesianPoint", () => {
     });
 
     test("enables creation of a node with a cartesian-3d point", async () => {
-        const serial = faker.string.uuid();
-        const x = faker.number.float();
-        const y = faker.number.float();
-        const z = faker.number.float();
+        const serial = "8482cc3a-1204-418e-8a31-74d24b27b542";
+        const x = 0.02628162084147334;
+        const y = 0.9550968739204109;
+        const z = 0.4940597955137491;
 
         const create = /* GraphQL */ `
             mutation CreateParts($serial: String!, $x: Float!, $y: Float!, $z: Float!) {
@@ -135,10 +134,10 @@ describe("CartesianPoint", () => {
     });
 
     test("enables update of a node with a cartesian point", async () => {
-        const serial = faker.string.uuid();
-        const x = faker.number.float();
-        const y = faker.number.float();
-        const newY = faker.number.float();
+        const serial = "f5e40cae-f839-4ec3-a12b-45da40e8de7f";
+        const x = 0.9797746981494129;
+        const y = 0.6287962510250509;
+        const newY = 0.8291290057823062;
 
         const beforeResult = await testHelper.executeCypher(`
             CALL {
@@ -196,11 +195,11 @@ describe("CartesianPoint", () => {
     });
 
     test("enables update of a node with a cartesian-3d point", async () => {
-        const serial = faker.string.uuid();
-        const x = faker.number.float();
-        const y = faker.number.float();
-        const z = faker.number.float();
-        const newY = faker.number.float();
+        const serial = "ff4af64d-90f6-4f74-ad65-13dce16502bc";
+        const x = 0.954262402607128;
+        const y = 0.9950293721631169;
+        const z = 0.30888770753517747;
+        const newY = 0.8628286835737526;
 
         const beforeResult = await testHelper.executeCypher(`
             CALL {
@@ -260,9 +259,9 @@ describe("CartesianPoint", () => {
     });
 
     test("enables query of a node with a cartesian point", async () => {
-        const serial = faker.string.uuid();
-        const x = faker.number.float();
-        const y = faker.number.float();
+        const serial = "bf92efbc-6c15-40ac-9cd5-8ab95fa4da90";
+        const x = 0.2800768264569342;
+        const y = 0.6105434170458466;
 
         const result = await testHelper.executeCypher(`
             CALL {
@@ -309,10 +308,10 @@ describe("CartesianPoint", () => {
     });
 
     test("enables query of a node with a cartesian-3d point", async () => {
-        const serial = faker.string.uuid();
-        const x = faker.number.float();
-        const y = faker.number.float();
-        const z = faker.number.float();
+        const serial = "c7715adc-9c9c-45ff-b4ed-6cb20bb044ad";
+        const x = 0.9446345162577927;
+        const y = 0.7858678111806512;
+        const z = 0.4248296618461609;
 
         const result = await testHelper.executeCypher(`
             CALL {

--- a/packages/graphql/tests/integration/types/point.int.test.ts
+++ b/packages/graphql/tests/integration/types/point.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -55,10 +54,10 @@ describe("Point", () => {
     });
 
     test("enables creation of a node with a wgs-84 point", async () => {
-        const id = faker.string.uuid();
-        const size = faker.number.int({ max: 100000 });
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude().toString());
+        const id = "abc075b9-bb99-4447-9cdb-b3af98e991bb";
+        const size = 40403;
+        const longitude = parseFloat("98.459");
+        const latitude = parseFloat("44.1705");
 
         const create = /* GraphQL */ `
             mutation CreatePhotographs($id: String!, $size: Int!, $longitude: Float!, $latitude: Float!) {
@@ -105,11 +104,11 @@ describe("Point", () => {
     });
 
     test("enables creation of a node with a wgs-84-3d point", async () => {
-        const id = faker.string.uuid();
-        const size = faker.number.int({ max: 100000 });
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude().toString());
-        const height = faker.number.float();
+        const id = "2922e9e1-ad37-4966-b940-d7d1915d1997";
+        const size = 94309;
+        const longitude = parseFloat("58.761");
+        const latitude = parseFloat("-64.2159");
+        const height = 0.23457504296675324;
 
         const create = /* GraphQL */ `
             mutation CreatePhotographs(
@@ -170,11 +169,11 @@ describe("Point", () => {
     });
 
     test("enables update of a node with a wgs-84 point", async () => {
-        const id = faker.string.uuid();
-        const size = faker.number.int({ max: 100000 });
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude().toString());
-        const newLatitude = parseFloat(faker.location.latitude().toString());
+        const id = "09132bb0-504a-407c-9096-6d945695dc89";
+        const size = 95026;
+        const longitude = parseFloat("117.5113");
+        const latitude = parseFloat("9.5509");
+        const newLatitude = parseFloat("10.6116");
 
         const beforeResult = await testHelper.executeCypher(`
             CALL {
@@ -237,12 +236,12 @@ describe("Point", () => {
     });
 
     test("enables update of a node with a wgs-84-3d point", async () => {
-        const id = faker.string.uuid();
-        const size = faker.number.int({ max: 100000 });
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude().toString());
-        const height = faker.number.float();
-        const newLatitude = parseFloat(faker.location.latitude().toString());
+        const id = "3b3170d8-03ed-43be-ae02-876a4233e2c7";
+        const size = 55312;
+        const longitude = parseFloat("102.1785");
+        const latitude = parseFloat("78.8688");
+        const height = 0.9209601751063019;
+        const newLatitude = parseFloat("71.2271");
 
         const beforeResult = await testHelper.executeCypher(`
             CALL {
@@ -309,10 +308,10 @@ describe("Point", () => {
 
     test("enables query of a node with a wgs-84 point", async () => {
         // Create node
-        const id = faker.string.uuid();
-        const size = faker.number.int({ max: 100000 });
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude({ max: 88 }).toString());
+        const id = "f8a5a58a-7380-4a39-9103-07a2c0528d8e";
+        const size = 31364;
+        const longitude = parseFloat("62.5196");
+        const latitude = parseFloat("-41.1021");
 
         const result = await testHelper.executeCypher(`
             CALL {
@@ -382,8 +381,8 @@ describe("Point", () => {
                 locations: [
                     { longitude, latitude },
                     {
-                        longitude: parseFloat(faker.location.longitude().toString()),
-                        latitude: parseFloat(faker.location.latitude().toString()),
+                        longitude: parseFloat("-156.8208"),
+                        latitude: parseFloat("64.9108"),
                     },
                 ],
             },
@@ -421,12 +420,12 @@ describe("Point", () => {
             variableValues: {
                 locations: [
                     {
-                        longitude: parseFloat(faker.location.longitude().toString()),
-                        latitude: parseFloat(faker.location.latitude().toString()),
+                        longitude: parseFloat("147.0866"),
+                        latitude: parseFloat("-64.3432"),
                     },
                     {
-                        longitude: parseFloat(faker.location.longitude().toString()),
-                        latitude: parseFloat(faker.location.latitude().toString()),
+                        longitude: parseFloat("-97.4775"),
+                        latitude: parseFloat("-61.2485"),
                     },
                 ],
             },
@@ -514,11 +513,11 @@ describe("Point", () => {
     });
 
     test("enables query for equality of a node with a wgs-84-3d point", async () => {
-        const id = faker.string.uuid();
-        const size = faker.number.int({ max: 100000 });
-        const longitude = parseFloat(faker.location.longitude().toString());
-        const latitude = parseFloat(faker.location.latitude().toString());
-        const height = faker.number.float();
+        const id = "3019fe82-5231-4103-8662-39c1fcc7d50c";
+        const size = 99119;
+        const longitude = parseFloat("125.6358");
+        const latitude = parseFloat("-7.2045");
+        const height = 0.6950517320074141;
 
         const result = await testHelper.executeCypher(`
             CALL {

--- a/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -42,10 +41,10 @@ describe("[CartesianPoint]", () => {
     });
 
     test("enables creation of a node with multiple cartesian points", async () => {
-        const id = faker.string.uuid();
-        const locations = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            x: faker.number.float(),
-            y: faker.number.float(),
+        const id = "9447ac23-6f8b-4ee3-88f1-0428c9e5a4af";
+        const locations = [...new Array(2)].map(() => ({
+            x: 0.08219389710575342,
+            y: 0.09543730691075325,
         }));
 
         const create = /* GraphQL */ `
@@ -92,11 +91,11 @@ describe("[CartesianPoint]", () => {
     });
 
     test("enables creation of a node with multiple cartesian-3d points", async () => {
-        const id = faker.string.uuid();
-        const locations = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            x: faker.number.float(),
-            y: faker.number.float(),
-            z: faker.number.float(),
+        const id = "fceabcc2-3086-48a5-9297-ea17e2dd9d4b";
+        const locations = [...new Array(8)].map(() => ({
+            x: 0.0814846286084503,
+            y: 0.9454853804782033,
+            z: 0.051746641751378775,
         }));
 
         const create = /* GraphQL */ `
@@ -143,13 +142,13 @@ describe("[CartesianPoint]", () => {
     });
 
     test("enables update of a node with multiple cartesian points", async () => {
-        const id = faker.string.uuid();
-        const locations = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            x: faker.number.float(),
-            y: faker.number.float(),
+        const id = "675a957f-a4ca-42fa-b33c-84bd9e9e66de";
+        const locations = [...new Array(8)].map(() => ({
+            x: 0.9849797878414392,
+            y: 0.7501204372383654,
         }));
         const newLocations = locations.map((location) => ({
-            x: faker.number.float(),
+            x: 0.9360741777345538,
             y: location.y,
         }));
 
@@ -223,14 +222,14 @@ describe("[CartesianPoint]", () => {
     });
 
     test("enables update of a node with multiple cartesian-3d points", async () => {
-        const id = faker.string.uuid();
-        const locations = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            x: faker.number.float(),
-            y: faker.number.float(),
-            z: faker.number.float(),
+        const id = "b6c4a0ac-16ae-463b-9bd1-3ecae2307484";
+        const locations = [...new Array(4)].map(() => ({
+            x: 0.8189982105977833,
+            y: 0.3447179892100394,
+            z: 0.8076386945322156,
         }));
         const newLocations = locations.map((location) => ({
-            x: faker.number.float(),
+            x: 0.6024873733986169,
             y: location.y,
             z: location.z,
         }));
@@ -307,10 +306,10 @@ describe("[CartesianPoint]", () => {
     });
 
     test("enables query of a node with multiple cartesian points", async () => {
-        const id = faker.string.uuid();
-        const locations = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            x: faker.number.float(),
-            y: faker.number.float(),
+        const id = "5ba92bc4-95e7-4361-857c-60edcd771391";
+        const locations = [...new Array(8)].map(() => ({
+            x: 0.02772025833837688,
+            y: 0.07264417805708945,
         }));
 
         await testHelper.executeCypher(
@@ -351,11 +350,11 @@ describe("[CartesianPoint]", () => {
     });
 
     test("enables query of a node with multiple cartesian-3d points", async () => {
-        const id = faker.string.uuid();
-        const locations = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            x: faker.number.float(),
-            y: faker.number.float(),
-            z: faker.number.float(),
+        const id = "052322ec-95e5-4b88-8a90-9f0c1df17ee3";
+        const locations = [...new Array(8)].map(() => ({
+            x: 0.8367510938551277,
+            y: 0.7110547178890556,
+            z: 0.9648887133225799,
         }));
 
         await testHelper.executeCypher(

--- a/packages/graphql/tests/integration/types/points.int.test.ts
+++ b/packages/graphql/tests/integration/types/points.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
 import { TestHelper } from "../utils/tests-helper";
@@ -42,10 +41,10 @@ describe("[Point]", () => {
     });
 
     test("enables creation of a node with multiple wgs-84 points", async () => {
-        const id = faker.string.uuid();
-        const waypoints = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
-            latitude: parseFloat(faker.location.latitude().toString()),
+        const id = "68b83f50-bf58-4858-b559-ac9f0480b84d";
+        const waypoints = [...new Array(3)].map(() => ({
+            longitude: parseFloat("-109.3787"),
+            latitude: parseFloat("-86.9408"),
         }));
 
         const create = `
@@ -92,11 +91,11 @@ describe("[Point]", () => {
     });
 
     test("enables creation of a node with multiple wgs-84-3d points", async () => {
-        const id = faker.string.uuid();
-        const waypoints = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
-            latitude: parseFloat(faker.location.latitude().toString()),
-            height: faker.number.float(),
+        const id = "dc253044-0795-4899-8419-8eedce25e2c3";
+        const waypoints = [...new Array(4)].map(() => ({
+            longitude: parseFloat("147.2789"),
+            latitude: parseFloat("-32.9044"),
+            height: 0.33790676412172616,
         }));
 
         const create = `
@@ -144,13 +143,13 @@ describe("[Point]", () => {
     });
 
     test("enables update of a node with multiple wgs-84 points", async () => {
-        const id = faker.string.uuid();
-        const waypoints = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
-            latitude: parseFloat(faker.location.latitude().toString()),
+        const id = "583824bf-87c3-48c7-a482-feb308e39553";
+        const waypoints = [...new Array(3)].map(() => ({
+            longitude: parseFloat("177.9109"),
+            latitude: parseFloat("58.4798"),
         }));
         const newWaypoints = waypoints.map((waypoint) => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
+            longitude: parseFloat("128.9727"),
             latitude: waypoint.latitude,
         }));
 
@@ -225,14 +224,14 @@ describe("[Point]", () => {
     });
 
     test("enables update of a node with multiple wgs-84-3d points", async () => {
-        const id = faker.string.uuid();
-        const waypoints = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
-            latitude: parseFloat(faker.location.latitude().toString()),
-            height: faker.number.float(),
+        const id = "2f2a284c-17c4-4d40-8a87-63516338d505";
+        const waypoints = [...new Array(4)].map(() => ({
+            longitude: parseFloat("25.2545"),
+            latitude: parseFloat("-73.11"),
+            height: 0.14806141727603972,
         }));
         const newWaypoints = waypoints.map((waypoint) => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
+            longitude: parseFloat("-81.0101"),
             latitude: waypoint.latitude,
             height: waypoint.height,
         }));
@@ -312,10 +311,10 @@ describe("[Point]", () => {
 
     test("enables query of a node with multiple wgs-84 points", async () => {
         // Create test data and prepare for testing
-        const id = faker.string.uuid();
-        const waypoints = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
-            latitude: parseFloat(faker.location.latitude().toString()),
+        const id = "25c4676e-1e38-4b1b-b156-6a7e28c8013e";
+        const waypoints = [...new Array(9)].map(() => ({
+            longitude: parseFloat("34.1879"),
+            latitude: parseFloat("30.5402"),
         }));
 
         await testHelper.executeCypher(
@@ -398,8 +397,8 @@ describe("[Point]", () => {
         const routesNotIncludesResult = await testHelper.executeGraphQL(routesNotIncludesQuery, {
             variableValues: {
                 waypoint: {
-                    longitude: parseFloat(faker.location.longitude().toString()),
-                    latitude: parseFloat(faker.location.latitude().toString()),
+                    longitude: parseFloat("124.5589"),
+                    latitude: parseFloat("89.7757"),
                 },
             },
         });
@@ -412,11 +411,11 @@ describe("[Point]", () => {
     });
 
     test("enables query of a node with multiple wgs-84-3d points", async () => {
-        const id = faker.string.uuid();
-        const waypoints = [...new Array(faker.number.int({ min: 2, max: 10 }))].map(() => ({
-            longitude: parseFloat(faker.location.longitude().toString()),
-            latitude: parseFloat(faker.location.latitude().toString()),
-            height: faker.number.float(),
+        const id = "dd320626-cc23-4938-9f33-ba624a3a3e8d";
+        const waypoints = [...new Array(7)].map(() => ({
+            longitude: parseFloat("146.1568"),
+            latitude: parseFloat("-54.6132"),
+            height: 0.03157347836531699,
         }));
 
         await testHelper.executeCypher(

--- a/packages/graphql/tests/integration/types/time.int.test.ts
+++ b/packages/graphql/tests/integration/types/time.int.test.ts
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 
-import { faker } from "@faker-js/faker";
 import { Time, isTime } from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseTime } from "../../../src/graphql/scalars/Time";
@@ -49,7 +48,7 @@ describe("Time", () => {
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
             const id = generate({ readable: false });
-            const time = faker.date.past().toISOString().split("T")[1];
+            const time = "2024-01-29T03:57:32.358Z".split("T")[1];
             const parsedTime = parseTime(time);
 
             const mutation = `
@@ -100,9 +99,7 @@ describe("Time", () => {
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
             const id = generate({ readable: false });
-            const times = [...new Array(faker.number.int({ min: 2, max: 4 }))].map(
-                () => faker.date.past().toISOString().split("T")[1]
-            );
+            const times = [...new Array(4)].map(() => "2023-06-09T11:17:47.789Z".split("T")[1]);
             const parsedTimes = times.map((time) => parseTime(time));
 
             const mutation = `
@@ -169,7 +166,7 @@ describe("Time", () => {
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
             const id = generate({ readable: false });
-            const time = faker.date.past().toISOString().split("T")[1];
+            const time = "2023-07-12T05:44:06.918Z".split("T")[1];
             const parsedTime = parseTime(time);
 
             await testHelper.executeCypher(
@@ -230,7 +227,7 @@ describe("Time", () => {
             await testHelper.initNeo4jGraphQL({ typeDefs });
 
             const id = generate({ readable: false });
-            const date = faker.date.future();
+            const date = new Date("2024-02-17T11:49:48.322Z");
             const time = date.toISOString().split("T")[1];
             const neo4jTime = Time.fromStandardDate(date);
             const parsedTime = parseTime(time);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,13 +1754,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@faker-js/faker@npm:8.4.1":
-  version: 8.4.1
-  resolution: "@faker-js/faker@npm:8.4.1"
-  checksum: 10c0/4f2aecddcfdc2cc8b50b2d15d1e37302a7c7a5bbd184ae910a9d271bc11248533ca74dcdd4a9ccbe20410553e7af0f6a4d334c5b955635e09a32ddf4a64942d4
-  languageName: node
-  linkType: hard
-
 "@fastify/accept-negotiator@npm:^1.0.0":
   version: 1.1.0
   resolution: "@fastify/accept-negotiator@npm:1.1.0"
@@ -2880,7 +2873,6 @@ __metadata:
     "@apollo/gateway": "npm:2.7.2"
     "@apollo/server": "npm:4.10.2"
     "@apollo/subgraph": "npm:^2.2.3"
-    "@faker-js/faker": "npm:8.4.1"
     "@graphql-tools/merge": "npm:^9.0.0"
     "@graphql-tools/resolvers-composition": "npm:^7.0.0"
     "@graphql-tools/schema": "npm:10.0.3"


### PR DESCRIPTION
# Description
Testing values generated with faker has been a source of flaky tests in several cases. This PR removes all usage of faker and replaces them with static values (generated with faker)
