### PR TITLE
Reintroduce deprecations for cypher filters

### DIFF
--- a/packages/graphql/src/schema/get-where-fields.ts
+++ b/packages/graphql/src/schema/get-where-fields.ts
@@ -214,7 +214,7 @@ export function getWhereFieldsForAttributes({
             directives: deprecatedDirectives,
         };
 
-        if (shouldAddDeprecatedFields(features, "negationFilters") && !field.isCypher()) {
+        if (shouldAddDeprecatedFields(features, "negationFilters")) {
             result[`${field.name}_NOT`] = {
                 type: field.getInputTypeNames().where.pretty,
                 directives: deprecatedDirectives.length ? deprecatedDirectives : [DEPRECATE_NOT],
@@ -247,7 +247,7 @@ export function getWhereFieldsForAttributes({
             type: field.getFilterableInputTypeName(),
             directives: deprecatedDirectives,
         };
-        if (shouldAddDeprecatedFields(features, "negationFilters") && !field.isCypher()) {
+        if (shouldAddDeprecatedFields(features, "negationFilters")) {
             result[`${field.name}_NOT_IN`] = {
                 type: field.getFilterableInputTypeName(),
                 directives: deprecatedDirectives.length ? deprecatedDirectives : [DEPRECATE_NOT],

--- a/packages/graphql/tests/schema/directives/cypher.test.ts
+++ b/packages/graphql/tests/schema/directives/cypher.test.ts
@@ -363,6 +363,8 @@ describe("Cypher", () => {
               totalScreenTime_IN: [Int!]
               totalScreenTime_LT: Int
               totalScreenTime_LTE: Int
+              totalScreenTime_NOT: Int @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
+              totalScreenTime_NOT_IN: [Int!] @deprecated(reason: \\"Negation filters will be deprecated, use the NOT operator to achieve the same behavior\\")
             }
 
             type ActorsConnection {


### PR DESCRIPTION
# Description

Instead of making the experience inconsistent in 5.x with the cypher field filters not having the same possible fields, these will instead be added and subsequently removed in the next major version.

