### PR TITLE
fix: use closeTo in vector similarity score tests

### DIFF
--- a/packages/graphql/tests/integration/directives/vector/vector-auth.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-auth.int.test.ts
@@ -199,7 +199,7 @@ describe("@vector directive - Auth", () => {
                             node: {
                                 name: "this is a name",
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                     ],
                 },
@@ -356,7 +356,7 @@ describe("@vector directive - Auth", () => {
                             node: {
                                 name: "this is a name",
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                         {
                             node: {

--- a/packages/graphql/tests/integration/directives/vector/vector-query.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-query.int.test.ts
@@ -170,7 +170,7 @@ describe("@vector directive - Query", () => {
                             node: {
                                 title: "Some Title",
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                         {
                             node: {
@@ -238,7 +238,7 @@ describe("@vector directive - Query", () => {
                                     ],
                                 },
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                         {
                             node: {

--- a/packages/graphql/tests/integration/directives/vector/vector-sorting.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-sorting.int.test.ts
@@ -162,7 +162,7 @@ describe("@vector directive - Query", () => {
                             node: {
                                 title: "Some Title",
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                         {
                             node: {
@@ -220,7 +220,7 @@ describe("@vector directive - Query", () => {
                             node: {
                                 title: "Some Title",
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                     ],
                 },
@@ -272,7 +272,7 @@ describe("@vector directive - Query", () => {
                             node: {
                                 title: "Some Title",
                             },
-                            score: 1,
+                            score: expect.closeTo(1),
                         },
                     ],
                 },


### PR DESCRIPTION
# Description

On Neo4j 5.23.0, quantization has been enabled on vector indexes by default, which can accelerate search performance but can slightly decrease accuracy. This caused our integration tests to fail on Aura which automatically updated to 5.23.0, as the score was now no longer `1` but instead something very close like `0.9999661445617676`.

This PR updates the tests to expect something `closeTo` 1, instead of exactly `1`.