### PR TITLE
Update exports for ogm so it works with named ESM import and CJS

### DIFF
--- a/.changeset/green-gorillas-learn.md
+++ b/.changeset/green-gorillas-learn.md
@@ -1,0 +1,5 @@
+---
+"@neo4j/graphql-ogm": minor
+---
+
+Enabled named import of OGM when using ES Modules

--- a/packages/ogm/src/index.ts
+++ b/packages/ogm/src/index.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
-export * from "./classes";
-export { DeleteInfo, GraphQLOptionsArg, GraphQLWhereArg, GraphQLSortArg } from "./types";
+import { Model, OGM } from "./classes";
 export { default as generate } from "./generate";
+export { DeleteInfo, GraphQLOptionsArg, GraphQLSortArg, GraphQLWhereArg } from "./types";
+export { Model, OGM };


### PR DESCRIPTION
# Description

This PR updates the way the OGM is exported so that ESM named imports work without an extra namespace.

Only import and usage before this PR (OGM can be named whatever as it uses default import):
```js
import OGM from "@neo4j/graphql-ogm";
...
const ogm = new OGM.OGM({ typeDefs, driver });
```

Import now possible after this PR:
```js
import { OGM } from "@neo4j/graphql-ogm";
...
const ogm = new OGM({ typeDefs, driver });
```

Importantly, this change is not breaking.

It still works with existing usages of `require`, as well default imports.

## Complexity

Low
