### PR TITLE
Remove connectComponentsPlanner argument from the Context

### DIFF
--- a/.changeset/five-turtles-grab.md
+++ b/.changeset/five-turtles-grab.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+Remove `connectComponentsPlanner` argument from the `CypherQueryOptions`

--- a/packages/graphql/src/types/index.ts
+++ b/packages/graphql/src/types/index.ts
@@ -256,12 +256,12 @@ export type CallbackOperations = "CREATE" | "UPDATE";
   Object keys and enum values map to values at https://neo4j.com/docs/cypher-manual/current/query-tuning/query-options/#cypher-query-options
 */
 export interface CypherQueryOptions {
+    /**
+     * Configure the runtime used: {@link https://neo4j.com/docs/cypher-manual/current/planning-and-tuning/runtimes/concepts | Cypher Runtimes}
+     * "interpreted" runtime option is deprecated.
+     */
     runtime?: "interpreted" | "slotted" | "pipelined" | "parallel";
     planner?: "cost" | "idp" | "dp";
-    /**
-     * @deprecated The Cypher query option `connectComponentsPlanner` is deprecated and will be removed without a replacement. https://neo4j.com/docs/cypher-manual/current/planning-and-tuning/query-tuning/#cypher-connect-components-planner
-     */
-    connectComponentsPlanner?: "greedy" | "idp";
     updateStrategy?: "default" | "eager";
     expressionEngine?: "default" | "interpreted" | "compiled";
     operatorEngine?: "default" | "interpreted" | "compiled";

--- a/packages/graphql/src/utils/execute.test.ts
+++ b/packages/graphql/src/utils/execute.test.ts
@@ -18,10 +18,10 @@
  */
 
 import type { Driver } from "neo4j-driver";
-import execute from "./execute";
 import { trimmer } from ".";
 import { ContextBuilder } from "../../tests/utils/builders/context-builder";
 import { Executor } from "../classes/Executor";
+import execute from "./execute";
 
 describe("execute", () => {
     test("should execute return records.toObject", async () => {
@@ -189,7 +189,7 @@ describe("execute", () => {
         `);
 
             const expectedCypher = trimmer(`
-            CYPHER runtime=interpreted planner=cost connectComponentsPlanner=greedy updateStrategy=default expressionEngine=compiled operatorEngine=compiled interpretedPipesFallback=all replan=default
+            CYPHER runtime=interpreted planner=cost updateStrategy=default expressionEngine=compiled operatorEngine=compiled interpretedPipesFallback=all replan=default
             CREATE (u:User {title: $title})
             RETURN u { .title } as u
         `);
@@ -257,7 +257,6 @@ describe("execute", () => {
                         cypherQueryOptions: {
                             runtime: "interpreted",
                             planner: "cost",
-                            connectComponentsPlanner: "greedy",
                             updateStrategy: "default",
                             expressionEngine: "compiled",
                             operatorEngine: "compiled",


### PR DESCRIPTION
# Description

Follow up on: (https://github.com/neo4j/graphql/pull/5228), this PR removes the argument `connectComponentsPlanner` and marks the interpreted runtime option as deprecated. 