### PR TITLE
Remove edges top level v6

### DIFF
--- a/packages/graphql/src/api-v6/queryIRFactory/ReadOperationFactory.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/ReadOperationFactory.ts
@@ -104,7 +104,7 @@ export class ReadOperationFactory {
             },
             pagination,
             sortFields: sortInputFields,
-            filters: this.filterFactory.createFilters({ entity, where: graphQLTree.args.where }),
+            filters: this.filterFactory.createTopLevelFilters({ entity, where: graphQLTree.args.where }),
         });
     }
 

--- a/packages/graphql/src/api-v6/queryIRFactory/ReadOperationFactory.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/ReadOperationFactory.ts
@@ -20,8 +20,8 @@
 import { cursorToOffset } from "graphql-relay";
 import type { Integer } from "neo4j-driver";
 import type { Neo4jGraphQLSchemaModel } from "../../schema-model/Neo4jGraphQLSchemaModel";
-import type { Attribute } from "../../schema-model/attribute/Attribute";
 import type { LimitAnnotation } from "../../schema-model/annotation/LimitAnnotation";
+import type { Attribute } from "../../schema-model/attribute/Attribute";
 import { AttributeAdapter } from "../../schema-model/attribute/model-adapters/AttributeAdapter";
 import { ConcreteEntity } from "../../schema-model/entity/ConcreteEntity";
 import { ConcreteEntityAdapter } from "../../schema-model/entity/model-adapters/ConcreteEntityAdapter";
@@ -60,13 +60,7 @@ export class ReadOperationFactory {
         this.filterFactory = new FilterFactory(schemaModel);
     }
 
-    public createAST({
-        graphQLTree,
-        entity,
-    }: {
-        graphQLTree: GraphQLTreeReadOperation;
-        entity: ConcreteEntity;
-    }): QueryAST {
+    public createAST({ graphQLTree, entity }: { graphQLTree: GraphQLTree; entity: ConcreteEntity }): QueryAST {
         const operation = this.generateOperation({
             graphQLTree,
             entity,

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/GlobalNodeResolveTreeParser.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/GlobalNodeResolveTreeParser.ts
@@ -20,11 +20,33 @@
 import type { ResolveTree } from "graphql-parse-resolve-info";
 import type { ConcreteEntity } from "../../../schema-model/entity/ConcreteEntity";
 import { TopLevelResolveTreeParser } from "./TopLevelResolveTreeParser";
-import type { GraphQLTreeReadOperation } from "./graphql-tree";
+import { findFieldByName } from "./find-field-by-name";
+import type { GraphQLTreeReadOperation, GraphQLTreeReadOperationTopLevel } from "./graphql-tree";
 
 export class GlobalNodeResolveTreeParser extends TopLevelResolveTreeParser {
     constructor({ entity }: { entity: ConcreteEntity }) {
         super({ entity: entity });
+    }
+
+    /** Parse a resolveTree into a Neo4j GraphQLTree */
+    public parseOperationTopLevel(resolveTree: ResolveTree): GraphQLTreeReadOperationTopLevel {
+        // FIXME
+        const connectionResolveTree = findFieldByName(
+            resolveTree,
+            this.entity.typeNames.connectionOperation,
+            "connection"
+        );
+
+        const connection = connectionResolveTree ? this.parseConnection(connectionResolveTree) : undefined;
+        const connectionOperationArgs = this.parseOperationArgsTopLevel(resolveTree.args);
+        return {
+            alias: resolveTree.alias,
+            args: connectionOperationArgs,
+            name: resolveTree.name,
+            fields: {
+                connection,
+            },
+        };
     }
 
     /** Parse a resolveTree into a Neo4j GraphQLTree */

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/GlobalNodeResolveTreeParser.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/GlobalNodeResolveTreeParser.ts
@@ -20,8 +20,7 @@
 import type { ResolveTree } from "graphql-parse-resolve-info";
 import type { ConcreteEntity } from "../../../schema-model/entity/ConcreteEntity";
 import { TopLevelResolveTreeParser } from "./TopLevelResolveTreeParser";
-import { findFieldByName } from "./find-field-by-name";
-import type { GraphQLTreeReadOperation, GraphQLTreeReadOperationTopLevel } from "./graphql-tree";
+import type { GraphQLTree } from "./graphql-tree";
 
 export class GlobalNodeResolveTreeParser extends TopLevelResolveTreeParser {
     constructor({ entity }: { entity: ConcreteEntity }) {
@@ -29,28 +28,7 @@ export class GlobalNodeResolveTreeParser extends TopLevelResolveTreeParser {
     }
 
     /** Parse a resolveTree into a Neo4j GraphQLTree */
-    public parseOperationTopLevel(resolveTree: ResolveTree): GraphQLTreeReadOperationTopLevel {
-        // FIXME
-        const connectionResolveTree = findFieldByName(
-            resolveTree,
-            this.entity.typeNames.connectionOperation,
-            "connection"
-        );
-
-        const connection = connectionResolveTree ? this.parseConnection(connectionResolveTree) : undefined;
-        const connectionOperationArgs = this.parseOperationArgsTopLevel(resolveTree.args);
-        return {
-            alias: resolveTree.alias,
-            args: connectionOperationArgs,
-            name: resolveTree.name,
-            fields: {
-                connection,
-            },
-        };
-    }
-
-    /** Parse a resolveTree into a Neo4j GraphQLTree */
-    public parseOperation(resolveTree: ResolveTree): GraphQLTreeReadOperation {
+    public parseTopLevelOperation(resolveTree: ResolveTree): GraphQLTree {
         const entityTypes = this.targetNode.typeNames;
         resolveTree.fieldsByTypeName[entityTypes.node] = {
             ...resolveTree.fieldsByTypeName["Node"],
@@ -62,10 +40,8 @@ export class GlobalNodeResolveTreeParser extends TopLevelResolveTreeParser {
             alias: resolveTree.alias,
             args: {
                 where: {
-                    edges: {
-                        node: {
-                            id: { equals: resolveTree.args.id as any },
-                        },
+                    node: {
+                        id: { equals: resolveTree.args.id as any },
                     },
                 },
             },

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/ResolveTreeParser.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/ResolveTreeParser.ts
@@ -165,7 +165,7 @@ export abstract class ResolveTreeParser<T extends ConcreteEntity | Relationship>
         };
     }
 
-    private parseConnection(resolveTree: ResolveTree): GraphQLTreeConnection {
+    protected parseConnection(resolveTree: ResolveTree): GraphQLTreeConnection {
         const entityTypes = this.entity.typeNames;
         const edgesResolveTree = findFieldByName(resolveTree, entityTypes.connection, "edges");
         const edgeResolveTree = edgesResolveTree ? this.parseEdges(edgesResolveTree) : undefined;

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/TopLevelResolveTreeParser.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/TopLevelResolveTreeParser.ts
@@ -52,7 +52,7 @@ export class TopLevelResolveTreeParser extends ResolveTreeParser<ConcreteEntity>
         };
     }
 
-    private parseOperationArgsTopLevel(resolveTreeArgs: Record<string, any>): GraphQLReadOperationArgsTopLevel {
+    protected parseOperationArgsTopLevel(resolveTreeArgs: Record<string, any>): GraphQLReadOperationArgsTopLevel {
         // Not properly parsed, assuming the type is the same
         return {
             where: resolveTreeArgs.where,

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/graphql-tree.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/graphql-tree.ts
@@ -19,7 +19,7 @@
 
 import type { Integer } from "neo4j-driver";
 
-export type GraphQLTree = GraphQLTreeReadOperation;
+export type GraphQLTree = GraphQLTreeReadOperationTopLevel;
 
 interface GraphQLTreeElement {
     alias: string;
@@ -59,12 +59,24 @@ export type RelationshipFilters = {
     };
 };
 
+export interface GraphQLTreeReadOperationTopLevel extends GraphQLTreeElement {
+    name: string;
+    fields: {
+        connection?: GraphQLTreeConnection;
+    };
+    args: GraphQLReadOperationArgsTopLevel;
+}
+
 export interface GraphQLTreeReadOperation extends GraphQLTreeElement {
+    name: string;
     fields: {
         connection?: GraphQLTreeConnection;
     };
     args: GraphQLReadOperationArgs;
-    name: string;
+}
+
+export interface GraphQLReadOperationArgsTopLevel {
+    where?: GraphQLNodeWhereArgs;
 }
 
 export interface GraphQLReadOperationArgs {

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/graphql-tree.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/graphql-tree.ts
@@ -76,7 +76,7 @@ export interface GraphQLTreeReadOperation extends GraphQLTreeElement {
 }
 
 export interface GraphQLReadOperationArgsTopLevel {
-    where?: GraphQLNodeWhereArgs;
+    where?: GraphQLWhereArgsTopLevel;
 }
 
 export interface GraphQLReadOperationArgs {
@@ -85,6 +85,10 @@ export interface GraphQLReadOperationArgs {
 
 export type GraphQLWhereArgs = LogicalOperation<{
     edges?: GraphQLEdgeWhereArgs;
+}>;
+
+export type GraphQLWhereArgsTopLevel = LogicalOperation<{
+    node?: GraphQLNodeWhereArgs;
 }>;
 
 export type GraphQLNodeWhereArgs = LogicalOperation<Record<string, GraphQLNodeFilters>>;

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
@@ -42,5 +42,5 @@ export function parseGlobalNodeResolveInfoTree({
     entity: ConcreteEntity;
 }): GraphQLTree {
     const parser = new GlobalNodeResolveTreeParser({ entity });
-    return parser.parseTopLevelOperation(resolveTree); // TODO: This needs to be parseOperationTopLevel
+    return parser.parseTopLevelOperation(resolveTree);
 }

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
@@ -21,7 +21,7 @@ import type { ResolveTree } from "graphql-parse-resolve-info";
 import type { ConcreteEntity } from "../../../schema-model/entity/ConcreteEntity";
 import { GlobalNodeResolveTreeParser } from "./GlobalNodeResolveTreeParser";
 import { TopLevelResolveTreeParser } from "./TopLevelResolveTreeParser";
-import type { GraphQLTree } from "./graphql-tree";
+import type { GraphQLTree, GraphQLTreeReadOperation } from "./graphql-tree";
 
 export function parseResolveInfoTree({
     resolveTree,
@@ -31,7 +31,7 @@ export function parseResolveInfoTree({
     entity: ConcreteEntity;
 }): GraphQLTree {
     const parser = new TopLevelResolveTreeParser({ entity });
-    return parser.parseOperation(resolveTree);
+    return parser.parseOperationTopLevel(resolveTree);
 }
 
 export function parseGlobalNodeResolveInfoTree({
@@ -40,7 +40,7 @@ export function parseGlobalNodeResolveInfoTree({
 }: {
     resolveTree: ResolveTree;
     entity: ConcreteEntity;
-}): GraphQLTree {
+}): GraphQLTreeReadOperation {
     const parser = new GlobalNodeResolveTreeParser({ entity });
-    return parser.parseOperation(resolveTree);
+    return parser.parseOperation(resolveTree); // TODO: This needs to be parseOperationTopLevel
 }

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
@@ -21,7 +21,7 @@ import type { ResolveTree } from "graphql-parse-resolve-info";
 import type { ConcreteEntity } from "../../../schema-model/entity/ConcreteEntity";
 import { GlobalNodeResolveTreeParser } from "./GlobalNodeResolveTreeParser";
 import { TopLevelResolveTreeParser } from "./TopLevelResolveTreeParser";
-import type { GraphQLTree, GraphQLTreeReadOperation } from "./graphql-tree";
+import type { GraphQLTree } from "./graphql-tree";
 
 export function parseResolveInfoTree({
     resolveTree,
@@ -40,7 +40,7 @@ export function parseGlobalNodeResolveInfoTree({
 }: {
     resolveTree: ResolveTree;
     entity: ConcreteEntity;
-}): GraphQLTreeReadOperation {
+}): GraphQLTree {
     const parser = new GlobalNodeResolveTreeParser({ entity });
-    return parser.parseOperation(resolveTree); // TODO: This needs to be parseOperationTopLevel
+    return parser.parseOperationTopLevel(resolveTree); // TODO: This needs to be parseOperationTopLevel
 }

--- a/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
+++ b/packages/graphql/src/api-v6/queryIRFactory/resolve-tree-parser/parse-resolve-info-tree.ts
@@ -42,5 +42,5 @@ export function parseGlobalNodeResolveInfoTree({
     entity: ConcreteEntity;
 }): GraphQLTree {
     const parser = new GlobalNodeResolveTreeParser({ entity });
-    return parser.parseOperationTopLevel(resolveTree); // TODO: This needs to be parseOperationTopLevel
+    return parser.parseTopLevelOperation(resolveTree); // TODO: This needs to be parseOperationTopLevel
 }

--- a/packages/graphql/src/api-v6/schema-generation/schema-types/TopLevelEntitySchemaTypes.ts
+++ b/packages/graphql/src/api-v6/schema-generation/schema-types/TopLevelEntitySchemaTypes.ts
@@ -81,15 +81,15 @@ export class TopLevelEntitySchemaTypes extends EntitySchemaTypes<TopLevelEntityT
         });
     }
 
-    protected get connectionSort(): InputTypeComposer {
-        return this.schemaBuilder.getOrCreateInputType(this.entityTypeNames.connectionSort, () => {
-            return {
-                fields: {
-                    node: this.nodeSort.NonNull.List,
-                },
-            };
-        });
-    }
+    // protected get connectionSort(): InputTypeComposer {
+    //     return this.schemaBuilder.getOrCreateInputType(this.entityTypeNames.connectionSort, () => {
+    //         return {
+    //             fields: {
+    //                 node: this.nodeSort.NonNull.List,
+    //             },
+    //         };
+    //     });
+    // }
 
     protected get edge(): ObjectTypeComposer {
         return this.schemaBuilder.getOrCreateObjectType(this.entityTypeNames.edge, () => {

--- a/packages/graphql/src/api-v6/schema-generation/schema-types/TopLevelEntitySchemaTypes.ts
+++ b/packages/graphql/src/api-v6/schema-generation/schema-types/TopLevelEntitySchemaTypes.ts
@@ -75,9 +75,19 @@ export class TopLevelEntitySchemaTypes extends EntitySchemaTypes<TopLevelEntityT
             name: this.entity.typeNames.queryField,
             type: this.connectionOperation,
             args: {
-                where: this.filterSchemaTypes.operationWhere,
+                where: this.filterSchemaTypes.operationWhereTopLevel,
             },
             resolver,
+        });
+    }
+
+    protected get connectionSort(): InputTypeComposer {
+        return this.schemaBuilder.getOrCreateInputType(this.entityTypeNames.connectionSort, () => {
+            return {
+                fields: {
+                    node: this.nodeSort.NonNull.List,
+                },
+            };
         });
     }
 
@@ -219,7 +229,7 @@ export class TopLevelEntitySchemaTypes extends EntitySchemaTypes<TopLevelEntityT
                     schemaTypes: this.schemaTypes,
                 });
                 const relationshipType = relationshipTypes.connectionOperation;
-                const operationWhere = relationshipTypes.filterSchemaTypes.operationWhere;
+                const operationWhere = relationshipTypes.filterSchemaTypes.operationWhereNested;
                 return [relationship.name, { type: relationshipType, args: { where: operationWhere } }];
             })
         );

--- a/packages/graphql/src/api-v6/schema-generation/schema-types/filter-schema-types/FilterSchemaTypes.ts
+++ b/packages/graphql/src/api-v6/schema-generation/schema-types/filter-schema-types/FilterSchemaTypes.ts
@@ -53,7 +53,25 @@ export abstract class FilterSchemaTypes<T extends TopLevelEntityTypeNames | Rela
         this.schemaTypes = schemaTypes;
     }
 
-    public get operationWhere(): InputTypeComposer {
+    // TODO: Perhaps we can reduce the duplication in the following methods. The only
+    // difference is node: this.nodeWhere vs edges: this.edgeWhere
+    public get operationWhereTopLevel(): InputTypeComposer {
+        return this.schemaBuilder.getOrCreateInputType(
+            this.entityTypeNames.operationWhere,
+            (itc: InputTypeComposer) => {
+                return {
+                    fields: {
+                        AND: itc.NonNull.List,
+                        OR: itc.NonNull.List,
+                        NOT: itc,
+                        node: this.nodeWhere,
+                    },
+                };
+            }
+        );
+    }
+
+    public get operationWhereNested(): InputTypeComposer {
         return this.schemaBuilder.getOrCreateInputType(
             this.entityTypeNames.operationWhere,
             (itc: InputTypeComposer) => {

--- a/packages/graphql/src/api-v6/schema-generation/schema-types/filter-schema-types/FilterSchemaTypes.ts
+++ b/packages/graphql/src/api-v6/schema-generation/schema-types/filter-schema-types/FilterSchemaTypes.ts
@@ -53,8 +53,6 @@ export abstract class FilterSchemaTypes<T extends TopLevelEntityTypeNames | Rela
         this.schemaTypes = schemaTypes;
     }
 
-    // TODO: Perhaps we can reduce the duplication in the following methods. The only
-    // difference is node: this.nodeWhere vs edges: this.edgeWhere
     public get operationWhereTopLevel(): InputTypeComposer {
         return this.schemaBuilder.getOrCreateInputType(
             this.entityTypeNames.operationWhere,

--- a/packages/graphql/src/api-v6/translators/translate-read-operation.ts
+++ b/packages/graphql/src/api-v6/translators/translate-read-operation.ts
@@ -23,7 +23,7 @@ import { DEBUG_TRANSLATE } from "../../constants";
 import type { ConcreteEntity } from "../../schema-model/entity/ConcreteEntity";
 import type { Neo4jGraphQLTranslationContext } from "../../types/neo4j-graphql-translation-context";
 import { ReadOperationFactory } from "../queryIRFactory/ReadOperationFactory";
-import type { GraphQLTreeReadOperation } from "../queryIRFactory/resolve-tree-parser/graphql-tree";
+import type { GraphQLTree } from "../queryIRFactory/resolve-tree-parser/graphql-tree";
 
 const debug = Debug(DEBUG_TRANSLATE);
 
@@ -33,7 +33,7 @@ export function translateReadOperation({
     graphQLTree,
 }: {
     context: Neo4jGraphQLTranslationContext;
-    graphQLTree: GraphQLTreeReadOperation;
+    graphQLTree: GraphQLTree;
     entity: ConcreteEntity;
 }): Cypher.CypherResult {
     const readFactory = new ReadOperationFactory(context.schemaModel);

--- a/packages/graphql/tests/api-v6/integration/directives/relayId/relayId-filters.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/directives/relayId/relayId-filters.int.test.ts
@@ -80,10 +80,8 @@ describe("RelayId projection with filters", () => {
         const connectionQuery = /* GraphQL */ `
             query {
                 ${Movie.plural}(where: {
-                    edges: {
-                        node: {
-                            id: { equals: "${movieGlobalId}"}
-                        }
+                    node: {
+                        id: { equals: "${movieGlobalId}"}
                     }
                 }) {
                     connection {

--- a/packages/graphql/tests/api-v6/integration/filters/logical/and-filter.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/logical/and-filter.test.ts
@@ -65,8 +65,8 @@ describe("Filters AND", () => {
                 ${Movie.plural}(
                     where: {
                         AND: [
-                            { edges: { node: { runtime: { equals: 90.5 } } } }
-                            { edges: { node: { year: { equals: 1999 } } } }
+                            { node: { runtime: { equals: 90.5 } } } 
+                            { node: { year: { equals: 1999 } } } 
                         ]
                     }
                 ) {
@@ -110,52 +110,9 @@ describe("Filters AND", () => {
                     where: {
                         AND: {
                             AND: [
-                                { edges: { node: { runtime: { equals: 90.5 } } } }
-                                { edges: { node: { year: { equals: 1999 } } } }
+                                { node: { runtime: { equals: 90.5 } } } 
+                                {  node: { year: { equals: 1999 } } } 
                             ]
-                        }
-                    }
-                ) {
-                    connection {
-                        edges {
-                            node {
-                                title
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-        const gqlResult = await testHelper.executeGraphQL(query);
-        expect(gqlResult.errors).toBeFalsy();
-        expect(gqlResult.data).toEqual({
-            [Movie.plural]: {
-                connection: {
-                    edges: expect.toIncludeSameMembers([
-                        {
-                            node: {
-                                title: "The Matrix",
-                            },
-                        },
-                        {
-                            node: {
-                                title: "The Matrix Thingy",
-                            },
-                        },
-                    ]),
-                },
-            },
-        });
-    });
-
-    test("AND filter in edges by node", async () => {
-        const query = /* GraphQL */ `
-            query {
-                ${Movie.plural}(
-                    where: {
-                        edges: {
-                            AND: [{ node: { runtime: { equals: 90.5 } } }, { node: { year: { equals: 1999 } } }]
                         }
                     }
                 ) {

--- a/packages/graphql/tests/api-v6/integration/filters/logical/not-filter.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/logical/not-filter.test.ts
@@ -61,55 +61,7 @@ describe("Filters NOT", () => {
     test("top level NOT filter by node", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(
-                    where: {
-                        NOT: 
-                            { edges: { node: { title: { equals: "The Matrix" } } } }
-                    }
-                ) {
-                    connection {
-                        edges {
-                            node {
-                                title
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-        const gqlResult = await testHelper.executeGraphQL(query);
-        expect(gqlResult.errors).toBeFalsy();
-        expect(gqlResult.data).toEqual({
-            [Movie.plural]: {
-                connection: {
-                    edges: expect.toIncludeSameMembers([
-                        {
-                            node: {
-                                title: "The Matrix Revelations",
-                            },
-                        },
-                        {
-                            node: {
-                                title: "The Matrix Reloaded",
-                            },
-                        },
-                    ]),
-                },
-            },
-        });
-    });
-
-    test("NOT filter in edges by node", async () => {
-        const query = /* GraphQL */ `
-            query {
-                ${Movie.plural}(
-                    where: {
-                        edges: {
-                            NOT: { node: { title: { equals: "The Matrix" } } }
-                        }
-                    }
-                ) {
+                ${Movie.plural}(where: { NOT: { node: { title: { equals: "The Matrix" } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/logical/or-filter.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/logical/or-filter.test.ts
@@ -62,12 +62,7 @@ describe("Filters OR", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: {
-                        OR: [
-                            { edges: { node: { title: { equals: "The Matrix" } } } }
-                            { edges: { node: { year: { equals: 2001 } } } }
-                        ]
-                    }
+                    where: { OR: [{ node: { title: { equals: "The Matrix" } } }, { node: { year: { equals: 2001 } } }] }
                 ) {
                     connection {
                         edges {
@@ -108,52 +103,6 @@ describe("Filters OR", () => {
                 ${Movie.plural}(
                     where: {
                         OR: {
-                            OR: [
-                                { edges: { node: { title: { equals: "The Matrix" } } } }
-                                { edges: { node: { year: { equals: 2001 } } } }
-                            ]
-                        }
-                    }
-                ) {
-                    connection {
-                        edges {
-                            node {
-                                title
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-        const gqlResult = await testHelper.executeGraphQL(query);
-        expect(gqlResult.errors).toBeFalsy();
-        expect(gqlResult.data).toEqual({
-            [Movie.plural]: {
-                connection: {
-                    edges: expect.toIncludeSameMembers([
-                        {
-                            node: {
-                                title: "The Matrix",
-                            },
-                        },
-                        {
-                            node: {
-                                title: "The Matrix Reloaded",
-                            },
-                        },
-                    ]),
-                },
-            },
-        });
-    });
-
-    test("OR filter in edges by node", async () => {
-        const query = /* GraphQL */ `
-            query {
-                ${Movie.plural}(
-                    where: {
-                        edges: {
                             OR: [{ node: { title: { equals: "The Matrix" } } }, { node: { year: { equals: 2001 } } }]
                         }
                     }

--- a/packages/graphql/tests/api-v6/integration/filters/nested/all.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/nested/all.int.test.ts
@@ -65,7 +65,7 @@ describe("Relationship filters with all", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { all: { node: { name: { equals: "Keanu" } } } } } } } }
+                    where: { node: { actors: { edges: { all: { node: { name: { equals: "Keanu" } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -99,7 +99,7 @@ describe("Relationship filters with all", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { all: { properties: { year: { equals: 1999 } } } } } } } }
+                    where: { node: { actors: { edges: { all: { properties: { year: { equals: 1999 } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -133,7 +133,7 @@ describe("Relationship filters with all", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { all: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } } }
+                    where: { node: { actors: { edges: { all: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } }
                 ) {
                     connection {
                         edges {

--- a/packages/graphql/tests/api-v6/integration/filters/nested/none.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/nested/none.int.test.ts
@@ -65,7 +65,7 @@ describe("Relationship filters with none", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { none: { node: { name: { equals: "Keanu" } } } } } } } }
+                    where: { node: { actors: { edges: { none: { node: { name: { equals: "Keanu" } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -104,7 +104,7 @@ describe("Relationship filters with none", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { none: { properties: { year: { equals: 1999 } } } } } } } }
+                    where: { node: { actors: { edges: { none: { properties: { year: { equals: 1999 } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -143,7 +143,7 @@ describe("Relationship filters with none", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { none: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } } }
+                    where: { node: { actors: { edges: { none: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } }
                 ) {
                     connection {
                         edges {

--- a/packages/graphql/tests/api-v6/integration/filters/nested/single.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/nested/single.int.test.ts
@@ -67,7 +67,7 @@ describe("Relationship filters with single", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { single: { node: { name: { equals: "Keanu" } } } } } } } }
+                    where: { node: { actors: { edges: { single: { node: { name: { equals: "Keanu" } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -101,7 +101,7 @@ describe("Relationship filters with single", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { single: { properties: { year: { equals: 1999 } } } } } } } }
+                    where: { node: { actors: { edges: { single: { properties: { year: { equals: 1999 } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -135,7 +135,7 @@ describe("Relationship filters with single", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { single: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } } }
+                    where: { node: { actors: { edges: { single: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } }
                 ) {
                     connection {
                         edges {

--- a/packages/graphql/tests/api-v6/integration/filters/nested/some.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/nested/some.int.test.ts
@@ -65,7 +65,7 @@ describe("Relationship filters with some", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { some: { node: { name: { equals: "Keanu" } } } } } } } }
+                    where: { node: { actors: { edges: { some: { node: { name: { equals: "Keanu" } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -104,7 +104,7 @@ describe("Relationship filters with some", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { some: { properties: { year: { equals: 1999 } } } } } } } }
+                    where: { node: { actors: { edges: { some: { properties: { year: { equals: 1999 } } } } } } }
                 ) {
                     connection {
                         edges {
@@ -143,7 +143,7 @@ describe("Relationship filters with some", () => {
         const query = /* GraphQL */ `
             query {
                 ${Movie.plural}(
-                    where: { edges: { node: { actors: { edges: { some: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } } }
+                    where: { node: { actors: { edges: { some: { OR: [{ properties: { year: { equals: 1999 } } }, { node: { name: { equals: "Keanu" } } }] } } } } }
                 ) {
                     connection {
                         edges {

--- a/packages/graphql/tests/api-v6/integration/filters/top-level-filters.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/top-level-filters.int.test.ts
@@ -49,13 +49,7 @@ describe("Top level filters", () => {
     test("should be able to get a Movie", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(
-                    where: {
-                        edges: {
-                            node: { year: { equals: 1999 }, runtime: { equals: 90.5 } }
-                        }
-                    }
-                ) {
+                ${Movie.plural}(where: { node: { year: { equals: 1999 }, runtime: { equals: 90.5 } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/boolean/boolean-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/boolean/boolean-equals.int.test.ts
@@ -50,7 +50,7 @@ describe("Boolean Filtering", () => {
     test("filter by true", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { equals:  true } } } }) {
+                ${Movie.plural}(where: { node: { value: { equals:  true } } }) {
                     connection {
                         edges {
                             node {
@@ -82,7 +82,7 @@ describe("Boolean Filtering", () => {
     test("filter by false", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { equals: false } } } }) {
+                ${Movie.plural}(where: { node: { value: { equals: false } } }) {
                     connection {
                         edges {
                             node {
@@ -114,7 +114,7 @@ describe("Boolean Filtering", () => {
     test("filter by NOT", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { equals: true } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { equals: true } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/date/array/date-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/date/array/date-equals.int.test.ts
@@ -62,7 +62,7 @@ describe("Date array - Equals", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
             query movies($date1: Date!, $date3: Date!) {
-              ${Movie.plural}(where: { edges: { node: { date: { equals: [$date1, $date3] }} }}) {
+              ${Movie.plural}(where: { node: { date: { equals: [$date1, $date3] }}}) {
                   connection{
                       edges  {
                           node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/date/date-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/date/date-equals.int.test.ts
@@ -58,7 +58,7 @@ describe("Date - Equals", () => {
 
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { date: { equals: "${datetime1.toString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { date: { equals: "${datetime1.toString()}" }} }) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/date/date-in.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/date/date-in.int.test.ts
@@ -62,7 +62,7 @@ describe("Date - IN", () => {
                 query {
                     ${
                         Movie.plural
-                    }(where: { edges: { node: { date: { in: ["${neoDate1.toString()}", "${neoDate3.toString()}"] }} }}) {
+                    }(where: { node: { date: { in: ["${neoDate1.toString()}", "${neoDate3.toString()}"] }} }) {
                         connection{
                             edges  {
                                 node {
@@ -123,7 +123,7 @@ describe("Date - IN", () => {
                 query {
                     ${
                         Movie.plural
-                    }(where: { edges: { node: { date: { NOT: { in: ["${neoDate1.toString()}", "${neoDate3.toString()}"] } }} }}) {
+                    }(where: { node: { date: { NOT: { in: ["${neoDate1.toString()}", "${neoDate3.toString()}"] } }} }) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/date/date-lt.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/date/date-lt.int.test.ts
@@ -58,7 +58,7 @@ describe("Date - LT", () => {
 
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { date: { lt: "${neoDate2.toString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { date: { lt: "${neoDate2.toString()}" }}}) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/datetime/array/datetime-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/datetime/array/datetime-equals.int.test.ts
@@ -44,9 +44,11 @@ describe("DateTime array - Equals", () => {
         const date1 = new Date(1716904582368);
         const date2 = new Date(1716900000000);
         const date3 = new Date(1716904582369);
-        const datetime1 = [neo4jDriver.types.DateTime.fromStandardDate(date1), neo4jDriver.types.DateTime.fromStandardDate(date3)];
+        const datetime1 = [
+            neo4jDriver.types.DateTime.fromStandardDate(date1),
+            neo4jDriver.types.DateTime.fromStandardDate(date3),
+        ];
         const datetime2 = [neo4jDriver.types.DateTime.fromStandardDate(date2)];
-     
 
         await testHelper.executeCypher(
             `
@@ -60,7 +62,9 @@ describe("DateTime array - Equals", () => {
 
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { datetime: { equals: ["${date1.toISOString()}", "${date3.toISOString()}"] }} }}) {
+                    ${
+                        Movie.plural
+                    }(where: { node: { datetime: { equals: ["${date1.toISOString()}", "${date3.toISOString()}"] }}}) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/datetime/datetime-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/datetime/datetime-equals.int.test.ts
@@ -58,7 +58,7 @@ describe("DateTime - Equals", () => {
 
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { datetime: { equals: "${date1.toISOString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { datetime: { equals: "${date1.toISOString()}" }}}) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/duration/array/duration-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/duration/array/duration-equals.int.test.ts
@@ -79,7 +79,7 @@ describe("Duration array - Equals", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
             query movies($date1: Duration!, $date3: Duration!) {
-              ${Movie.plural}(where: { edges: { node: { duration: { equals: [$date1, $date3] }} }}) {
+              ${Movie.plural}(where: { node: { duration: { equals: [$date1, $date3] }} }) {
                   connection{
                       edges  {
                           node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/duration/duration-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/duration/duration-equals.int.test.ts
@@ -66,7 +66,7 @@ describe("Duration - Equals", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { duration: { equals: "${duration1.toString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { duration: { equals: "${duration1.toString()}" }} }) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/duration/duration-lt.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/duration/duration-lt.int.test.ts
@@ -68,7 +68,7 @@ describe("Duration - LT", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { duration: { lt: "${duration2.toString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { duration: { lt: "${duration2.toString()}" }} }) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/localdatetime/array/localdatetime-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/localdatetime/array/localdatetime-equals.int.test.ts
@@ -48,7 +48,7 @@ describe("LocalDateTime array - Equals", () => {
 
         const date3 = new Date("2026-09-17T11:49:48.322Z");
         const localdatetime3 = neo4jDriver.types.LocalDateTime.fromStandardDate(date3);
-        
+
         const dateList1 = [localdatetime1, localdatetime3];
         const dateList2 = [localdatetime2];
 
@@ -63,7 +63,7 @@ describe("LocalDateTime array - Equals", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
             query movies($date1: LocalDateTime!, $date3: LocalDateTime!) {
-              ${Movie.plural}(where: { edges: { node: { localDateTime: { equals: [$date1, $date3] }} }}) {
+              ${Movie.plural}(where: { node: { localDateTime: { equals: [$date1, $date3] }}}) {
                   connection{
                       edges  {
                           node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/localdatetime/localdatetime-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/localdatetime/localdatetime-equals.int.test.ts
@@ -59,9 +59,7 @@ describe("LocalDateTime - Equals", () => {
 
         const query = /* GraphQL */ `
                 query {
-                    ${
-                        Movie.plural
-                    }(where: { edges: { node: { localDateTime: { equals: "${localdatetime1.toString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { localDateTime: { equals: "${localdatetime1.toString()}" }} }) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/number/array/number-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/number/array/number-equals.int.test.ts
@@ -52,7 +52,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering array - 'equals
     test.each(["list", "listNullable"])("%s filter by 'equals'", async (field) => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { ${field}: { equals: [2001, 2000] } } } }) {
+                ${Movie.plural}(where: { node: { ${field}: { equals: [2001, 2000] } } }) {
                     connection {
                         edges {
                             node {
@@ -84,7 +84,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering array - 'equals
     test.each(["list", "listNullable"])("%s filter by NOT 'equals'", async (field) => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { ${field}: { equals: [2001, 2000] } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { ${field}: { equals: [2001, 2000] } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/number/number-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/number/number-equals.int.test.ts
@@ -51,7 +51,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'equals'", (t
     test("filter by 'equals'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { equals: 2001 } } } }) {
+                ${Movie.plural}(where: { node: { value: { equals: 2001 } } }) {
                     connection {
                         edges {
                             node {
@@ -83,7 +83,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'equals'", (t
     test("filter by NOT 'equals'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { equals: 2001 } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { equals: 2001 } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/number/number-gt.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/number/number-gt.int.test.ts
@@ -51,7 +51,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'gt' and 'gte
     test("filter by 'gt'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { gt: 1999 } } } }) {
+                ${Movie.plural}(where: { node: { value: { gt: 1999 } } }) {
                     connection {
                         edges {
                             node {
@@ -83,7 +83,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'gt' and 'gte
     test("filter by NOT 'gt'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { gt: 1999 } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { gt: 1999 } } } }) {
                     connection {
                         edges {
                             node {
@@ -120,7 +120,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'gt' and 'gte
     test("filter by 'gte'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { gte: 1999 } } } }) {
+                ${Movie.plural}(where: { node: { value: { gte: 1999 } } }) {
                     connection {
                         edges {
                             node {
@@ -157,7 +157,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'gt' and 'gte
     test("filter by NOT 'gte'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { gte: 1999 } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { gte: 1999 } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/number/number-in.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/number/number-in.int.test.ts
@@ -51,7 +51,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'in'", (type)
     test("filter by 'in'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { in: [1999, 2001] } } } }) {
+                ${Movie.plural}(where: { node: { value: { in: [1999, 2001] } } }) {
                     connection {
                         edges {
                             node {
@@ -88,7 +88,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering - 'in'", (type)
     test("filter by NOT 'in'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { in: [1999, 2001] } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { in: [1999, 2001] } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/number/number-lt.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/number/number-lt.int.test.ts
@@ -51,7 +51,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering", (type) => {
     test("filter by 'lt'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { lt: 1999 } } } }) {
+                ${Movie.plural}(where: { node: { value: { lt: 1999 } } }) {
                     connection {
                         edges {
                             node {
@@ -83,7 +83,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering", (type) => {
     test("filter by NOT 'lt'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { lt: 1999 } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { lt: 1999 } } } }) {
                     connection {
                         edges {
                             node {
@@ -120,7 +120,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering", (type) => {
     test("filter by 'lte'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { lte: 1999 } } } }) {
+                ${Movie.plural}(where: { node: { value: { lte: 1999 } } }) {
                     connection {
                         edges {
                             node {
@@ -157,7 +157,7 @@ describe.each(["Float", "Int", "BigInt"] as const)("%s Filtering", (type) => {
     test("filter by NOT 'lte'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { lte: 1999 } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { lte: 1999 } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/string/string-contains.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/string/string-contains.int.test.ts
@@ -50,7 +50,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'contains'", (type) => 
     test("filter by 'contains'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { contains: "Matrix" } } } }) {
+                ${Movie.plural}(where: { node: { value: { contains: "Matrix" } } }) {
                     connection {
                         edges {
                             node {
@@ -87,7 +87,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'contains'", (type) => 
     test("filter by NOT 'contains'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { contains: "Matrix" } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { contains: "Matrix" } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/string/string-ends-with-int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/string/string-ends-with-int.test.ts
@@ -50,7 +50,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'endsWith'", (type) => 
     test("filter by 'endsWith'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { endsWith: "The Matrix" } } } }) {
+                ${Movie.plural}(where: { node: { value: { endsWith: "The Matrix" } } }) {
                     connection {
                         edges {
                             node {
@@ -87,7 +87,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'endsWith'", (type) => 
     test("filter by NOT 'endsWith'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { endsWith: "The Matrix" } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { endsWith: "The Matrix" } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/string/string-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/string/string-equals.int.test.ts
@@ -50,7 +50,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'equals'", (type) => {
     test("filter by 'equals'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { equals: "The Matrix" } } } }) {
+                ${Movie.plural}(where: { node: { value: { equals: "The Matrix" } } }) {
                     connection {
                         edges {
                             node {
@@ -82,7 +82,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'equals'", (type) => {
     test("filter by NOT 'equals'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { equals: "The Matrix" } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { equals: "The Matrix" } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/string/string-in.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/string/string-in.int.test.ts
@@ -50,7 +50,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'in'", (type) => {
     test("filter by 'in'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { in: ["The Matrix", "The Matrix 2"] } } } }) {
+                ${Movie.plural}(where: { node: { value: { in: ["The Matrix", "The Matrix 2"] } } }) {
                     connection {
                         edges {
                             node {
@@ -87,7 +87,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'in'", (type) => {
     test("filter by NOT 'in'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { in: ["The Matrix", "The Matrix 2"] } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { in: ["The Matrix", "The Matrix 2"] } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/string/string-starts-with.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/string/string-starts-with.int.test.ts
@@ -50,7 +50,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'startsWith'", (type) =
     test("filter by 'startsWith'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { node: { value: { startsWith: "The" } } } }) {
+                ${Movie.plural}(where: { node: { value: { startsWith: "The" } } }) {
                     connection {
                         edges {
                             node {
@@ -87,7 +87,7 @@ describe.each(["ID", "String"] as const)("%s Filtering - 'startsWith'", (type) =
     test("filter by NOT 'startsWith'", async () => {
         const query = /* GraphQL */ `
             query {
-                ${Movie.plural}(where: { edges: { NOT: { node: { value: { startsWith: "The" } } } } }) {
+                ${Movie.plural}(where: { NOT: { node: { value: { startsWith: "The" } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/time/array/time-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/time/array/time-equals.int.test.ts
@@ -62,7 +62,7 @@ describe("Time array - Equals", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
             query movies($date1: Time!, $date3: Time!) {
-              ${Movie.plural}(where: { edges: { node: { time: { equals: [$date1, $date3] }} }}) {
+              ${Movie.plural}(where: { node: { time: { equals: [$date1, $date3] }} }) {
                   connection{
                       edges  {
                           node {

--- a/packages/graphql/tests/api-v6/integration/filters/types/time/time-equals.int.test.ts
+++ b/packages/graphql/tests/api-v6/integration/filters/types/time/time-equals.int.test.ts
@@ -58,7 +58,7 @@ describe("Time - Equals", () => {
         await testHelper.initNeo4jGraphQL({ typeDefs });
         const query = /* GraphQL */ `
                 query {
-                    ${Movie.plural}(where: { edges: { node: { time: { equals: "${time1.toString()}" }} }}) {
+                    ${Movie.plural}(where: { node: { time: { equals: "${time1.toString()}" }}}) {
                         connection{
                             edges  {
                                 node {

--- a/packages/graphql/tests/api-v6/schema/directives/relayId.test.ts
+++ b/packages/graphql/tests/api-v6/schema/directives/relayId.test.ts
@@ -66,23 +66,12 @@ describe("RelayId", () => {
             }
 
             input MovieConnectionSort {
-              edges: [MovieEdgeSort!]
+              node: [MovieSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
-            }
-
-            input MovieEdgeSort {
-              node: MovieSort
-            }
-
-            input MovieEdgeWhere {
-              AND: [MovieEdgeWhere!]
-              NOT: MovieEdgeWhere
-              OR: [MovieEdgeWhere!]
-              node: MovieWhere
             }
 
             type MovieOperation {
@@ -93,7 +82,7 @@ describe("RelayId", () => {
               AND: [MovieOperationWhere!]
               NOT: MovieOperationWhere
               OR: [MovieOperationWhere!]
-              edges: MovieEdgeWhere
+              node: MovieWhere
             }
 
             input MovieSort {

--- a/packages/graphql/tests/api-v6/schema/directives/relayId.test.ts
+++ b/packages/graphql/tests/api-v6/schema/directives/relayId.test.ts
@@ -66,12 +66,16 @@ describe("RelayId", () => {
             }
 
             input MovieConnectionSort {
-              node: [MovieSort!]
+              edges: [MovieEdgeSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
+            }
+
+            input MovieEdgeSort {
+              node: MovieSort
             }
 
             type MovieOperation {

--- a/packages/graphql/tests/api-v6/schema/relationship.test.ts
+++ b/packages/graphql/tests/api-v6/schema/relationship.test.ts
@@ -55,12 +55,16 @@ describe("Relationships", () => {
             }
 
             input ActorConnectionSort {
-              node: [ActorSort!]
+              edges: [ActorEdgeSort!]
             }
 
             type ActorEdge {
               cursor: String
               node: Actor
+            }
+
+            input ActorEdgeSort {
+              node: ActorSort
             }
 
             type ActorMoviesConnection {
@@ -203,12 +207,16 @@ describe("Relationships", () => {
             }
 
             input MovieConnectionSort {
-              node: [MovieSort!]
+              edges: [MovieEdgeSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
+            }
+
+            input MovieEdgeSort {
+              node: MovieSort
             }
 
             type MovieOperation {
@@ -315,12 +323,16 @@ describe("Relationships", () => {
             }
 
             input ActorConnectionSort {
-              node: [ActorSort!]
+              edges: [ActorEdgeSort!]
             }
 
             type ActorEdge {
               cursor: String
               node: Actor
+            }
+
+            input ActorEdgeSort {
+              node: ActorSort
             }
 
             type ActorMoviesConnection {
@@ -481,12 +493,16 @@ describe("Relationships", () => {
             }
 
             input MovieConnectionSort {
-              node: [MovieSort!]
+              edges: [MovieEdgeSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
+            }
+
+            input MovieEdgeSort {
+              node: MovieSort
             }
 
             type MovieOperation {

--- a/packages/graphql/tests/api-v6/schema/relationship.test.ts
+++ b/packages/graphql/tests/api-v6/schema/relationship.test.ts
@@ -55,23 +55,12 @@ describe("Relationships", () => {
             }
 
             input ActorConnectionSort {
-              edges: [ActorEdgeSort!]
+              node: [ActorSort!]
             }
 
             type ActorEdge {
               cursor: String
               node: Actor
-            }
-
-            input ActorEdgeSort {
-              node: ActorSort
-            }
-
-            input ActorEdgeWhere {
-              AND: [ActorEdgeWhere!]
-              NOT: ActorEdgeWhere
-              OR: [ActorEdgeWhere!]
-              node: ActorWhere
             }
 
             type ActorMoviesConnection {
@@ -135,7 +124,7 @@ describe("Relationships", () => {
               AND: [ActorOperationWhere!]
               NOT: ActorOperationWhere
               OR: [ActorOperationWhere!]
-              edges: ActorEdgeWhere
+              node: ActorWhere
             }
 
             input ActorSort {
@@ -214,23 +203,12 @@ describe("Relationships", () => {
             }
 
             input MovieConnectionSort {
-              edges: [MovieEdgeSort!]
+              node: [MovieSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
-            }
-
-            input MovieEdgeSort {
-              node: MovieSort
-            }
-
-            input MovieEdgeWhere {
-              AND: [MovieEdgeWhere!]
-              NOT: MovieEdgeWhere
-              OR: [MovieEdgeWhere!]
-              node: MovieWhere
             }
 
             type MovieOperation {
@@ -241,7 +219,7 @@ describe("Relationships", () => {
               AND: [MovieOperationWhere!]
               NOT: MovieOperationWhere
               OR: [MovieOperationWhere!]
-              edges: MovieEdgeWhere
+              node: MovieWhere
             }
 
             input MovieSort {
@@ -337,23 +315,12 @@ describe("Relationships", () => {
             }
 
             input ActorConnectionSort {
-              edges: [ActorEdgeSort!]
+              node: [ActorSort!]
             }
 
             type ActorEdge {
               cursor: String
               node: Actor
-            }
-
-            input ActorEdgeSort {
-              node: ActorSort
-            }
-
-            input ActorEdgeWhere {
-              AND: [ActorEdgeWhere!]
-              NOT: ActorEdgeWhere
-              OR: [ActorEdgeWhere!]
-              node: ActorWhere
             }
 
             type ActorMoviesConnection {
@@ -420,7 +387,7 @@ describe("Relationships", () => {
               AND: [ActorOperationWhere!]
               NOT: ActorOperationWhere
               OR: [ActorOperationWhere!]
-              edges: ActorEdgeWhere
+              node: ActorWhere
             }
 
             input ActorSort {
@@ -514,23 +481,12 @@ describe("Relationships", () => {
             }
 
             input MovieConnectionSort {
-              edges: [MovieEdgeSort!]
+              node: [MovieSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
-            }
-
-            input MovieEdgeSort {
-              node: MovieSort
-            }
-
-            input MovieEdgeWhere {
-              AND: [MovieEdgeWhere!]
-              NOT: MovieEdgeWhere
-              OR: [MovieEdgeWhere!]
-              node: MovieWhere
             }
 
             type MovieOperation {
@@ -541,7 +497,7 @@ describe("Relationships", () => {
               AND: [MovieOperationWhere!]
               NOT: MovieOperationWhere
               OR: [MovieOperationWhere!]
-              edges: MovieEdgeWhere
+              node: MovieWhere
             }
 
             input MovieSort {

--- a/packages/graphql/tests/api-v6/schema/simple.test.ts
+++ b/packages/graphql/tests/api-v6/schema/simple.test.ts
@@ -49,23 +49,12 @@ describe("Simple Aura-API", () => {
             }
 
             input MovieConnectionSort {
-              edges: [MovieEdgeSort!]
+              node: [MovieSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
-            }
-
-            input MovieEdgeSort {
-              node: MovieSort
-            }
-
-            input MovieEdgeWhere {
-              AND: [MovieEdgeWhere!]
-              NOT: MovieEdgeWhere
-              OR: [MovieEdgeWhere!]
-              node: MovieWhere
             }
 
             type MovieOperation {
@@ -76,7 +65,7 @@ describe("Simple Aura-API", () => {
               AND: [MovieOperationWhere!]
               NOT: MovieOperationWhere
               OR: [MovieOperationWhere!]
-              edges: MovieEdgeWhere
+              node: MovieWhere
             }
 
             input MovieSort {
@@ -148,23 +137,12 @@ describe("Simple Aura-API", () => {
             }
 
             input ActorConnectionSort {
-              edges: [ActorEdgeSort!]
+              node: [ActorSort!]
             }
 
             type ActorEdge {
               cursor: String
               node: Actor
-            }
-
-            input ActorEdgeSort {
-              node: ActorSort
-            }
-
-            input ActorEdgeWhere {
-              AND: [ActorEdgeWhere!]
-              NOT: ActorEdgeWhere
-              OR: [ActorEdgeWhere!]
-              node: ActorWhere
             }
 
             type ActorOperation {
@@ -175,7 +153,7 @@ describe("Simple Aura-API", () => {
               AND: [ActorOperationWhere!]
               NOT: ActorOperationWhere
               OR: [ActorOperationWhere!]
-              edges: ActorEdgeWhere
+              node: ActorWhere
             }
 
             input ActorSort {
@@ -199,23 +177,12 @@ describe("Simple Aura-API", () => {
             }
 
             input MovieConnectionSort {
-              edges: [MovieEdgeSort!]
+              node: [MovieSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
-            }
-
-            input MovieEdgeSort {
-              node: MovieSort
-            }
-
-            input MovieEdgeWhere {
-              AND: [MovieEdgeWhere!]
-              NOT: MovieEdgeWhere
-              OR: [MovieEdgeWhere!]
-              node: MovieWhere
             }
 
             type MovieOperation {
@@ -226,7 +193,7 @@ describe("Simple Aura-API", () => {
               AND: [MovieOperationWhere!]
               NOT: MovieOperationWhere
               OR: [MovieOperationWhere!]
-              edges: MovieEdgeWhere
+              node: MovieWhere
             }
 
             input MovieSort {
@@ -299,23 +266,12 @@ describe("Simple Aura-API", () => {
             }
 
             input MovieConnectionSort {
-              edges: [MovieEdgeSort!]
+              node: [MovieSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
-            }
-
-            input MovieEdgeSort {
-              node: MovieSort
-            }
-
-            input MovieEdgeWhere {
-              AND: [MovieEdgeWhere!]
-              NOT: MovieEdgeWhere
-              OR: [MovieEdgeWhere!]
-              node: MovieWhere
             }
 
             type MovieOperation {
@@ -326,7 +282,7 @@ describe("Simple Aura-API", () => {
               AND: [MovieOperationWhere!]
               NOT: MovieOperationWhere
               OR: [MovieOperationWhere!]
-              edges: MovieEdgeWhere
+              node: MovieWhere
             }
 
             input MovieSort {

--- a/packages/graphql/tests/api-v6/schema/simple.test.ts
+++ b/packages/graphql/tests/api-v6/schema/simple.test.ts
@@ -49,12 +49,16 @@ describe("Simple Aura-API", () => {
             }
 
             input MovieConnectionSort {
-              node: [MovieSort!]
+              edges: [MovieEdgeSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
+            }
+
+            input MovieEdgeSort {
+              node: MovieSort
             }
 
             type MovieOperation {
@@ -137,12 +141,16 @@ describe("Simple Aura-API", () => {
             }
 
             input ActorConnectionSort {
-              node: [ActorSort!]
+              edges: [ActorEdgeSort!]
             }
 
             type ActorEdge {
               cursor: String
               node: Actor
+            }
+
+            input ActorEdgeSort {
+              node: ActorSort
             }
 
             type ActorOperation {
@@ -177,12 +185,16 @@ describe("Simple Aura-API", () => {
             }
 
             input MovieConnectionSort {
-              node: [MovieSort!]
+              edges: [MovieEdgeSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
+            }
+
+            input MovieEdgeSort {
+              node: MovieSort
             }
 
             type MovieOperation {
@@ -266,12 +278,16 @@ describe("Simple Aura-API", () => {
             }
 
             input MovieConnectionSort {
-              node: [MovieSort!]
+              edges: [MovieEdgeSort!]
             }
 
             type MovieEdge {
               cursor: String
               node: Movie
+            }
+
+            input MovieEdgeSort {
+              node: MovieSort
             }
 
             type MovieOperation {

--- a/packages/graphql/tests/api-v6/schema/types/array.test.ts
+++ b/packages/graphql/tests/api-v6/schema/types/array.test.ts
@@ -257,13 +257,6 @@ describe("Scalars", () => {
               node: NodeType
             }
 
-            input NodeTypeEdgeWhere {
-              AND: [NodeTypeEdgeWhere!]
-              NOT: NodeTypeEdgeWhere
-              OR: [NodeTypeEdgeWhere!]
-              node: NodeTypeWhere
-            }
-
             type NodeTypeOperation {
               connection(after: String, first: Int): NodeTypeConnection
             }
@@ -272,7 +265,7 @@ describe("Scalars", () => {
               AND: [NodeTypeOperationWhere!]
               NOT: NodeTypeOperationWhere
               OR: [NodeTypeOperationWhere!]
-              edges: NodeTypeEdgeWhere
+              node: NodeTypeWhere
             }
 
             type NodeTypeRelatedNodeConnection {
@@ -402,13 +395,6 @@ describe("Scalars", () => {
               node: RelatedNode
             }
 
-            input RelatedNodeEdgeWhere {
-              AND: [RelatedNodeEdgeWhere!]
-              NOT: RelatedNodeEdgeWhere
-              OR: [RelatedNodeEdgeWhere!]
-              node: RelatedNodeWhere
-            }
-
             type RelatedNodeOperation {
               connection(after: String, first: Int): RelatedNodeConnection
             }
@@ -417,7 +403,7 @@ describe("Scalars", () => {
               AND: [RelatedNodeOperationWhere!]
               NOT: RelatedNodeOperationWhere
               OR: [RelatedNodeOperationWhere!]
-              edges: RelatedNodeEdgeWhere
+              node: RelatedNodeWhere
             }
 
             type RelatedNodeProperties {

--- a/packages/graphql/tests/api-v6/schema/types/scalars.test.ts
+++ b/packages/graphql/tests/api-v6/schema/types/scalars.test.ts
@@ -163,12 +163,16 @@ describe("Scalars", () => {
             }
 
             input NodeTypeConnectionSort {
-              node: [NodeTypeSort!]
+              edges: [NodeTypeEdgeSort!]
             }
 
             type NodeTypeEdge {
               cursor: String
               node: NodeType
+            }
+
+            input NodeTypeEdgeSort {
+              node: NodeTypeSort
             }
 
             type NodeTypeOperation {
@@ -305,12 +309,16 @@ describe("Scalars", () => {
             }
 
             input RelatedNodeConnectionSort {
-              node: [RelatedNodeSort!]
+              edges: [RelatedNodeEdgeSort!]
             }
 
             type RelatedNodeEdge {
               cursor: String
               node: RelatedNode
+            }
+
+            input RelatedNodeEdgeSort {
+              node: RelatedNodeSort
             }
 
             type RelatedNodeOperation {

--- a/packages/graphql/tests/api-v6/schema/types/scalars.test.ts
+++ b/packages/graphql/tests/api-v6/schema/types/scalars.test.ts
@@ -163,23 +163,12 @@ describe("Scalars", () => {
             }
 
             input NodeTypeConnectionSort {
-              edges: [NodeTypeEdgeSort!]
+              node: [NodeTypeSort!]
             }
 
             type NodeTypeEdge {
               cursor: String
               node: NodeType
-            }
-
-            input NodeTypeEdgeSort {
-              node: NodeTypeSort
-            }
-
-            input NodeTypeEdgeWhere {
-              AND: [NodeTypeEdgeWhere!]
-              NOT: NodeTypeEdgeWhere
-              OR: [NodeTypeEdgeWhere!]
-              node: NodeTypeWhere
             }
 
             type NodeTypeOperation {
@@ -190,7 +179,7 @@ describe("Scalars", () => {
               AND: [NodeTypeOperationWhere!]
               NOT: NodeTypeOperationWhere
               OR: [NodeTypeOperationWhere!]
-              edges: NodeTypeEdgeWhere
+              node: NodeTypeWhere
             }
 
             type NodeTypeRelatedNodeConnection {
@@ -316,23 +305,12 @@ describe("Scalars", () => {
             }
 
             input RelatedNodeConnectionSort {
-              edges: [RelatedNodeEdgeSort!]
+              node: [RelatedNodeSort!]
             }
 
             type RelatedNodeEdge {
               cursor: String
               node: RelatedNode
-            }
-
-            input RelatedNodeEdgeSort {
-              node: RelatedNodeSort
-            }
-
-            input RelatedNodeEdgeWhere {
-              AND: [RelatedNodeEdgeWhere!]
-              NOT: RelatedNodeEdgeWhere
-              OR: [RelatedNodeEdgeWhere!]
-              node: RelatedNodeWhere
             }
 
             type RelatedNodeOperation {
@@ -343,7 +321,7 @@ describe("Scalars", () => {
               AND: [RelatedNodeOperationWhere!]
               NOT: RelatedNodeOperationWhere
               OR: [RelatedNodeOperationWhere!]
-              edges: RelatedNodeEdgeWhere
+              node: RelatedNodeWhere
             }
 
             type RelatedNodeProperties {

--- a/packages/graphql/tests/api-v6/schema/types/spatial.test.ts
+++ b/packages/graphql/tests/api-v6/schema/types/spatial.test.ts
@@ -88,13 +88,6 @@ describe("Spatial Types", () => {
               node: NodeType
             }
 
-            input NodeTypeEdgeWhere {
-              AND: [NodeTypeEdgeWhere!]
-              NOT: NodeTypeEdgeWhere
-              OR: [NodeTypeEdgeWhere!]
-              node: NodeTypeWhere
-            }
-
             type NodeTypeOperation {
               connection(after: String, first: Int): NodeTypeConnection
             }
@@ -103,7 +96,7 @@ describe("Spatial Types", () => {
               AND: [NodeTypeOperationWhere!]
               NOT: NodeTypeOperationWhere
               OR: [NodeTypeOperationWhere!]
-              edges: NodeTypeEdgeWhere
+              node: NodeTypeWhere
             }
 
             type NodeTypeRelatedNodeConnection {
@@ -200,13 +193,6 @@ describe("Spatial Types", () => {
               node: RelatedNode
             }
 
-            input RelatedNodeEdgeWhere {
-              AND: [RelatedNodeEdgeWhere!]
-              NOT: RelatedNodeEdgeWhere
-              OR: [RelatedNodeEdgeWhere!]
-              node: RelatedNodeWhere
-            }
-
             type RelatedNodeOperation {
               connection(after: String, first: Int): RelatedNodeConnection
             }
@@ -215,7 +201,7 @@ describe("Spatial Types", () => {
               AND: [RelatedNodeOperationWhere!]
               NOT: RelatedNodeOperationWhere
               OR: [RelatedNodeOperationWhere!]
-              edges: RelatedNodeEdgeWhere
+              node: RelatedNodeWhere
             }
 
             type RelatedNodeProperties {

--- a/packages/graphql/tests/api-v6/schema/types/temporals.test.ts
+++ b/packages/graphql/tests/api-v6/schema/types/temporals.test.ts
@@ -157,12 +157,16 @@ describe("Temporals", () => {
             }
 
             input NodeTypeConnectionSort {
-              node: [NodeTypeSort!]
+              edges: [NodeTypeEdgeSort!]
             }
 
             type NodeTypeEdge {
               cursor: String
               node: NodeType
+            }
+
+            input NodeTypeEdgeSort {
+              node: NodeTypeSort
             }
 
             type NodeTypeOperation {
@@ -281,12 +285,16 @@ describe("Temporals", () => {
             }
 
             input RelatedNodeConnectionSort {
-              node: [RelatedNodeSort!]
+              edges: [RelatedNodeEdgeSort!]
             }
 
             type RelatedNodeEdge {
               cursor: String
               node: RelatedNode
+            }
+
+            input RelatedNodeEdgeSort {
+              node: RelatedNodeSort
             }
 
             type RelatedNodeOperation {

--- a/packages/graphql/tests/api-v6/schema/types/temporals.test.ts
+++ b/packages/graphql/tests/api-v6/schema/types/temporals.test.ts
@@ -157,23 +157,12 @@ describe("Temporals", () => {
             }
 
             input NodeTypeConnectionSort {
-              edges: [NodeTypeEdgeSort!]
+              node: [NodeTypeSort!]
             }
 
             type NodeTypeEdge {
               cursor: String
               node: NodeType
-            }
-
-            input NodeTypeEdgeSort {
-              node: NodeTypeSort
-            }
-
-            input NodeTypeEdgeWhere {
-              AND: [NodeTypeEdgeWhere!]
-              NOT: NodeTypeEdgeWhere
-              OR: [NodeTypeEdgeWhere!]
-              node: NodeTypeWhere
             }
 
             type NodeTypeOperation {
@@ -184,7 +173,7 @@ describe("Temporals", () => {
               AND: [NodeTypeOperationWhere!]
               NOT: NodeTypeOperationWhere
               OR: [NodeTypeOperationWhere!]
-              edges: NodeTypeEdgeWhere
+              node: NodeTypeWhere
             }
 
             type NodeTypeRelatedNodeConnection {
@@ -292,23 +281,12 @@ describe("Temporals", () => {
             }
 
             input RelatedNodeConnectionSort {
-              edges: [RelatedNodeEdgeSort!]
+              node: [RelatedNodeSort!]
             }
 
             type RelatedNodeEdge {
               cursor: String
               node: RelatedNode
-            }
-
-            input RelatedNodeEdgeSort {
-              node: RelatedNodeSort
-            }
-
-            input RelatedNodeEdgeWhere {
-              AND: [RelatedNodeEdgeWhere!]
-              NOT: RelatedNodeEdgeWhere
-              OR: [RelatedNodeEdgeWhere!]
-              node: RelatedNodeWhere
             }
 
             type RelatedNodeOperation {
@@ -319,7 +297,7 @@ describe("Temporals", () => {
               AND: [RelatedNodeOperationWhere!]
               NOT: RelatedNodeOperationWhere
               OR: [RelatedNodeOperationWhere!]
-              edges: RelatedNodeEdgeWhere
+              node: RelatedNodeWhere
             }
 
             type RelatedNodeProperties {

--- a/packages/graphql/tests/api-v6/tck/filters/array/array-filters.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/array/array-filters.test.ts
@@ -40,7 +40,7 @@ describe("Array filters", () => {
     test("array filters", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(where: { edges: { node: { alternativeTitles: { equals: ["potato"] } } } }) {
+                movies(where: { node: { alternativeTitles: { equals: ["potato"] } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/tck/filters/logical-filters/and-filter.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/logical-filters/and-filter.test.ts
@@ -42,60 +42,7 @@ describe("AND filters", () => {
         const query = /* GraphQL */ `
             query {
                 movies(
-                    where: {
-                        AND: [
-                            { edges: { node: { title: { equals: "The Matrix" } } } }
-                            { edges: { node: { year: { equals: 100 } } } }
-                        ]
-                    }
-                ) {
-                    connection {
-                        edges {
-                            node {
-                                title
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-        const result = await translateQuery(neoSchema, query, { v6Api: true });
-
-        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
-            WHERE (this0.title = $param0 AND this0.year = $param1)
-            WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
-            CALL {
-                WITH edges
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
-            }
-            RETURN { connection: { edges: var1, totalCount: totalCount } } AS this"
-        `);
-
-        expect(formatParams(result.params)).toMatchInlineSnapshot(`
-            "{
-                \\"param0\\": \\"The Matrix\\",
-                \\"param1\\": {
-                    \\"low\\": 100,
-                    \\"high\\": 0
-                }
-            }"
-        `);
-    });
-
-    test("AND logical filter on edges", async () => {
-        const query = /* GraphQL */ `
-            query {
-                movies(
-                    where: {
-                        edges: {
-                            AND: [{ node: { title: { equals: "The Matrix" } } }, { node: { year: { equals: 100 } } }]
-                        }
-                    }
+                    where: { AND: [{ node: { title: { equals: "The Matrix" } } }, { node: { year: { equals: 100 } } }] }
                 ) {
                     connection {
                         edges {
@@ -138,11 +85,7 @@ describe("AND filters", () => {
     test("AND logical filter in nodes", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: {
-                        edges: { node: { AND: [{ title: { equals: "The Matrix" } }, { year: { equals: 100 } }] } }
-                    }
-                ) {
+                movies(where: { node: { AND: [{ title: { equals: "The Matrix" } }, { year: { equals: 100 } }] } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/tck/filters/logical-filters/not-filter.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/logical-filters/not-filter.test.ts
@@ -41,7 +41,7 @@ describe("NOT filters", () => {
     test("NOT logical filter in where", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(where: { NOT: { edges: { node: { title: { equals: "The Matrix" } } } } }) {
+                movies(where: { NOT: { node: { title: { equals: "The Matrix" } } } }) {
                     connection {
                         edges {
                             node {
@@ -76,56 +76,10 @@ describe("NOT filters", () => {
         `);
     });
 
-    test("NOT logical filter on edges", async () => {
-        const query = /* GraphQL */ `
-            query {
-                movies(
-                    where: { edges: { NOT: { node: { title: { equals: "The Matrix" }, year: { equals: 100 } } } } }
-                ) {
-                    connection {
-                        edges {
-                            node {
-                                title
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-        const result = await translateQuery(neoSchema, query, { v6Api: true });
-
-        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
-            WHERE NOT (this0.title = $param0 AND this0.year = $param1)
-            WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
-            CALL {
-                WITH edges
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
-            }
-            RETURN { connection: { edges: var1, totalCount: totalCount } } AS this"
-        `);
-
-        expect(formatParams(result.params)).toMatchInlineSnapshot(`
-            "{
-                \\"param0\\": \\"The Matrix\\",
-                \\"param1\\": {
-                    \\"low\\": 100,
-                    \\"high\\": 0
-                }
-            }"
-        `);
-    });
-
     test("NOT logical filter on nodes", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: { edges: { node: { NOT: { title: { equals: "The Matrix" }, year: { equals: 100 } } } } }
-                ) {
+                movies(where: { node: { NOT: { title: { equals: "The Matrix" }, year: { equals: 100 } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/tck/filters/logical-filters/or-filter.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/logical-filters/or-filter.test.ts
@@ -42,60 +42,7 @@ describe("OR filters", () => {
         const query = /* GraphQL */ `
             query {
                 movies(
-                    where: {
-                        OR: [
-                            { edges: { node: { title: { equals: "The Matrix" } } } }
-                            { edges: { node: { year: { equals: 100 } } } }
-                        ]
-                    }
-                ) {
-                    connection {
-                        edges {
-                            node {
-                                title
-                            }
-                        }
-                    }
-                }
-            }
-        `;
-
-        const result = await translateQuery(neoSchema, query, { v6Api: true });
-
-        expect(formatCypher(result.cypher)).toMatchInlineSnapshot(`
-            "MATCH (this0:Movie)
-            WHERE (this0.title = $param0 OR this0.year = $param1)
-            WITH collect({ node: this0 }) AS edges
-            WITH edges, size(edges) AS totalCount
-            CALL {
-                WITH edges
-                UNWIND edges AS edge
-                WITH edge.node AS this0
-                RETURN collect({ node: { title: this0.title, __resolveType: \\"Movie\\" } }) AS var1
-            }
-            RETURN { connection: { edges: var1, totalCount: totalCount } } AS this"
-        `);
-
-        expect(formatParams(result.params)).toMatchInlineSnapshot(`
-            "{
-                \\"param0\\": \\"The Matrix\\",
-                \\"param1\\": {
-                    \\"low\\": 100,
-                    \\"high\\": 0
-                }
-            }"
-        `);
-    });
-
-    test("OR logical filter in edges", async () => {
-        const query = /* GraphQL */ `
-            query {
-                movies(
-                    where: {
-                        edges: {
-                            OR: [{ node: { title: { equals: "The Matrix" } } }, { node: { year: { equals: 100 } } }]
-                        }
-                    }
+                    where: { OR: [{ node: { title: { equals: "The Matrix" } } }, { node: { year: { equals: 100 } } }] }
                 ) {
                     connection {
                         edges {
@@ -138,9 +85,7 @@ describe("OR filters", () => {
     test("OR logical filter in nodes", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: { edges: { node: { OR: [{ title: { equals: "The Matrix" } }, { year: { equals: 100 } }] } } }
-                ) {
+                movies(where: { node: { OR: [{ title: { equals: "The Matrix" } }, { year: { equals: 100 } }] } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/tck/filters/nested/all.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/nested/all.test.ts
@@ -47,9 +47,7 @@ describe("Nested Filters with all", () => {
     test("query nested relationship with all filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: { edges: { node: { actors: { edges: { all: { node: { name: { equals: "Keanu" } } } } } } } }
-                ) {
+                movies(where: { node: { actors: { edges: { all: { node: { name: { equals: "Keanu" } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -93,11 +91,7 @@ describe("Nested Filters with all", () => {
     test("query nested relationship properties with all filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: {
-                        edges: { node: { actors: { edges: { all: { properties: { year: { equals: 1999 } } } } } } }
-                    }
-                ) {
+                movies(where: { node: { actors: { edges: { all: { properties: { year: { equals: 1999 } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -146,16 +140,14 @@ describe("Nested Filters with all", () => {
             query {
                 movies(
                     where: {
-                        edges: {
-                            node: {
-                                actors: {
-                                    edges: {
-                                        all: {
-                                            OR: [
-                                                { node: { name: { equals: "Keanu" } } }
-                                                { node: { name: { endsWith: "eeves" } } }
-                                            ]
-                                        }
+                        node: {
+                            actors: {
+                                edges: {
+                                    all: {
+                                        OR: [
+                                            { node: { name: { equals: "Keanu" } } }
+                                            { node: { name: { endsWith: "eeves" } } }
+                                        ]
                                     }
                                 }
                             }

--- a/packages/graphql/tests/api-v6/tck/filters/nested/none.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/nested/none.test.ts
@@ -47,9 +47,7 @@ describe("Nested Filters with none", () => {
     test("query nested relationship with none filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: { edges: { node: { actors: { edges: { none: { node: { name: { equals: "Keanu" } } } } } } } }
-                ) {
+                movies(where: { node: { actors: { edges: { none: { node: { name: { equals: "Keanu" } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -90,11 +88,7 @@ describe("Nested Filters with none", () => {
     test("query nested relationship properties with none filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: {
-                        edges: { node: { actors: { edges: { none: { properties: { year: { equals: 1999 } } } } } } }
-                    }
-                ) {
+                movies(where: { node: { actors: { edges: { none: { properties: { year: { equals: 1999 } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -140,16 +134,14 @@ describe("Nested Filters with none", () => {
             query {
                 movies(
                     where: {
-                        edges: {
-                            node: {
-                                actors: {
-                                    edges: {
-                                        some: {
-                                            OR: [
-                                                { node: { name: { equals: "Keanu" } } }
-                                                { node: { name: { endsWith: "eeves" } } }
-                                            ]
-                                        }
+                        node: {
+                            actors: {
+                                edges: {
+                                    some: {
+                                        OR: [
+                                            { node: { name: { equals: "Keanu" } } }
+                                            { node: { name: { endsWith: "eeves" } } }
+                                        ]
                                     }
                                 }
                             }

--- a/packages/graphql/tests/api-v6/tck/filters/nested/single.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/nested/single.test.ts
@@ -47,11 +47,7 @@ describe("Nested Filters with single", () => {
     test("query nested relationship with single filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: {
-                        edges: { node: { actors: { edges: { single: { node: { name: { equals: "Keanu" } } } } } } }
-                    }
-                ) {
+                movies(where: { node: { actors: { edges: { single: { node: { name: { equals: "Keanu" } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -89,11 +85,7 @@ describe("Nested Filters with single", () => {
     test("query nested relationship properties with single filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: {
-                        edges: { node: { actors: { edges: { single: { properties: { year: { equals: 1999 } } } } } } }
-                    }
-                ) {
+                movies(where: { node: { actors: { edges: { single: { properties: { year: { equals: 1999 } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -136,16 +128,14 @@ describe("Nested Filters with single", () => {
             query {
                 movies(
                     where: {
-                        edges: {
-                            node: {
-                                actors: {
-                                    edges: {
-                                        single: {
-                                            OR: [
-                                                { node: { name: { equals: "Keanu" } } }
-                                                { node: { name: { endsWith: "eeves" } } }
-                                            ]
-                                        }
+                        node: {
+                            actors: {
+                                edges: {
+                                    single: {
+                                        OR: [
+                                            { node: { name: { equals: "Keanu" } } }
+                                            { node: { name: { endsWith: "eeves" } } }
+                                        ]
                                     }
                                 }
                             }

--- a/packages/graphql/tests/api-v6/tck/filters/nested/some.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/nested/some.test.ts
@@ -47,9 +47,7 @@ describe("Nested Filters with some", () => {
     test("query nested relationship with some filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: { edges: { node: { actors: { edges: { some: { node: { name: { equals: "Keanu" } } } } } } } }
-                ) {
+                movies(where: { node: { actors: { edges: { some: { node: { name: { equals: "Keanu" } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -90,11 +88,7 @@ describe("Nested Filters with some", () => {
     test("query nested relationship properties with some filter", async () => {
         const query = /* GraphQL */ `
             query {
-                movies(
-                    where: {
-                        edges: { node: { actors: { edges: { some: { properties: { year: { equals: 1999 } } } } } } }
-                    }
-                ) {
+                movies(where: { node: { actors: { edges: { some: { properties: { year: { equals: 1999 } } } } } } }) {
                     connection {
                         edges {
                             node {
@@ -140,16 +134,14 @@ describe("Nested Filters with some", () => {
             query {
                 movies(
                     where: {
-                        edges: {
-                            node: {
-                                actors: {
-                                    edges: {
-                                        some: {
-                                            OR: [
-                                                { node: { name: { equals: "Keanu" } } }
-                                                { node: { name: { endsWith: "eeves" } } }
-                                            ]
-                                        }
+                        node: {
+                            actors: {
+                                edges: {
+                                    some: {
+                                        OR: [
+                                            { node: { name: { equals: "Keanu" } } }
+                                            { node: { name: { endsWith: "eeves" } } }
+                                        ]
                                     }
                                 }
                             }

--- a/packages/graphql/tests/api-v6/tck/filters/top-level-filters.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/top-level-filters.test.ts
@@ -35,6 +35,7 @@ describe("Top level filters", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
+            debug: true,
         });
     });
 
@@ -43,9 +44,7 @@ describe("Top level filters", () => {
             query {
                 movies(
                     where: {
-                        edges: {
-                            node: { title: { equals: "The Matrix" }, year: { equals: 100 }, runtime: { equals: 90.5 } }
-                        }
+                        node: { title: { equals: "The Matrix" }, year: { equals: 100 }, runtime: { equals: 90.5 } }
                     }
                 ) {
                     connection {

--- a/packages/graphql/tests/api-v6/tck/filters/top-level-filters.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/top-level-filters.test.ts
@@ -35,7 +35,6 @@ describe("Top level filters", () => {
 
         neoSchema = new Neo4jGraphQL({
             typeDefs,
-            debug: true,
         });
     });
 

--- a/packages/graphql/tests/api-v6/tck/filters/types/array/temporals-array.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/types/array/temporals-array.test.ts
@@ -77,19 +77,17 @@ describe("Temporal types", () => {
             query {
                 typeNodes(
                     where: {
-                        edges: {
-                            node: {
-                                dateTime: { equals: ["2015-06-24T12:50:35.556+0100"] }
-                                localDateTime: { equals: ["2003-09-14T12:00:00"] }
-                                duration: { equals: ["P1Y"] }
-                                time: { equals: ["22:00:15.555"] }
-                                localTime: { equals: ["12:50:35.556"] }
-                                dateTimeNullable: { equals: ["2015-06-24T12:50:35.556+0100"] }
-                                localDateTimeNullable: { equals: ["2003-09-14T12:00:00"] }
-                                durationNullable: { equals: ["P1Y"] }
-                                timeNullable: { equals: ["22:00:15.555"] }
-                                localTimeNullable: { equals: ["12:50:35.556"] }
-                            }
+                        node: {
+                            dateTime: { equals: ["2015-06-24T12:50:35.556+0100"] }
+                            localDateTime: { equals: ["2003-09-14T12:00:00"] }
+                            duration: { equals: ["P1Y"] }
+                            time: { equals: ["22:00:15.555"] }
+                            localTime: { equals: ["12:50:35.556"] }
+                            dateTimeNullable: { equals: ["2015-06-24T12:50:35.556+0100"] }
+                            localDateTimeNullable: { equals: ["2003-09-14T12:00:00"] }
+                            durationNullable: { equals: ["P1Y"] }
+                            timeNullable: { equals: ["22:00:15.555"] }
+                            localTimeNullable: { equals: ["12:50:35.556"] }
                         }
                     }
                 ) {

--- a/packages/graphql/tests/api-v6/tck/filters/types/cartesian-filters.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/types/cartesian-filters.test.ts
@@ -42,7 +42,7 @@ describe.skip("CartesianPoint filters", () => {
     test("CartesianPoint EQUALS", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { equals: { x: 1.0, y: 2.0 } } } } }) {
+                locations(where: { node: { value: { equals: { x: 1.0, y: 2.0 } } } }) {
                     connection {
                         edges {
                             node {
@@ -90,7 +90,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point NOT EQUALS", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { NOT: { equals: { x: 1.0, y: 2.0 } } } } } }) {
+                locations(where: { node: { value: { NOT: { equals: { x: 1.0, y: 2.0  } }  } }) {
                     connection {
                         edges {
                             node {
@@ -137,7 +137,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point IN", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { in: [{ x: 1.0, y: 2.0 }] } } } }) {
+                locations(where: { node: { value: { in: [{ x: 1.0, y: 2.0 }] } } }) {
                     connection {
                         edges {
                             node {
@@ -186,7 +186,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point NOT IN", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { NOT: { in: [{ x: 1.0, y: 2.0 }] } } } } }) {
+                locations(where: { node: { value: { NOT: { in: [{ x: 1.0, y: 2.0 }] } } } }) {
                     connection {
                         edges {
                             node {
@@ -236,7 +236,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point LT", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { lt: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } } }) {
+                locations(where: { node: { value: { lt: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } }) {
                     connection {
                         edges {
                             node {
@@ -286,9 +286,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point LTE", async () => {
         const query = /* GraphQL */ `
             {
-                locations(
-                    where: { edges: { node: { value: { lte: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } } }
-                ) {
+                locations(where: { node: { value: { lte: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } }) {
                     connection {
                         edges {
                             node {
@@ -338,7 +336,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point GT", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { gt: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } } }) {
+                locations(where: { node: { value: { gt: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } }) {
                     connection {
                         edges {
                             node {
@@ -388,9 +386,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point GTE", async () => {
         const query = /* GraphQL */ `
             {
-                locations(
-                    where: { edges: { node: { value: { gte: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } } }
-                ) {
+                locations(where: { node: { value: { gte: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } }) {
                     connection {
                         edges {
                             node {
@@ -440,9 +436,7 @@ describe.skip("CartesianPoint filters", () => {
     test("Simple Point DISTANCE EQ", async () => {
         const query = /* GraphQL */ `
             {
-                locations(
-                    where: { edges: { node: { value: { distance: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } } }
-                ) {
+                locations(where: { node: { value: { distance: { point: { x: 1.1, y: 2.2 }, distance: 3.3 } } } }) {
                     connection {
                         edges {
                             node {

--- a/packages/graphql/tests/api-v6/tck/filters/types/point-filters.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/types/point-filters.test.ts
@@ -42,7 +42,7 @@ describe.skip("Point filters", () => {
     test("Simple Point EQUALS", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { equals: { longitude: 1.0, latitude: 2.0 } } } } }) {
+                locations(where: { node: { value: { equals: { longitude: 1.0, latitude: 2.0 } } } }) {
                     connection {
                         edges {
                             node {
@@ -90,9 +90,7 @@ describe.skip("Point filters", () => {
     test("Simple Point NOT EQUALS", async () => {
         const query = /* GraphQL */ `
             {
-                locations(
-                    where: { edges: { node: { value: { NOT: { equals: { longitude: 1.0, latitude: 2.0 } } } } } }
-                ) {
+                locations(where: { node: { value: { NOT: { equals: { longitude: 1.0, latitude: 2.0 } } } } }) {
                     connection {
                         edges {
                             node {
@@ -139,7 +137,7 @@ describe.skip("Point filters", () => {
     test("Simple Point IN", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { in: [{ longitude: 1.0, latitude: 2.0 }] } } } }) {
+                locations(where: { node: { value: { in: [{ longitude: 1.0, latitude: 2.0 }] } } }) {
                     connection {
                         edges {
                             node {
@@ -188,7 +186,7 @@ describe.skip("Point filters", () => {
     test("Simple Point NOT IN", async () => {
         const query = /* GraphQL */ `
             {
-                locations(where: { edges: { node: { value: { NOT: { in: [{ longitude: 1.0, latitude: 2.0 }] } } } } }) {
+                locations(where: { node: { value: { NOT: { in: [{ longitude: 1.0, latitude: 2.0 }] } } } }) {
                     connection {
                         edges {
                             node {
@@ -239,9 +237,7 @@ describe.skip("Point filters", () => {
         const query = /* GraphQL */ `
             {
                 locations(
-                    where: {
-                        edges: { node: { value: { lt: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
-                    }
+                    where: { node: { value: { lt: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
                 ) {
                     connection {
                         edges {
@@ -293,9 +289,7 @@ describe.skip("Point filters", () => {
         const query = /* GraphQL */ `
             {
                 locations(
-                    where: {
-                        edges: { node: { value: { lte: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
-                    }
+                    where: { node: { value: { lte: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
                 ) {
                     connection {
                         edges {
@@ -347,9 +341,7 @@ describe.skip("Point filters", () => {
         const query = /* GraphQL */ `
             {
                 locations(
-                    where: {
-                        edges: { node: { value: { gt: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
-                    }
+                    where: { node: { value: { gt: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
                 ) {
                     connection {
                         edges {
@@ -401,9 +393,7 @@ describe.skip("Point filters", () => {
         const query = /* GraphQL */ `
             {
                 locations(
-                    where: {
-                        edges: { node: { value: { gte: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
-                    }
+                    where: { node: { value: { gte: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } } }
                 ) {
                     connection {
                         edges {
@@ -456,9 +446,7 @@ describe.skip("Point filters", () => {
             {
                 locations(
                     where: {
-                        edges: {
-                            node: { value: { distance: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } }
-                        }
+                        node: { value: { distance: { point: { longitude: 1.1, latitude: 2.2 }, distance: 3.3 } } }
                     }
                 ) {
                     connection {

--- a/packages/graphql/tests/api-v6/tck/filters/types/temporals-filters.test.ts
+++ b/packages/graphql/tests/api-v6/tck/filters/types/temporals-filters.test.ts
@@ -62,14 +62,12 @@ describe("Temporal types", () => {
             query {
                 typeNodes(
                     where: {
-                        edges: {
-                            node: {
-                                dateTime: { equals: "2015-06-24T12:50:35.556+0100" }
-                                localDateTime: { gt: "2003-09-14T12:00:00" }
-                                duration: { gte: "P1Y" }
-                                time: { lt: "22:00:15.555" }
-                                localTime: { lte: "12:50:35.556" }
-                            }
+                        node: {
+                            dateTime: { equals: "2015-06-24T12:50:35.556+0100" }
+                            localDateTime: { gt: "2003-09-14T12:00:00" }
+                            duration: { gte: "P1Y" }
+                            time: { lt: "22:00:15.555" }
+                            localTime: { lte: "12:50:35.556" }
                         }
                     }
                 ) {


### PR DESCRIPTION
# Description
This PR removes `edges` from top level filtering in version 6

Note that this PR does not cover sort argument
