### PR TITLE
Remove connection wrapper from vector index

### DIFF
--- a/.changeset/modern-pugs-film.md
+++ b/.changeset/modern-pugs-film.md
@@ -1,0 +1,39 @@
+---
+"@neo4j/graphql": minor
+---
+
+Remove connection wrapper on vector queries
+
+_Previous:_
+
+```graphql
+query MovieVectorQuery($vector: [Float!]!) {
+    myVectorQuery(vector: $vector) {
+        moviesConnection {
+            edges {
+                cursor
+                score
+                node {
+                    title
+                }
+            }
+        }
+    }
+}
+```
+
+_Now:_
+
+```graphql
+query MovieVectorQuery($vector: [Float!]!) {
+    myVectorQuery(vector: $vector) {
+        edges {
+            cursor
+            score
+            node {
+                title
+            }
+        }
+    }
+}
+```

--- a/.changeset/modern-pugs-film.md
+++ b/.changeset/modern-pugs-film.md
@@ -2,7 +2,7 @@
 "@neo4j/graphql": minor
 ---
 
-Remove connection wrapper on vector queries
+Remove connection wrapper on vector queries.
 
 _Previous:_
 
@@ -37,3 +37,5 @@ query MovieVectorQuery($vector: [Float!]!) {
     }
 }
 ```
+
+Vector index is now a stable feature.

--- a/packages/graphql/src/schema-model/entity/model-adapters/ConcreteEntityOperations.ts
+++ b/packages/graphql/src/schema-model/entity/model-adapters/ConcreteEntityOperations.ts
@@ -40,7 +40,6 @@ type FulltextTypeNames = {
 };
 
 type VectorTypeNames = {
-    result: string;
     connection: string;
     edge: string;
     where: string;
@@ -107,7 +106,6 @@ export class ConcreteEntityOperations extends ImplementingEntityOperations<Concr
 
     public get vectorTypeNames(): VectorTypeNames {
         return {
-            result: `${this.pascalCaseSingular}VectorResult`,
             connection: `${this.pascalCasePlural}VectorConnection`,
             edge: `${this.pascalCaseSingular}VectorEdge`,
             where: `${this.pascalCaseSingular}VectorWhere`,

--- a/packages/graphql/src/schema/generation/vector-input.ts
+++ b/packages/graphql/src/schema/generation/vector-input.ts
@@ -76,7 +76,7 @@ export function withVectorResultTypeConnection({
     composer: SchemaComposer;
     concreteEntityAdapter: ConcreteEntityAdapter;
 }): ObjectTypeComposer {
-    const typeName = concreteEntityAdapter.operations.vectorTypeNames.result;
+    const typeName = concreteEntityAdapter.operations.vectorTypeNames.connection;
     if (composer.has(typeName)) {
         return composer.getOTC(typeName);
     }
@@ -91,7 +91,7 @@ export function withVectorResultTypeConnection({
     });
 
     const connection = composer.createObjectTC({
-        name: concreteEntityAdapter.operations.vectorTypeNames.connection,
+        name: typeName,
         fields: {
             totalCount: new GraphQLNonNull(GraphQLInt),
             pageInfo: new GraphQLNonNull(PageInfo),
@@ -99,11 +99,5 @@ export function withVectorResultTypeConnection({
         },
     });
 
-    const result = composer.createObjectTC({
-        name: typeName,
-        fields: {
-            [concreteEntityAdapter.operations.rootTypeFieldNames.connection]: connection.NonNull,
-        },
-    });
-    return result;
+    return connection;
 }

--- a/packages/graphql/src/schema/resolvers/query/vector.ts
+++ b/packages/graphql/src/schema/resolvers/query/vector.ts
@@ -78,11 +78,11 @@ export function vectorResolver({
         });
 
         return {
-            [entityAdapter.operations.rootTypeFieldNames.connection]: {
-                totalCount,
-                edges: connection.edges,
-                pageInfo: connection.pageInfo,
-            },
+            // [entityAdapter.operations.rootTypeFieldNames.connection]: {
+            totalCount,
+            edges: connection.edges,
+            pageInfo: connection.pageInfo,
+            // },
         };
     };
 }

--- a/packages/graphql/src/schema/resolvers/query/vector.ts
+++ b/packages/graphql/src/schema/resolvers/query/vector.ts
@@ -78,11 +78,9 @@ export function vectorResolver({
         });
 
         return {
-            // [entityAdapter.operations.rootTypeFieldNames.connection]: {
             totalCount,
             edges: connection.edges,
             pageInfo: connection.pageInfo,
-            // },
         };
     };
 }

--- a/packages/graphql/src/translate/queryAST/factory/Operations/VectorFactory.ts
+++ b/packages/graphql/src/translate/queryAST/factory/Operations/VectorFactory.ts
@@ -55,20 +55,13 @@ export class VectorFactory {
         });
 
         let scoreField: ScoreField | undefined;
-        const vectorResultField = resolveTree.fieldsByTypeName[entity.operations.vectorTypeNames.result];
-        if (!vectorResultField) {
+        const vectorConnectionFields = resolveTree.fieldsByTypeName[entity.operations.vectorTypeNames.connection];
+
+        if (!vectorConnectionFields) {
             throw new Error("Vector result field not found");
         }
 
-        const filteredResolveTree = findFieldsByNameInFieldsByTypeNameField(
-            vectorResultField,
-            entity.operations.rootTypeFieldNames.connection
-        )[0]!;
-        // Adds the args to the nested resolve tree for vector
-        filteredResolveTree.args = resolveTree.args;
-
-        const connectionFields = getFieldsByTypeName(filteredResolveTree, entity.operations.vectorTypeNames.connection);
-        const filteredResolveTreeEdges = findFieldsByNameInFieldsByTypeNameField(connectionFields, "edges");
+        const filteredResolveTreeEdges = findFieldsByNameInFieldsByTypeNameField(vectorConnectionFields, "edges");
         const edgeFields = getFieldsByTypeName(filteredResolveTreeEdges, entity.operations.vectorTypeNames.edge);
         const scoreFields = findFieldsByNameInFieldsByTypeNameField(edgeFields, "score");
 
@@ -97,11 +90,11 @@ export class VectorFactory {
             whereArgs: resolveTreeWhere,
         });
 
-        this.addScoreSort(operation, filteredResolveTree, context);
+        this.addScoreSort(operation, resolveTree, context);
 
         this.queryASTFactory.operationsFactory.hydrateConnectionOperation({
             target: entity,
-            resolveTree: filteredResolveTree,
+            resolveTree: resolveTree,
             context,
             operation,
             whereArgs: resolveTreeWhere,

--- a/packages/graphql/tests/integration/directives/vector/vector-auth.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-auth.int.test.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import console from "console";
 import type { GraphQLError } from "graphql";
 import { type Driver } from "neo4j-driver";
 import { generate } from "randomstring";
@@ -173,12 +174,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     }
                 }
@@ -193,16 +192,14 @@ describe("@vector directive - Auth", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Person.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                name: "this is a name",
-                            },
-                            score: expect.closeTo(1),
+                edges: [
+                    {
+                        node: {
+                            name: "this is a name",
                         },
-                    ],
-                },
+                        score: expect.closeTo(1),
+                    },
+                ],
             },
         });
     });
@@ -252,12 +249,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     }
                 }
@@ -273,9 +268,7 @@ describe("@vector directive - Auth", () => {
         // expect(gqlResult.data?.[queryType] as any[]).toBeArrayOfSize(0);
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Person.operations.connection]: {
-                    edges: [],
-                },
+                edges: [],
             },
         });
     });
@@ -329,12 +322,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     }
                 }
@@ -350,28 +341,26 @@ describe("@vector directive - Auth", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Person.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                name: "this is a name",
-                            },
-                            score: expect.closeTo(1),
+                edges: [
+                    {
+                        node: {
+                            name: "this is a name",
                         },
-                        {
-                            node: {
-                                name: "This is a different name",
-                            },
-                            score: expect.closeTo(0.56),
+                        score: expect.closeTo(1),
+                    },
+                    {
+                        node: {
+                            name: "This is a different name",
                         },
-                        {
-                            node: {
-                                name: "Another name",
-                            },
-                            score: expect.closeTo(0.48),
+                        score: expect.closeTo(0.56),
+                    },
+                    {
+                        node: {
+                            name: "Another name",
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.48),
+                    },
+                ],
             },
         });
     });
@@ -425,12 +414,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     }
                 }
@@ -492,12 +479,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector, where: { node: { name: "${person2.name}" } }) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     } 
                 }
@@ -513,16 +498,14 @@ describe("@vector directive - Auth", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Person.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                name: "This is a different name",
-                            },
-                            score: expect.closeTo(1),
+                edges: [
+                    {
+                        node: {
+                            name: "This is a different name",
                         },
-                    ],
-                },
+                        score: expect.closeTo(1),
+                    },
+                ],
             },
         });
     });
@@ -572,12 +555,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     }
                 }
@@ -643,12 +624,10 @@ describe("@vector directive - Auth", () => {
         const query = /* GraphQL */ `
             query($vector: [Float!]) {
                 ${queryName}(vector: $vector) {
-                    ${Person.operations.connection} {
-                        edges {
-                            score
-                            node {
-                                name
-                            }
+                    edges {
+                        score
+                        node {
+                            name
                         }
                     }
                 }

--- a/packages/graphql/tests/integration/directives/vector/vector-filtering.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-filtering.int.test.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import console from "console";
 import { type Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { Neo4jGraphQL } from "../../../../src/classes";
@@ -147,12 +148,10 @@ describe("@vector directive - filtering", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector,where: { node: { title_CONTAINS: "Another" } }) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -163,22 +162,20 @@ describe("@vector directive - filtering", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Another Title: The revenge",
-                            },
-                            score: expect.closeTo(0.999),
+                edges: [
+                    {
+                        node: {
+                            title: "Another Title: The revenge",
                         },
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.51),
+                        score: expect.closeTo(0.999),
+                    },
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.51),
+                    },
+                ],
             },
         });
     });
@@ -199,12 +196,10 @@ describe("@vector directive - filtering", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector, where: { score: {min: 0.5, max: 0.99 }}) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -215,16 +210,14 @@ describe("@vector directive - filtering", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.51),
+                edges: [
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.51),
+                    },
+                ],
             },
         });
     });

--- a/packages/graphql/tests/integration/directives/vector/vector-pagination.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-pagination.int.test.ts
@@ -150,12 +150,10 @@ describe("@vector directive - pagination", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector, first: 2, after: "${cursor}") {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -166,22 +164,20 @@ describe("@vector directive - pagination", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.56),
+                edges: [
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                        {
-                            node: {
-                                title: "Another Title: The revenge",
-                            },
-                            score: expect.closeTo(0.48),
+                        score: expect.closeTo(0.56),
+                    },
+                    {
+                        node: {
+                            title: "Another Title: The revenge",
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.48),
+                    },
+                ],
             },
         });
     });

--- a/packages/graphql/tests/integration/directives/vector/vector-query.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-query.int.test.ts
@@ -148,12 +148,10 @@ describe("@vector directive - Query", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -164,22 +162,20 @@ describe("@vector directive - Query", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Some Title",
-                            },
-                            score: expect.closeTo(1),
+                edges: [
+                    {
+                        node: {
+                            title: "Some Title",
                         },
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.56),
+                        score: expect.closeTo(1),
+                    },
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.56),
+                    },
+                ],
             },
         });
     });
@@ -200,16 +196,14 @@ describe("@vector directive - Query", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                    actorsConnection {
-                                        edges {
-                                            node {
-                                                name
-                                            }
+                        edges {
+                            score
+                            node {
+                                title
+                                actorsConnection {
+                                    edges {
+                                        node {
+                                            name
                                         }
                                     }
                                 }
@@ -223,34 +217,32 @@ describe("@vector directive - Query", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Some Title",
-                                actorsConnection: {
-                                    edges: [
-                                        {
-                                            node: {
-                                                name: "Keanu",
-                                            },
+                edges: [
+                    {
+                        node: {
+                            title: "Some Title",
+                            actorsConnection: {
+                                edges: [
+                                    {
+                                        node: {
+                                            name: "Keanu",
                                         },
-                                    ],
-                                },
+                                    },
+                                ],
                             },
-                            score: expect.closeTo(1),
                         },
-                        {
-                            node: {
-                                title: "Another Title",
-                                actorsConnection: {
-                                    edges: [],
-                                },
+                        score: expect.closeTo(1),
+                    },
+                    {
+                        node: {
+                            title: "Another Title",
+                            actorsConnection: {
+                                edges: [],
                             },
-                            score: expect.closeTo(0.56),
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.56),
+                    },
+                ],
             },
         });
     });

--- a/packages/graphql/tests/integration/directives/vector/vector-sorting.int.test.ts
+++ b/packages/graphql/tests/integration/directives/vector/vector-sorting.int.test.ts
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+import console from "console";
 import { type Driver } from "neo4j-driver";
 import { generate } from "randomstring";
 import type { Neo4jGraphQL } from "../../../../src/classes";
@@ -140,12 +141,10 @@ describe("@vector directive - Query", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector, sort: {score: DESC} ) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -156,22 +155,20 @@ describe("@vector directive - Query", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Some Title",
-                            },
-                            score: expect.closeTo(1),
+                edges: [
+                    {
+                        node: {
+                            title: "Some Title",
                         },
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.56),
+                        score: expect.closeTo(1),
+                    },
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                    ],
-                },
+                        score: expect.closeTo(0.56),
+                    },
+                ],
             },
         });
     });
@@ -192,12 +189,10 @@ describe("@vector directive - Query", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector, sort: {score: ASC} ) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -208,22 +203,20 @@ describe("@vector directive - Query", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.56),
+                edges: [
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                        {
-                            node: {
-                                title: "Some Title",
-                            },
-                            score: expect.closeTo(1),
+                        score: expect.closeTo(0.56),
+                    },
+                    {
+                        node: {
+                            title: "Some Title",
                         },
-                    ],
-                },
+                        score: expect.closeTo(1),
+                    },
+                ],
             },
         });
     });
@@ -244,12 +237,10 @@ describe("@vector directive - Query", () => {
         const query = `
                 query($vector: [Float!]) {
                     ${queryName}(vector: $vector, sort: {node: {title: ASC}} ) {
-                        ${Movie.operations.connection}{
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -260,22 +251,20 @@ describe("@vector directive - Query", () => {
         expect(gqlResult.errors).toBeFalsy();
         expect(gqlResult.data).toEqual({
             [queryName]: {
-                [Movie.operations.connection]: {
-                    edges: [
-                        {
-                            node: {
-                                title: "Another Title",
-                            },
-                            score: expect.closeTo(0.56),
+                edges: [
+                    {
+                        node: {
+                            title: "Another Title",
                         },
-                        {
-                            node: {
-                                title: "Some Title",
-                            },
-                            score: expect.closeTo(1),
+                        score: expect.closeTo(0.56),
+                    },
+                    {
+                        node: {
+                            title: "Some Title",
                         },
-                    ],
-                },
+                        score: expect.closeTo(1),
+                    },
+                ],
             },
         });
     });

--- a/packages/graphql/tests/schema/vector.test.ts
+++ b/packages/graphql/tests/schema/vector.test.ts
@@ -128,10 +128,6 @@ describe("@vector schema", () => {
               score: Float!
             }
 
-            type MovieVectorResult {
-              moviesConnection: MoviesVectorConnection!
-            }
-
             \\"\\"\\"The input for sorting a Vector query on an index of Movie\\"\\"\\"
             input MovieVectorSort {
               node: MovieSort
@@ -197,11 +193,11 @@ describe("@vector schema", () => {
             }
 
             type Query {
-              descriptionQuery(after: String, first: Int, sort: [MovieVectorSort!], vector: [Float!], where: MovieVectorWhere): MovieVectorResult!
+              descriptionQuery(after: String, first: Int, sort: [MovieVectorSort!], vector: [Float!], where: MovieVectorWhere): MoviesVectorConnection!
               movies(options: MovieOptions, where: MovieWhere): [Movie!]!
               moviesAggregate(where: MovieWhere): MovieAggregateSelection!
               moviesConnection(after: String, first: Int, sort: [MovieSort], where: MovieWhere): MoviesConnection!
-              titleQuery(after: String, first: Int, sort: [MovieVectorSort!], vector: [Float!], where: MovieVectorWhere): MovieVectorResult!
+              titleQuery(after: String, first: Int, sort: [MovieVectorSort!], vector: [Float!], where: MovieVectorWhere): MoviesVectorConnection!
             }
 
             \\"\\"\\"An enum for sorting in either ascending or descending order.\\"\\"\\"

--- a/packages/graphql/tests/tck/directives/vector/auth.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/auth.test.ts
@@ -66,11 +66,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }
@@ -266,11 +264,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }
@@ -468,11 +464,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }
@@ -675,11 +669,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }
@@ -882,11 +874,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }
@@ -1093,11 +1083,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }
@@ -1298,11 +1286,9 @@ describe("Cypher -> vector -> Auth", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
+                    edges {
+                        node {
+                            title
                         }
                     }
                 }

--- a/packages/graphql/tests/tck/directives/vector/match.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/match.test.ts
@@ -57,13 +57,11 @@ describe("Vector index match", () => {
         const query = /* GraphQL */ `
                 query MovieVectorQuery($vector: [Float!]!) {
                     ${queryName}(vector: $vector) {
-                        moviesConnection {
-                            edges {
-                                cursor
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            cursor
+                            score
+                            node {
+                                title
                             }
                         }
                     }
@@ -231,14 +229,12 @@ describe("Vector index match", () => {
         const query = /* GraphQL */ `
                 query MovieVectorQuery($vector: [Float!]!) {
                     ${queryName}(vector: $vector, where: { node: { released_GT: 2000 } }) {
-                        moviesConnection {
-                            edges {
-                                cursor
-                                score
-                                node {
-                                    title
-                                    released
-                                }
+                        edges {
+                            cursor
+                            score
+                            node {
+                                title
+                                released
                             }
                         }
                     }
@@ -410,12 +406,10 @@ describe("Vector index match", () => {
         const query = /* GraphQL */ `
                 query MovieVectorQuery($vector: [Float!]!) {
                     ${queryName}(vector: $vector, sort: { node: { title: DESC } }) {
-                        moviesConnection {
-                            edges {
-                                score
-                                node {
-                                    title
-                                }
+                        edges {
+                            score
+                            node {
+                                title
                             }
                         }
                     }

--- a/packages/graphql/tests/tck/directives/vector/phrase.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/phrase.test.ts
@@ -66,13 +66,11 @@ describe("phrase input - genAI plugin", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($phrase: String!) {
                 ${queryName}(phrase: $phrase) {
-                    moviesConnection {
-                        edges {
-                            cursor
-                            score
-                            node {
-                                title
-                            }
+                    edges {
+                        cursor
+                        score
+                        node {
+                            title
                         }
                     }
                 }

--- a/packages/graphql/tests/tck/directives/vector/score.test.ts
+++ b/packages/graphql/tests/tck/directives/vector/score.test.ts
@@ -56,13 +56,11 @@ describe("Cypher -> vector -> Score", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector, where: { score: { min: 0.5 } }) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
-                            score
+                    edges {
+                        node {
+                            title
                         }
+                        score
                     }
                 }
             }
@@ -230,13 +228,11 @@ describe("Cypher -> vector -> Score", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector, sort: { score: ASC }) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
-                            score
+                    edges {
+                        node {
+                            title
                         }
+                        score
                     }
                 }
             }
@@ -405,13 +401,11 @@ describe("Cypher -> vector -> Score", () => {
         const query = /* GraphQL */ `
             query MovieVectorQuery($vector: [Float!]!) {
                 ${queryName}(vector: $vector, sort: [{ score: ASC }, { node: { title: DESC } }]) {
-                    moviesConnection {
-                        edges {
-                            node {
-                                title
-                            }
-                            score
+                    edges {
+                        node {
+                            title
                         }
+                        score
                     }
                 }
             }


### PR DESCRIPTION
# Description

Remove connection wrapper on vector queries

_Previous:_

```graphql
query MovieVectorQuery($vector: [Float!]!) {
    myVectorQuery(vector: $vector) {
        moviesConnection {
            edges {
                cursor
                score
                node {
                    title
                }
            }
        }
    }
}
```

_Now:_

```graphql
query MovieVectorQuery($vector: [Float!]!) {
    myVectorQuery(vector: $vector) {
        edges {
            cursor
            score
            node {
                title
            }
        }
    }
}
```
