### PR TITLE
Add warning if `@subscriptionsAuthorization` missing

### DIFF
--- a/.changeset/odd-numbers-remain.md
+++ b/.changeset/odd-numbers-remain.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql": patch
+---
+
+A warning will now be given during validation of type definitions if subscriptions has been enabled, and `@authorization` has been used without `@subscriptionsAuthorization`

--- a/packages/graphql/src/schema/validation/custom-rules/utils/get-directive-names.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/utils/get-directive-names.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FieldDefinitionNode, ObjectTypeDefinitionNode } from "graphql";
+import { filterTruthy } from "../../../../utils/utils";
+
+export function getDirectiveNames(field: FieldDefinitionNode | ObjectTypeDefinitionNode): string[] {
+    const fieldDirectives = field.directives ?? [];
+    return filterTruthy(fieldDirectives.map((d) => d.name.value));
+}

--- a/packages/graphql/src/schema/validation/custom-rules/warnings/object-fields-without-resolver.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/warnings/object-fields-without-resolver.ts
@@ -28,7 +28,8 @@ import {
 } from "graphql";
 import type { SDLValidationContext } from "graphql/validation/ValidationContext";
 import { DEBUG_GRAPHQL } from "../../../../constants";
-import { filterTruthy, haveSharedElement } from "../../../../utils/utils";
+import { haveSharedElement } from "../../../../utils/utils";
+import { getDirectiveNames } from "../utils/get-directive-names";
 import { getInnerTypeName } from "../utils/utils";
 
 const debug = Debug(DEBUG_GRAPHQL);
@@ -113,9 +114,4 @@ function typeNeedsResolver(type: string, document: DocumentNode): boolean {
     } else {
         return true;
     }
-}
-
-function getDirectiveNames(field: FieldDefinitionNode | ObjectTypeDefinitionNode): string[] {
-    const fieldDirectives = field.directives ?? [];
-    return filterTruthy(fieldDirectives.map((d) => d.name.value));
 }

--- a/packages/graphql/src/schema/validation/custom-rules/warnings/subscriptions-authorization-missing.test.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/warnings/subscriptions-authorization-missing.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+    EnumTypeDefinitionNode,
+    InterfaceTypeDefinitionNode,
+    ObjectTypeDefinitionNode,
+    UnionTypeDefinitionNode,
+} from "graphql";
+import { gql } from "graphql-tag";
+import validateDocument from "../../validate-document";
+
+const additionalDefinitions = {
+    enums: [] as EnumTypeDefinitionNode[],
+    interfaces: [] as InterfaceTypeDefinitionNode[],
+    unions: [] as UnionTypeDefinitionNode[],
+    objects: [] as ObjectTypeDefinitionNode[],
+};
+
+describe("WarnObjectFieldsWithoutResolver", () => {
+    let warn: jest.SpyInstance;
+
+    beforeEach(() => {
+        warn = jest.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warn.mockReset();
+    });
+    describe("Subscriptions authorization rule", () => {
+        test("warns if @authorization is used on type and @subscriptionsAuthorization is missing", () => {
+            const doc = gql`
+                type User @authorization(filter: [{ where: { node: { id: "$jwt.sub" } } }]) {
+                    id: ID!
+                    name: String!
+                    password: String!
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: { subscriptions: true },
+            });
+            expect(warn).toHaveBeenCalled();
+        });
+
+        test("warns if @authorization is used on field and @subscriptionsAuthorization is missing", () => {
+            const doc = gql`
+                type User {
+                    id: ID!
+                    name: String!
+                    password: String! @authorization(filter: [{ where: { node: { id: "$jwt.sub" } } }])
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: { subscriptions: true },
+            });
+            expect(warn).toHaveBeenCalled();
+        });
+
+        test("does not warn if both directives are used on type", () => {
+            const doc = gql`
+                type User
+                    @authorization(filter: [{ where: { node: { id: "$jwt.sub" } } }])
+                    @subscriptionsAuthorization(filter: [{ where: { node: { id: "$jwt.sub" } } }]) {
+                    id: ID!
+                    name: String!
+                    password: String!
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: { subscriptions: true },
+            });
+            expect(warn).toHaveBeenCalled();
+        });
+
+        test("does not warn if both directives are used on field", () => {
+            const doc = gql`
+                type User {
+                    id: ID!
+                    name: String!
+                    password: String!
+                        @authorization(filter: [{ where: { node: { id: "$jwt.sub" } } }])
+                        @subscriptionsAuthorization(filter: [{ where: { node: { id: "$jwt.sub" } } }])
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: { subscriptions: true },
+            });
+            expect(warn).toHaveBeenCalled();
+        });
+
+        test("does not warn if subscriptions not enabled", () => {
+            const doc = gql`
+                type User @authorization(filter: [{ where: { node: { id: "$jwt.sub" } } }]) {
+                    id: ID!
+                    name: String!
+                    password: String!
+                }
+            `;
+
+            validateDocument({
+                document: doc,
+                additionalDefinitions,
+                features: {},
+            });
+            expect(warn).toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/graphql/src/schema/validation/custom-rules/warnings/subscriptions-authorization-missing.ts
+++ b/packages/graphql/src/schema/validation/custom-rules/warnings/subscriptions-authorization-missing.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) "Neo4j"
+ * Neo4j Sweden AB [http://neo4j.com]
+ *
+ * This file is part of Neo4j.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ASTVisitor, ObjectTypeDefinitionNode } from "graphql";
+import { getDirectiveNames } from "../utils/get-directive-names";
+
+export function WarnIfSubscriptionsAuthorizationMissing(subscriptions: boolean) {
+    return function (): ASTVisitor {
+        let warningAlreadyIssued = false;
+
+        return {
+            ObjectTypeDefinition(objectType: ObjectTypeDefinitionNode) {
+                if (warningAlreadyIssued || !subscriptions) {
+                    return;
+                }
+
+                const directiveNames = getDirectiveNames(objectType);
+
+                if (
+                    directiveNames.includes("authorization") &&
+                    !directiveNames.includes("subscriptionsAuthorization")
+                ) {
+                    console.warn(
+                        "'@subscriptionsAuthorization' not found on a type/field which has '@authorization' - subscriptions events are not subject to the authorization rules specified in '@authorization' directives."
+                    );
+                    warningAlreadyIssued = true;
+                }
+            },
+        };
+    };
+}

--- a/packages/graphql/src/schema/validation/validate-document.ts
+++ b/packages/graphql/src/schema/validation/validate-document.ts
@@ -65,6 +65,7 @@ import { WarnIfAuthorizationFeatureDisabled } from "./custom-rules/warnings/auth
 import { WarnIfAMaxLimitCanBeBypassedThroughInterface } from "./custom-rules/warnings/limit-max-can-be-bypassed";
 import { WarnIfListOfListsFieldDefinition } from "./custom-rules/warnings/list-of-lists";
 import { WarnObjectFieldsWithoutResolver } from "./custom-rules/warnings/object-fields-without-resolver";
+import { WarnIfSubscriptionsAuthorizationMissing } from "./custom-rules/warnings/subscriptions-authorization-missing";
 import { validateSchemaCustomizations } from "./validate-schema-customizations";
 import { validateSDL } from "./validate-sdl";
 
@@ -218,6 +219,7 @@ function runValidationRulesOnFilteredDocument({
             WarnObjectFieldsWithoutResolver({
                 customResolvers: asArray(userCustomResolvers ?? []),
             }),
+            WarnIfSubscriptionsAuthorizationMissing(Boolean(features?.subscriptions)),
         ],
         schema
     );


### PR DESCRIPTION
# Description

Adds a warning if subscriptions are enabled and only `@authorization` is added to a type/field.

## Complexity

Complexity: Low
