### PR TITLE
Fix bug reported in issue 5030, cannot use argument phrase in custom cypher queries.

### DIFF
--- a/.changeset/giant-cups-think.md
+++ b/.changeset/giant-cups-think.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fixws a bug where a custom Cypher query with an argument named phrase was interpreted as FullText query.

--- a/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/OperationFactory.ts
@@ -41,7 +41,7 @@ import type { CompositeCypherOperation } from "../ast/operations/composite/Compo
 import type { CompositeReadOperation } from "../ast/operations/composite/CompositeReadOperation";
 import type { Operation } from "../ast/operations/operations";
 import type { FulltextSelection } from "../ast/selection/FulltextSelection";
-import { assertIsConcreteEntity } from "../utils/is-concrete-entity";
+import { assertIsConcreteEntity, isConcreteEntity } from "../utils/is-concrete-entity";
 import { isInterfaceEntity } from "../utils/is-interface-entity";
 import { isUnionEntity } from "../utils/is-union-entity";
 import type { AuthorizationFactory } from "./AuthorizationFactory";
@@ -104,10 +104,13 @@ export class OperationsFactory {
         reference?: any;
     }): Operation {
         // Handles deprecated top level fulltext
-        if (context.resolveTree.args.phrase) {
-            if (!context.fulltext) {
-                throw new Error("Failed to get context fulltext");
-            }
+        if (
+            entity &&
+            isConcreteEntity(entity) &&
+            Boolean(entity.annotations.fulltext) &&
+            context.fulltext &&
+            context.resolveTree.args.phrase
+        ) {
             const indexName = context.fulltext.indexName ?? context.fulltext.name;
             if (indexName === undefined) {
                 throw new Error("The name of the fulltext index should be defined using the indexName argument.");

--- a/packages/graphql/tests/integration/issues/5030.int.test.ts
+++ b/packages/graphql/tests/integration/issues/5030.int.test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { UniqueType } from "../../utils/graphql-types";
+import { TestHelper } from "../../utils/tests-helper";
+
+describe("https://github.com/neo4j/graphql/issues/5030", () => {
+    const testHelper = new TestHelper();
+
+    let Movie: UniqueType;
+
+    beforeAll(async () => {
+        Movie = testHelper.createUniqueType("Movie");
+
+        const typeDefs = /* GraphQL */ `
+            type ${Movie} @fulltext(indexes: [{ name: "MovieTitle", fields: ["title"] }]) {
+                title: String
+                released: Int
+            }
+            type Query {
+                customCypher(phrase: String!): [${Movie}!]!
+                    @cypher(
+                        statement: """
+                            MATCH (m:${Movie.name}) 
+                            WHERE m.title = $phrase
+                            RETURN m as this
+                        """
+                        columnName: "this"
+                    )
+            }
+        `;
+        await testHelper.initNeo4jGraphQL({
+            typeDefs,
+        });
+        await testHelper.executeCypher(`
+            CREATE (:${Movie.name} { title: "The Matrix", released: 2001 })
+        `);
+    });
+
+    afterAll(async () => {
+        await testHelper.close();
+    });
+
+    test("custom @cypher should works with an argument name as phrase", async () => {
+        const query = /* GraphQL */ `
+            query {
+                customCypher(phrase: "The Matrix") {
+                    title
+                    released
+                }
+            }
+        `;
+
+        const response = await testHelper.executeGraphQL(query);
+
+        expect(response.errors).toBeFalsy();
+        expect(response.data).toEqual({
+            ["customCypher"]: expect.toIncludeSameMembers([
+                {
+                    title: "The Matrix",
+                    released: 2001,
+                },
+            ]),
+        });
+    });
+});

--- a/packages/graphql/tests/tck/issues/5030.test.ts
+++ b/packages/graphql/tests/tck/issues/5030.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Neo4jGraphQL } from "../../../src";
+import { formatCypher, formatParams, translateQuery } from "../utils/tck-test-utils";
+
+describe("https://github.com/neo4j/graphql/issues/5030", () => {
+    let typeDefs: string;
+    let neoSchema: Neo4jGraphQL;
+
+    beforeAll(() => {
+        typeDefs = /* GraphQL */ `
+            type Movie @fulltext(indexes: [{ name: "MovieTitle", fields: ["title"] }]) {
+                title: String
+                released: Int
+            }
+            type Query {
+                customCypher(phrase: String!): [Movie!]!
+                    @cypher(
+                        statement: """
+                        MATCH (m:Movie) RETURN m as this
+                        """
+                        columnName: "this"
+                    )
+            }
+        `;
+
+        neoSchema = new Neo4jGraphQL({
+            typeDefs,
+        });
+    });
+
+    test("custom cypher fields should works when used with argument named phrase", async () => {
+        const query = /* GraphQL */ `
+            query {
+                customCypher(phrase: "hello") {
+                    title
+                }
+            }
+        `;
+
+        const result = await translateQuery(neoSchema, query, {
+            contextValues: {},
+        });
+
+        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
+            "CALL {
+                MATCH (m:Movie) RETURN m as this
+            }
+            WITH this AS this0
+            WITH this0 { .title } AS this0
+            RETURN this0 AS this"
+        `);
+
+        expect(formatParams(result.params)).toMatchInlineSnapshot(`"{}"`);
+    });
+});


### PR DESCRIPTION
# Description

Fix a bug where the custom Cypher query with an argument named phrase was interpreted as FullText query, added extra checks to identify if it's a legacy FullText query.

Complexity: Low

Closes #5030 


