### PR TITLE
Move test-helper to common test utils

### DIFF
--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization-where.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe(`Field Level Authorization Where Requests`, () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-authorization.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Field Level Aggregations Auth", () => {
     const testCases = [

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-field-authorization.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Field Level Aggregations Field Authorization", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/authorization/field-aggregation-where-with-authorization.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe(`Field Level Authorization Where Requests`, () => {
     let token: string;

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations-graphql-alias.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Field Level Aggregations Graphql alias", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/field-level-aggregations.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Field Level Aggregations", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/nested-field-level-aggregations.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Nested Field Level Aggregations", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/field-level/where/field-aggregation-where.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("Field Level Aggregations Where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/alias.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-alias", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/authorization.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level authorization", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/basic.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-basic", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/bigint.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { generate } from "randomstring";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-bigint", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/count.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { generate } from "randomstring";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Aggregate -> count", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/datetime.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-datetime", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/duration.int.test.ts
@@ -20,7 +20,7 @@
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-duration", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/float.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-float", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/id.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-id", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/int.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-int", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/many.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-many", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/top-level/string.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-top_level-string", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/AND-OR-operations.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Nested within AND/OR", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/count.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("aggregations-where-count", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/bigint.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-bigint", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/datetime.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-datetime", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/duration.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-duration", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/float.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-float", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/id.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-id", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/int.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-int", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/edge/string.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-edge-string", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/delete/top-level-where.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../../utils/graphql-types";
-import { TestHelper } from "../../../../utils/tests-helper";
+import { TestHelper } from "../../../../../utils/tests-helper";
 
 describe("Delete using top level aggregate where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/connect-arg.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../../utils/graphql-types";
-import { TestHelper } from "../../../../utils/tests-helper";
+import { TestHelper } from "../../../../../utils/tests-helper";
 
 describe("Connect using aggregate where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/disconnect-arg.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../../utils/graphql-types";
-import { TestHelper } from "../../../../utils/tests-helper";
+import { TestHelper } from "../../../../../utils/tests-helper";
 
 describe("Disconnect using aggregate where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/top-level-where.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../../utils/graphql-types";
-import { TestHelper } from "../../../../utils/tests-helper";
+import { TestHelper } from "../../../../../utils/tests-helper";
 
 describe("Delete using top level aggregate where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/mutations/update/update-arg.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../../../utils/graphql-types";
-import { TestHelper } from "../../../../utils/tests-helper";
+import { TestHelper } from "../../../../../utils/tests-helper";
 
 describe("Update using aggregate where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/node/bigint-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/bigint-connections.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-bigint - connections", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/bigint.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-bigint", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/node/datetime-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/datetime-connections.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-datetime - connections", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/datetime.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-datetime", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/float-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/float-connections.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-float - connections", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/float.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-float", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/node/id-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/id-connections.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-id - connections", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/id.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-id", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/aggregations/where/node/int-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int-connections.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-int - connections", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/int.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-int", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/string-connections.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/string-connections.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-string - connections", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
+++ b/packages/graphql/tests/integration/aggregations/where/node/string.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("aggregations-where-node-string", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/aliasing.int.test.ts
+++ b/packages/graphql/tests/integration/aliasing.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Aliasing", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push-errors.int.test.ts
@@ -22,7 +22,7 @@ import { gql } from "graphql-tag";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-pop-and-push", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-and-push.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-pop-and-push", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop-errors.int.test.ts
@@ -22,7 +22,7 @@ import { gql } from "graphql-tag";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-pop-errors", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-pop.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-pop", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push-errors.int.test.ts
@@ -22,7 +22,7 @@ import { gql } from "graphql-tag";
 import { IncomingMessage } from "http";
 import { Socket } from "net";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-push", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-push.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-push", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("array-subscription", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/composite-where.int.test.ts
+++ b/packages/graphql/tests/integration/composite-where.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("composite-where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/config-options/query-options.int.test.ts
+++ b/packages/graphql/tests/integration/config-options/query-options.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import type { Neo4jGraphQL } from "../../../src";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("query options", () => {
     let neoSchema: Neo4jGraphQL;

--- a/packages/graphql/tests/integration/connect-or-create/connect-or-create-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/connect-or-create-authorization.int.test.ts
@@ -19,7 +19,7 @@
 
 import { type Integer } from "neo4j-driver";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("connectOrCreate", () => {
     describe("Update -> ConnectOrCreate", () => {

--- a/packages/graphql/tests/integration/connect-or-create/connect-or-create-id.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/connect-or-create-id.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("connect-or-create with @id", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connect-or-create/create-connect-or-create-union.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/create-connect-or-create-union.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { type Integer } from "neo4j-driver";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Create -> ConnectOrCreate Union", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connect-or-create/create-connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/create-connect-or-create.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Integer, QueryResult } from "neo4j-driver";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 async function runAndParseRecords<T extends Record<string, unknown>>(
     testHelper: TestHelper,

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-top-level.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Integer } from "neo4j-driver";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Update -> ConnectOrCreate Top Level", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union-top-level.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { type Integer } from "neo4j-driver";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Update -> ConnectOrCreate union top level", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create-union.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { type Integer } from "neo4j-driver";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Update -> ConnectOrCreate Union", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connect-or-create/update-connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/connect-or-create/update-connect-or-create.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { Integer } from "neo4j-driver";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Update -> ConnectOrCreate", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connection-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/connection-resolvers.int.test.ts
@@ -20,7 +20,7 @@
 import { offsetToCursor } from "graphql-relay";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Connection Resolvers", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/alias.int.test.ts
+++ b/packages/graphql/tests/integration/connections/alias.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Connections Alias", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/enums.int.test.ts
+++ b/packages/graphql/tests/integration/connections/enums.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Enum Relationship Properties", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/filtering.int.test.ts
+++ b/packages/graphql/tests/integration/connections/filtering.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Connections Filtering", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/connections/interfaces-top-level.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Interfaces top level connections", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/connections/interfaces.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Connections -> Interfaces", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/nested.int.test.ts
+++ b/packages/graphql/tests/integration/connections/nested.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Connections Alias", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/connections/sort.int.test.ts
+++ b/packages/graphql/tests/integration/connections/sort.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 const testLabel = generate({ charset: "alphabetic" });
 

--- a/packages/graphql/tests/integration/connections/unions.int.test.ts
+++ b/packages/graphql/tests/integration/connections/unions.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { Neo4jGraphQL } from "../../../src/classes";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Connections -> Unions", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/create.int.test.ts
+++ b/packages/graphql/tests/integration/create.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("create", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/custom-directives.int.test.ts
+++ b/packages/graphql/tests/integration/custom-directives.int.test.ts
@@ -23,7 +23,7 @@ import { defaultFieldResolver, graphql } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Custom Directives", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/custom-resolvers.int.test.ts
@@ -21,7 +21,7 @@ import { createSourceEventStream, parse } from "graphql";
 import { driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Custom Resolvers", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/custom-scalar-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/custom-scalar-filtering.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Custom Scalar Filtering", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/cypher-params.int.test.ts
+++ b/packages/graphql/tests/integration/cypher-params.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("cypherParams", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/default-values.int.test.ts
+++ b/packages/graphql/tests/integration/default-values.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Default values", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/delete-interface.int.test.ts
+++ b/packages/graphql/tests/integration/delete-interface.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("delete interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/delete-union.int.test.ts
+++ b/packages/graphql/tests/integration/delete-union.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("delete union relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/delete.int.test.ts
+++ b/packages/graphql/tests/integration/delete.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("delete", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/alias.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias.int.test.ts
@@ -20,7 +20,7 @@
 import * as neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("@alias directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/alias/connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/connect-or-create.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("@alias directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/alias/nodes.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/nodes.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("@alias directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/alias/unions.int.test.ts
+++ b/packages/graphql/tests/integration/directives/alias/unions.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("@alias directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/allow-unauthenticated.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/allow-unauthenticated.int.test.ts
@@ -21,7 +21,7 @@ import { IncomingMessage } from "http";
 import { Socket } from "net";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 // Reference: https://github.com/neo4j/graphql/pull/355
 // Reference: https://github.com/neo4j/graphql/issues/345

--- a/packages/graphql/tests/integration/directives/authorization/allow.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/allow.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/allow", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/bind.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/bind.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/bind", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/custom-cypher.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/custom-cypher.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("should inject the auth into cypher directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/custom-resolvers.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/custom-resolvers.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/custom-resolvers", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/is-authenticated.int.test.ts
@@ -23,7 +23,7 @@ import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/is-authenticated", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/jwks-endpoint.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/jwks-endpoint.int.test.ts
@@ -26,7 +26,7 @@ import createJWKSMock from "mock-jwks";
 import { generate } from "randomstring";
 import supertest from "supertest";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/jwks-endpoint", () => {
     let jwksMock: JWKSMock;

--- a/packages/graphql/tests/integration/directives/authorization/object-path.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/object-path.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/object-path", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/roles.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/roles.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/roles", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/authorization/where.int.test.ts
+++ b/packages/graphql/tests/integration/directives/authorization/where.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/where", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/coalesce.int.test.ts
+++ b/packages/graphql/tests/integration/directives/coalesce.int.test.ts
@@ -19,7 +19,7 @@
 
 import { GraphQLError } from "graphql";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("@coalesce directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/customResolver.int.test.ts
+++ b/packages/graphql/tests/integration/directives/customResolver.int.test.ts
@@ -21,7 +21,7 @@ import gql from "graphql-tag";
 import { INVALID_REQUIRED_FIELD_ERROR } from "../../../src/schema/get-custom-resolver-meta";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("@customResolver directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/cypher/cypher-interface.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/cypher-interface.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("cypher targeting interface", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/cypher/cypher-union.int.test.ts
+++ b/packages/graphql/tests/integration/directives/cypher/cypher-union.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("cypher targeting union", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/cypher/cypher.ts
+++ b/packages/graphql/tests/integration/directives/cypher/cypher.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("cypher directive", () => {
     const testHelper = new TestHelper();
@@ -101,9 +101,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResult.errors).toBeFalsy();
 
-                expect((gqlResult?.data as any).customMovies).toEqual([
-                    { title: movieTitle, actors: [{ name: actorName }] },
-                ]);
+                expect((gqlResult?.data).customMovies).toEqual([{ title: movieTitle, actors: [{ name: actorName }] }]);
             });
 
             test("should query custom query and return relationship data with custom where on field", async () => {
@@ -164,9 +162,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResult.errors).toBeFalsy();
 
-                expect((gqlResult?.data as any).customMovies).toEqual([
-                    { title: movieTitle, actors: [{ name: actorName }] },
-                ]);
+                expect((gqlResult?.data).customMovies).toEqual([{ title: movieTitle, actors: [{ name: actorName }] }]);
             });
 
             test("should query custom query and return relationship data with auth", async () => {
@@ -308,16 +304,16 @@ describe("cypher directive", () => {
 
                 expect(gqlResult.errors).toBeFalsy();
 
-                expect((gqlResult?.data as any).customMovies).toHaveLength(3);
-                expect((gqlResult?.data as any).customMovies).toContainEqual({
+                expect((gqlResult?.data).customMovies).toHaveLength(3);
+                expect((gqlResult?.data).customMovies).toContainEqual({
                     title: movieTitle1,
                     actors: [{ name: actorName }],
                 });
-                expect((gqlResult?.data as any).customMovies).toContainEqual({
+                expect((gqlResult?.data).customMovies).toContainEqual({
                     title: movieTitle2,
                     actors: [{ name: actorName }],
                 });
-                expect((gqlResult?.data as any).customMovies).toContainEqual({
+                expect((gqlResult?.data).customMovies).toContainEqual({
                     title: movieTitle3,
                     actors: [{ name: actorName }],
                 });
@@ -488,9 +484,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResult.errors).toBeFalsy();
 
-                expect((gqlResult?.data as any).customMovies).toEqual([
-                    { title: movieTitle, actors: [{ name: actorName }] },
-                ]);
+                expect((gqlResult?.data).customMovies).toEqual([{ title: movieTitle, actors: [{ name: actorName }] }]);
             });
 
             test("should query custom mutation and return relationship data with custom where on field", async () => {
@@ -550,9 +544,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResult.errors).toBeFalsy();
 
-                expect((gqlResult?.data as any).customMovies).toEqual([
-                    { title: movieTitle, actors: [{ name: actorName }] },
-                ]);
+                expect((gqlResult?.data).customMovies).toEqual([{ title: movieTitle, actors: [{ name: actorName }] }]);
             });
 
             test("should query custom mutation and return relationship data with auth", async () => {
@@ -688,9 +680,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResultWithDefaultValue.errors).toBeFalsy();
 
-                expect((gqlResultWithDefaultValue?.data as any).townDestinationList).toEqual(
-                    expectedTownDestinationList
-                );
+                expect((gqlResultWithDefaultValue?.data).townDestinationList).toEqual(expectedTownDestinationList);
             });
 
             test("should return test value", async () => {
@@ -712,9 +702,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResultWithDefaultValue.errors).toBeFalsy();
 
-                expect((gqlResultWithDefaultValue?.data as any).townDestinationList).toEqual(
-                    expectedTownDestinationList
-                );
+                expect((gqlResultWithDefaultValue?.data).townDestinationList).toEqual(expectedTownDestinationList);
             });
         });
 
@@ -782,9 +770,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResultWithMissingValue.errors).toBeFalsy();
 
-                expect((gqlResultWithMissingValue?.data as any).townDestinationList).toEqual(
-                    expectedTownDestinationList
-                );
+                expect((gqlResultWithMissingValue?.data).townDestinationList).toEqual(expectedTownDestinationList);
             });
 
             test("should return test value", async () => {
@@ -806,9 +792,7 @@ describe("cypher directive", () => {
 
                 expect(gqlResultWithMissingValue.errors).toBeFalsy();
 
-                expect((gqlResultWithMissingValue?.data as any).townDestinationList).toEqual(
-                    expectedTownDestinationList
-                );
+                expect((gqlResultWithMissingValue?.data).townDestinationList).toEqual(expectedTownDestinationList);
             });
         });
 

--- a/packages/graphql/tests/integration/directives/default.int.test.ts
+++ b/packages/graphql/tests/integration/directives/default.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { GraphQLError } from "graphql";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("@default directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/fulltext/fulltext-argument.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext/fulltext-argument.int.test.ts
@@ -20,7 +20,7 @@
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { isMultiDbUnsupportedError } from "../../../utils/is-multi-db-unsupported-error";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("@fulltext directive", () => {
     let driver: Driver;

--- a/packages/graphql/tests/integration/directives/fulltext/fulltext-index.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext/fulltext-index.int.test.ts
@@ -20,7 +20,7 @@
 import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import { isMultiDbUnsupportedError } from "../../../utils/is-multi-db-unsupported-error";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("@fulltext directive - indexes constraints", () => {
     let driver: Driver;

--- a/packages/graphql/tests/integration/directives/fulltext/fulltext-query.int.test.ts
+++ b/packages/graphql/tests/integration/directives/fulltext/fulltext-query.int.test.ts
@@ -26,7 +26,7 @@ import { upperFirst } from "../../../../src/utils/upper-first";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
 import { isMultiDbUnsupportedError } from "../../../utils/is-multi-db-unsupported-error";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 function generatedTypeDefs(personType: UniqueType, movieType: UniqueType): string {
     return `

--- a/packages/graphql/tests/integration/directives/id.int.test.ts
+++ b/packages/graphql/tests/integration/directives/id.int.test.ts
@@ -20,7 +20,7 @@
 import isUUID from "is-uuid";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("@id directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/node/label.int.test.ts
+++ b/packages/graphql/tests/integration/directives/node/label.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Node directive labels", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/populatedBy.int.test.ts
+++ b/packages/graphql/tests/integration/directives/populatedBy.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("@populatedBy directive", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/relationship/nestedOperations.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relationship/nestedOperations.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("@relationhip - nestedOperations", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-database-name.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-database-name.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import { toGlobalId } from "../../../../src/utils/global-ids";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("RelayId projection with different database name", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-field-alias.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection-with-field-alias.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import { toGlobalId } from "../../../../src/utils/global-ids";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 // used to confirm the issue: https://github.com/neo4j/graphql/issues/4158
 describe("RelayId projection with GraphQL field alias", () => {

--- a/packages/graphql/tests/integration/directives/relayId/relayId-projection.int.test.ts
+++ b/packages/graphql/tests/integration/directives/relayId/relayId-projection.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import { toGlobalId } from "../../../../src/utils/global-ids";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("RelayId projection", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/timestamp/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/directives/timestamp/datetime.int.test.ts
@@ -20,7 +20,7 @@
 import { type DateTime } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("timestamp/datetime", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/timestamp/time.int.test.ts
+++ b/packages/graphql/tests/integration/directives/timestamp/time.int.test.ts
@@ -21,7 +21,7 @@ import type { Integer } from "neo4j-driver";
 import { isTime } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("timestamp/time", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/directives/unique.int.test.ts
+++ b/packages/graphql/tests/integration/directives/unique.int.test.ts
@@ -22,7 +22,7 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { Neo4jDatabaseInfo } from "../../../src/classes/Neo4jDatabaseInfo";
 import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("assertIndexesAndConstraints/unique", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/enums.int.test.ts
+++ b/packages/graphql/tests/integration/enums.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("enums", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/field-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/field-filtering.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("field-filtering", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/advanced-filtering.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Advanced Filtering", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-interface-relationship.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/filter-union-relationship.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("union relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/filtering/operations.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/operations.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Filtering Operations", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/single-relationship.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Single relationship (1-*) filtering", () => {
     let Person: UniqueType;

--- a/packages/graphql/tests/integration/filtering/typename-in-auth.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/typename-in-auth.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("typename_IN with auth", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/filtering/typename-in.int.test.ts
+++ b/packages/graphql/tests/integration/filtering/typename-in.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("typename_IN", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/find.int.test.ts
+++ b/packages/graphql/tests/integration/find.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("find", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/fragments.int.test.ts
+++ b/packages/graphql/tests/integration/fragments.int.test.ts
@@ -19,7 +19,7 @@
 
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("fragments", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/global-node.int.test.ts
+++ b/packages/graphql/tests/integration/global-node.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { toGlobalId } from "../../src/utils/global-ids";
 import { createBearerToken } from "../utils/create-bearer-token";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Global node resolution", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/info.int.test.ts
+++ b/packages/graphql/tests/integration/info.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("info", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-field-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-field-level-with-auth.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { GraphQLError } from "graphql";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Interface Field Level Aggregations with authorization", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-field-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-field-level.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Interface Field Level Aggregations", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { GraphQLError } from "graphql";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Top-level interface query fields with authorization", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/aggregation-interfaces-top-level.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Top-level interface query fields", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-field-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-field-level-with-auth.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { GraphQLError } from "graphql";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Field-level filter interface query fields with authorization", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-field-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-field-level.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Field-level filter interface query fields", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-top-level-with-auth.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-top-level-with-auth.int.test.ts
@@ -19,7 +19,7 @@
 
 import type { GraphQLError } from "graphql";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Top-level filter interface query fields with authorization", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/aggegations/filter-aggregation-interfaces-top-level.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Top-level filter interface query fields", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/interface-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/interface-filtering.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Interface filtering", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/interfaces-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/interfaces-top-level.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Top-level interface query fields", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/interfaces.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Interfaces tests", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/interfaces/relationships/create/connect.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/create/connect.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/create/create.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-filters.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-filters.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface filters of declared relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-one-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-one-level-chain.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface implementing interface with declared relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-simple.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-simple.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface with declared relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-three-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-three-level-chain.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface implementing interface with declared relationships - three level interface chain", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-two-level-chain.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/interface-two-level-chain.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface implementing interface with declared relationships - two level interface chain", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-mutations.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-mutations.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 // TODO: maybe use type-narrowing-connections
 describe("type narrowing - mutations setup", () => {

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-nested.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing-nested.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("type narrowing nested connections", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/declare-relationship/type-narrowing.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("type narrowing - simple case", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/delete/delete.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/read.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/read.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/update/connect.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/connect.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/update/create.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/create.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/update/delete.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/delete.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/update/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/disconnect.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/interfaces/relationships/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/interfaces/relationships/update/update.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../../../utils/graphql-types";
-import { TestHelper } from "../../../utils/tests-helper";
+import { TestHelper } from "../../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1049.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1049.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1049", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1050.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1050.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1050", () => {
     let testUser: UniqueType;

--- a/packages/graphql/tests/integration/issues/1115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1115.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1115", () => {
     let parentType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1121.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1121.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1121", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1127.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1127.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1127", () => {
     let customerType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1132.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1132.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1132", () => {
     const secret = "secret";

--- a/packages/graphql/tests/integration/issues/1150.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1150.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1150", () => {
     const secret = "secret";

--- a/packages/graphql/tests/integration/issues/1221.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1221.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1221", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1249.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1249", () => {
     const testHelper = new TestHelper();
@@ -28,7 +28,7 @@ describe("https://github.com/neo4j/graphql/issues/1249", () => {
     let Supplier: UniqueType;
     let typeDefs: string;
 
-    beforeAll( () => {
+    beforeAll(() => {
         Bulk = testHelper.createUniqueType("Bulk");
         Material = testHelper.createUniqueType("Material");
         Supplier = testHelper.createUniqueType("Supplier");

--- a/packages/graphql/tests/integration/issues/1287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1287.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1287", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1320.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1320.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1320", () => {
     let riskType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1348.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1348.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1348", () => {
     let Series: UniqueType;

--- a/packages/graphql/tests/integration/issues/1364.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1364.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1364", () => {
     let testActor: UniqueType;

--- a/packages/graphql/tests/integration/issues/1414.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1414.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1414", () => {
     let testProduct: UniqueType;

--- a/packages/graphql/tests/integration/issues/1430.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1430.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1430", () => {
     let testAbce: UniqueType;

--- a/packages/graphql/tests/integration/issues/1528.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1528.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1528", () => {
     let testPerson: UniqueType;

--- a/packages/graphql/tests/integration/issues/1535.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1535.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1535", () => {
     let testTenant: UniqueType;

--- a/packages/graphql/tests/integration/issues/1536.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1536.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1536", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1551.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1551.int.test.ts
@@ -19,7 +19,7 @@
 
 import { GraphQLError } from "graphql";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1551", () => {
     let testType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1566.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1566.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1566", () => {
     let testContent: UniqueType;

--- a/packages/graphql/tests/integration/issues/1640.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1640.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1640", () => {
     let testAdmin: UniqueType;

--- a/packages/graphql/tests/integration/issues/1683.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1683.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1683", () => {
     let systemType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1686.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1686.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1686", () => {
     let productionType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1687.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1687.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1687", () => {
     let productionType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1735.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1735.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1735", () => {
     let actorType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1751.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1751.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1735", () => {
     let organizationType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1756.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1756.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1756", () => {
     let productType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1760.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1760.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1760", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1761.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1761.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1761", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1779.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1779.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1779", () => {
     let personType: UniqueType;

--- a/packages/graphql/tests/integration/issues/1782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1782.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1782", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1783.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1783.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1783", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1817.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1817.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1817", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/1848.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1848.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1848", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/190.int.test.ts
+++ b/packages/graphql/tests/integration/issues/190.int.test.ts
@@ -20,7 +20,7 @@
 import type { DocumentNode } from "graphql";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/190", () => {
     let User: UniqueType;
@@ -117,7 +117,7 @@ describe("https://github.com/neo4j/graphql/issues/190", () => {
 
         expect(result.errors).toBeFalsy();
 
-        expect(result?.data?.[User.plural]).toHaveLength(2);
+        expect((result?.data as any)?.[User.plural]).toHaveLength(2);
 
         expect((result?.data as any)?.[User.plural].filter((u) => u.uid === "user1")[0].demographics).toHaveLength(3);
         expect((result?.data as any)?.[User.plural].filter((u) => u.uid === "user1")[0].demographics).toContainEqual({

--- a/packages/graphql/tests/integration/issues/1933.int.test.ts
+++ b/packages/graphql/tests/integration/issues/1933.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1933", () => {
     let employeeType: UniqueType;

--- a/packages/graphql/tests/integration/issues/200.int.test.ts
+++ b/packages/graphql/tests/integration/issues/200.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/200", () => {
     let Category: UniqueType;

--- a/packages/graphql/tests/integration/issues/2022.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2022.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2022", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2068.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2068.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/pull/2068", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/207.int.test.ts
+++ b/packages/graphql/tests/integration/issues/207.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/207", () => {
     let Book: UniqueType;

--- a/packages/graphql/tests/integration/issues/2100.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2100.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2100", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2189.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2189.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2189", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2249.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2249.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2249", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2250.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2250.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2250", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2261.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2261.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2261", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2262.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2262.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2262", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2267.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2267.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2267", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/227.int.test.ts
+++ b/packages/graphql/tests/integration/issues/227.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/227", () => {
     let Member: UniqueType;

--- a/packages/graphql/tests/integration/issues/235.int.test.ts
+++ b/packages/graphql/tests/integration/issues/235.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/235", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2388.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2388", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2396.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2396.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2396", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2437.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2437.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2437", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/247.int.test.ts
+++ b/packages/graphql/tests/integration/issues/247.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/247", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2474.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2474.int.test.ts
@@ -19,7 +19,7 @@
 
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2548.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2548.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2548", () => {
     const secret = "secret";

--- a/packages/graphql/tests/integration/issues/2560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2560.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2560", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2574.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2574.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2574", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2581.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2581.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2581", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2630.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2630", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2652.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2652.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2652", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2662.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2662.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2662", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2669.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2669.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2669", () => {
     const testHelper = new TestHelper();
@@ -47,7 +47,7 @@ describe("https://github.com/neo4j/graphql/issues/2669", () => {
         }
         `;
 
-         await testHelper.initNeo4jGraphQL({ typeDefs });
+        await testHelper.initNeo4jGraphQL({ typeDefs });
 
         await testHelper.executeCypher(`CREATE (m:${typeMovie.name} { title: "Terminator"})<-[:ACTED_IN { screentime: 60, character: "Terminator" }]-(:${typeActor.name} { name: "Arnold", age: 54, born: datetime('1980-07-02')})
         CREATE (m)<-[:ACTED_IN { screentime: 120, character: "Sarah" }]-(:${typeActor.name} {name: "Linda", age:37, born: datetime('2000-02-02')})`);

--- a/packages/graphql/tests/integration/issues/2670.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2670.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2670", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2697.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2697.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2697", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2708.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2708.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2708", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2709.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2709.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2709", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2713.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2713.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2713", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2766.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2766.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2766", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2782.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2782.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2782", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2803.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2803.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2803", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2812.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2812.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2812", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2820.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2820.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2820", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/283.int.test.ts
+++ b/packages/graphql/tests/integration/issues/283.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/283", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2847.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2847", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2871.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2871.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2871", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/288.int.test.ts
+++ b/packages/graphql/tests/integration/issues/288.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/288", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2889.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2889.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2889", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2981.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2981.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2981", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/2982.int.test.ts
+++ b/packages/graphql/tests/integration/issues/2982.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2982", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3009.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3009.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3009", () => {
     let User: UniqueType;

--- a/packages/graphql/tests/integration/issues/3015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3015.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3015", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3027.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3027.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3027", () => {
     describe("union", () => {

--- a/packages/graphql/tests/integration/issues/315.int.test.ts
+++ b/packages/graphql/tests/integration/issues/315.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/315", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3165.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3165.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3165", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3251.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3251.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3251", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/326.int.test.ts
+++ b/packages/graphql/tests/integration/issues/326.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/326", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/330.int.test.ts
+++ b/packages/graphql/tests/integration/issues/330.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 // Reference: https://github.com/neo4j/graphql/pull/330
 // Reference: https://github.com/neo4j/graphql/pull/303#discussion_r671148932

--- a/packages/graphql/tests/integration/issues/3355.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3355.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3355", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3394.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3394.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3394", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3428.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3428.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3428", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/349.int.test.ts
+++ b/packages/graphql/tests/integration/issues/349.int.test.ts
@@ -21,7 +21,7 @@ import { getDirective, MapperKind, mapSchema } from "@graphql-tools/utils";
 import type { GraphQLSchema } from "graphql";
 import { graphql } from "graphql";
 import { gql } from "graphql-tag";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/349", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/350.int.test.ts
+++ b/packages/graphql/tests/integration/issues/350.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/350", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/354.int.test.ts
+++ b/packages/graphql/tests/integration/issues/354.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/354", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/360.int.test.ts
+++ b/packages/graphql/tests/integration/issues/360.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/360", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/369.int.test.ts
+++ b/packages/graphql/tests/integration/issues/369.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/369", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3746.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3746.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3746", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3765.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3765.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3765", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/387.int.test.ts
+++ b/packages/graphql/tests/integration/issues/387.int.test.ts
@@ -21,7 +21,7 @@ import type { DocumentNode } from "graphql";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/387", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/388.int.test.ts
+++ b/packages/graphql/tests/integration/issues/388.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/388", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3888.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3888.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3888", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3901.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3901.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3901", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3912.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3912.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3912", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3929.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3929.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3929", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3932.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3932.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3932", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/3938.int.test.ts
+++ b/packages/graphql/tests/integration/issues/3938.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/3938", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4004.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4004.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4004", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4007.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4007.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4007", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4015.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4015.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4007", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/402.int.test.ts
+++ b/packages/graphql/tests/integration/issues/402.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/402", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4056.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4056.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLResponse } from "@apollo/server";
 import { ApolloServer } from "@apollo/server";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4056", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4077.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4077.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4077", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4099.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4099.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4099", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4110.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4110.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4110", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4112.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4112.int.test.ts
@@ -20,7 +20,7 @@
 import gql from "graphql-tag";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4112", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4113.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4113.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4113", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4115.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4115.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4115", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4118.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4118.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4118", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/413.int.test.ts
+++ b/packages/graphql/tests/integration/issues/413.int.test.ts
@@ -21,7 +21,7 @@ import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/413", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4170.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4170.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4170", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4196.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4196.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4196", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4214.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4214.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4214", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4223.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4223.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4223", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4239.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4239.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4239", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4268.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4268.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4268", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4287.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4287.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4287", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4292.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4292.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4292", () => {
     let User: UniqueType;

--- a/packages/graphql/tests/integration/issues/433.int.test.ts
+++ b/packages/graphql/tests/integration/issues/433.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/433", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/440.int.test.ts
+++ b/packages/graphql/tests/integration/issues/440.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/440", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4405.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4405.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4405", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4429.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4429.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4429", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4450.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4450.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4450", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4477.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4477.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4477", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4520.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4520.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 const testLabel = generate({ charset: "alphabetic" });
 

--- a/packages/graphql/tests/integration/issues/4532.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4532.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4532", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4583.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import gql from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4583", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4615.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4615.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4615", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4617.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4617.int.test.ts
@@ -21,7 +21,7 @@ import type { GraphQLError } from "graphql";
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4617", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/464.int.test.ts
+++ b/packages/graphql/tests/integration/issues/464.int.test.ts
@@ -23,7 +23,7 @@ import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { Neo4jGraphQL } from "../../../src/classes";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/464", () => {
     let typeAuthor: UniqueType;

--- a/packages/graphql/tests/integration/issues/4667.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4667.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4667", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4704.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4704.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4704", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4741.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4741.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4741", () => {
     let Opportunity: UniqueType;

--- a/packages/graphql/tests/integration/issues/4759.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4759.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4759", () => {
     let Node1: UniqueType;

--- a/packages/graphql/tests/integration/issues/4814.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4814.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4814", () => {
     let AStep: UniqueType;

--- a/packages/graphql/tests/integration/issues/4831.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4831.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4831", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4838.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4838.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4838", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/487.int.test.ts
+++ b/packages/graphql/tests/integration/issues/487.int.test.ts
@@ -19,7 +19,7 @@
 
 import gql from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/487", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/488.int.test.ts
+++ b/packages/graphql/tests/integration/issues/488.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/488", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/4908.int.test.ts
+++ b/packages/graphql/tests/integration/issues/4908.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/4908", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/505.int.test.ts
+++ b/packages/graphql/tests/integration/issues/505.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/505", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/526.int.test.ts
+++ b/packages/graphql/tests/integration/issues/526.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/526 - Int Argument on Custom Query Converted to Float", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/549.int.test.ts
+++ b/packages/graphql/tests/integration/issues/549.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { gql } from "graphql-tag";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/549", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/556.int.test.ts
+++ b/packages/graphql/tests/integration/issues/556.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/556 - Input Object type ArticleCreateInput must define one or more fields", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/560.int.test.ts
+++ b/packages/graphql/tests/integration/issues/560.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/560", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/572.int.test.ts
+++ b/packages/graphql/tests/integration/issues/572.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { gql } from "graphql-tag";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Revert https://github.com/neo4j/graphql/pull/572", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/579.int.test.ts
+++ b/packages/graphql/tests/integration/issues/579.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/pull/579", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/582.int.test.ts
+++ b/packages/graphql/tests/integration/issues/582.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/582", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/583.int.test.ts
+++ b/packages/graphql/tests/integration/issues/583.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/583", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/594.int.test.ts
+++ b/packages/graphql/tests/integration/issues/594.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/594", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/619.int.test.ts
+++ b/packages/graphql/tests/integration/issues/619.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/619", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/620.int.test.ts
+++ b/packages/graphql/tests/integration/issues/620.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/620", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/630.int.test.ts
+++ b/packages/graphql/tests/integration/issues/630.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/630", () => {
     let typeMovie: UniqueType;

--- a/packages/graphql/tests/integration/issues/832.int.test.ts
+++ b/packages/graphql/tests/integration/issues/832.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/832", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/847.int.test.ts
+++ b/packages/graphql/tests/integration/issues/847.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/847", () => {
     let personType: UniqueType;

--- a/packages/graphql/tests/integration/issues/894.int.test.ts
+++ b/packages/graphql/tests/integration/issues/894.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/894", () => {
     let testUser: UniqueType;

--- a/packages/graphql/tests/integration/issues/915.int.test.ts
+++ b/packages/graphql/tests/integration/issues/915.int.test.ts
@@ -25,7 +25,7 @@ import { int, isInt } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
 import { isMultiDbUnsupportedError } from "../../utils/is-multi-db-unsupported-error";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 // Adapted from BigInt
 const PositiveInt = new GraphQLScalarType({

--- a/packages/graphql/tests/integration/issues/923.int.test.ts
+++ b/packages/graphql/tests/integration/issues/923.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import type { Integer } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/923", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/976.int.test.ts
+++ b/packages/graphql/tests/integration/issues/976.int.test.ts
@@ -19,7 +19,7 @@
 
 import { type Integer } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/976", () => {
     let testBibliographicReference: UniqueType;

--- a/packages/graphql/tests/integration/issues/988.int.test.ts
+++ b/packages/graphql/tests/integration/issues/988.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/988", () => {
     let seriesType: UniqueType;

--- a/packages/graphql/tests/integration/issues/bind-any.int.test.ts
+++ b/packages/graphql/tests/integration/issues/bind-any.int.test.ts
@@ -19,7 +19,7 @@
 
 import { GraphQLError } from "graphql";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/2474", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
+++ b/packages/graphql/tests/integration/issues/context-variable-not-always-resolved-on-cypher-queries.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("context-variable-not-always-resolved-on-cypher-queries", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
+++ b/packages/graphql/tests/integration/issues/date-in-edge.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("587: Dates in edges can cause wrongly generated cypher", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
+++ b/packages/graphql/tests/integration/issues/escape-in-union.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Empty fields on unions due to escaped labels", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/interface-post-multi-create.int.test.ts
+++ b/packages/graphql/tests/integration/issues/interface-post-multi-create.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Projecting interface relationships following create of multiple nodes", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
+++ b/packages/graphql/tests/integration/issues/label-cypher-injection.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Label cypher injection", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/issues/only-info.int.test.ts
+++ b/packages/graphql/tests/integration/issues/only-info.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/567", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/limit.int.test.ts
+++ b/packages/graphql/tests/integration/limit.int.test.ts
@@ -17,7 +17,7 @@
  * limitations under the License.
  */
 
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("https://github.com/neo4j/graphql/issues/1628", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/mass-delete.int.test.ts
+++ b/packages/graphql/tests/integration/mass-delete.int.test.ts
@@ -20,7 +20,7 @@
 import type { DocumentNode } from "graphql";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Mass Delete", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/math.int.test.ts
+++ b/packages/graphql/tests/integration/math.int.test.ts
@@ -20,7 +20,7 @@
 import type { GraphQLError } from "graphql";
 import { int } from "neo4j-driver";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Mathematical operations tests", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/middleware.int.test.ts
+++ b/packages/graphql/tests/integration/middleware.int.test.ts
@@ -20,7 +20,7 @@
 import { applyMiddleware } from "graphql-middleware";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Middleware Resolvers", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/multi-database.int.test.ts
+++ b/packages/graphql/tests/integration/multi-database.int.test.ts
@@ -21,7 +21,7 @@ import type { Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
 import { isMultiDbUnsupportedError } from "../utils/is-multi-db-unsupported-error";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("multi-database", () => {
     let driver: Driver;

--- a/packages/graphql/tests/integration/nested-unions.int.test.ts
+++ b/packages/graphql/tests/integration/nested-unions.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("Nested unions", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect-overwrite.int.test.ts
@@ -20,7 +20,7 @@
 import type { DocumentNode } from "graphql";
 import { gql } from "graphql-tag";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - connect with and without `overwrite` argument", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/relationship-properties/connect-union.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect-union.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - connect on union", () => {
     let Movie: UniqueType;

--- a/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/connect.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - connect", () => {
     let Movie: UniqueType;

--- a/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/create.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - create", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/delete.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - delete", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/disconnect.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - disconnect", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/read.int.test.ts
@@ -22,7 +22,7 @@ import { offsetToCursor } from "graphql-relay";
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - read", () => {
     const testHelper = new TestHelper();
@@ -101,7 +101,7 @@ describe("Relationship properties - read", () => {
 
         expect(result.errors).toBeFalsy();
 
-        expect(result?.data?.[typeMovie.plural]).toHaveLength(1);
+        expect((result?.data as any)?.[typeMovie.plural]).toHaveLength(1);
 
         expect((result?.data as any)?.[typeMovie.plural][0].actorsConnection.totalCount).toBe(3);
         expect((result?.data as any)?.[typeMovie.plural][0].actorsConnection.pageInfo).toEqual({
@@ -343,7 +343,7 @@ describe("Relationship properties - read", () => {
 
         expect(result.errors).toBeFalsy();
 
-        expect(result?.data?.[typeMovie.plural]).toEqual([
+        expect((result?.data as any)?.[typeMovie.plural]).toEqual([
             {
                 actorsConnection: {
                     edges: [

--- a/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
+++ b/packages/graphql/tests/integration/relationship-properties/update.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Relationship properties - update", () => {
     let testHelper: TestHelper;

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwks-auth-plugin.int.test.ts
@@ -21,7 +21,7 @@ import type { JWKSMock } from "mock-jwks";
 import createJWKSMock from "mock-jwks";
 import type { Neo4jGraphQLAuthenticationError } from "../../../src/classes";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Global authentication - Authorization JWKS plugin", () => {
     let jwksMock: JWKSMock;

--- a/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/global-authentication-jwt-auth-plugin.int.test.ts
@@ -20,7 +20,7 @@
 import type { Neo4jGraphQLAuthenticationError } from "../../../src/classes";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Global authentication - Authorization JWT plugin", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
+++ b/packages/graphql/tests/integration/rfcs/query-limits.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import { generate } from "randomstring";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("integration/rfcs/query-limits", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
+++ b/packages/graphql/tests/integration/rfcs/rfc-003.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("integration/rfc/003", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/root-connections.int.test.ts
+++ b/packages/graphql/tests/integration/root-connections.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("root-connections", () => {
     const testHelper: TestHelper = new TestHelper();

--- a/packages/graphql/tests/integration/scalars.int.test.ts
+++ b/packages/graphql/tests/integration/scalars.int.test.ts
@@ -20,7 +20,7 @@
 import { GraphQLScalarType } from "graphql";
 import { Kind } from "graphql/language";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 const GraphQLUpperCaseString = new GraphQLScalarType({
     name: "UpperCaseString",

--- a/packages/graphql/tests/integration/sort.int.test.ts
+++ b/packages/graphql/tests/integration/sort.int.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 const testLabel = generate({ charset: "alphabetic" });
 

--- a/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/auth/allow.int.test.ts
@@ -21,7 +21,7 @@ import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/allow", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
@@ -19,7 +19,7 @@
 
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Subscriptions connect with create", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/create/connect-or-create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/connect-or-create.int.test.ts
@@ -22,7 +22,7 @@ import { gql } from "graphql-tag";
 import type { Integer } from "neo4j-driver";
 import type { Neo4jGraphQLSubscriptionsEngine } from "../../../../src/types";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Create -> ConnectOrCreate", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/create/create-authorization.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create-authorization.int.test.ts
@@ -21,7 +21,7 @@ import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { createBearerToken } from "../../../utils/create-bearer-token";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("auth/bind", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Subscriptions create", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
@@ -21,7 +21,7 @@ import { faker } from "@faker-js/faker";
 import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("interface relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/delete/delete-auth.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete-auth.int.test.ts
@@ -20,7 +20,7 @@
 import { generate } from "randomstring";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import { createBearerToken } from "../../../utils/create-bearer-token";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Subscriptions delete", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Subscriptions delete", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/top-level-where.int.test.ts
@@ -19,7 +19,7 @@
 
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Delete using top level aggregate where - subscriptions enabled", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { Neo4jGraphQLSubscriptionsDefaultEngine } from "../../../src/classes/subscription/Neo4jGraphQLSubscriptionsDefaultEngine";
 import type { EventMeta } from "../../../src/types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Subscriptions Single Instance Plugin", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -22,7 +22,7 @@ import { gql } from "graphql-tag";
 import { int } from "neo4j-driver";
 import { TestSubscriptionsEngine } from "../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Subscriptions to spatial types", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/top-level-where.int.test.ts
@@ -19,7 +19,7 @@
 
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Delete using top level aggregate where - subscriptions enabled", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { TestSubscriptionsEngine } from "../../../utils/TestSubscriptionsEngine";
 import type { UniqueType } from "../../../utils/graphql-types";
-import { TestHelper } from "../../utils/tests-helper";
+import { TestHelper } from "../../../utils/tests-helper";
 
 describe("Subscriptions update", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/bigint.int.test.ts
+++ b/packages/graphql/tests/integration/types/bigint.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("BigInt", () => {
     const testHelper = new TestHelper();
@@ -112,7 +112,7 @@ describe("BigInt", () => {
 
             expect(gqlResult.errors).toBeFalsy();
 
-            expect(gqlResult?.data as any).toEqual({
+            expect(gqlResult?.data).toEqual({
                 [File.plural]: [
                     {
                         name,
@@ -155,7 +155,7 @@ describe("BigInt", () => {
 
             expect(gqlResult.errors).toBeFalsy();
 
-            expect(gqlResult?.data as any).toEqual({
+            expect(gqlResult?.data).toEqual({
                 [File.plural]: [
                     {
                         name,
@@ -201,7 +201,7 @@ describe("BigInt", () => {
 
             expect(gqlResult.errors).toBeFalsy();
 
-            expect(gqlResult?.data as any).toEqual({
+            expect(gqlResult?.data).toEqual({
                 [File.plural]: [
                     {
                         name,

--- a/packages/graphql/tests/integration/types/date.int.test.ts
+++ b/packages/graphql/tests/integration/types/date.int.test.ts
@@ -20,7 +20,7 @@
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Date", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/datetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/datetime.int.test.ts
@@ -20,7 +20,7 @@
 import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("DateTime", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/duration.int.test.ts
+++ b/packages/graphql/tests/integration/types/duration.int.test.ts
@@ -21,7 +21,7 @@ import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseDuration } from "../../../src/graphql/scalars/Duration";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Duration", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/float.int.test.ts
+++ b/packages/graphql/tests/integration/types/float.int.test.ts
@@ -20,7 +20,7 @@
 import { int } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Float", () => {
     const imdbRatingFloat = 4.0;

--- a/packages/graphql/tests/integration/types/localdatetime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localdatetime.int.test.ts
@@ -22,7 +22,7 @@ import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseLocalDateTime } from "../../../src/graphql/scalars/LocalDateTime";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("LocalDateTime", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/localtime.int.test.ts
+++ b/packages/graphql/tests/integration/types/localtime.int.test.ts
@@ -22,7 +22,7 @@ import neo4jDriver from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseLocalTime } from "../../../src/graphql/scalars/LocalTime";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("LocalTime", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/point-cartesian.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("CartesianPoint", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/point.int.test.ts
+++ b/packages/graphql/tests/integration/types/point.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Point", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
+++ b/packages/graphql/tests/integration/types/points-cartesian.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("[CartesianPoint]", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/points.int.test.ts
+++ b/packages/graphql/tests/integration/types/points.int.test.ts
@@ -20,7 +20,7 @@
 import { faker } from "@faker-js/faker";
 import { int } from "neo4j-driver";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("[Point]", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/types/time.int.test.ts
+++ b/packages/graphql/tests/integration/types/time.int.test.ts
@@ -22,7 +22,7 @@ import { Time, isTime } from "neo4j-driver";
 import { generate } from "randomstring";
 import { parseTime } from "../../../src/graphql/scalars/Time";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Time", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/undirected-relationships.test.ts
+++ b/packages/graphql/tests/integration/undirected-relationships.test.ts
@@ -19,7 +19,7 @@
 
 import { gql } from "graphql-tag";
 import { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("undirected relationships", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/unions/union-relationship-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/unions/union-relationship-filtering.int.test.ts
@@ -19,7 +19,7 @@
 
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Union filtering", () => {
     const secret = "the-secret";

--- a/packages/graphql/tests/integration/unions/unions-top-level.int.test.ts
+++ b/packages/graphql/tests/integration/unions/unions-top-level.int.test.ts
@@ -18,7 +18,7 @@
  */
 
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("Top-level union query fields", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/unions/unions.int.test.ts
+++ b/packages/graphql/tests/integration/unions/unions.int.test.ts
@@ -22,7 +22,7 @@ import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
 import type { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("unions", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create-auth.int.test.ts
@@ -19,7 +19,7 @@
 
 import { generate } from "randomstring";
 import { createBearerToken } from "../../utils/create-bearer-token";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 /*
  * Auth rules are already tested in the auth tests,

--- a/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
+++ b/packages/graphql/tests/integration/unwind-create/unwind-create.int.test.ts
@@ -20,7 +20,7 @@
 import { int } from "neo4j-driver";
 import { generate } from "randomstring";
 import { UniqueType } from "../../utils/graphql-types";
-import { TestHelper } from "../utils/tests-helper";
+import { TestHelper } from "../../utils/tests-helper";
 
 describe("unwind-create", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/integration/update.int.test.ts
+++ b/packages/graphql/tests/integration/update.int.test.ts
@@ -20,7 +20,7 @@
 import { gql } from "graphql-tag";
 import { generate } from "randomstring";
 import type { UniqueType } from "../utils/graphql-types";
-import { TestHelper } from "./utils/tests-helper";
+import { TestHelper } from "../utils/tests-helper";
 
 describe("update", () => {
     const testHelper = new TestHelper();

--- a/packages/graphql/tests/tck/utils/tck-test-utils.ts
+++ b/packages/graphql/tests/tck/utils/tck-test-utils.ts
@@ -22,8 +22,8 @@ import { graphql } from "graphql";
 import { Neo4jError } from "neo4j-driver";
 import type { Neo4jGraphQL } from "../../../src";
 import { Neo4jDatabaseInfo } from "../../../src/classes/Neo4jDatabaseInfo";
-import { TestHelper } from "../../integration/utils/tests-helper";
 import { DriverBuilder } from "../../utils/builders/driver-builder";
+import { TestHelper } from "../../utils/tests-helper";
 
 export function setTestEnvVars(envVars: string | undefined): void {
     if (envVars) {

--- a/packages/graphql/tests/utils/tests-helper.ts
+++ b/packages/graphql/tests/utils/tests-helper.ts
@@ -21,12 +21,12 @@ import Cypher from "@neo4j/cypher-builder";
 import type { ExecutionResult, GraphQLArgs } from "graphql";
 import { graphql as graphqlRuntime } from "graphql";
 import * as neo4j from "neo4j-driver";
-import type { Neo4jGraphQLConstructor, Neo4jGraphQLContext } from "../../../src";
-import { Neo4jGraphQL } from "../../../src";
-import { Neo4jDatabaseInfo } from "../../../src/classes";
-import type { Neo4jEdition } from "../../../src/classes/Neo4jDatabaseInfo";
-import { createBearerToken } from "../../utils/create-bearer-token";
-import { UniqueType } from "../../utils/graphql-types";
+import type { Neo4jGraphQLConstructor, Neo4jGraphQLContext } from "../../src";
+import { Neo4jGraphQL } from "../../src";
+import { Neo4jDatabaseInfo } from "../../src/classes";
+import type { Neo4jEdition } from "../../src/classes/Neo4jDatabaseInfo";
+import { createBearerToken } from "./create-bearer-token";
+import { UniqueType } from "./graphql-types";
 
 const INT_TEST_DB_NAME = "neo4jgraphqlinttestdatabase";
 const DEFAULT_DB = "neo4j";


### PR DESCRIPTION
# Description

This PR moves the test helper to the general test utils, to be reused outside of the integration tests
