### PR TITLE
Always serialize ids as strings in subscriptions

### DIFF
--- a/packages/graphql-amqp-subscriptions-engine/tests/e2e/rabbitmq.e2e.test.ts
+++ b/packages/graphql-amqp-subscriptions-engine/tests/e2e/rabbitmq.e2e.test.ts
@@ -45,7 +45,7 @@ describe("Subscriptions RabbitMQ Integration", () => {
                     },
                     old: undefined,
                 },
-                id: 2,
+                id: "2",
                 timestamp: 2,
                 typename: "test",
             };

--- a/packages/graphql/src/schema/resolvers/subscriptions/where/where.test.ts
+++ b/packages/graphql/src/schema/resolvers/subscriptions/where/where.test.ts
@@ -36,7 +36,7 @@ describe("subscriptionWhere", () => {
                     title: "movie1",
                 },
             },
-            id: 1,
+            id: "1",
             timestamp: 1,
             typename: "Movie",
         };
@@ -68,7 +68,7 @@ describe("subscriptionWhere", () => {
                     title: "movie1",
                 },
             },
-            id: 1,
+            id: "1",
             timestamp: 1,
             typename: "Movie",
         };

--- a/packages/graphql/src/schema/subscriptions/publish-events-to-subscription-mechanism.ts
+++ b/packages/graphql/src/schema/subscriptions/publish-events-to-subscription-mechanism.ts
@@ -88,10 +88,10 @@ function parseEvents(schemaModel: Neo4jGraphQLSchemaModel) {
 }
 
 type EventType = "create" | "update" | "delete" | "create_relationship" | "delete_relationship";
-type MapIdToListOfTypenamesType = Map<number, { fromTypename: string; toTypename: string }[]>;
+type MapIdToListOfTypenamesType = Map<string, { fromTypename: string; toTypename: string }[]>;
 function removeDuplicateEvents(events: SubscriptionsEvent[], ...eventTypes: EventType[]): SubscriptionsEvent[] {
     const resultIdsByEventType = eventTypes.reduce((acc, eventType) => {
-        acc.set(eventType, new Map<number, { fromTypename: string; toTypename: string }[]>());
+        acc.set(eventType, new Map<string, { fromTypename: string; toTypename: string }[]>());
         return acc;
     }, new Map<EventType, MapIdToListOfTypenamesType>());
 
@@ -157,7 +157,7 @@ function isRelationshipWithLabelsSubscriptionMeta(
 }
 function serializeNodeSubscriptionEvent(event: NodeSubscriptionMeta): SubscriptionsEvent {
     return {
-        id: serializeNeo4jValue(event.id),
+        id: event.id.toString(),
         typename: event.typename,
         timestamp: serializeNeo4jValue(event.timestamp),
         event: event.event,
@@ -171,9 +171,9 @@ function serializeRelationshipSubscriptionEvent(
     event: RelationshipSubscriptionMetaTypenameParameters
 ): SubscriptionsEvent {
     return {
-        id: serializeNeo4jValue(event.id),
-        id_from: serializeNeo4jValue(event.id_from),
-        id_to: serializeNeo4jValue(event.id_to),
+        id: event.id.toString(),
+        id_from: event.id_from.toString(),
+        id_to: event.id_to.toString(),
         relationshipName: event.relationshipName,
         fromTypename: serializeNeo4jValue(event.fromTypename),
         toTypename: serializeNeo4jValue(event.toTypename),

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -314,7 +314,7 @@ export type NodeSubscriptionsEvent =
               old: undefined;
               new: Record<string, any>;
           };
-          id: number;
+          id: string;
           timestamp: number;
       }
     | {
@@ -324,7 +324,7 @@ export type NodeSubscriptionsEvent =
               old: Record<string, any>;
               new: Record<string, any>;
           };
-          id: number;
+          id: string;
           timestamp: number;
       }
     | {
@@ -334,7 +334,7 @@ export type NodeSubscriptionsEvent =
               old: Record<string, any>;
               new: undefined;
           };
-          id: number;
+          id: string;
           timestamp: number;
       };
 export type RelationshipSubscriptionsEvent =
@@ -346,11 +346,11 @@ export type RelationshipSubscriptionsEvent =
               to: Record<string, any>;
               relationship: Record<string, any>;
           };
-          id_from: number;
-          id_to: number;
+          id_from: string;
+          id_to: string;
           fromTypename: string;
           toTypename: string;
-          id: number;
+          id: string;
           timestamp: number;
       }
     | {
@@ -361,11 +361,11 @@ export type RelationshipSubscriptionsEvent =
               to: Record<string, any>;
               relationship: Record<string, any>;
           };
-          id_from: number;
-          id_to: number;
+          id_from: string;
+          id_to: string;
           fromTypename: string;
           toTypename: string;
-          id: number;
+          id: string;
           timestamp: number;
       };
 /** Serialized subscription event */

--- a/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
+++ b/packages/graphql/tests/integration/array-methods/array-subscription.int.test.ts
@@ -85,7 +85,7 @@ describe("array-subscription", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {
@@ -119,7 +119,7 @@ describe("array-subscription", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {
@@ -153,7 +153,7 @@ describe("array-subscription", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {

--- a/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create-relationship/create.int.test.ts
@@ -174,9 +174,9 @@ describe("Subscriptions connect with create", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -197,9 +197,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -220,9 +220,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -243,9 +243,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -331,9 +331,9 @@ describe("Subscriptions connect with create", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -354,9 +354,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -435,9 +435,9 @@ describe("Subscriptions connect with create", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -459,9 +459,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -615,9 +615,9 @@ describe("Subscriptions connect with create", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -639,9 +639,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -662,9 +662,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -685,9 +685,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -708,9 +708,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -732,9 +732,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -756,9 +756,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {
@@ -780,9 +780,9 @@ describe("Subscriptions connect with create", () => {
                     toTypename: typeMovie.name,
                 },
                 {
-                    id: expect.anything(), // NOTE: This should be expect.any(Number) or expect.any(String) (Issue #4890)
-                    id_from: expect.any(Number),
-                    id_to: expect.any(Number),
+                    id: expect.any(String),
+                    id_from: expect.any(String),
+                    id_to: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create_relationship",
                     properties: {

--- a/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/create.int.test.ts
@@ -91,42 +91,42 @@ describe("Subscriptions create", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: { old: undefined, new: { id: "2" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: { old: undefined, new: { name: "Andrés" } },
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: { old: undefined, new: { id: "1" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: { old: undefined, new: { id: "4" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: { old: undefined, new: { name: "Darrell" } },
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: { old: undefined, new: { id: "3" } },

--- a/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/create/interfaces.int.test.ts
@@ -217,7 +217,7 @@ describe("interface relationships", () => {
             expect.arrayContaining([
                 {
                     event: "create",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: {
                             name: name2,
@@ -229,7 +229,7 @@ describe("interface relationships", () => {
                 },
                 {
                     event: "create",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: {
                             runtime: movieRuntime,
@@ -242,7 +242,7 @@ describe("interface relationships", () => {
                 },
                 {
                     event: "create",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: {
                             runtime: episodeRuntime,
@@ -254,7 +254,7 @@ describe("interface relationships", () => {
                 },
                 {
                     event: "create",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: {
                             title: seriesTitle,
@@ -266,7 +266,7 @@ describe("interface relationships", () => {
                 },
                 {
                     event: "create",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: {
                             name: name1,

--- a/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/delete/delete.int.test.ts
@@ -79,14 +79,14 @@ describe("Subscriptions delete", () => {
 
         expect(plugin.eventList).toIncludeAllMembers([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "delete",
                 properties: { old: { id: "1" }, new: undefined },
                 typename: typeMovie.name,
             },
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "delete",
                 properties: { old: { id: "2" }, new: undefined },
@@ -118,35 +118,35 @@ describe("Subscriptions delete", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "1" }, new: undefined },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "3" }, new: undefined },
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "2" }, new: undefined },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "5" }, new: undefined },
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "4" }, new: undefined },
@@ -192,28 +192,28 @@ describe("Subscriptions delete", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "1" }, new: undefined },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "3" }, new: undefined },
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "2" }, new: undefined },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: { old: { id: "4" }, new: undefined },

--- a/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/single-instance-plugin.int.test.ts
@@ -78,7 +78,7 @@ describe("Subscriptions Single Instance Plugin", () => {
         const eventMeta = await onEventPromise;
 
         expect(eventMeta).toEqual({
-            id: expect.any(Number),
+            id: expect.any(String),
             timestamp: expect.any(Number),
             event: "create",
             properties: { old: undefined, new: { id: "1" } },

--- a/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/spatial-types.int.test.ts
@@ -150,7 +150,7 @@ describe("Subscriptions to spatial types", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: {
@@ -163,7 +163,7 @@ describe("Subscriptions to spatial types", () => {
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: {
@@ -252,7 +252,7 @@ describe("Subscriptions to spatial types", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: {
@@ -489,7 +489,7 @@ describe("Subscriptions to spatial types", () => {
 
         expect(plugin.eventList).toIncludeSameMembers([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "create",
                 properties: {
@@ -502,7 +502,7 @@ describe("Subscriptions to spatial types", () => {
                 typename: typeMovie.name,
             },
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "create",
                 properties: {
@@ -589,7 +589,7 @@ describe("Subscriptions to spatial types", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: {

--- a/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
+++ b/packages/graphql/tests/integration/subscriptions/update/update.int.test.ts
@@ -151,7 +151,7 @@ describe("Subscriptions update", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "The Matrix" } },
@@ -183,14 +183,14 @@ describe("Subscriptions update", () => {
         expect(plugin.eventList).toEqual(
             expect.toIncludeSameMembers([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "The Matrix" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: {
@@ -253,14 +253,14 @@ describe("Subscriptions update", () => {
         expect(plugin.eventList).toEqual(
             expect.toIncludeSameMembers([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "The Matrix" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: {
@@ -270,7 +270,7 @@ describe("Subscriptions update", () => {
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: {
@@ -338,28 +338,28 @@ describe("Subscriptions update", () => {
             expect.toIncludeSameMembers([
                 {
                     event: "update",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: { new: { id: "1", name: "The Matrix" }, old: { id: "1", name: "Terminator" } },
                     timestamp: expect.any(Number),
                     typename: typeMovie.name,
                 },
                 {
                     event: "update",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: { new: { name: "ford" }, old: { name: "arthur" } },
                     timestamp: expect.any(Number),
                     typename: typeActor.name,
                 },
                 {
                     event: "update",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: { new: { id: "3", name: "new movie title" }, old: { id: "3", name: "Terminator 2" } },
                     timestamp: expect.any(Number),
                     typename: typeMovie.name,
                 },
                 {
                     event: "update",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: { id: "4", name: "new movie title" },
                         old: { id: "4", name: "The Many Adventures of Winnie the Pooh 2" },
@@ -369,7 +369,7 @@ describe("Subscriptions update", () => {
                 },
                 {
                     event: "update",
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     properties: {
                         new: { id: "2", name: "The Matrix" },
                         old: { id: "2", name: "The Many Adventures of Winnie the Pooh" },
@@ -422,14 +422,14 @@ describe("Subscriptions update", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "Terminator 2" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: {
@@ -486,14 +486,14 @@ describe("Subscriptions update", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "Terminator 2" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: {
@@ -555,14 +555,14 @@ describe("Subscriptions update", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "Terminator 2" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: {
@@ -572,7 +572,7 @@ describe("Subscriptions update", () => {
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: {
@@ -652,14 +652,14 @@ describe("Subscriptions update", () => {
         expect(plugin.eventList).toEqual(
             expect.arrayContaining([
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "update",
                     properties: { old: { id: "1", name: "Terminator" }, new: { id: "1", name: "Terminator 2" } },
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: {
@@ -669,7 +669,7 @@ describe("Subscriptions update", () => {
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "delete",
                     properties: {
@@ -679,7 +679,7 @@ describe("Subscriptions update", () => {
                     typename: typeMovie.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: {
@@ -689,7 +689,7 @@ describe("Subscriptions update", () => {
                     typename: typeActor.name,
                 },
                 {
-                    id: expect.any(Number),
+                    id: expect.any(String),
                     timestamp: expect.any(Number),
                     event: "create",
                     properties: {
@@ -723,7 +723,7 @@ describe("Subscriptions update", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {
@@ -761,7 +761,7 @@ describe("Subscriptions update", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {
@@ -800,7 +800,7 @@ describe("Subscriptions update", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {
@@ -859,7 +859,7 @@ describe("Subscriptions update", () => {
 
         expect(plugin.eventList).toEqual([
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {
@@ -869,7 +869,7 @@ describe("Subscriptions update", () => {
                 typename: typeActor.name,
             },
             {
-                id: expect.any(Number),
+                id: expect.any(String),
                 timestamp: expect.any(Number),
                 event: "update",
                 properties: {


### PR DESCRIPTION
# Description

For subscriptions events, we were serialising fields coming from neo4j depending on the type from neo4j. This led to a difference between integer and BigInts ids as they were serialised as numbers or strings respectively. This PR changes the logic to always serialise ids as strings, irrespective of the value coming from Neo4j. This is in line with the way GraphQL treats ID types (always serialise to string).
Tests have been updated.

## Complexity

Complexity: Low

# Issue

Closes #4890 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
