### PR TITLE
Hide validation warning under env variable #4843

### DIFF
--- a/.changeset/good-lizards-fail.md
+++ b/.changeset/good-lizards-fail.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Validation warning on objects without resolver only appear under env variable `DEBUG=@neo4j/graphql:graphql`

--- a/packages/graphql/src/constants.ts
+++ b/packages/graphql/src/constants.ts
@@ -30,6 +30,7 @@ export const DEBUG_EXECUTE = `${DEBUG_PREFIX}:execution`;
 export const DEBUG_GENERATE = `${DEBUG_PREFIX}:generate`;
 export const DEBUG_GRAPHQL = `${DEBUG_PREFIX}:graphql`;
 export const DEBUG_TRANSLATE = `${DEBUG_PREFIX}:translate`;
+
 export const RELATIONSHIP_REQUIREMENT_PREFIX = "@neo4j/graphql/RELATIONSHIP-REQUIRED";
 
 export const RESERVED_TYPE_NAMES = [

--- a/packages/graphql/src/schema/validation/custom-rules/warnings/object-fields-without-resolver.test.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/warnings/object-fields-without-resolver.test.ts
@@ -25,7 +25,6 @@ import type {
 } from "graphql";
 import { gql } from "graphql-tag";
 import validateDocument from "../../validate-document";
-import { VALIDATE_OBJECT_FIELD_WARN_MSG } from "./object-fields-without-resolver";
 
 const additionalDefinitions = {
     enums: [] as EnumTypeDefinitionNode[],
@@ -44,48 +43,45 @@ describe("WarnObjectFieldsWithoutResolver", () => {
     afterEach(() => {
         warn.mockReset();
     });
-
-    test("Error on object field array  without resolver", () => {
-        const doc = gql`
-            type Movie {
-                actors: [Actor!]!
-            }
-
-            type Actor {
-                name: String
-            }
-        `;
-
-        validateDocument({
-            document: doc,
-            additionalDefinitions,
-            features: {},
-        });
-        expect(warn).toHaveBeenCalledWith(`${VALIDATE_OBJECT_FIELD_WARN_MSG} actors`);
-        expect(warn).toHaveBeenCalledOnce();
-    });
-
-    test("Error on object field without resolver", () => {
-        const doc = gql`
-            type Movie {
-                actors: Actor
-            }
-
-            type Actor {
-                name: String
-            }
-        `;
-
-        validateDocument({
-            document: doc,
-            additionalDefinitions,
-            features: {},
-        });
-        expect(warn).toHaveBeenCalledWith(`${VALIDATE_OBJECT_FIELD_WARN_MSG} actors`);
-        expect(warn).toHaveBeenCalledOnce();
-    });
-
     describe("Does not show warning", () => {
+        test("Error on object field array  without resolver throw warning in debug", () => {
+            const doc = gql`
+                type Movie {
+                    actors: [Actor!]!
+                }
+
+                type Actor {
+                    name: String
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+            expect(warn).not.toHaveBeenCalled();
+        });
+
+        test("Error on object field without resolver throw warning in debug", () => {
+            const doc = gql`
+                type Movie {
+                    actors: Actor
+                }
+
+                type Actor {
+                    name: String
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+            expect(warn).not.toHaveBeenCalled();
+        });
+
         test("Relationship", () => {
             const doc = gql`
                 type Movie {

--- a/packages/graphql/src/schema/validation/custom-rules/warnings/object-fields-without-resolver.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/warnings/object-fields-without-resolver.ts
@@ -18,6 +18,7 @@
  */
 
 import type { IResolvers } from "@graphql-tools/utils";
+import Debug from "debug";
 import {
     Kind,
     type ASTVisitor,
@@ -26,8 +27,11 @@ import {
     type ObjectTypeDefinitionNode,
 } from "graphql";
 import type { SDLValidationContext } from "graphql/validation/ValidationContext";
+import { DEBUG_GRAPHQL } from "../../../../constants";
 import { filterTruthy, haveSharedElement } from "../../../../utils/utils";
 import { getInnerTypeName } from "../utils/utils";
+
+const debug = Debug(DEBUG_GRAPHQL);
 
 export const VALIDATE_OBJECT_FIELD_WARN_MSG = "Object types need a way to be resolved for field: ";
 
@@ -54,7 +58,7 @@ export function WarnObjectFieldsWithoutResolver({ customResolvers }: { customRes
 
                         if (!hasResolvableDirective && !hasCustomResolver) {
                             const fieldName = fieldNode.name.value;
-                            console.warn(`${VALIDATE_OBJECT_FIELD_WARN_MSG} ${fieldName}`);
+                            debug(`${VALIDATE_OBJECT_FIELD_WARN_MSG} ${fieldName}`);
                         }
                     }
                 }


### PR DESCRIPTION
To avoid verbose output on valid use cases when using the OGM, the warning on object fields without a resolver is now shown under the DEBUG env variable
