### PR TITLE
Aggregate types schema generation improvements

### DIFF
--- a/.changeset/breezy-mice-perform.md
+++ b/.changeset/breezy-mice-perform.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Optimise schema generation for aggregations, reducing schema generation time


### PR DESCRIPTION
# Description

This PR optimises the performance of `makeAggregationFields` which was identified as a bottleneck for some type definitions relying on lots of types with aggregations

On some large type definitions, schema generation times are reduced by ~8%
