### PR TITLE
Fix support for matrix arguments

### DIFF
--- a/.changeset/tiny-kangaroos-shake.md
+++ b/.changeset/tiny-kangaroos-shake.md
@@ -1,0 +1,13 @@
+---
+"@neo4j/graphql": patch
+---
+
+Fix schema error when defining matrix values as arguments on custom fields #5142.
+
+For example:
+
+```graphql
+type Query {
+    test(fields: [[String!]]!): String!
+}
+```

--- a/packages/graphql/src/schema-model/argument/model-adapters/ArgumentAdapter.ts
+++ b/packages/graphql/src/schema-model/argument/model-adapters/ArgumentAdapter.ts
@@ -225,14 +225,29 @@ export class ArgumentAdapter {
      *
      */
 
+    // Duplicate from AttributeAdapter
     getTypePrettyName(): string {
-        if (this.isList()) {
-            return `[${this.getTypeName()}${this.isListElementRequired() ? "!" : ""}]${this.isRequired() ? "!" : ""}`;
+        if (!this.isList()) {
+            return `${this.getTypeName()}${this.isRequired() ? "!" : ""}`;
         }
-        return `${this.getTypeName()}${this.isRequired() ? "!" : ""}`;
+        const listType = this.type as ListType;
+        if (listType.ofType instanceof ListType) {
+            // matrix case
+            return `[[${this.getTypeName()}${this.isListElementRequired() ? "!" : ""}]]${this.isRequired() ? "!" : ""}`;
+        }
+        return `[${this.getTypeName()}${this.isListElementRequired() ? "!" : ""}]${this.isRequired() ? "!" : ""}`;
     }
 
+    // Duplicate from AttributeAdapter
     getTypeName(): string {
-        return this.isList() ? this.type.ofType.name : this.type.name;
+        if (!this.isList()) {
+            return this.type.name;
+        }
+        const listType = this.type as ListType;
+        if (listType.ofType instanceof ListType) {
+            // matrix case
+            return listType.ofType.ofType.name;
+        }
+        return listType.ofType.name;
     }
 }


### PR DESCRIPTION
# Description

Fix schema error when defining matrix values as arguments on custom fields #5142.

For example:

```graphql
type Query {
    test(fields: [[String!]]!): String!
}
```


