### PR TITLE
add duration type to introspector

### DIFF
--- a/.changeset/long-lies-hear.md
+++ b/.changeset/long-lies-hear.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/introspector": patch
+---
+
+Add Duration type to introspector

--- a/packages/introspector/src/transforms/neo4j-graphql/utils/map-neo4j-to-graphql-type.ts
+++ b/packages/introspector/src/transforms/neo4j-graphql/utils/map-neo4j-to-graphql-type.ts
@@ -29,6 +29,7 @@ const map = {
     DateTime: "DateTime",
     LocalTime: "LocalTime",
     LocalDateTime: "LocalDateTime",
+    Duration: "Duration",
     Time: "Time",
     Point: "Point",
 
@@ -44,6 +45,7 @@ const map = {
     TimeArray: "[Time]",
     LocalTimeArray: "[LocalTime]",
     LocalDateTimeArray: "[LocalDateTime]",
+    DurationArray: "[Duration]",
     PointArray: "[Point]",
 };
 

--- a/packages/introspector/tests/integration/graphql/graphs.test.ts
+++ b/packages/introspector/tests/integration/graphql/graphs.test.ts
@@ -190,11 +190,12 @@ describe("GraphQL - Infer Schema on graphs", () => {
             pay: 200.5,
             str: "String",
             int: neo4j.int(1),
+            screenTime: new neo4j.Duration(0, 0, 3600, 0),
         };
         const wSession = driver.session({ defaultAccessMode: neo4j.session.WRITE, database: dbName });
         await wSession.writeTransaction((tx) =>
             tx.run(
-                `CREATE (m:Movie {title: $props.title})
+                `CREATE (m:Movie {title: $props.title, screenTime: $props.screenTime})
                 CREATE (a:Actor {name: $props.name})
                 CREATE (a2:Actor {name: $props.name2})
                 MERGE (a)-[:ACTED_IN {roles: $props.roles, pay: $props.pay, amb: $props.str}]->(m)
@@ -229,6 +230,7 @@ describe("GraphQL - Infer Schema on graphs", () => {
             type Movie {
             	actorsActedIn: [Actor!]! @relationship(type: \\"ACTED_IN\\", direction: IN, properties: \\"ActedInProperties\\")
             	actorsDirected: [Actor!]! @relationship(type: \\"DIRECTED\\", direction: IN, properties: \\"DirectedProperties\\")
+            	screenTime: Duration!
             	title: String!
             	wonPrizeForActors: [Actor!]! @relationship(type: \\"WON_PRIZE_FOR\\", direction: OUT)
             }"


### PR DESCRIPTION
# Description

Previously Neo4j Duration types were introspected as String, which would break on query execution with the library. This PR adds the Duration type to the introspector, which is then interpreted by the library as a custom graphql scalar.

## Complexity

Complexity: Low

# Issue

> **Note**
>
>  Please link to the GitHub issue(s) in which the proposal for this work was discussed
>  
>  To link to multiple issues, use full syntax for each, for example `Closes #1, closes #2, closes #3`

Closes 

# Checklist

The following requirements should have been met (depending on the changes in the branch):

- [ ] Documentation has been updated
- [ ] TCK tests have been updated
- [ ] Integration tests have been updated
- [ ] Example applications have been updated
- [ ] New files have copyright header
- [ ] CLA (https://neo4j.com/developer/cla/) has been signed
