### PR TITLE
Add parallel as an option for `runtime` in `CypherQueryOptions`

### DIFF
--- a/.changeset/spicy-oranges-jam.md
+++ b/.changeset/spicy-oranges-jam.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Add parallel as an option for `runtime` in `CypherQueryOptions`

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -256,8 +256,11 @@ export type CallbackOperations = "CREATE" | "UPDATE";
   Object keys and enum values map to values at https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/#cypher-query-options
 */
 export interface CypherQueryOptions {
-    runtime?: "interpreted" | "slotted" | "pipelined";
+    runtime?: "interpreted" | "slotted" | "pipelined" | "parallel";
     planner?: "cost" | "idp" | "dp";
+    /**
+     * @deprecated The Cypher query option `connectComponentsPlanner` is deprecated and will be removed without a replacement. https://neo4j.com/docs/cypher-manual/current/planning-and-tuning/query-tuning/#cypher-connect-components-planner
+     */
     connectComponentsPlanner?: "greedy" | "idp";
     updateStrategy?: "default" | "eager";
     expressionEngine?: "default" | "interpreted" | "compiled";


### PR DESCRIPTION
# Description

Add parallel as an option for `runtime` in `CypherQueryOptions`.

This also marks `connectComponentsPlanner` as deprecated. @MacondoExpress, can you remove this in the v6 branch, and also remove the `interpreted` runtime option?

## Complexity

Complexity: Low

